### PR TITLE
chore: update curve-lending-js to 1.6.9

### DIFF
--- a/apps/lend/package.json
+++ b/apps/lend/package.json
@@ -18,7 +18,7 @@
     "analyze": "ANALYZE=true next build"
   },
   "dependencies": {
-    "@curvefi/lending-api": "^1.6.8",
+    "@curvefi/lending-api": "^1.6.9",
     "@lingui/detect-locale": "^4.6.0",
     "@lingui/react": "^4.6.0",
     "@supercharge/promise-pool": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,10 +1455,10 @@
     ethers "^6.11.0"
     memoizee "^0.4.15"
 
-"@curvefi/lending-api@^1.6.8":
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/@curvefi/lending-api/-/lending-api-1.6.8.tgz#3d5e9e3f6d305a34ffb450e859daa3c5f42a5da5"
-  integrity sha512-aGsM1kK9yk1AouhgNbYnddWXul8JLk/57upKaCE+orMAeoLneEDkwgd9i4hyp6SxngE/HbThC5pS59qkcbwKLQ==
+"@curvefi/lending-api@^1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@curvefi/lending-api/-/lending-api-1.6.9.tgz#aff6ce77919843e4366af82d03b1d11bda0198fc"
+  integrity sha512-LljMBh+Kp74fjcuGKR0Xlmj8+18pYdXyhLqBPX2p7Yp6b9LzklZLysZRP7Kp2xyI0DS3miq0ZkId1FGIwfoeAA==
   dependencies:
     axios "^0.21.1"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
Changes:
- Updated curve-lending-js to 1.6.9 on Curve Lend