### PR TITLE
fix: onboard disconnect bug

### DIFF
--- a/packages/onboard-helpers/src/index.ts
+++ b/packages/onboard-helpers/src/index.ts
@@ -76,6 +76,9 @@ export function initOnboard(i18n, locale, themeType, networks) {
         enabled: false,
       },
     },
+    connect: {
+      autoConnectLastWallet: true,
+    },
   })
 
   if (walletState && locale) {


### PR DESCRIPTION
It was impossible to disable the wallet when using Web3-Onboard 

[a disconnect error by default value or other reason can not set local storage #2227
](https://github.com/blocknative/web3-onboard/issues/2227)