### PR TITLE
task: enabled tricrypto pool creation on additional networks

### DIFF
--- a/apps/main/src/networks.ts
+++ b/apps/main/src/networks.ts
@@ -155,34 +155,34 @@ const networks: Record<ChainId, NetworkConfig> = {
           '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599', // wbtc
         ],
       },
-      // {
-      //   name: 'paypool',
-      //   pool: '0x383e6b4437b59fff47b619cba855ca29342a8559',
-      //   token: '0x383e6b4437b59fff47b619cba855ca29342a8559',
-      //   coins: [
-      //     '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
-      //     '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // usdc
-      //   ],
-      // },
-      // {
-      //   name: 'fraxpyusd',
-      //   pool: '0xa5588f7cdf560811710a2d82d3c9c99769db1dcb',
-      //   token: '0xa5588f7cdf560811710a2d82d3c9c99769db1dcb',
-      //   coins: [
-      //     '0x853d955acef822db058eb8505911ed77f175b99e', // frax
-      //     '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
-      //   ],
-      // },
-      // {
-      //   name: '3payllama',
-      //   pool: '0x2e1d500091ef244fdcb6b83c86143e28388e473a',
-      //   token: '0x2e1d500091ef244fdcb6b83c86143e28388e473a',
-      //   coins: [
-      //     '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
-      //     '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e', // crvUSD
-      //     '0x853d955acef822db058eb8505911ed77f175b99e', // frax
-      //   ],
-      // },
+      {
+        name: 'paypool',
+        pool: '0x383e6b4437b59fff47b619cba855ca29342a8559',
+        token: '0x383e6b4437b59fff47b619cba855ca29342a8559',
+        coins: [
+          '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
+          '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // usdc
+        ],
+      },
+      {
+        name: 'fraxpyusd',
+        pool: '0xa5588f7cdf560811710a2d82d3c9c99769db1dcb',
+        token: '0xa5588f7cdf560811710a2d82d3c9c99769db1dcb',
+        coins: [
+          '0x853d955acef822db058eb8505911ed77f175b99e', // frax
+          '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
+        ],
+      },
+      {
+        name: '3payllama',
+        pool: '0x2e1d500091ef244fdcb6b83c86143e28388e473a',
+        token: '0x2e1d500091ef244fdcb6b83c86143e28388e473a',
+        coins: [
+          '0x6c3ea9036406852006290770bedfcaba0e23a0e8', // pyusd
+          '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e', // crvUSD
+          '0x853d955acef822db058eb8505911ed77f175b99e', // frax
+        ],
+      },
       {
         name: 'fraxusdp',
         pool: '0xf253f83aca21aabd2a20553ae0bf7f65c755a07f',
@@ -249,6 +249,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     ],
     stableSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
     pricesApi: true,
@@ -288,6 +289,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     ],
     stableSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
   },
@@ -354,6 +356,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     basePools: [],
     stableSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
   },
@@ -380,6 +383,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     stableSwapFactory: true,
     cryptoSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
     pricesApi: true,
@@ -450,6 +454,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     basePools: [],
     stableSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
   },
@@ -468,6 +473,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     },
     stableSwapNg: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     hasFactory: true,
   },
   1313161554: {
@@ -539,6 +545,7 @@ const networks: Record<ChainId, NetworkConfig> = {
     stableSwapFactory: true,
     cryptoSwapFactory: true,
     twocryptoFactory: true,
+    tricryptoFactory: true,
     stableSwapNg: true,
     hasFactory: true,
   },


### PR DESCRIPTION
Changes:
- Enabled tricypto pool creation on: optimism, gnosis, kava, fantom, avalanche, celo, bsc