### PR TITLE
fix: init campaign rewards from all lend pages

### DIFF
--- a/apps/lend/src/components/CampaignRewardsBanner.tsx
+++ b/apps/lend/src/components/CampaignRewardsBanner.tsx
@@ -15,6 +15,15 @@ const CampaignRewardsBanner: React.FC<CampaignRewardsBannerProps> = ({ borrowAdd
 
   if (!supplyCampaignRewardsPool && !borrowCampaignRewardsPool) return null
 
+  const campaignRewardsPools = () => {
+    if (supplyCampaignRewardsPool && borrowCampaignRewardsPool) {
+      return [...supplyCampaignRewardsPool, ...borrowCampaignRewardsPool]
+    }
+    if (supplyCampaignRewardsPool) return supplyCampaignRewardsPool
+    if (borrowCampaignRewardsPool) return borrowCampaignRewardsPool
+    return []
+  }
+
   const message =
     supplyCampaignRewardsPool && borrowCampaignRewardsPool
       ? t`Supplying and borrowing in this pool earns points!`
@@ -22,12 +31,7 @@ const CampaignRewardsBanner: React.FC<CampaignRewardsBannerProps> = ({ borrowAdd
       ? t`Supplying in this pool earns points!`
       : t`Borrowing in this pool earns points!`
 
-  return (
-    <CampaignBannerComp
-      campaignRewardsPool={[...supplyCampaignRewardsPool, ...borrowCampaignRewardsPool]}
-      message={message}
-    />
-  )
+  return <CampaignBannerComp campaignRewardsPool={campaignRewardsPools()} message={message} />
 }
 
 export default CampaignRewardsBanner

--- a/apps/lend/src/components/PageLoanCreate/index.tsx
+++ b/apps/lend/src/components/PageLoanCreate/index.tsx
@@ -1,6 +1,6 @@
 import type { FormType } from '@/components/PageLoanCreate/types'
 
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import { t } from '@lingui/macro'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -16,6 +16,7 @@ const LoanCreate = (pageProps: PageContentProps) => {
   const navigate = useNavigate()
 
   const resetState = useStore((state) => state.loanCreate.resetState)
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   // form tabs
   const FORM_TYPES = useMemo(() => {
@@ -26,6 +27,13 @@ const LoanCreate = (pageProps: PageContentProps) => {
     }
     return forms
   }, [owmDataCachedOrApi?.hasLeverage])
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   return (
     <AppFormContent variant="primary" shadowed>

--- a/apps/lend/src/components/PageLoanManage/index.tsx
+++ b/apps/lend/src/components/PageLoanManage/index.tsx
@@ -1,6 +1,6 @@
 import type { CollateralFormType, FormType, LeverageFormType, LoanFormType } from '@/components/PageLoanManage/types'
 
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useEffect } from 'react'
 import { t } from '@lingui/macro'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -17,13 +17,14 @@ import LoanCollateralAdd from '@/components/PageLoanManage/LoanCollateralAdd'
 import LoanCollateralRemove from '@/components/PageLoanManage/LoanCollateralRemove'
 
 const ManageLoan = (pageProps: PageContentProps) => {
-  const { rOwmId, rFormType, userActiveKey, owmDataCachedOrApi } = pageProps
+  const { rOwmId, rFormType, userActiveKey, owmDataCachedOrApi, rChainId } = pageProps
   const params = useParams()
   const navigate = useNavigate()
   const tabsRef = useRef<HTMLDivElement>(null)
   const { selectedTabIdx, tabPositions, setSelectedTabIdx } = useSlideTabState(tabsRef, rFormType)
 
   const loanExistsResp = useStore((state) => state.user.loansExistsMapper[userActiveKey])
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   const FORM_TYPES = useMemo(() => {
     const forms: { key: FormType; label: string }[] = [
@@ -65,6 +66,13 @@ const ManageLoan = (pageProps: PageContentProps) => {
     },
     [loanExistsResp, navigate, params, rOwmId]
   )
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   const tabs =
     !rFormType || rFormType === 'loan'

--- a/apps/lend/src/components/PageVault/index.tsx
+++ b/apps/lend/src/components/PageVault/index.tsx
@@ -1,11 +1,12 @@
 import type { FormType, VaultDepositFormType, VaultWithdrawFormType } from '@/components/PageVault/types'
 
 import { t } from '@lingui/macro'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { getVaultPathname } from '@/utils/utilsRouter'
 import { useSlideTabState } from '@/ui/hooks'
+import useStore from '@/store/useStore'
 
 import { AppFormContent, AppFormContentWrapper, AppFormSlideTab, AppFormHeader } from '@/ui/AppForm'
 import SlideTabsWrapper, { SlideTabs } from '@/ui/TabSlide'
@@ -16,10 +17,12 @@ import VaultUnstake from '@/components/PageVault/VaultUnstake'
 import VaultClaim from '@/components/PageVault/VaultClaim'
 
 const Vault = (pageProps: PageContentProps) => {
-  const { rOwmId, rFormType } = pageProps
+  const { rOwmId, rFormType, rChainId } = pageProps
   const params = useParams()
   const navigate = useNavigate()
   const tabsRef = useRef<HTMLDivElement>(null)
+
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   const { selectedTabIdx, tabPositions, setSelectedTabIdx } = useSlideTabState(tabsRef, rFormType)
 
@@ -40,6 +43,13 @@ const Vault = (pageProps: PageContentProps) => {
   ]
 
   const tabs = !rFormType || rFormType === 'deposit' ? DEPOSIT_TABS : WITHDRAW_TABS
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   return (
     <AppFormContent variant="primary" shadowed>


### PR DESCRIPTION
Changes
- Init campaign rewards data from all lend pages
- Fix array spread bug in lend campaign rewards banner component