### PR TITLE
task: update max gamma value for twocrypto pool creation

### DIFF
--- a/apps/main/src/components/PageCreatePool/constants.ts
+++ b/apps/main/src/components/PageCreatePool/constants.ts
@@ -287,7 +287,7 @@ export const TWOCRYPTO_MIN_MAX_PARAMETERS = {
   },
   gamma: {
     min: 10 ** 10 / 1e18,
-    max: (2 * 10 ** 15) / 1e18,
+    max: (199 * 10 ** 15) / 1e18,
   },
   allowedExtraProfit: {
     min: 0,


### PR DESCRIPTION
Changes:
- Updated maximum allowed Gamma in twocrypto pool creation (from 0.002 to 0.199)