### PR TITLE
fix: router swap wrong token symbol on not enough balance message.

### DIFF
--- a/apps/main/src/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/components/PageRouterSwap/index.tsx
@@ -510,7 +510,9 @@ const QuickSwap = ({
       <AlertFormError errorKey={formStatus.error} handleBtnClose={() => updateFormValues({}, false, '', false)} />
 
       {formValues.fromError ? (
-        <AlertBox alertType="error">{t`Not enough balance for ${tokensNameMapper[searchedParams.toAddress]}`}</AlertBox>
+        <AlertBox alertType="error">{t`Not enough balance for ${
+          tokensNameMapper[searchedParams.fromAddress]
+        }`}</AlertBox>
       ) : null}
 
       <FormConnectWallet loading={!steps.length} curve={curve}>


### PR DESCRIPTION
<img width="398" alt="Screenshot 2024-03-06 at 9 02 08 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/f8a2c9cd-eaac-466b-9aee-54679bf7b673">
