### PR TITLE
chore: update curvejs to 2.56.11

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -21,7 +21,7 @@
     "test": "start-server-and-test server-start http://localhost:3000 cypress:open"
   },
   "dependencies": {
-    "@curvefi/api": "^2.56.9",
+    "@curvefi/api": "^2.56.11",
     "@lingui/react": "^4.6.0",
     "@supercharge/promise-pool": "^2.3.2",
     "bignumber.js": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,10 +1444,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@curvefi/api@^2.56.9":
-  version "2.56.9"
-  resolved "https://registry.yarnpkg.com/@curvefi/api/-/api-2.56.9.tgz#a30fed9d2632138b6f502a79a07fd75565ef6497"
-  integrity sha512-hjdRsxs/rg6WpwzeQjSdx26gw2WHZR2X1hE+REHP4K91byc7NfJAi6K5zyHQYDapmJRp1O2qpbCJFnejX5nUig==
+"@curvefi/api@^2.56.11":
+  version "2.56.11"
+  resolved "https://registry.yarnpkg.com/@curvefi/api/-/api-2.56.11.tgz#9edd9ff859d976809decf4ae89fe6f36b53f211b"
+  integrity sha512-p+Ynhj3hnpDinIAcVYIe/4b1bsKYECKRAzsvMK5ogoCQ7kzyx9dmOqxj9cXDN+FJqsTdMM1kqXMKmwcl1Q587A==
   dependencies:
     axios "^0.21.1"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
Changes:
- Update curve-js to 2.56.11