### PR TITLE
Task: update latest oracle price value in chart on store state updates

### DIFF
--- a/packages/ui/src/Chart/CandleChart.tsx
+++ b/packages/ui/src/Chart/CandleChart.tsx
@@ -32,6 +32,7 @@ type Props = {
   oraclePriceVisible?: boolean
   liqRangeCurrentVisible?: boolean
   liqRangeNewVisible?: boolean
+  latestOraclePrice?: string
 }
 
 const CandleChart = ({
@@ -52,6 +53,7 @@ const CandleChart = ({
   oraclePriceVisible,
   liqRangeCurrentVisible,
   liqRangeNewVisible,
+  latestOraclePrice,
 }: Props) => {
   const chartContainerRef = useRef(null)
   const chartRef = useRef<IChartApi | null>(null)
@@ -400,6 +402,17 @@ const CandleChart = ({
     refetchingCapped,
     volumeData,
   ])
+
+  // update the latest data point to ensure the oracle price is current in case there hasn't been recent events in the pool
+  useEffect(() => {
+    if (latestOraclePrice && oraclePriceSeriesRef.current && oraclePriceData) {
+      oraclePriceSeriesRef.current.update({
+        time: oraclePriceData[oraclePriceData.length - 1].time,
+        value: +latestOraclePrice,
+      })
+    }
+  }, [latestOraclePrice, oraclePriceData])
+
   useEffect(() => {
     wrapperRef.current = new ResizeObserver((entries) => {
       if (isUnmounting) return

--- a/packages/ui/src/Chart/ChartWrapper.tsx
+++ b/packages/ui/src/Chart/ChartWrapper.tsx
@@ -51,6 +51,7 @@ type Props = {
   lastFetchEndTime: number
   refetchingCapped: boolean
   selectChartList?: LabelList[]
+  latestOraclePrice?: string
 }
 
 const DEFAULT_CHART_COLORS: ChartColors = {
@@ -97,6 +98,7 @@ const ChartWrapper = ({
   toggleOraclePriceVisible,
   toggleLiqRangeCurrentVisible,
   toggleLiqRangeNewVisible,
+  latestOraclePrice,
 }: Props) => {
   const [magnet, setMagnet] = useState(false)
   const clonedOhlcData = cloneDeep(ohlcData)
@@ -182,7 +184,7 @@ const ChartWrapper = ({
               refetchPricesData()
             }}
           >
-            <Icon name={'Renew'} size={16} aria-label={'Toggle magnet mode'} />
+            <Icon name={'Renew'} size={16} aria-label={'Refresh chart'} />
           </RefreshButton>
           <MagnetButton
             size="small"
@@ -253,6 +255,7 @@ const ChartWrapper = ({
               liqRangeCurrentVisible={liqRangeCurrentVisible}
               liqRangeNewVisible={liqRangeNewVisible}
               oraclePriceVisible={oraclePriceVisible}
+              latestOraclePrice={latestOraclePrice}
             />
           </ResponsiveContainer>
         )}
@@ -268,6 +271,15 @@ const ChartWrapper = ({
             minHeight={chartExpanded ? chartHeight.expanded.toString() + 'px' : chartHeight.standard.toString() + 'px'}
           >
             <ErrorMessage>{'There was an error fetching the Chart data.'}</ErrorMessage>
+            <RefreshButton
+              size="small"
+              variant="text"
+              onClick={() => {
+                refetchPricesData()
+              }}
+            >
+              <Icon name={'Renew'} size={16} aria-label={'Refresh chart'} />
+            </RefreshButton>
           </StyledSpinnerWrapper>
         )}
       </ContentWrapper>
@@ -339,7 +351,8 @@ const ResponsiveContainer = styled.div<{ chartExpanded: boolean; chartHeight: Ch
 `
 
 const StyledSpinnerWrapper = styled(SpinnerWrapper)`
-  /* margin: var(--spacing-3) 0 var(--spacing-3); */
+  flex-direction: column;
+  gap: var(--spacing-2);
 `
 
 const ErrorMessage = styled.p`


### PR DESCRIPTION
Changes:
- Use app state for oracle price to ensure the last data point is accurate in case there hasn't been recent events
- Fixed deleverage liquidation range in chart
- Added refresh button to chart error message