### PR TITLE
fix: soft liquidation repay, borrow more, self-liquidate mode

### DIFF
--- a/apps/lend/src/components/AlertFormError.tsx
+++ b/apps/lend/src/components/AlertFormError.tsx
@@ -5,44 +5,43 @@ import React, { useMemo } from 'react'
 
 import AlertBox from '@/ui/AlertBox'
 
-const ALERT_FORM_ERROR_KEYS = {
+export enum FormError {
   // vault
 
-  // all
-  'error-api': 'error-api',
-  'error-existing-loan': 'error-existing-loan',
-  'error-est-gas-approval': 'error-est-gas-approval',
-  'error-invalid-provider': 'error-invalid-provider',
-  'error-wallet-balances': 'error-wallet-balances',
-  'error-step-approve': 'error-step-approve',
-  'error-liquidation-mode': 'error-liquidation-mode',
-  'error-total-supply': 'error-total-supply',
-} as const
+  // repay
+  FullRepaymentRequired = 'error-full-repayment-required',
 
-export type AlertFormErrorKey = keyof typeof ALERT_FORM_ERROR_KEYS
+  // all
+  API = 'error-api',
+  ExistingLoan = 'error-existing-loan',
+  EstGasApproval = 'error-est-gas-approval',
+  InvalidProvider = 'error-invalid-provider',
+  WalletBalances = 'error-wallet-balances',
+  StepApprove = 'error-step-approve',
+  LiquidationMode = 'error-liquidation-mode',
+  TotalSupply = 'error-total-supply',
+}
 
 interface Props extends Omit<AlertBoxProps, 'alertType'> {
-  errorKey: AlertFormErrorKey | string
+  errorKey: FormError | string
 }
 
 // generate message that only display if it cannot get error message from api.
 const AlertFormError = ({ errorKey, ...props }: React.PropsWithChildren<Props>) => {
   const errorMessage = useMemo(() => {
     // locale will update inside component
-    const messages: { [key: AlertFormErrorKey | string]: string } = {
+    const messages: { [key: FormError | string]: string } = {
       // vault
-      [ALERT_FORM_ERROR_KEYS['error-api']]: t`Unable to get data from api`,
+      [FormError.API]: t`Unable to get data from api`,
 
       // all
-      [ALERT_FORM_ERROR_KEYS['error-existing-loan']]: t`Unable to check if loan existed`,
-      [ALERT_FORM_ERROR_KEYS['error-wallet-balances']]: t`Unable to get wallet balances`,
-      [ALERT_FORM_ERROR_KEYS['error-est-gas-approval']]: t`Unable to get approval or estimated gas`,
-      [ALERT_FORM_ERROR_KEYS['error-invalid-provider']]: t`Unable to find provider`,
-      [ALERT_FORM_ERROR_KEYS['error-step-approve']]: t`Unable to approve spending`,
-      [ALERT_FORM_ERROR_KEYS[
-        'error-liquidation-mode'
-      ]]: t`You cannot adjust your collateral while in liquidation mode. Your options are repayment or self-liquidation.`,
-      [ALERT_FORM_ERROR_KEYS['error-total-supply']]: t`Unable to get total supply`,
+      [FormError.ExistingLoan]: t`Unable to check if loan existed`,
+      [FormError.WalletBalances]: t`Unable to get wallet balances`,
+      [FormError.EstGasApproval]: t`Unable to get approval or estimated gas`,
+      [FormError.InvalidProvider]: t`Unable to find provider`,
+      [FormError.StepApprove]: t`Unable to approve spending`,
+      [FormError.LiquidationMode]: t`You cannot adjust your collateral while in liquidation mode. Your options are repayment or self-liquidation.`,
+      [FormError.TotalSupply]: t`Unable to get total supply`,
     }
 
     if (errorKey) {

--- a/apps/lend/src/components/AlertFormWarning.tsx
+++ b/apps/lend/src/components/AlertFormWarning.tsx
@@ -5,34 +5,32 @@ import React, { useMemo } from 'react'
 
 import AlertBox from '@/ui/AlertBox'
 
-const ALERT_FORM_WARNING_KEYS = {
+export enum FormWarning {
   // loan deleverage
-  'warning-full-repayment-only': 'warning-full-repayment-only',
+  FullRepaymentOnly = 'warning-full-repayment-only',
 
-  'warning-is-payoff-amount': 'warning-is-payoff-amount',
-  'warning-not-in-liquidation-mode': 'warning-not-in-liquidation-mode',
-  'warning-not-enough-crvusd': 'warning-not-enough-crvusd',
-} as const
-
-export type AlertFormWarningKey = keyof typeof ALERT_FORM_WARNING_KEYS
+  IsPayoffAmount = 'warning-is-payoff-amount',
+  NotInLiquidationMode = 'warning-not-in-liquidation-mode',
+  NotEnoughCrvusd = 'warning-not-enough-crvusd',
+}
 
 interface Props extends Omit<AlertBoxProps, 'alertType'> {
-  errorKey: AlertFormWarningKey | string
+  errorKey: FormWarning | string
 }
 
 const AlertFormWarning = ({ errorKey, ...props }: React.PropsWithChildren<Props>) => {
   const errorMessage = useMemo(() => {
-    const messages: { [key: AlertFormWarningKey | string]: { message: string; alertType?: AlertType } } = {
-      [ALERT_FORM_WARNING_KEYS['warning-full-repayment-only']]: {
+    const messages: { [key: FormWarning | string]: { message: string; alertType?: AlertType } } = {
+      [FormWarning.FullRepaymentOnly]: {
         message: t`Only full repayment is allowed when in soft-liquidation mode.`,
       },
-      [ALERT_FORM_WARNING_KEYS['warning-is-payoff-amount']]: {
+      [FormWarning.IsPayoffAmount]: {
         message: t`You will no longer be able to manage this loan once it is paid off.`,
       },
-      [ALERT_FORM_WARNING_KEYS['warning-not-in-liquidation-mode']]: {
+      [FormWarning.NotInLiquidationMode]: {
         message: t`You are not in liquidation mode.`,
       },
-      [ALERT_FORM_WARNING_KEYS['warning-not-enough-crvusd']]: {
+      [FormWarning.NotEnoughCrvusd]: {
         message: t`You do not have enough crvUSD for self-liquidation.`,
       },
     }

--- a/apps/lend/src/components/AlertLoanSummary/components/SummaryFull.tsx
+++ b/apps/lend/src/components/AlertLoanSummary/components/SummaryFull.tsx
@@ -12,33 +12,38 @@ const SummaryFull = ({
   pendingMessage,
   receive = '',
   formValueStateCollateral = '',
-  formValueUserBorrowed = '',
   userState,
   collateralSymbol,
   borrowedSymbol,
 }: SummaryProps) => {
-  const { debt: stateDebt = '', collateral: stateCollateral = '' } = userState ?? {}
+  const { debt: stateDebt = '', collateral: stateCollateral = '', borrowed: stateBorrowed = '' } = userState ?? {}
 
-  const returnToWallet = useMemo(() => {
-    return [
-      {
-        ...(+receive > 0
-          ? { value: +receive - +stateDebt, symbol: borrowedSymbol }
-          : { value: +formValueUserBorrowed - +stateDebt, symbol: borrowedSymbol }),
-      },
-      { value: +stateCollateral - +formValueStateCollateral, symbol: collateralSymbol },
-    ].filter(({ value }) => +value > 0)
-  }, [
-    borrowedSymbol,
-    collateralSymbol,
-    formValueStateCollateral,
-    formValueUserBorrowed,
-    receive,
-    stateCollateral,
-    stateDebt,
-  ])
+  const { balance, returnToWallet } = useMemo(() => {
+    let resp = { balance: 0, returnToWallet: [] as { value: number | string; symbol: string }[] }
 
-  const balance = +stateDebt - +receive - +formValueUserBorrowed
+    if (+receive > 0) {
+      const repayTotal = +receive + +stateBorrowed
+      resp.balance = +stateDebt - repayTotal
+
+      const returnToWalletCollateral = +stateCollateral - +formValueStateCollateral
+      if (returnToWalletCollateral) {
+        resp.returnToWallet.push({ value: returnToWalletCollateral, symbol: collateralSymbol })
+      }
+
+      const returnToWalletBorrowed = Math.abs(resp.balance) >= 1 ? Math.abs(resp.balance) : 0
+      if (returnToWalletBorrowed) {
+        resp.returnToWallet.push({ value: returnToWalletBorrowed, symbol: borrowedSymbol })
+      }
+    } else {
+      resp.returnToWallet.push({ value: stateCollateral, symbol: collateralSymbol })
+      if (+stateBorrowed - +stateDebt > 0) {
+        resp.returnToWallet.push({ value: +stateBorrowed - +stateDebt, symbol: borrowedSymbol })
+      }
+    }
+
+    return resp
+  }, [borrowedSymbol, collateralSymbol, formValueStateCollateral, receive, stateBorrowed, stateCollateral, stateDebt])
+
   const minWidth = '170px;'
 
   return (
@@ -48,16 +53,28 @@ const SummaryFull = ({
       {title}
 
       <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
+
       {+receive > 0 ? (
-        <Item $minWidth={minWidth} label={t`Receive:`} value={`-${format(receive || '0')} ${borrowedSymbol}`} />
-      ) : (
-        <Item
-          $minWidth={minWidth}
-          label={t`Wallet:`}
-          value={`${formValueUserBorrowed ? '-' : ''}${format(formValueUserBorrowed)} ${borrowedSymbol}`}
-        />
-      )}
-      <Item $isDivider $minWidth={minWidth} label="" value={`${format(balance)} ${borrowedSymbol}`} />
+        <>
+          {+stateBorrowed > 0 && (
+            <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+          )}
+          <Item $minWidth={minWidth} label={t`Receive:`} value={`-${format(receive || '0')} ${borrowedSymbol}`} />
+          <Item $isDivider $minWidth={minWidth} label="" value={`${format(balance)} ${borrowedSymbol}`} />
+        </>
+      ) : +stateBorrowed > 0 ? (
+        <>
+          <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+          {+stateDebt - +stateBorrowed > 0 && (
+            <Item
+              $minWidth={minWidth}
+              label={t`Wallet:`}
+              value={`-${format(+stateDebt - +stateBorrowed)} ${borrowedSymbol}`}
+            />
+          )}
+          <Item $isDivider $minWidth={minWidth} label="" value={`0 ${borrowedSymbol}`} />
+        </>
+      ) : null}
 
       {returnToWallet.map(({ value, symbol }, idx) => {
         const isFirst = idx === 0
@@ -66,7 +83,7 @@ const SummaryFull = ({
             key={symbol}
             {...(isFirst ? { $marginTop: 'var(--spacing-3)' } : {})}
             $minWidth={minWidth}
-            label={isFirst ? t`Return to wallet:` : ''}
+            label={isFirst ? t`Return to wallet ≈` : ''}
             value={`${format(value)} ${symbol}`}
           />
         )

--- a/apps/lend/src/components/AlertLoanSummary/components/SummaryFull.tsx
+++ b/apps/lend/src/components/AlertLoanSummary/components/SummaryFull.tsx
@@ -18,30 +18,31 @@ const SummaryFull = ({
 }: SummaryProps) => {
   const { debt: stateDebt = '', collateral: stateCollateral = '', borrowed: stateBorrowed = '' } = userState ?? {}
 
-  const { balance, returnToWallet } = useMemo(() => {
-    let resp = { balance: 0, returnToWallet: [] as { value: number | string; symbol: string }[] }
+  const [balance, returnToWallet] = useMemo(() => {
+    let balance = 0
+    let returnToWallet: { value: number | string; symbol: string }[] = []
 
     if (+receive > 0) {
       const repayTotal = +receive + +stateBorrowed
-      resp.balance = +stateDebt - repayTotal
+      balance = +stateDebt - repayTotal
 
       const returnToWalletCollateral = +stateCollateral - +formValueStateCollateral
       if (returnToWalletCollateral) {
-        resp.returnToWallet.push({ value: returnToWalletCollateral, symbol: collateralSymbol })
+        returnToWallet.push({ value: returnToWalletCollateral, symbol: collateralSymbol })
       }
 
-      const returnToWalletBorrowed = Math.abs(resp.balance) >= 1 ? Math.abs(resp.balance) : 0
+      const returnToWalletBorrowed = Math.abs(balance) >= 1 ? Math.abs(balance) : 0
       if (returnToWalletBorrowed) {
-        resp.returnToWallet.push({ value: returnToWalletBorrowed, symbol: borrowedSymbol })
+        returnToWallet.push({ value: returnToWalletBorrowed, symbol: borrowedSymbol })
       }
     } else {
-      resp.returnToWallet.push({ value: stateCollateral, symbol: collateralSymbol })
+      returnToWallet.push({ value: stateCollateral, symbol: collateralSymbol })
       if (+stateBorrowed - +stateDebt > 0) {
-        resp.returnToWallet.push({ value: +stateBorrowed - +stateDebt, symbol: borrowedSymbol })
+        returnToWallet.push({ value: +stateBorrowed - +stateDebt, symbol: borrowedSymbol })
       }
     }
 
-    return resp
+    return [balance, returnToWallet]
   }, [borrowedSymbol, collateralSymbol, formValueStateCollateral, receive, stateBorrowed, stateCollateral, stateDebt])
 
   const minWidth = '170px;'
@@ -54,7 +55,7 @@ const SummaryFull = ({
 
       <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
 
-      {+receive > 0 ? (
+      {+receive > 0 && (
         <>
           {+stateBorrowed > 0 && (
             <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
@@ -62,7 +63,9 @@ const SummaryFull = ({
           <Item $minWidth={minWidth} label={t`Receive:`} value={`-${format(receive || '0')} ${borrowedSymbol}`} />
           <Item $isDivider $minWidth={minWidth} label="" value={`${format(balance)} ${borrowedSymbol}`} />
         </>
-      ) : +stateBorrowed > 0 ? (
+      )}
+
+      {+receive <= 0 && +stateBorrowed > 0 && (
         <>
           <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
           {+stateDebt - +stateBorrowed > 0 && (
@@ -74,7 +77,7 @@ const SummaryFull = ({
           )}
           <Item $isDivider $minWidth={minWidth} label="" value={`0 ${borrowedSymbol}`} />
         </>
-      ) : null}
+      )}
 
       {returnToWallet.map(({ value, symbol }, idx) => {
         const isFirst = idx === 0

--- a/apps/lend/src/components/AlertLoanSummary/components/SummaryPartial.tsx
+++ b/apps/lend/src/components/AlertLoanSummary/components/SummaryPartial.tsx
@@ -3,7 +3,6 @@ import type { SummaryProps } from '@/components/AlertLoanSummary/types'
 import React from 'react'
 import { t } from '@lingui/macro'
 
-import { formatNumber } from '@/ui/utils'
 import { format } from '@/components/AlertLoanSummary/utils'
 
 import Item from '@/components/AlertLoanSummary/components/Item'
@@ -16,9 +15,8 @@ const SummaryPartial = ({
   userState,
   borrowedSymbol,
 }: SummaryProps) => {
-  const { debt: stateDebt = '0' } = userState ?? {}
+  const { debt: stateDebt = '0', borrowed: stateBorrowed = '0' } = userState ?? {}
 
-  const balance = +stateDebt - +formValueUserBorrowed
   const minWidth = '190px'
 
   return (
@@ -27,24 +25,26 @@ const SummaryPartial = ({
 
       {title}
 
+      <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
+
       {+receive > 0 ? (
         <>
-          <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
-          <Item
-            $minWidth={minWidth}
-            label={t`Receive:`}
-            value={`${+receive > 0 ? '-' : ''}${format(receive)} ${borrowedSymbol}`}
-          />
+          {+stateBorrowed > 0 && (
+            <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+          )}
+          <Item $minWidth={minWidth} label={t`Receive:`} value={`-${format(receive)} ${borrowedSymbol}`} />
           <Item
             $minWidth={minWidth}
             $isDivider
             label={t`Debt balance:`}
-            value={`${format(+stateDebt - +receive)} ${borrowedSymbol}`}
+            value={`${format(+stateDebt - (+receive + +stateBorrowed))} ${borrowedSymbol}`}
           />
         </>
       ) : (
         <>
-          <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
+          {+stateBorrowed > 0 && (
+            <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+          )}
           <Item
             $minWidth={minWidth}
             label={t`Wallet:`}
@@ -54,7 +54,7 @@ const SummaryPartial = ({
             $minWidth={minWidth}
             $isDivider
             label={t`Debt balance:`}
-            value={`${format(balance)} ${borrowedSymbol}`}
+            value={`${format(+stateDebt - (+stateBorrowed + +formValueUserBorrowed))} ${borrowedSymbol}`}
           />
         </>
       )}

--- a/apps/lend/src/components/AlertLoanSummary/components/SummarySelfLiquidate.tsx
+++ b/apps/lend/src/components/AlertLoanSummary/components/SummarySelfLiquidate.tsx
@@ -1,8 +1,9 @@
 import type { SummaryProps } from '@/components/AlertLoanSummary/types'
 
 import { t } from '@lingui/macro'
-import React from 'react'
+import React, { useMemo } from 'react'
 
+import { BN } from '@/ui/utils'
 import { format } from '@/components/AlertLoanSummary/utils'
 
 import Item from '@/components/AlertLoanSummary/components/Item'
@@ -18,9 +19,33 @@ const SummarySelfLiquidate = ({
   const { debt: stateDebt = '0', collateral: stateCollateral = '0', borrowed: stateBorrowed = '0' } = userState ?? {}
   const { borrowed: walletBorrowed = '0' } = userWallet ?? {}
 
-  const amountNeededFromWallet = +stateDebt - +stateBorrowed
-  const walletAmount = amountNeededFromWallet - +walletBorrowed <= 0 ? amountNeededFromWallet : +walletBorrowed
-  const remainingBalance = +stateDebt - +stateBorrowed - +walletAmount
+  const walletAmount = useMemo(() => {
+    const amountNeeded = +stateDebt - +stateBorrowed
+    const amountNeededFromWallet = amountNeeded > 0 ? amountNeeded : 0
+
+    return amountNeededFromWallet > 0
+      ? BN(amountNeededFromWallet).isGreaterThan(walletBorrowed)
+        ? walletBorrowed
+        : amountNeededFromWallet
+      : 0
+  }, [stateBorrowed, stateDebt, walletBorrowed])
+
+  const returnToWallet = useMemo(() => {
+    let amounts = [] as { value: string | number; symbol: string }[]
+
+    // return to wallet from state collateral
+    if (+stateCollateral > 0) {
+      amounts.push({ value: stateCollateral, symbol: collateralSymbol })
+    }
+
+    // return to wallet from state borrowed
+    const returnToWalletStateBorrowed = +stateBorrowed - +stateDebt
+    if (returnToWalletStateBorrowed > 0) {
+      amounts.push({ value: returnToWalletStateBorrowed, symbol: borrowedSymbol })
+    }
+    return amounts
+  }, [borrowedSymbol, collateralSymbol, stateBorrowed, stateCollateral, stateDebt])
+
   const minWidth = '170px'
 
   return (
@@ -33,22 +58,23 @@ const SummarySelfLiquidate = ({
       {+stateBorrowed > 0 && (
         <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
       )}
-      <Item $minWidth={minWidth} label={t`Wallet:`} value={`-${format(walletAmount)} ${borrowedSymbol}`} />
-      <Item
-        $isDivider
-        $minWidth={minWidth}
-        label={remainingBalance > 0 ? t`Debt balance:` : ''}
-        value={`${format(remainingBalance)} ${borrowedSymbol}`}
-      />
 
-      {remainingBalance === 0 && (
-        <Item
-          $marginTop="var(--spacing-3)"
-          $minWidth={minWidth}
-          label={t`Return to wallet ≈`}
-          value={`${format(stateCollateral)} ${collateralSymbol}`}
-        />
+      {+walletAmount > 0 && (
+        <Item $minWidth={minWidth} label={t`Wallet:`} value={`-${format(walletAmount)} ${borrowedSymbol}`} />
       )}
+
+      {returnToWallet.map(({ value, symbol }, idx) => {
+        const isFirst = idx === 0
+        return (
+          <Item
+            key={symbol}
+            {...(isFirst ? { $marginTop: 'var(--spacing-3)' } : {})}
+            $minWidth={minWidth}
+            label={isFirst ? t`Return to wallet ≈` : ''}
+            value={`${format(value)} ${symbol}`}
+          />
+        )
+      })}
     </>
   )
 }

--- a/apps/lend/src/components/AlertLoanSummary/components/SummarySelfLiquidate.tsx
+++ b/apps/lend/src/components/AlertLoanSummary/components/SummarySelfLiquidate.tsx
@@ -21,7 +21,7 @@ const SummarySelfLiquidate = ({
   const amountNeededFromWallet = +stateDebt - +stateBorrowed
   const walletAmount = amountNeededFromWallet - +walletBorrowed <= 0 ? amountNeededFromWallet : +walletBorrowed
   const remainingBalance = +stateDebt - +stateBorrowed - +walletAmount
-  const minWidth = '180px'
+  const minWidth = '170px'
 
   return (
     <>
@@ -30,7 +30,9 @@ const SummarySelfLiquidate = ({
       {title}
 
       <Item $minWidth={minWidth} label={t`Debt:`} value={`${format(stateDebt)} ${borrowedSymbol}`} />
-      <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+      {+stateBorrowed > 0 && (
+        <Item $minWidth={minWidth} label={t`Collateral:`} value={`-${format(stateBorrowed)} ${borrowedSymbol}`} />
+      )}
       <Item $minWidth={minWidth} label={t`Wallet:`} value={`-${format(walletAmount)} ${borrowedSymbol}`} />
       <Item
         $isDivider
@@ -43,7 +45,7 @@ const SummarySelfLiquidate = ({
         <Item
           $marginTop="var(--spacing-3)"
           $minWidth={minWidth}
-          label={t`Return to wallet:`}
+          label={t`Return to wallet ≈`}
           value={`${format(stateCollateral)} ${collateralSymbol}`}
         />
       )}

--- a/apps/lend/src/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/lend/src/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -245,9 +245,8 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   usePageVisibleInterval(
     () => {
@@ -309,7 +308,15 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
   useEffect(() => {
     if (isLoaded) updateFormValues({})
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, maxSlippage, isAdvanceMode])
+  }, [maxSlippage, isAdvanceMode])
+
+  useEffect(() => {
+    if (isLoaded) {
+      resetState()
+      updateFormValues({})
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded])
 
   const disabled = !!formStatus.step
 

--- a/apps/lend/src/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -264,9 +264,8 @@ const LoanBorrowMore = ({
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   usePageVisibleInterval(
     () => {
@@ -287,7 +286,10 @@ const LoanBorrowMore = ({
   )
 
   useEffect(() => {
-    if (isLoaded) updateFormValues({})
+    if (isLoaded) {
+      resetState()
+      updateFormValues({})
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded])
 

--- a/apps/lend/src/components/PageLoanManage/LoanBorrowMore/utils.ts
+++ b/apps/lend/src/components/PageLoanManage/LoanBorrowMore/utils.ts
@@ -21,8 +21,8 @@ export function _getStepTokensStr(
   { collateral_token, borrowed_token }: OWM
 ) {
   let list = []
-  const haveUserCollateral = +userCollateral > 0 && !userCollateralError
-  const haveUserBorrowed = +userBorrowed > 0 && !userBorrowedError
+  const haveUserCollateral = +userCollateral > 0
+  const haveUserBorrowed = +userBorrowed > 0
 
   if (haveUserBorrowed) list.push({ value: userBorrowed, symbol: borrowed_token.symbol })
   if (haveUserCollateral) list.push({ value: userCollateral, symbol: collateral_token.symbol })

--- a/apps/lend/src/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -163,12 +163,14 @@ const LoanCollateralAdd = ({
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   useEffect(() => {
-    if (isLoaded) updateFormValues({})
+    if (isLoaded) {
+      resetState()
+      updateFormValues({})
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded])
 

--- a/apps/lend/src/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -183,13 +183,15 @@ const LoanCollateralRemove = ({
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   // init
   useEffect(() => {
-    if (isLoaded) updateFormValues({})
+    if (isLoaded) {
+      resetState()
+      updateFormValues({})
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded])
 

--- a/apps/lend/src/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanRepay/index.tsx
@@ -60,6 +60,7 @@ const LoanRepay = ({
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
   const fetchStepApprove = useStore((state) => state.loanRepay.fetchStepApprove)
   const fetchStepRepay = useStore((state) => state.loanRepay.fetchStepRepay)
+  const fetchAllUserDetails = useStore((state) => state.user.fetchAll)
   const notifyNotification = useStore((state) => state.wallet.notifyNotification)
   const setFormValues = useStore((state) => state.loanRepay.setFormValues)
   const resetState = useStore((state) => state.loanRepay.resetState)
@@ -163,7 +164,7 @@ const LoanRepay = ({
               userWallet={userBalances}
               borrowed_token={owm.borrowed_token}
               collateral_token={owm.collateral_token}
-              type={(swapRequired && detailInfoLeverage?.repayIsFull) || isFullRepay ? 'full' : 'partial'}
+              type={detailInfoLeverage?.repayIsFull || isFullRepay ? 'full' : 'partial'}
             />
           </AlertBox>
         )
@@ -255,9 +256,8 @@ const LoanRepay = ({
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   usePageVisibleInterval(
     () => {
@@ -279,7 +279,10 @@ const LoanRepay = ({
   )
 
   useEffect(() => {
-    if (isLoaded) updateFormValues({})
+    if (isLoaded) {
+      resetState()
+      updateFormValues({})
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded])
 
@@ -326,9 +329,11 @@ const LoanRepay = ({
   const activeStep = signerAddress ? getActiveStep(steps) : null
   const disable = formStatus.isInProgress
   const isFullRepay = formValues.isFullRepay || (detailInfoLeverage?.repayIsFull ?? false)
-  const { swapRequired } = _parseValues(formValues)
+  const isPayableWithStateBorrowed = state ? BN(state.borrowed).isGreaterThanOrEqualTo(state.debt) : false
+  const isPayableWithWalletBorrowed =
+    state && userBalances ? BN(userBalances.borrowed).isGreaterThanOrEqualTo(state.debt) : false
   const disableCheckbox =
-    !signerAddress || disable || swapRequired || (state && userBalances && +state.debt > +userBalances.borrowed)
+    !signerAddress || disable || !!expectedBorrowed || (!isPayableWithWalletBorrowed && !isPayableWithStateBorrowed)
 
   return (
     <>
@@ -347,8 +352,10 @@ const LoanRepay = ({
                 tokenAddress={collateral_token?.address}
                 tokenSymbol={collateral_token?.symbol}
                 tokenBalance={formatNumber(state?.collateral, { defaultValue: '-' })}
-                handleInpChange={(stateCollateral) => updateFormValues({ stateCollateral })}
-                handleMaxClick={() => updateFormValues({ stateCollateral: state?.collateral ?? '' })}
+                handleInpChange={(stateCollateral) => updateFormValues({ stateCollateral, isFullRepay: false })}
+                handleMaxClick={() =>
+                  updateFormValues({ stateCollateral: state?.collateral ?? '', isFullRepay: false })
+                }
               />
 
               <InpToken
@@ -363,8 +370,10 @@ const LoanRepay = ({
                 tokenAddress={collateral_token?.address}
                 tokenSymbol={collateral_token?.symbol}
                 tokenBalance={formatNumber(userBalances?.collateral, { defaultValue: '-' })}
-                handleInpChange={(userCollateral) => updateFormValues({ userCollateral })}
-                handleMaxClick={() => updateFormValues({ userCollateral: userBalances?.collateral ?? '' })}
+                handleInpChange={(userCollateral) => updateFormValues({ userCollateral, isFullRepay: false })}
+                handleMaxClick={() =>
+                  updateFormValues({ userCollateral: userBalances?.collateral ?? '', isFullRepay: false })
+                }
               />
             </>
           )}
@@ -372,7 +381,7 @@ const LoanRepay = ({
           <InpToken
             id="userBorrowed"
             inpError={formValues.userBorrowedError}
-            inpDisabled={disable}
+            inpDisabled={disable || (!hasLeverage && !state)}
             inpLabelLoading={!!signerAddress && typeof userBalances?.borrowed === 'undefined'}
             inpLabelDescription={formatNumber(userBalances?.borrowed, { defaultValue: '-' })}
             inpValue={formValues.userBorrowed}
@@ -381,17 +390,40 @@ const LoanRepay = ({
             tokenBalance={userBalances?.borrowed}
             debt={state?.debt ?? '0'}
             handleInpChange={(userBorrowed) => {
-              const isFullRepay = BN(userBorrowed).isEqualTo(state?.debt ?? '0')
-              updateFormValues({ userBorrowed, isFullRepay })
-            }}
-            handleMaxClick={() => {
-              if (userBalances && state) {
-                let isFullRepay = BN(userBalances.borrowed).isGreaterThanOrEqualTo(state?.debt ?? '0')
-                const max = isFullRepay ? state.debt : userBalances.borrowed
-                updateFormValues({ userBorrowed: max, isFullRepay })
+              if (expectedBorrowed) {
+                updateFormValues({ userBorrowed, isFullRepay: false })
               } else {
-                updateFormValues({ userBorrowed: '', isFullRepay: false })
+                let isFullRepay = false
+                if (state) {
+                  const { borrowed: stateBorrowed, debt: stateDebt } = state
+                  isFullRepay = BN(BN(stateBorrowed).plus(userBorrowed)).isGreaterThanOrEqualTo(stateDebt)
+                }
+                updateFormValues({ userBorrowed, isFullRepay })
               }
+            }}
+            handleMaxClick={async () => {
+              let userBorrowed = ''
+              let isFullRepay = false
+
+              if (+userBalances.borrowed === 0) {
+                userBorrowed = ''
+              } else if (expectedBorrowed) {
+                userBorrowed = userBalances.borrowed
+              } else if (api && owmData && userBalances && state?.debt) {
+                const { userLoanDetailsResp } = await fetchAllUserDetails(api, owmData, true)
+                const { borrowed: stateBorrowed = '0', debt: stateDebt = '0' } =
+                  userLoanDetailsResp?.details?.state ?? {}
+
+                const amountNeeded = BN(stateDebt).minus(stateBorrowed)
+                const amountNeededWithInterestRate = amountNeeded.plus(amountNeeded.multipliedBy(0.01))
+                if (amountNeededWithInterestRate.isGreaterThan(userBalances.borrowed)) {
+                  userBorrowed = userBalances.borrowed
+                } else {
+                  userBorrowed = ''
+                  isFullRepay = true
+                }
+              }
+              updateFormValues({ userBorrowed, isFullRepay })
             }}
           />
         </FieldsWrapper>
@@ -407,7 +439,7 @@ const LoanRepay = ({
           if (isFullRepay) {
             updateFormValues({ ...DEFAULT_FORM_VALUES, isFullRepay })
           } else {
-            updateFormValues({ isFullRepay })
+            updateFormValues({ ...DEFAULT_FORM_VALUES })
           }
         }}
       >
@@ -439,13 +471,18 @@ const LoanRepay = ({
         <LoanFormConnect haveSigner={!!signerAddress} loading={!api}>
           {txInfoBar}
           {!!healthMode.message && <AlertBox alertType="warning">{healthMode.message}</AlertBox>}
-          {(formStatus.error || formStatus.stepError) && (
+          {formStatus.error === 'error-full-repayment-required' ? (
+            <AlertBox alertType="error">
+              {t`Only partial repayment from wallet's ${borrowed_token?.symbol} or full repayment from collateral or wallet's ${collateral_token?.symbol} is
+              allowed during liquidation mode.`}
+            </AlertBox>
+          ) : formStatus.error || formStatus.stepError ? (
             <AlertFormError
               limitHeight
               errorKey={formStatus.error || formStatus.stepError}
               handleBtnClose={() => updateFormValues({})}
             />
-          )}
+          ) : null}
           {steps && <Stepper steps={steps} />}
         </LoanFormConnect>
       )}

--- a/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -164,9 +164,8 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
 
     return () => {
       isSubscribed.current = false
-      resetState()
     }
-  }, [resetState])
+  }, [])
 
   // max slippage
   useEffect(() => {

--- a/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -52,6 +52,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
   const [txInfoBar, setTxInfoBar] = useState<React.ReactNode | null>(null)
 
   const { signerAddress } = api ?? {}
+  const { state } = userDetails ?? {}
 
   const reset = useCallback(() => {
     setTxInfoBar(null)
@@ -69,13 +70,14 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
       formStatus: FormStatus,
       liquidationAmt: string,
       maxSlippage: string,
-      steps: Step[]
+      steps: Step[],
+      state: Omit<UserLoanState, 'error'>
     ) => {
       const { chainId, signerAddress } = api
       const { owm } = owmData
-      const { error, warning, isApproved, isComplete, isInProgress, step } = formStatus
+      const { error, loading, warning, isApproved, isComplete, isInProgress, step } = formStatus
 
-      const isValid = !!signerAddress && !formEstGas?.loading && +liquidationAmt > 0 && !error && !warning
+      const isValid = !!signerAddress && !formEstGas?.loading && !loading && !error && !warning
 
       if (isValid) {
         const notifyMessage = t`Self-liquidate ${owm.borrowed_token.symbol} at ${maxSlippage}% max slippage.`
@@ -87,7 +89,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
               collateral_token={owm.collateral_token}
               receive=""
               formValueStateCollateral=""
-              userState={userDetails?.state}
+              userState={state}
               userWallet={userBalances}
               type="self"
             />
@@ -153,7 +155,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
 
       return stepsKey.map((k) => stepsObj[k])
     },
-    [userDetails?.state, fetchStepApprove, fetchStepLiquidate, notifyNotification, params, reset, userBalances]
+    [fetchStepApprove, fetchStepLiquidate, notifyNotification, params, reset, userBalances]
   )
 
   // onMount
@@ -166,20 +168,29 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
     }
   }, [resetState])
 
-  // init
+  // max slippage
   useEffect(() => {
     if (isLoaded && api && owmData && maxSlippage) fetchDetails(api, owmData, maxSlippage)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, maxSlippage])
+  }, [maxSlippage])
+
+  // init
+  useEffect(() => {
+    if (isLoaded && api && owmData && maxSlippage) {
+      resetState()
+      fetchDetails(api, owmData, maxSlippage)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded])
 
   // steps
   useEffect(() => {
-    if (isLoaded && api && owmData) {
-      const updatedSteps = getSteps(api, owmData, formEstGas, formStatus, liquidationAmt, maxSlippage, steps)
+    if (isLoaded && api && owmData && state) {
+      const updatedSteps = getSteps(api, owmData, formEstGas, formStatus, liquidationAmt, maxSlippage, steps, state)
       setSteps(updatedSteps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, formEstGas?.loading, liquidationAmt, formStatus, maxSlippage, userBalances])
+  }, [isLoaded, formEstGas?.loading, liquidationAmt, formStatus, maxSlippage, userBalances, state])
 
   const activeStep = signerAddress ? getActiveStep(steps) : null
 
@@ -207,7 +218,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, owmData, userAct
       ) : (
         <LoanFormConnect haveSigner={!!signerAddress} loading={!isLoaded}>
           {txInfoBar}
-          {!!formStatus.warning && <AlertFormWarning errorKey={formStatus.warning} />}
+          {!formStatus.loading && !!formStatus.warning && <AlertFormWarning errorKey={formStatus.warning} />}
           {(formStatus.error || formStatus.stepError) && (
             <AlertFormError limitHeight errorKey={formStatus.error || formStatus.stepError} handleBtnClose={reset} />
           )}

--- a/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/types.ts
+++ b/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/types.ts
@@ -1,9 +1,10 @@
 import type { FormStatus as Fs } from '@/components/PageLoanManage/types'
+import { FormWarning } from '@/components/AlertFormWarning'
 
 export type StepKey = 'APPROVAL' | 'SELF_LIQUIDATE' | ''
 
 export interface FormStatus extends Fs {
   loading: boolean
-  warning: 'warning-not-in-liquidation-mode' | 'warning-not-enough-crvusd' | ''
+  warning: FormWarning | ''
   step: StepKey
 }

--- a/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/types.ts
+++ b/apps/lend/src/components/PageLoanManage/LoanSelfLiquidation/types.ts
@@ -3,6 +3,7 @@ import type { FormStatus as Fs } from '@/components/PageLoanManage/types'
 export type StepKey = 'APPROVAL' | 'SELF_LIQUIDATE' | ''
 
 export interface FormStatus extends Fs {
+  loading: boolean
   warning: 'warning-not-in-liquidation-mode' | 'warning-not-enough-crvusd' | ''
   step: StepKey
 }

--- a/apps/lend/src/components/PageLoanManage/Page.tsx
+++ b/apps/lend/src/components/PageLoanManage/Page.tsx
@@ -67,6 +67,7 @@ const Page: NextPage = () => {
       const { signerAddress } = api
       // check for an existing loan
       const loanExists = signerAddress ? (await fetchUserLoanExists(api, owmData, true))?.loanExists : false
+      if (loanExists) setMarketsStateKey('marketDetailsView', 'user')
       setLoaded(true)
 
       // delay fetch rest after form details are fetch first
@@ -79,7 +80,7 @@ const Page: NextPage = () => {
         setInitialLoaded(true)
       }, REFRESH_INTERVAL['3s'])
     },
-    [fetchAllMarketDetails, fetchAllUserMarketDetails, fetchUserLoanExists]
+    [fetchAllMarketDetails, fetchAllUserMarketDetails, fetchUserLoanExists, setMarketsStateKey]
   )
 
   // onMount

--- a/apps/lend/src/components/PageLoanManage/Page.tsx
+++ b/apps/lend/src/components/PageLoanManage/Page.tsx
@@ -126,7 +126,7 @@ const Page: NextPage = () => {
     owmDataCachedOrApi,
     userActiveKey,
     borrowed_token: owmDataCachedOrApi?.owm?.borrowed_token,
-    collateral_token: owmDataCachedOrApi?.owm.collateral_token,
+    collateral_token: owmDataCachedOrApi?.owm?.collateral_token,
   }
 
   return (

--- a/apps/lend/src/components/PageMarketList/index.tsx
+++ b/apps/lend/src/components/PageMarketList/index.tsx
@@ -80,7 +80,7 @@ const MarketList = (pageProps: PageMarketList) => {
 
   useEffect(() => {
     if (isLoaded) {
-      updateFormValues()
+      updateFormValues(true)
       setInitialLoaded(true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/lend/src/store/createLoanBorrowMoreSlice.ts
+++ b/apps/lend/src/store/createLoanBorrowMoreSlice.ts
@@ -203,6 +203,19 @@ const createLoanBorrowMore = (_: SetState<State>, get: GetState<State>): LoanBor
 
       const { signerAddress } = api
 
+      // validation - if in soft-liquidation mode, user cannot add more collateral
+      if (signerAddress && +cFormValues.userCollateral > 0) {
+        const userActiveKey = helpers.getUserActiveKey(api, owmData)
+        const state = await user.loansDetailsMapper[userActiveKey]?.details?.state
+
+        if (!state) return
+
+        const isInSoftLiquidationMode = +state.borrowed > 0
+        if (isInSoftLiquidationMode) {
+          sliceState.setStateByKey('formStatus', { ...cFormStatus, error: 'error-liquidation-mode' })
+        }
+      }
+
       // validation
       if (signerAddress) {
         const userBalances = await user.fetchUserMarketBalances(api, owmData, shouldRefetch)

--- a/apps/lend/src/store/createLoanRepaySlice.ts
+++ b/apps/lend/src/store/createLoanRepaySlice.ts
@@ -7,6 +7,7 @@ import cloneDeep from 'lodash/cloneDeep'
 
 import { DEFAULT_FORM_EST_GAS } from '@/components/PageLoanManage/utils'
 import { DEFAULT_FORM_VALUES, DEFAULT_FORM_STATUS, _parseValues } from '@/components/PageLoanManage/LoanRepay/utils'
+import { FormError } from '@/components/AlertFormError'
 import { _parseActiveKey } from '@/utils/helpers'
 import apiLending, { helpers } from '@/lib/apiLending'
 
@@ -91,7 +92,7 @@ const createLoanRepaySlice = (set: SetState<State>, get: GetState<State>): LoanR
         sliceState.setStateByActiveKey('detailInfoLeverage', resp.activeKey, { ...resp.resp, error: resp.error })
 
         if (resp.resp && !resp.resp.repayIsAvailable && !resp.resp.repayIsFull) {
-          sliceState.setStateByKey('formStatus', { ...formStatus, error: 'error-full-repayment-required' })
+          sliceState.setStateByKey('formStatus', { ...formStatus, error: FormError.FullRepaymentRequired })
         } else {
           respError = resp.error
         }

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -3,7 +3,7 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "downlevelIteration": true,

--- a/packages/tsconfig/ui.json
+++ b/packages/tsconfig/ui.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "es6"
+    "target": "ES2020"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@carbon/icons-react": "11.17.0",
     "@lingui/detect-locale": "^4.6.0",
+    "ethers": "^6.11.0",
     "bignumber.js": "^9.0.1",
     "lodash": "4.17.21",
     "react-aria": "3.22.0",

--- a/packages/ui/src/utils/utilsWeb3.ts
+++ b/packages/ui/src/utils/utilsWeb3.ts
@@ -1,3 +1,5 @@
+import { parseUnits } from 'ethers'
+
 export function gweiToWai(gwei: number) {
   return Math.trunc(gwei * 1e9)
 }
@@ -12,4 +14,57 @@ export function gweiToEther(gwei: number) {
 
 export function weiToEther(wei: number) {
   return wei / 1e18
+}
+
+export function _getTokenDecimal(val: string) {
+  return val.includes('.') ? val.split('.')[1].length : 0
+}
+
+export function _parseUnits(val: string, tokenDecimal: number) {
+  // parseUnits will throw error if value is empty string
+  let parsedVal = val || '0'
+
+  // parseUnits will throw error if decimal part is > token decimal
+  if (parsedVal.includes('.')) {
+    const [integerPart, decimalPart] = parsedVal.split('.')
+    const parsedIntegerPart = decimalPart.length > tokenDecimal ? decimalPart.substring(0, 18) : decimalPart
+    parsedVal = `${integerPart}.${parsedIntegerPart}`
+  }
+
+  return parseUnits(parsedVal, tokenDecimal)
+}
+
+export function _biSum(values: (string | bigint)[], tokenDecimal: number) {
+  let sum = 0n
+
+  values.forEach((val) => {
+    sum += typeof val === 'bigint' ? val : _parseUnits(val, tokenDecimal)
+  })
+
+  return sum
+}
+
+export function _biMinus(val1: string, val2: string, tokenDecimal: number) {
+  const biVal1 = _parseUnits(val1, tokenDecimal)
+  const biVal2 = _parseUnits(val2, tokenDecimal)
+
+  return biVal1 - biVal2
+}
+
+export function _biCalculatePercentage(startingNumber: bigint, percentage: bigint) {
+  return (startingNumber * percentage) / 100n
+}
+
+export function _bIisGreaterThan(inputVal: bigint | string, compareValue: string, tokenDecimal: number) {
+  const biInputValue = typeof inputVal === 'bigint' ? inputVal : _parseUnits(inputVal, tokenDecimal)
+  const biCompareValue = _parseUnits(compareValue, tokenDecimal)
+
+  return biInputValue > biCompareValue
+}
+
+export function _bIisGreaterThanOrEqualTo(inputVal: bigint | string, compareValue: string, tokenDecimal: number) {
+  const biInputValue = typeof inputVal === 'bigint' ? inputVal : _parseUnits(inputVal, tokenDecimal)
+  const biCompareValue = _parseUnits(compareValue, tokenDecimal)
+
+  return biInputValue >= biCompareValue
 }

--- a/packages/ui/src/utils/utilsWeb3.ts
+++ b/packages/ui/src/utils/utilsWeb3.ts
@@ -16,54 +16,66 @@ export function weiToEther(wei: number) {
   return wei / 1e18
 }
 
+export function _biCalculatePercentage(startingNumber: bigint, percentage: bigint) {
+  return (startingNumber * percentage) / 100n
+}
+
 export function _getTokenDecimal(val: string) {
   return val.includes('.') ? val.split('.')[1].length : 0
 }
 
-export function _parseUnits(val: string, tokenDecimal: number) {
+export function _parseBigIntValue(val: string | bigint, tokenDecimal: number | undefined = 18) {
+  return typeof val === 'bigint' ? val : _parseUnits(val, tokenDecimal)
+}
+
+export function _parseUnits(val: string, tokenDecimal: number | undefined = 18) {
   // parseUnits will throw error if value is empty string
   let parsedVal = val || '0'
 
   // parseUnits will throw error if decimal part is > token decimal
   if (parsedVal.includes('.')) {
     const [integerPart, decimalPart] = parsedVal.split('.')
-    const parsedIntegerPart = decimalPart.length > tokenDecimal ? decimalPart.substring(0, 18) : decimalPart
+    const parsedIntegerPart = decimalPart.substring(0, tokenDecimal)
     parsedVal = `${integerPart}.${parsedIntegerPart}`
   }
 
   return parseUnits(parsedVal, tokenDecimal)
 }
 
-export function _biSum(values: (string | bigint)[], tokenDecimal: number) {
+export function _biSum(values: (string | bigint)[], tokenDecimal: number | undefined = 18) {
   let sum = 0n
 
   values.forEach((val) => {
-    sum += typeof val === 'bigint' ? val : _parseUnits(val, tokenDecimal)
+    sum += _parseBigIntValue(val, tokenDecimal)
   })
 
   return sum
 }
 
-export function _biMinus(val1: string, val2: string, tokenDecimal: number) {
+export function _biMinus(val1: string, val2: string, tokenDecimal: number | undefined = 18) {
   const biVal1 = _parseUnits(val1, tokenDecimal)
   const biVal2 = _parseUnits(val2, tokenDecimal)
 
   return biVal1 - biVal2
 }
 
-export function _biCalculatePercentage(startingNumber: bigint, percentage: bigint) {
-  return (startingNumber * percentage) / 100n
-}
-
-export function _bIisGreaterThan(inputVal: bigint | string, compareValue: string, tokenDecimal: number) {
-  const biInputValue = typeof inputVal === 'bigint' ? inputVal : _parseUnits(inputVal, tokenDecimal)
+export function _biIsGreaterThan(
+  inputVal: bigint | string,
+  compareValue: string,
+  tokenDecimal: number | undefined = 18
+) {
+  const biInputValue = _parseBigIntValue(inputVal)
   const biCompareValue = _parseUnits(compareValue, tokenDecimal)
 
   return biInputValue > biCompareValue
 }
 
-export function _bIisGreaterThanOrEqualTo(inputVal: bigint | string, compareValue: string, tokenDecimal: number) {
-  const biInputValue = typeof inputVal === 'bigint' ? inputVal : _parseUnits(inputVal, tokenDecimal)
+export function _biIsGreaterThanOrEqualTo(
+  inputVal: bigint | string,
+  compareValue: string,
+  tokenDecimal: number | undefined = 18
+) {
+  const biInputValue = _parseBigIntValue(inputVal, tokenDecimal)
   const biCompareValue = _parseUnits(compareValue, tokenDecimal)
 
   return biInputValue >= biCompareValue

--- a/yarn.lock
+++ b/yarn.lock
@@ -4642,11 +4642,11 @@
   integrity sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==
 
 "@safe-global/safe-apps-provider@^0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.2.tgz#336f3f4bb6ebbad9354e6551687491efc73991bc"
-  integrity sha512-yHHAcppwE7aIUWEeZiYAClQzZCdP5l0Kbd0CBlhKAsTcqZnx4Gh3G3G3frY5LlWcGzp9qmQ5jv+J1GBpaZLDgw==
+  version "0.18.3"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.3.tgz#805a42e24f5dde803cb96dac251a3c9e256de45b"
+  integrity sha512-f/0cNv3S4v7p8rowAjj0hDCg8Q8P/wBjp5twkNWeBdvd0RDr7BuRBPPk74LCqmjQ82P+1ltLlkmVFSmxTIT7XQ==
   dependencies:
-    "@safe-global/safe-apps-sdk" "^9.0.0"
+    "@safe-global/safe-apps-sdk" "^9.1.0"
     events "^3.3.0"
 
 "@safe-global/safe-apps-sdk@^8.1.0":
@@ -4657,13 +4657,13 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^1.0.0"
 
-"@safe-global/safe-apps-sdk@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.0.0.tgz#56635663f5a73773c5929d9c45ffea2b75dab69b"
-  integrity sha512-fEqmQBU3JqTjORSl3XYrcaxdxkUqeeM39qsQjqCzzTHioN8DEfg3JCLq6EBoXzcKTVOYi8SPzLV7KJccdDw+4w==
+"@safe-global/safe-apps-sdk@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz#0e65913e0f202e529ed3c846e0f5a98c2d35aa98"
+  integrity sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
-    viem "^1.6.0"
+    viem "^2.1.1"
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.13.2"
@@ -5681,10 +5681,10 @@
     "@walletconnect/types" "^1.8.0"
     "@walletconnect/utils" "^1.8.0"
 
-"@walletconnect/core@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.13.1.tgz#a59646e39a5beaa3f3551d129af43cd404cf4faf"
-  integrity sha512-h0MSYKJu9i1VEs5koCTT7c5YeQ1Kj0ncTFiMqANbDnB1r3mBulXn+FKtZ2fCmf1j7KDpgluuUzpSs+sQfPcv4Q==
+"@walletconnect/core@2.13.2":
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.13.2.tgz#8f83a12afdbfd23f04a045caf0efd9cbf8af8063"
+  integrity sha512-t1miHox71hh7tUrYFhLzNkm67wSS4kwVWO2jpwY5aHOoqkFpDSjb3A3nr+Adjrz4ZNxpObLJutQpApqkgwisjw==
   dependencies:
     "@walletconnect/heartbeat" "1.2.2"
     "@walletconnect/jsonrpc-provider" "1.0.14"
@@ -5697,8 +5697,8 @@
     "@walletconnect/relay-auth" "1.0.4"
     "@walletconnect/safe-json" "1.0.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.13.1"
-    "@walletconnect/utils" "2.13.1"
+    "@walletconnect/types" "2.13.2"
+    "@walletconnect/utils" "2.13.2"
     events "3.3.0"
     isomorphic-unfetch "3.1.0"
     lodash.isequal "4.5.0"
@@ -5779,19 +5779,19 @@
     events "^3.3.0"
 
 "@walletconnect/ethereum-provider@^2.13.0":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.13.1.tgz#a9bdb8f9da303088b7b724fa98f4b5ca0d46a36d"
-  integrity sha512-bHJVqb++GrrMGlapsbSvvIyBlwulMGZEx6N5xwAl6ImPVzbDN0g0XmibNkjzJXVsi/+/d0R/HmKS1WyJQSNx3w==
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.13.2.tgz#4312f54f085df3e4c6672f4d7d33a96cea48ebd8"
+  integrity sha512-clGxTv5xb1uxTs2yLB95ePN+ap7zUEZm0KZdjl4eB9FLypVow017MvOH1RSBC/2fp0Y8iUkYXCXRD+Cr9Thszg==
   dependencies:
     "@walletconnect/jsonrpc-http-connection" "1.0.8"
     "@walletconnect/jsonrpc-provider" "1.0.14"
     "@walletconnect/jsonrpc-types" "1.0.4"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/modal" "2.6.2"
-    "@walletconnect/sign-client" "2.13.1"
-    "@walletconnect/types" "2.13.1"
-    "@walletconnect/universal-provider" "2.13.1"
-    "@walletconnect/utils" "2.13.1"
+    "@walletconnect/sign-client" "2.13.2"
+    "@walletconnect/types" "2.13.2"
+    "@walletconnect/universal-provider" "2.13.2"
+    "@walletconnect/utils" "2.13.2"
     events "3.3.0"
 
 "@walletconnect/events@1.0.1", "@walletconnect/events@^1.0.1":
@@ -6037,19 +6037,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.13.1.tgz#7bdc9226218fd33caf3aef69dff0b4140abc7fa8"
-  integrity sha512-e+dcqcLsedB4ZjnePFM5Cy8oxu0dyz5iZfhfKH/MOrQV/hyhZ+hJwh4MmkO2QyEu2PERKs9o2Uc6x8RZdi0UAQ==
+"@walletconnect/sign-client@2.13.2":
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.13.2.tgz#ab7b78c3dec4172a69fe09885a8e6542b634992a"
+  integrity sha512-KIjAYwEkjR55uy0eZTRbKKxiLpC/hZYmjZEQf2stcTVuTOes5q3aZDlHXFHrVWn8b0pl7k0BqcDDNGklU7Xaew==
   dependencies:
-    "@walletconnect/core" "2.13.1"
+    "@walletconnect/core" "2.13.2"
     "@walletconnect/events" "1.0.1"
     "@walletconnect/heartbeat" "1.2.2"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "2.1.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.13.1"
-    "@walletconnect/utils" "2.13.1"
+    "@walletconnect/types" "2.13.2"
+    "@walletconnect/utils" "2.13.2"
     events "3.3.0"
 
 "@walletconnect/sign-client@2.9.1":
@@ -6083,10 +6083,10 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.13.1.tgz#393e3bd4d60a755f3a70cbe769b58cf153450310"
-  integrity sha512-CIrdt66d38xdunGCy5peOOP17EQkCEGKweXc3+Gn/RWeSiRU35I7wjC/Bp4iWcgAQ6iBTZv4jGGST5XyrOp+Pg==
+"@walletconnect/types@2.13.2":
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.13.2.tgz#2b371b25dee1b8920b753a860eb10afe68efcc81"
+  integrity sha512-rcomCPp1dwslIZC/e01BLSWC6to2TFM4I1QbAo7kaqh6xTVN9rCtGfdaNi0RbtfBhCEULFvc18v33r/wR0iAPQ==
   dependencies:
     "@walletconnect/events" "1.0.1"
     "@walletconnect/heartbeat" "1.2.2"
@@ -6112,19 +6112,19 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.8.0.tgz#3f5e85b2d6b149337f727ab8a71b8471d8d9a195"
   integrity sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==
 
-"@walletconnect/universal-provider@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.13.1.tgz#e007c4963ca73fea7c29dc3ca4ca57e2607daafc"
-  integrity sha512-A/6WysrvzXWtYD933PKjJlj7PGtOWdkwKeRDiD6JEVk5fQ+DQ1x0p5qcUhaa57r3S0p559YvRNvHFFjx+PpMqA==
+"@walletconnect/universal-provider@2.13.2":
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.13.2.tgz#287253fe45342fc961eafd6ad4c1d2a2301ccf62"
+  integrity sha512-CZEFtTCXOhqcU474MyAlj1VFsX9oCXe9V/6DWsgS0SrfYCFfqAgHQLsv2xR/zteNsQH6wid0rPwcMCnWngp2hQ==
   dependencies:
     "@walletconnect/jsonrpc-http-connection" "1.0.8"
     "@walletconnect/jsonrpc-provider" "1.0.14"
     "@walletconnect/jsonrpc-types" "1.0.4"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "2.1.2"
-    "@walletconnect/sign-client" "2.13.1"
-    "@walletconnect/types" "2.13.1"
-    "@walletconnect/utils" "2.13.1"
+    "@walletconnect/sign-client" "2.13.2"
+    "@walletconnect/types" "2.13.2"
+    "@walletconnect/utils" "2.13.2"
     events "3.3.0"
 
 "@walletconnect/universal-provider@2.9.1":
@@ -6142,10 +6142,10 @@
     "@walletconnect/utils" "2.9.1"
     events "^3.3.0"
 
-"@walletconnect/utils@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.13.1.tgz#f44e81028754c6e056dba588ad9b9fa5ad047645"
-  integrity sha512-EcooXXlqy5hk9hy/nK2wBF/qxe7HjH0K8ZHzjKkXRkwAE5pCvy0IGXIXWmUR9sw8LFJEqZyd8rZdWLKNUe8hqA==
+"@walletconnect/utils@2.13.2":
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.13.2.tgz#9b4c00005ef3c82438313f44e7126a6a5ab7670e"
+  integrity sha512-wDu+g/lWO93dVrntWgxwiX6XeuCHD9kxMWLEtyGZ7AmWHZv3U1Z8EWIU/e9kv4yBQxmHN3b0DhcrowfcMF3YOA==
   dependencies:
     "@stablelib/chacha20poly1305" "1.0.1"
     "@stablelib/hkdf" "1.0.1"
@@ -6155,7 +6155,7 @@
     "@walletconnect/relay-api" "1.0.10"
     "@walletconnect/safe-json" "1.0.2"
     "@walletconnect/time" "1.0.2"
-    "@walletconnect/types" "2.13.1"
+    "@walletconnect/types" "2.13.2"
     "@walletconnect/window-getters" "1.0.1"
     "@walletconnect/window-metadata" "1.0.1"
     detect-browser "5.3.0"
@@ -15563,18 +15563,18 @@ viem@^1.0.0:
     isows "1.0.3"
     ws "8.13.0"
 
-viem@^1.6.0:
-  version "1.21.4"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-1.21.4.tgz#883760e9222540a5a7e0339809202b45fe6a842d"
-  integrity sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==
+viem@^2.1.1:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.13.8.tgz#d6aaeecc84e5ee5cac1566f103ed4cf0335ef811"
+  integrity sha512-JX8dOrCJKazNVs7YAahXnX+NANp0nlK16GyYjtQXILnar1daCPsLy4uzKgZDBVBD6DdRP2lsbPfo4X7QX3q5EQ==
   dependencies:
     "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.2.0"
     "@noble/hashes" "1.3.2"
     "@scure/bip32" "1.3.2"
     "@scure/bip39" "1.2.1"
-    abitype "0.9.8"
-    isows "1.0.3"
+    abitype "1.0.0"
+    isows "1.0.4"
     ws "8.13.0"
 
 wait-on@^7.2.0:


### PR DESCRIPTION
| Borrow more | Repay | Self Liquidate |
| --- | --- | --- |
|Borrow more SL error <img width="1251" alt="borrow_more_SL_wallet_collateral" src="https://github.com/curvefi/curve-frontend/assets/6961602/e78eace0-39aa-4072-acf6-f8654c4b4680">|Repay SL in full with Collateral's crvUSD <img width="1252" alt="repay_SL_collateral_collateral_full" src="https://github.com/curvefi/curve-frontend/assets/6961602/316b08e3-4073-4c79-8ac2-16d7384539dd">|Self-liquidate from collateral crvUSD <img width="1278" alt="self_liq_SL_collateral_borrowed" src="https://github.com/curvefi/curve-frontend/assets/6961602/2d7f820b-19a6-47f4-be15-f74dad04cc72"> |
||Repay SL partial error <img width="1252" alt="repay_SL_collateral_collateral_partial" src="https://github.com/curvefi/curve-frontend/assets/6961602/e900ac5e-6e89-4102-9a0c-1494c1c038a6">|Self-liquidate with wallet's crvUSD and collateral crvUSD <img width="1282" alt="self_liq_SL_wallet_borrowed" src="https://github.com/curvefi/curve-frontend/assets/6961602/bee89d45-8d41-4708-8fa5-2e68cf1d4a15">|
||Repay SL mix full <img width="1244" alt="repay_SL_mix_full" src="https://github.com/curvefi/curve-frontend/assets/6961602/790f0bcc-d117-42b4-8394-2a6d201f5243">|Self-liquiate with not enough crvUSD <img width="1288" alt="self_liq_SL_wallet_no_borrowed" src="https://github.com/curvefi/curve-frontend/assets/6961602/81fbc94e-dfea-4ccc-9024-a7870b3231c5">|
||Repay SL from Collateral crvUSD<img width="1283" alt="repay_SL_wallet_borrowed_full" src="https://github.com/curvefi/curve-frontend/assets/6961602/ccdb2538-1ee1-4ea2-9454-75248a93db41">||


