### PR TITLE
fix links

### DIFF
--- a/apps/loan/src/components/PageDisclaimer/Page.tsx
+++ b/apps/loan/src/components/PageDisclaimer/Page.tsx
@@ -34,7 +34,7 @@ const Page: NextPage = () => {
           decreases, the system automatically sells off collateral in a &lsquo;soft liquidation mode&rsquo;. If the
           collateral&apos;s price increases, the system recovers the collateral. This process could lead to some losses
           due to liquidation and de-liquidation. Additional information can be found on{' '}
-          <StyledExternalLink href="https://docs.curve.fi/LLAMMA/overview/">LLAMMA Overview</StyledExternalLink>.
+          <StyledExternalLink href="https://docs.curve.fi/crvUSD/amm/">LLAMMA Overview</StyledExternalLink>.
         </p>
 
         <p>Please consider the following risk disclaimers when using the Curve Stablecoin infrastructure:</p>

--- a/apps/main/src/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
+++ b/apps/main/src/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
@@ -50,7 +50,7 @@ const Rewards = ({ chainId, poolData, rewardsApy }: Props) => {
               <StyledInformationIcon name="InformationSquare" size={16} />
             </StyledTooltip>
             <StyledDescriptionChip>
-              <ExternalLink $noStyles href="https://resources.curve.fi/lp/understanding-curve-pools#base-vapy">
+              <ExternalLink $noStyles href="https://resources.curve.fi/lp/understanding-curve-pools/#base-vapy">
                 {t`Learn more`}
               </ExternalLink>
             </StyledDescriptionChip>
@@ -132,7 +132,7 @@ const Rewards = ({ chainId, poolData, rewardsApy }: Props) => {
               })}
           </Box>
           <BoostingLink>
-            <ExternalLink $noStyles href="https://resources.curve.fi/reward-gauges/boosting-your-crv-rewards">
+            <ExternalLink $noStyles href="https://resources.curve.fi/reward-gauges/boosting-your-crv-rewards/">
               {t`Learn more about Boosting your CRV rewards`}
             </ExternalLink>
           </BoostingLink>


### PR DESCRIPTION
This time with verified commits:

- Fixed LLAMMA link in risk disclaimer. The documentation structure was restructured a while ago, which broke the link i think.
- Hyperlinks on the pool page were working, but when using the navigation bar on Resources from that side, a 404 occurred. This should fix it.