### PR TITLE
task: updated etherscan url link

### DIFF
--- a/packages/ui/src/utils/utilsNetworks.ts
+++ b/packages/ui/src/utils/utilsNetworks.ts
@@ -57,7 +57,7 @@ export const baseNetworksConfig = {
     rpcUrlConnectWallet: `https://eth.drpc.org`,
     symbol: 'ETH',
     scanAddressPath: (hash: string) => `https://etherscan.io/address/${hash}`,
-    scanTxPath: (hash: string) => `https://etherscan.com/tx/${hash}`,
+    scanTxPath: (hash: string) => `https://etherscan.io/tx/${hash}`,
     scanTokenPath: (hash: string) => `https://etherscan.io/token/${hash}`,
   },
   10: {


### PR DESCRIPTION
Changes:
- Changed scanTxPath to .io from .com for etherscan links on mainnet