### PR TITLE
task: hide oracle pool ohlc data option if api has no oracle pools for market in Lend

### DIFF
--- a/packages/ui/src/Chart/DialogSelectChart.tsx
+++ b/packages/ui/src/Chart/DialogSelectChart.tsx
@@ -16,7 +16,7 @@ const DialogSelect = ({ selectedChartIndex, selectChartList, setChartSelectedInd
   return (
     <>
       {selectChartList.length === 1 ? (
-        <ChartsTitle>{selectChartList[selectedChartIndex]?.label ?? `Loading`}</ChartsTitle>
+        <ChartsTitle>{selectChartList[0]?.label ?? `Loading`}</ChartsTitle>
       ) : (
         <Popover
           buttonProps={{ isDisabled }}


### PR DESCRIPTION
Changes:
- Added check to hide oracle pool ohlc data option if the api has no access to oracle pool data for the lending market