### PR TITLE
fix: update maxFeePerGas decimal limit on arbitrum

### DIFF
--- a/apps/main/src/store/createGasSlice.ts
+++ b/apps/main/src/store/createGasSlice.ts
@@ -89,7 +89,7 @@ const createGasSlice = (set: SetState<State>, get: GetState<State>): GasSlice =>
             parsedGasInfo = await parseGasInfo(curve, provider)
 
             if (parsedGasInfo && customFeeData) {
-              parsedGasInfo.gasInfo.max = [gweiToWai(customFeeData.maxFeePerGas)]
+              parsedGasInfo.gasInfo.max = [gweiToWai(Number(customFeeData.maxFeePerGas.toFixed(2)))]
               parsedGasInfo.gasInfo.priority = [gweiToWai(customFeeData.maxPriorityFeePerGas)]
               curve.setCustomFeeData(customFeeData)
             }


### PR DESCRIPTION
Changes:
- Enforced number type and limited maxFeePerGas to two decimals on arbitrum