### PR TITLE
Task enable pool creation on fractal

### DIFF
--- a/apps/main/src/components/PageCreatePool/SelectTokenModal/ComboBoxTokenPicker.tsx
+++ b/apps/main/src/components/PageCreatePool/SelectTokenModal/ComboBoxTokenPicker.tsx
@@ -90,16 +90,18 @@ const ComboBoxTokenPicker = ({
 
     const result = fuse.search(filterValue)
 
+    const checkedResult = filterValue.length !== 42 ? result : result[0].item.address === filterValue ? result : []
+
     settokenQueryStatus('')
-    if (filterValue.length === 42 && result.length === 0) {
+    if (filterValue.length === 42 && checkedResult.length === 0) {
       settokenQueryStatus('LOADING')
       verifyTokens()
     }
 
     if (filterValue.length === 0) {
       return filteredTokens
-    } else if (result.length > 0) {
-      return result.map((r) => r.item)
+    } else if (checkedResult.length > 0) {
+      return checkedResult.map((r) => r.item)
     } else {
       return tokens.filter((item) => endsWith(item.address, filterValue))
     }

--- a/apps/main/src/networks.ts
+++ b/apps/main/src/networks.ts
@@ -552,6 +552,10 @@ const networks: Record<ChainId, NetworkConfig> = {
       toAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     },
     showInSelectNetwork: false,
+    hasFactory: true,
+    twocryptoFactory: true,
+    tricryptoFactory: true,
+    stableSwapNg: true,
   },
 }
 


### PR DESCRIPTION
Changes:

- Enabled stableswap-ng, twocoin crypto, tricrypto pool creation on Fractal network
- Increased accuracy of token filtering for user added tokens in fuse.js search for pool creation