### PR TITLE
task: combine APR into one item

### DIFF
--- a/apps/lend/src/components/DetailInfoRate.tsx
+++ b/apps/lend/src/components/DetailInfoRate.tsx
@@ -21,20 +21,20 @@ const DetailInfoRate = ({
   const ratesResp = useStore((state) => state.markets.ratesMapper[rChainId]?.[rOwmId])
 
   const { rates, error } = ratesResp ?? {}
-  const futureRate = isBorrow ? futureRates?.borrowApy : futureRates?.lendApy
+  const futureRate = isBorrow ? futureRates?.borrowApy : futureRates?.lendApr
 
   return (
     <DetailInfo
       loading={typeof ratesResp === 'undefined'}
       loadingSkeleton={[100, 20]}
-      label={isBorrow ? t`Borrow APY:` : t`Lend APY:`}
+      label={isBorrow ? t`Borrow APY:` : t`Lend APR:`}
     >
       <span>
         {error ? (
           '?'
         ) : (
           <strong>
-            {formatNumber(isBorrow ? rates?.borrowApy : rates?.lendApy, {
+            {formatNumber(isBorrow ? rates?.borrowApy : rates?.lendApr, {
               ...FORMAT_OPTIONS.PERCENT,
               defaultValue: '-',
             })}

--- a/apps/lend/src/components/DetailsMarket/components/DetailsLoan.tsx
+++ b/apps/lend/src/components/DetailsMarket/components/DetailsLoan.tsx
@@ -36,7 +36,7 @@ const DetailsLoan = ({ type, ...pageProps }: PageContentProps & { type: MarketLi
     [
       { title: t`Collateral`, value: <CellToken {...cellProps} type="collateral" /> },
       { title: t`Borrow`, value: <CellToken {...cellProps} type="borrowed" /> },
-      { title: t`Lend APY`, value: <CellRate {...cellProps} type="supply" /> },
+      { title: t`Lend APR`, value: <CellRate {...cellProps} type="supply" /> },
       { title: t`Borrow APY`, value: <CellRate {...cellProps} type="borrow" className="paddingLeft" /> },
       { title: t`Available`, value: <CellCap {...cellProps} type="available" /> },
     ],

--- a/apps/lend/src/components/DetailsMarket/components/DetailsSupply.tsx
+++ b/apps/lend/src/components/DetailsMarket/components/DetailsSupply.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { t } from '@lingui/macro'
+import styled from 'styled-components'
 
 import { breakpoints } from '@/ui/utils'
 
@@ -14,13 +15,11 @@ import {
 import Box from '@/ui/Box'
 import CellCap from '@/components/SharedCellData/CellCap'
 import CellLoanTotalDebt from '@/components/SharedCellData/CellLoanTotalDebt'
-import CellRate from '@/components/SharedCellData/CellRate'
 import CellToken from '@/components/SharedCellData/CellToken'
 import CellSupplyTotalLiquidity from '@/components/SharedCellData/CellSupplyTotalLiquidity'
 import DetailsSupplyRewards from '@/components/DetailsMarket/components/DetailsSupplyRewards'
 import DetailsContracts from '@/components/DetailsMarket/components/DetailsContracts'
 import MarketParameters from '@/components/DetailsMarket/components/MarketParameters'
-import styled from 'styled-components'
 
 const DetailsSupply = ({ type, ...pageProps }: PageContentProps & { type: MarketListType }) => {
   const { rChainId, rOwmId, owmDataCachedOrApi, borrowed_token, collateral_token } = pageProps
@@ -35,11 +34,10 @@ const DetailsSupply = ({ type, ...pageProps }: PageContentProps & { type: Market
   const details = [
     [
       { title: t`Supply token`, value: <CellToken {...cellProps} type="borrowed" /> },
-      { title: t`Lend APY`, value: <CellRate {...cellProps} type="supply" /> },
       { title: 'TVL', value: <CellSupplyTotalLiquidity {...cellProps} /> },
+      { title: t`Available`, value: <CellCap {...cellProps} type="available" /> },
     ],
     [
-      { title: t`Available`, value: <CellCap {...cellProps} type="available" /> },
       { title: t`Total Debt`, value: <CellLoanTotalDebt {...cellProps} /> },
       { title: t`Total supplied`, value: <CellCap {...cellProps} type="cap" /> },
       { title: t`Utilization %`, value: <CellCap {...cellProps} type="utilization" /> },

--- a/apps/lend/src/components/DetailsMarket/components/MarketParameters.tsx
+++ b/apps/lend/src/components/DetailsMarket/components/MarketParameters.tsx
@@ -32,7 +32,7 @@ const MarketParameters = ({
   const marketDetails: { label: string; value: string | number | undefined; formatOptions?: NumberFormatOptions; title?: string; isError: string; isRow?: boolean }[][] = type === 'borrow' ?
     [
       [
-        { label: t`Fee`, value: parameters?.fee, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 3 }, isError: parametersError },
+        { label: t`AMM swap fee`, value: parameters?.fee, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 3 }, isError: parametersError },
         { label: t`Admin fee`, value: parameters?.admin_fee, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 3 }, isError: parametersError },
         { label: t`A`, value: parameters?.A, formatOptions: { useGrouping: false }, isError: parametersError },
         { label: t`Loan discount`, value: parameters?.loan_discount, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 2 }, isError: parametersError },

--- a/apps/lend/src/components/DetailsUser/components/DetailsUserSupply.tsx
+++ b/apps/lend/src/components/DetailsUser/components/DetailsUserSupply.tsx
@@ -45,7 +45,7 @@ const DetailsUserSupply = (pageProps: PageContentProps) => {
   const stats: Detail[][] = [
     [
       { title: t`Supply Token`, value: <CellToken {...cellProps} type="borrowed" /> },
-      { title: t`Lend APY`, value: <CellRate {...cellProps} type="supply" /> },
+      { title: t`Lend APR`, value: <CellRate {...cellProps} type="supply" /> },
     ],
     [
       {

--- a/apps/lend/src/components/PageMarketList/Page.tsx
+++ b/apps/lend/src/components/PageMarketList/Page.tsx
@@ -11,6 +11,7 @@ import type {
 import { t } from '@lingui/macro'
 import React, { useEffect, useState } from 'react'
 import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import styled from 'styled-components'
 
 import { ROUTE } from '@/constants'
 import { getPath } from '@/utils/utilsRouter'
@@ -58,7 +59,7 @@ const Page: NextPage = () => {
     utilization: { name: t`Utilization %` },
     capUtilization: { name: t`Supplied / Utilization` },
     rateBorrow: { name: t`Borrow APY` },
-    rateLend: { name: t`Lend APY` },
+    rateLend: { name: t`Lend APR` },
     myDebt: { name: t`My debt` },
     myHealth: { name: t`My health` },
     myWalletCollateral: { name: t`Wallet balance` },
@@ -131,7 +132,7 @@ const Page: NextPage = () => {
   return (
     <>
       <DocumentHead title={t`Markets`} />
-      <AppPageContainer>
+      <StyledAppPageContainer $maxWidth={parsedSearchParams?.filterTypeKey === 'supply' ? '850px' : ''}>
         {rChainId && parsedSearchParams && (
           <MarketList
             rChainId={rChainId}
@@ -146,11 +147,23 @@ const Page: NextPage = () => {
             updatePath={updatePath}
           />
         )}
-      </AppPageContainer>
+      </StyledAppPageContainer>
       <Settings showScrollButton />
     </>
   )
 }
+
+const StyledAppPageContainer = styled(AppPageContainer)<{ $maxWidth: string }>`
+  ${({ $maxWidth }) => {
+    if ($maxWidth) {
+      return `
+        max-width: ${$maxWidth};
+        margin-left: auto;
+        margin-right: auto;
+      `
+    }
+  }}
+`
 
 function _querySymbol(searchPath: string) {
   return searchPath === '?' ? '' : '&'

--- a/apps/lend/src/components/PageMarketList/Page.tsx
+++ b/apps/lend/src/components/PageMarketList/Page.tsx
@@ -29,7 +29,7 @@ const Page: NextPage = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const { routerParams, api } = usePageOnMount(params, location, navigate)
+  const { pageLoaded, routerParams, api } = usePageOnMount(params, location, navigate)
   const { rChainId } = routerParams
 
   const isLoadingApi = useStore((state) => state.isLoadingApi)
@@ -99,7 +99,7 @@ const Page: NextPage = () => {
 
   useEffect(() => {
     setLoaded(false)
-    if (!isLoadingApi) {
+    if (pageLoaded && !isLoadingApi) {
       const paramFilterKey = (searchParams.get('filter') || 'all').toLowerCase()
       const paramFilterTypeKey = (searchParams.get('type') || 'borrow').toLowerCase()
       const paramHideSmallPools = searchParams.get('hideSmallMarkets') || 'true'
@@ -127,7 +127,7 @@ const Page: NextPage = () => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingApi, searchParams])
+  }, [pageLoaded, isLoadingApi, searchParams])
 
   return (
     <>

--- a/apps/lend/src/components/PageMarketList/components/MarketListItemContentBody.tsx
+++ b/apps/lend/src/components/PageMarketList/components/MarketListItemContentBody.tsx
@@ -49,7 +49,7 @@ const MarketListItemContentBody = ({
   }, [isOpen])
 
   return (
-    <FoldContentWrapper isOpen={isOpen ?? true}>
+    <FoldContentWrapper>
       <TableRowViewContentTable
         {...pageProps}
         params={params}
@@ -65,25 +65,14 @@ const MarketListItemContentBody = ({
   )
 }
 
-const FoldContentWrapper = styled.div<{ isOpen: boolean }>`
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.2s ease-in-out; /* Add transition for max-height */
+const FoldContentWrapper = styled.div`
+  border: 1px solid var(--box_header--primary--background-color);
+  box-shadow: 3px 3px 0 var(--box--primary--shadow-color);
+  margin: 0 var(--spacing-narrow);
 
-  ${({ isOpen }) => {
-    if (isOpen) {
-      return `
-        max-height: 1000px; /* Set a large value for max-height to accommodate content */
-        border: 1px solid var(--box_header--primary--background-color);
-        box-shadow: 3px 3px 0 var(--box--primary--shadow-color);
-        margin: 0 var(--spacing-narrow);
-  
-        @media (min-width: ${breakpoints.sm}rem) {
-          margin: 0 var(--spacing-normal);
-        }
-      `
-    }
-  }}
+  @media (min-width: ${breakpoints.sm}rem) {
+    margin: 0 var(--spacing-normal);
+  }
 `
 
 function _getSomeLoansExists(loanExistsMapper: UsersLoansExistsMapper) {

--- a/apps/lend/src/components/PageMarketList/components/MarketListNoResult.tsx
+++ b/apps/lend/src/components/PageMarketList/components/MarketListNoResult.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { t } from '@lingui/macro'
 import styled from 'styled-components'
 
+import { shortenAccount } from '@/ui/utils'
 import useStore from '@/store/useStore'
 
 import AlertBox from '@/ui/AlertBox'
@@ -11,7 +12,11 @@ import Box from '@/ui/Box'
 import Button from '@/ui/Button'
 import ExternalLink from 'ui/src/Link/ExternalLink'
 
-const MarketListNoResult = ({ searchParams, updatePath }: Pick<PageMarketList, 'searchParams' | 'updatePath'>) => {
+const MarketListNoResult = ({
+  searchParams,
+  signerAddress,
+  updatePath,
+}: Pick<PageMarketList, 'searchParams' | 'updatePath'> & { signerAddress: string | undefined }) => {
   const owmDatasError = useStore((state) => state.markets.error)
 
   return (
@@ -25,6 +30,14 @@ const MarketListNoResult = ({ searchParams, updatePath }: Pick<PageMarketList, '
           {t`No market found for "${searchParams.searchText}". Feel free to search other tabs, or`}{' '}
           <Button variant="text" onClick={() => updatePath({ searchText: '' })}>
             {t`view all markets.`}
+          </Button>
+        </>
+      ) : searchParams.filterKey === 'user' && signerAddress ? (
+        <>
+          {t`No market found for "${shortenAccount(signerAddress)}".`}
+          <br />{' '}
+          <Button variant="text" onClick={() => updatePath({ filterKey: 'all' })}>
+            {t`view all markets`}
           </Button>
         </>
       ) : (

--- a/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/TableRow.tsx
+++ b/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/TableRow.tsx
@@ -81,14 +81,13 @@ const TableRow = ({
       { className: 'center noPadding border-right', content: <CellInPool {...cellProps} isInMarket={userSupplied} />, show: showSupplySignerCell },
       { className: `left ${showSupplySignerCell ? '' : 'paddingLeft'}`, content: <CellToken {...cellProps} isVisible={isVisible} type='borrowed' /> },
       { className: 'right border-left border-right', content: <CellUserVaultShares {...cellProps} />, show: showSupplySignerCell },
-      { className: 'right', content: <CellRate {...cellProps} type='supply' /> },
       { className: 'right', content: <CellRewards {...cellProps} type='crv-other' /> },
       { className: 'right', content: <CellSupplyTotalLiquidity {...cellProps} /> },
     ]
   }
 
   return (
-    <Tr ref={ref} className={`row--info ${isVisible ? '' : 'pending'}`} onClick={handleCellClick}>
+    <Tr ref={ref} className={`row--info ${isVisible ? '' : 'pending'}`} onClick={(evt) => handleCellClick(evt.target)}>
       {CONTENT[isBorrow ? 'borrow' : 'supply'].map(({ className, content, isInMarket, show }, idx) => {
         return (
           _showContent(show) && (

--- a/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/TableRowMobile.tsx
+++ b/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/TableRowMobile.tsx
@@ -105,10 +105,9 @@ const TableRowMobile = ({
       ],
       [
         { sortIdKey: 'tokenSupply', label: tableLabelsMapper.tokenSupply.name, content: <CellToken {...cellProps} type='borrowed' hideIcon /> },
-        { sortIdKey: 'rateLend', label: tableLabelsMapper.rateLend.name, content: <CellRate {...cellProps} type='supply' />, },
       ],
       [
-        { sortIdKey: '', label: t`Rewards APR`, labels: [{ sortIdKey: 'rewardsCRV', label: tableLabelsMapper.rewardsCRV.name }, { sortIdKey: 'rewardsOthers', label: tableLabelsMapper.rewardsOthers.name }], content: <CellRewards {...cellProps} type='crv-other' /> }
+        { sortIdKey: '', label: t`Total APR`, content: <CellRewards {...cellProps} type='crv-other' /> }
       ]
     ]
   }
@@ -140,7 +139,7 @@ const TableRowMobile = ({
         </MobileLabelWrapper>
 
         <MobileTableContentWrapper className={isHideDetail ? '' : 'show'}>
-          <MobileTableContent onClick={handleCellClick}>
+          <MobileTableContent onClick={(evt) => handleCellClick(evt.target)}>
             {!isHideDetail && (
               <>
                 <DetailsContent>
@@ -154,9 +153,11 @@ const TableRowMobile = ({
                           <DetailContent key={details[0].label}>
                             {details.map(({ label, labels, content, show }, idx) => {
                               const key = `detail-${label}-${idx}`
+                              const detailsLength = details.length
+                              const isLast = detailsLength - 1 === idx
                               return (
                                 _showContent(show) && (
-                                  <DetailWrapper key={key}>
+                                  <DetailWrapper key={key} detailsLength={detailsLength} isLast={isLast}>
                                     {typeof labels !== 'undefined' ? (
                                       <Box flex flexDirection="column">
                                         <TextCaption isBold isCaps>
@@ -193,11 +194,11 @@ const TableRowMobile = ({
                 </DetailsContent>
                 <MobileTableActions>
                   {isBorrow ? (
-                    <Button variant="filled" onClick={handleCellClick}>
+                    <Button variant="filled" onClick={(evt) => handleCellClick(evt.target)}>
                       {loanExists ? t`Manage Loan` : t`Get Loan`}
                     </Button>
                   ) : (
-                    <Button variant="filled" onClick={handleCellClick}>
+                    <Button variant="filled" onClick={(evt) => handleCellClick(evt.target)}>
                       {t`Supply ${borrowed_token?.symbol ?? ''}`}
                     </Button>
                   )}
@@ -211,10 +212,11 @@ const TableRowMobile = ({
   )
 }
 
-const DetailWrapper = styled.div`
+const DetailWrapper = styled.div<{ detailsLength: number; isLast: boolean }>`
   display: grid;
   grid-gap: var(--spacing-1);
-  margin-right: var(--spacing-narrow);
+  ${({ detailsLength }) => detailsLength === 1 && 'width: 100%'};
+  ${({ isLast }) => !isLast && `margin-right: var(--spacing-narrow)`};
 `
 
 const DetailContent = styled.div`

--- a/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/index.tsx
+++ b/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/index.tsx
@@ -49,9 +49,12 @@ const TableRowViewContentTable = ({
 
   const isMdUp = useStore((state) => state.layout.isMdUp)
   const loansExistsMapper = useStore((state) => state.user.loansExistsMapper)
+  const marketsBalancesMapper = useStore((state) => state.user.marketsBalancesMapper)
   const owmDatasCachedMapper = useStore((state) => state.storeCache.owmDatasMapper[rChainId])
   const owmDatasMapper = useStore((state) => state.markets.owmDatasMapper[rChainId])
   const setMarketsStateByKey = useStore((state) => state.markets.setStateByKey)
+
+  const { filterTypeKey } = searchParams
 
   const result = useMemo(() => {
     if (long || short) {
@@ -98,8 +101,16 @@ const TableRowViewContentTable = ({
             const handleCellClick = (target: EventTarget) => {
               const { nodeName } = target as HTMLElement
               if (nodeName !== 'BUTTON') {
-                setMarketsStateByKey('marketDetailsView', loanExists ? 'user' : 'market')
-                if (searchParams.filterTypeKey === 'supply') {
+                // update view
+                if (filterTypeKey === 'borrow') {
+                  setMarketsStateByKey('marketDetailsView', loanExists ? 'user' : 'market')
+                } else if (filterTypeKey === 'supply') {
+                  const { gauge = '0', vaultShares = '0' } = marketsBalancesMapper[userActiveKey] ?? {}
+                  const haveSupply = +gauge + +vaultShares > 0
+                  setMarketsStateByKey('marketDetailsView', haveSupply ? 'user' : 'market')
+                }
+
+                if (filterTypeKey === 'supply') {
                   navigate(getVaultPathname(params, owmId, 'deposit'))
                 } else if (loanExists) {
                   navigate(getLoanManagePathname(params, owmId, 'loan'))

--- a/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/index.tsx
+++ b/apps/lend/src/components/PageMarketList/components/TableRowViewContentTable/index.tsx
@@ -95,14 +95,17 @@ const TableRowViewContentTable = ({
             const userActiveKey = helpers.getUserActiveKey(api, owmDataCachedOrApi)
             const loanExists = loansExistsMapper[userActiveKey]?.loanExists
 
-            const handleCellClick = () => {
-              setMarketsStateByKey('marketDetailsView', loanExists ? 'user' : 'market')
-              if (searchParams.filterTypeKey === 'supply') {
-                navigate(getVaultPathname(params, owmId, 'deposit'))
-              } else if (loanExists) {
-                navigate(getLoanManagePathname(params, owmId, 'loan'))
-              } else {
-                navigate(getLoanCreatePathname(params, owmId, 'create'))
+            const handleCellClick = (target: EventTarget) => {
+              const { nodeName } = target as HTMLElement
+              if (nodeName !== 'BUTTON') {
+                setMarketsStateByKey('marketDetailsView', loanExists ? 'user' : 'market')
+                if (searchParams.filterTypeKey === 'supply') {
+                  navigate(getVaultPathname(params, owmId, 'deposit'))
+                } else if (loanExists) {
+                  navigate(getLoanManagePathname(params, owmId, 'loan'))
+                } else {
+                  navigate(getLoanCreatePathname(params, owmId, 'create'))
+                }
               }
             }
 

--- a/apps/lend/src/components/PageMarketList/index.tsx
+++ b/apps/lend/src/components/PageMarketList/index.tsx
@@ -52,11 +52,10 @@ const MarketList = (pageProps: PageMarketList) => {
     ],
     supply: [
       { sortIdKey: 'isInMarket', label: tableLabelsMapper.isInMarket.name, className: 'center noPadding', show: showSupplySignerCell, isNotSortable: true, width: '20px' },
-      { sortIdKey: 'tokenSupply', label: tableLabelsMapper.tokenSupply.name, className: 'left', width: '280px' },
+      { sortIdKey: 'tokenSupply', label: tableLabelsMapper.tokenSupply.name, className: 'left', width: '140px' },
       { sortIdKey: 'myVaultShares', label: tableLabelsMapper.myVaultShares.name, className: 'right', show: showSupplySignerCell, width: '240px' },
-      { sortIdKey: 'rateLend', label: tableLabelsMapper.rateLend.name, className: 'right' },
-      { sortIdKey: '', label: t`Rewards APR`, buttons: [{ sortIdKey: 'rewardsCRV', label: tableLabelsMapper.rewardsCRV.name }, { sortIdKey: 'rewardsOthers', label: tableLabelsMapper.rewardsOthers.name }], className: 'right', width: '240px' },
-      { sortIdKey: 'totalLiquidity', label: tableLabelsMapper.totalLiquidity.name, className: 'right', width: '210px' },
+      { sortIdKey: '', label: t`Total APR`, className: 'right' },
+      { sortIdKey: 'totalLiquidity', label: tableLabelsMapper.totalLiquidity.name, className: 'right', width: '160px' },
     ]
   }
 

--- a/apps/lend/src/components/PageMarketList/index.tsx
+++ b/apps/lend/src/components/PageMarketList/index.tsx
@@ -70,6 +70,11 @@ const MarketList = (pageProps: PageMarketList) => {
   )
 
   useEffect(() => {
+    if (isLoaded && isPageVisible) updateFormValues(searchParams, true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPageVisible])
+
+  useEffect(() => {
     if (isLoaded) updateFormValues(searchParams)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded, searchParams])
@@ -79,11 +84,6 @@ const MarketList = (pageProps: PageMarketList) => {
     if (isLoaded && Object.keys(usdRatesMapper).length > 0) updateFormValues(searchParams)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [usdRatesMapper])
-
-  useEffect(() => {
-    if (isPageVisible) updateFormValues(searchParams, true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPageVisible])
 
   const tableLabels = FOLD_TABLE_LABELS[searchParams.filterTypeKey]
 
@@ -95,7 +95,7 @@ const MarketList = (pageProps: PageMarketList) => {
       {/* MARKET LIST */}
       <MarketListWrapper>
         {formStatus.noResult && !formStatus.isLoading ? (
-          <MarketListNoResult searchParams={searchParams} updatePath={updatePath} />
+          <MarketListNoResult searchParams={searchParams} signerAddress={signerAddress} updatePath={updatePath} />
         ) : Array.isArray(result) ? (
           result.map((marketListItem) => (
             <MarketListItemContent

--- a/apps/lend/src/components/PageMarketList/types.ts
+++ b/apps/lend/src/components/PageMarketList/types.ts
@@ -101,7 +101,7 @@ export type TableRowProps = Pick<PageMarketList, 'rChainId' | 'api' | 'searchPar
   showBorrowSignerCell: boolean
   showSupplySignerCell: boolean
   userActiveKey: string
-  handleCellClick(): void
+  handleCellClick(evt: EventTarget): void
 }
 
 export type TableCellProps = {

--- a/apps/lend/src/components/SharedCellData/CellRate.tsx
+++ b/apps/lend/src/components/SharedCellData/CellRate.tsx
@@ -1,11 +1,13 @@
 import type { ChipProps } from '@/ui/Typography/types'
 
 import React from 'react'
+import styled from 'styled-components'
 
 import { FORMAT_OPTIONS, formatNumber } from '@/ui/utils'
 import useStore from '@/store/useStore'
 
 import Chip from '@/ui/Typography/Chip'
+import Icon from '@/ui/Icon'
 
 const CellRate = ({
   rChainId,
@@ -20,17 +22,29 @@ const CellRate = ({
   const resp = useStore((state) => state.markets.ratesMapper[rChainId]?.[rOwmId])
 
   const { rates, error } = resp ?? {}
-  const rate = type === 'borrow' ? rates?.borrowApy : rates?.lendApy
 
   return (
     <>
       {typeof resp === 'undefined' ? null : error ? (
         '?'
-      ) : (
-        <Chip {...props}>{formatNumber(rate, FORMAT_OPTIONS.PERCENT)}</Chip>
-      )}
+      ) : type === 'borrow' ? (
+        <Chip {...props}>{formatNumber(rates?.borrowApy, FORMAT_OPTIONS.PERCENT)}</Chip>
+      ) : type === 'supply' ? (
+        <Chip
+          {...props}
+          tooltipProps={{ minWidth: '100px' }}
+          tooltip={<Tooltip>{formatNumber(rates?.lendApy, FORMAT_OPTIONS.PERCENT)} APY</Tooltip>}
+        >
+          {formatNumber(rates?.lendApr, FORMAT_OPTIONS.PERCENT)}{' '}
+          <Icon name="InformationSquare" className="svg-tooltip" size={16} />
+        </Chip>
+      ) : null}
     </>
   )
 }
+
+const Tooltip = styled.div`
+  white-space: nowrap;
+`
 
 export default CellRate

--- a/apps/lend/src/components/SharedCellData/CellRewardsTooltip.tsx
+++ b/apps/lend/src/components/SharedCellData/CellRewardsTooltip.tsx
@@ -1,0 +1,113 @@
+import React from 'react'
+import { t } from '@lingui/macro'
+import styled from 'styled-components'
+
+import TextCaption from '@/ui/TextCaption'
+
+const CellRewardsTooltip = ({
+  className = '',
+  isMobile,
+  noPadding,
+  totalApr,
+  tooltipValues,
+}: {
+  className?: string
+  isMobile?: boolean
+  noPadding?: boolean
+  totalApr: { min: string; max: string; minMax: string }
+  tooltipValues: { lendApr: string; lendApy: string; crv: string; crvBoosted: string; incentives: string[] }
+}) => {
+  return (
+    <TooltipWrapper className={className} isMobile={isMobile || noPadding}>
+      {!isMobile ? (
+        <TooltipTitle>
+          <TextCaption isBold isCaps>
+            Total APR
+          </TextCaption>
+          {totalApr.minMax}
+        </TooltipTitle>
+      ) : null}
+
+      {/* LEND */}
+      <TooltipItem>
+        <span>{t`Lend APR`}</span>{' '}
+        <span>
+          {tooltipValues.lendApr} <TextCaption>({tooltipValues.lendApy})</TextCaption>
+        </span>
+      </TooltipItem>
+
+      {/* CRV */}
+      {tooltipValues.crv && (
+        <TooltipItem>
+          <span>
+            CRV APR <TextCaption>(unboosted)</TextCaption>
+          </span>{' '}
+          <span>{tooltipValues.crv}</span>
+        </TooltipItem>
+      )}
+      {tooltipValues.crvBoosted && (
+        <TooltipItem>
+          <span>CRV APR {tooltipValues.crvBoosted && <TextCaption>(max boosted)</TextCaption>}</span>{' '}
+          <span>{tooltipValues.crvBoosted}</span>
+        </TooltipItem>
+      )}
+
+      {/* INCENTIVES */}
+      {tooltipValues.incentives.length > 0 && (
+        <TooltipItem>
+          <span>{t`Incentives APR`}</span>{' '}
+          <span>
+            {tooltipValues.incentives.map((incentive) => {
+              return (
+                <React.Fragment key={incentive}>
+                  {incentive}
+                  <br />
+                </React.Fragment>
+              )
+            })}
+          </span>
+        </TooltipItem>
+      )}
+    </TooltipWrapper>
+  )
+}
+
+const TooltipWrapper = styled.div<{ isMobile?: boolean }>`
+  text-align: left;
+
+  ${({ isMobile }) => {
+    if (!isMobile) {
+      return `
+        font-weight: bold;
+        padding-left: var(--spacing-2);
+        padding-right: var(--spacing-2);
+      `
+    } else {
+      return `padding-top: var(--spacing-1);`
+    }
+  }}
+`
+
+const TooltipTitle = styled.h3`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--spacing-normal);
+  font-size: var(--font-size-4);
+`
+
+const TooltipItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-2);
+  margin-bottom: var(--spacing-1);
+
+  > span:first-of-type {
+    white-space: nowrap;
+    padding-right: var(--spacing-2);
+  }
+  > span:last-of-type {
+    text-align: right;
+  }
+`
+
+export default CellRewardsTooltip

--- a/apps/lend/src/hooks/useSupplyTotalApr.ts
+++ b/apps/lend/src/hooks/useSupplyTotalApr.ts
@@ -1,0 +1,91 @@
+import { useMemo } from 'react'
+import useStore from '@/store/useStore'
+
+import { INVALID_ADDRESS } from '@/constants'
+import { FORMAT_OPTIONS, formatNumber } from '@/ui/utils'
+
+function useSupplyTotalApr(rChainId: ChainId, rOwmId: string) {
+  const owmData = useStore((state) => state.markets.owmDatasMapper[rChainId]?.[rOwmId])
+  const marketRewardsResp = useStore((state) => state.markets.rewardsMapper[rChainId]?.[rOwmId])
+  const marketRatesResp = useStore((state) => state.markets.ratesMapper[rChainId]?.[rOwmId])
+
+  const { gauge } = owmData?.owm?.addresses ?? {}
+  const { error: rewardsError } = marketRewardsResp ?? {}
+  const { error: ratesError } = marketRatesResp ?? {}
+
+  const { totalApr, tooltipValues } = useMemo(
+    () => _getTotalAndTooltip(marketRewardsResp, marketRatesResp),
+    [marketRewardsResp, marketRatesResp]
+  )
+
+  return {
+    isReady: typeof marketRewardsResp !== 'undefined' && typeof marketRatesResp !== 'undefined',
+    isError: rewardsError || ratesError,
+    invalidGaugeAddress: typeof gauge !== 'undefined' && gauge === INVALID_ADDRESS,
+    totalApr,
+    tooltipValues,
+  }
+}
+
+function _getTotalApr(lendApr: number, crvBase: number, crvBoost: number, others: RewardOther[]) {
+  const othersTotal = (others ?? []).reduce((prev, curr) => {
+    prev += curr.apy
+    return prev
+  }, 0)
+
+  const min = (lendApr + crvBase + othersTotal).toString()
+  const max = (lendApr + crvBoost + othersTotal).toString()
+
+  return {
+    min,
+    max,
+    minMax:
+      min === max
+        ? formatNumber(min, FORMAT_OPTIONS.PERCENT)
+        : `${formatNumber(min, FORMAT_OPTIONS.PERCENT)} - ${formatNumber(max, FORMAT_OPTIONS.PERCENT)}`,
+  }
+}
+
+function _getTooltipValue(lendApr: number, lendApy: number, crvBase: number, crvBoost: number, others: RewardOther[]) {
+  return {
+    lendApr: formatNumber(lendApr, FORMAT_OPTIONS.PERCENT),
+    lendApy: `${formatNumber(lendApy, FORMAT_OPTIONS.PERCENT)} APY`,
+    crv: crvBase > 0 ? formatNumber(crvBase, FORMAT_OPTIONS.PERCENT) : '',
+    crvBoosted: crvBoost > 0 ? formatNumber(crvBoost, FORMAT_OPTIONS.PERCENT) : '',
+    incentives: others.map((o) => `${formatNumber(o.apy, FORMAT_OPTIONS.PERCENT)} ${o.symbol}`),
+    incentivesObj: others,
+  }
+}
+
+function _getTotalAndTooltip(marketRewardsResp: MarketRewards, marketRatesResp: MarketRates) {
+  let resp: {
+    totalApr: { min: string; max: string; minMax: string }
+    tooltipValues: {
+      lendApr: string
+      lendApy: string
+      crv: string
+      crvBoosted: string
+      incentives: string[]
+      incentivesObj: RewardOther[]
+    } | null
+  } = {
+    totalApr: { min: '', max: '', minMax: '' },
+    tooltipValues: null,
+  }
+
+  if (typeof marketRewardsResp === 'undefined' || typeof marketRatesResp === 'undefined') return resp
+
+  const { other, crv } = marketRewardsResp.rewards ?? {}
+  const { rates } = marketRatesResp ?? {}
+
+  const lendApr = +(rates?.lendApr || '0')
+  const lendApy = +(rates?.lendApy || '0')
+  const [crvBase = 0, crvBoost = 0] = crv ?? []
+  const others = other ?? []
+
+  resp.totalApr = _getTotalApr(lendApr, crvBase, crvBoost, others)
+  resp.tooltipValues = _getTooltipValue(lendApr, lendApy, crvBase, crvBoost, others)
+  return resp
+}
+
+export default useSupplyTotalApr

--- a/apps/lend/src/hooks/useSupplyTotalApr.ts
+++ b/apps/lend/src/hooks/useSupplyTotalApr.ts
@@ -58,22 +58,11 @@ function _getTooltipValue(lendApr: number, lendApy: number, crvBase: number, crv
 }
 
 function _getTotalAndTooltip(marketRewardsResp: MarketRewards, marketRatesResp: MarketRates) {
-  let resp: {
-    totalApr: { min: string; max: string; minMax: string }
-    tooltipValues: {
-      lendApr: string
-      lendApy: string
-      crv: string
-      crvBoosted: string
-      incentives: string[]
-      incentivesObj: RewardOther[]
-    } | null
-  } = {
-    totalApr: { min: '', max: '', minMax: '' },
-    tooltipValues: null,
-  }
-
-  if (typeof marketRewardsResp === 'undefined' || typeof marketRatesResp === 'undefined') return resp
+  if (typeof marketRewardsResp === 'undefined' || typeof marketRatesResp === 'undefined')
+    return {
+      totalApr: { min: '', max: '', minMax: '' },
+      tooltipValues: null,
+    }
 
   const { other, crv } = marketRewardsResp.rewards ?? {}
   const { rates } = marketRatesResp ?? {}
@@ -83,9 +72,10 @@ function _getTotalAndTooltip(marketRewardsResp: MarketRewards, marketRatesResp: 
   const [crvBase = 0, crvBoost = 0] = crv ?? []
   const others = other ?? []
 
-  resp.totalApr = _getTotalApr(lendApr, crvBase, crvBoost, others)
-  resp.tooltipValues = _getTooltipValue(lendApr, lendApy, crvBase, crvBoost, others)
-  return resp
+  return {
+    totalApr: _getTotalApr(lendApr, crvBase, crvBoost, others),
+    tooltipValues: _getTooltipValue(lendApr, lendApy, crvBase, crvBoost, others),
+  }
 }
 
 export default useSupplyTotalApr

--- a/apps/lend/src/layout/Header.tsx
+++ b/apps/lend/src/layout/Header.tsx
@@ -117,7 +117,15 @@ const Header = () => {
   const handleNetworkChange = (selectedChainId: React.Key) => {
     if (rChainId !== selectedChainId) {
       const network = networks[selectedChainId as ChainId].id
-      navigate(`${rLocalePathname}/${network}/${getRestPartialPathname()}`)
+      const [currPath] = window.location.hash.split('?')
+
+      if (currPath.endsWith('markets')) {
+        // include search params when in market list page
+        navigate(`${rLocalePathname}/${network}/${getRestFullPathname()}`)
+      } else {
+        navigate(`${rLocalePathname}/${network}/${getRestPartialPathname()}`)
+      }
+
       updateConnectState('loading', CONNECT_STAGE.SWITCH_NETWORK, [rChainId, selectedChainId])
     }
   }

--- a/apps/lend/src/lib/apiLending.ts
+++ b/apps/lend/src/lib/apiLending.ts
@@ -370,6 +370,7 @@ const market = {
             rewards.other = _filterZeroApy(others)
             rewards.crv = crv
           }
+          // rewards typescript say APY, but it is actually APR
           resp.rewards = rewards
           results[owm.id] = resp
         }

--- a/apps/lend/src/store/createUserSlice.ts
+++ b/apps/lend/src/store/createUserSlice.ts
@@ -119,7 +119,7 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
       // fetch data
       if (typeof fnMapper[k] !== 'function') log('missing function2', k)
       const resp = await fnMapper[k](api, parsedOwmDatas)
-      const cMapper = cloneDeep(storedMapper)
+      const cMapper = { ...storedMapper }
 
       Object.keys(resp).forEach((userActiveKey) => {
         cMapper[userActiveKey] = resp[userActiveKey]


### PR DESCRIPTION
<img width="886" alt="Screenshot 2024-04-23 at 8 49 32 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/f0b65451-8b94-42c8-ba51-edfca22d6be4">
<img width="351" alt="Screenshot 2024-04-23 at 7 07 11 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/79aacbe7-ff4c-433f-a82b-bdffe5bff024">

- Remove Lend APY and Rewards APR column. Combine them into Total APR column, add Tooltip to show breakdown.
- Reduce Supply market list size.

<img width="867" alt="Screenshot 2024-04-23 at 7 07 55 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/a7260e69-69ab-46e3-b15f-c7fc98fb2c9c">

- Update Rewards tAPR section to Total APR

<img width="323" alt="Screenshot 2024-04-23 at 7 12 05 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/3e5f6aa7-b5ca-43c0-a0fb-00984e33f04a">

- Update text Fee to AMM swap fee


<img width="324" alt="Screenshot 2024-04-23 at 7 13 27 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/7b990691-fa48-4b6b-a686-f2c850f9c044">
<img width="316" alt="Screenshot 2024-04-23 at 7 13 33 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/3f1a93be-0700-4a74-9bf2-a39d6771691b">

-Update mobile view with Total APR


<img width="394" alt="Screenshot 2024-04-23 at 7 14 25 AM" src="https://github.com/curvefi/curve-frontend/assets/6961602/0db29ac8-b934-46c9-a757-2fee394cee35">

- Update Lend APY to Lend APR

--- 
- Fixed User supply list filter not showing properly.
- Add search params routes for market list when navigating between networks.