### PR TITLE
Task lend ohlc chart fallback oracle price line

### DIFF
--- a/apps/lend/src/components/ChartOhlcWrapper/index.tsx
+++ b/apps/lend/src/components/ChartOhlcWrapper/index.tsx
@@ -49,8 +49,6 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
     fetchLlammaOhlcData,
     fetchOraclePoolOhlcData,
     fetchMoreData,
-    setChartSelectedIndex,
-    selectedChartIndex,
     activityHidden,
     chartExpanded,
     setChartExpanded,
@@ -64,6 +62,7 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
   const priceInfo = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId]?.prices ?? null)
   const { oraclePrice } = priceInfo ?? {}
   const [poolInfo, setPoolInfo] = useState<'chart' | 'poolActivity'>('chart')
+  const [selectedChartIndex, setChartSelectedIndex] = useState(0)
 
   const ohlcDataUnavailable = chartLlammaOhlc.dataDisabled && chartOraclePoolOhlc.dataDisabled
 

--- a/apps/lend/src/components/ChartOhlcWrapper/index.tsx
+++ b/apps/lend/src/components/ChartOhlcWrapper/index.tsx
@@ -43,8 +43,6 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
     chartLlammaOhlc,
     chartOraclePoolOhlc,
     timeOption,
-    volumeData,
-    oraclePriceData,
     setChartTimeOption,
     fetchLlammaOhlcData,
     fetchOraclePoolOhlcData,
@@ -69,6 +67,17 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
   const currentChart = useMemo(() => {
     return selectedChartIndex === 0 ? chartOraclePoolOhlc : chartLlammaOhlc
   }, [chartLlammaOhlc, chartOraclePoolOhlc, selectedChartIndex])
+
+  const oraclePriceData = useMemo(() => {
+    if (selectedChartIndex === 0) {
+      if (chartOraclePoolOhlc.oraclePriceData.length > 0) return chartOraclePoolOhlc.oraclePriceData
+      if (chartLlammaOhlc.oraclePriceData.length > 0) return chartLlammaOhlc.oraclePriceData
+      return undefined
+    }
+    if (chartLlammaOhlc.oraclePriceData.length > 0) return chartLlammaOhlc.oraclePriceData
+    if (chartOraclePoolOhlc.oraclePriceData.length > 0) return chartOraclePoolOhlc.oraclePriceData
+    return undefined
+  }, [chartLlammaOhlc.oraclePriceData, chartOraclePoolOhlc.oraclePriceData, selectedChartIndex])
 
   const selectedLiqRange = useMemo(() => {
     let liqRanges: LiquidationRanges = {
@@ -336,7 +345,7 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
           chartExpanded={chartExpanded}
           themeType={themeType}
           ohlcData={currentChart.data}
-          volumeData={volumeData}
+          volumeData={chartLlammaOhlc.volumeData}
           oraclePriceData={oraclePriceData}
           liquidationRange={selectedLiqRange}
           timeOption={timeOption}
@@ -396,8 +405,8 @@ const ChartOhlcWrapper: React.FC<ChartOhlcWrapperProps> = ({ rChainId, userActiv
           chartExpanded={false}
           themeType={themeType}
           ohlcData={currentChart.data}
-          volumeData={volumeData}
-          oraclePriceData={oraclePriceData.length > 0 ? oraclePriceData : undefined}
+          volumeData={chartLlammaOhlc.volumeData}
+          oraclePriceData={oraclePriceData}
           liquidationRange={selectedLiqRange}
           timeOption={timeOption}
           selectedChartIndex={selectedChartIndex}

--- a/apps/lend/src/store/createOhlcChartSlice.ts
+++ b/apps/lend/src/store/createOhlcChartSlice.ts
@@ -24,6 +24,9 @@ import { convertToLocaleTimestamp } from '@/ui/Chart/utils'
 type SliceState = {
   chartLlammaOhlc: {
     data: LpPriceOhlcDataFormatted[]
+    oraclePriceData: OraclePriceData[]
+    baselinePriceData: LlamaBaselinePriceData[]
+    volumeData: VolumeData[]
     refetchingCapped: boolean
     lastFetchEndTime: number
     fetchStatus: FetchingStatus
@@ -31,15 +34,14 @@ type SliceState = {
   }
   chartOraclePoolOhlc: {
     data: LpPriceOhlcDataFormatted[]
+    oraclePriceData: OraclePriceData[]
+    baselinePriceData: LlamaBaselinePriceData[]
     refetchingCapped: boolean
     lastFetchEndTime: number
     fetchStatus: FetchingStatus
     // flag for disabling oracle pool data if no oracle pools are found for the market on the api
     dataDisabled: boolean
   }
-  volumeData: VolumeData[]
-  oraclePriceData: OraclePriceData[]
-  baselinePriceData: LlamaBaselinePriceData[]
   lendTradesData: LlammaTradeEvent[]
   lendControllerData: LlammaControllerEvent[]
   activityFetchStatus: FetchingStatus
@@ -95,7 +97,13 @@ export type OhlcChartSlice = {
       timeUnit: string,
       start: number,
       end: number
-    ): Promise<{ data: LpPriceOhlcDataFormatted[]; refetchingCapped: boolean; lastFetchEndTime: number }>
+    ): Promise<{
+      ohlcData: LpPriceOhlcDataFormatted[]
+      oracleData: OraclePriceData[]
+      baselineData: LlamaBaselinePriceData[]
+      refetchingCapped: boolean
+      lastFetchEndTime: number
+    }>
     fetchMoreData(
       chainId: ChainId,
       controller: string,
@@ -118,6 +126,9 @@ export type OhlcChartSlice = {
 const DEFAULT_STATE: SliceState = {
   chartLlammaOhlc: {
     data: [],
+    volumeData: [],
+    oraclePriceData: [],
+    baselinePriceData: [],
     refetchingCapped: false,
     lastFetchEndTime: 0,
     fetchStatus: 'LOADING',
@@ -125,14 +136,13 @@ const DEFAULT_STATE: SliceState = {
   },
   chartOraclePoolOhlc: {
     data: [],
+    oraclePriceData: [],
+    baselinePriceData: [],
     refetchingCapped: false,
     lastFetchEndTime: 0,
     fetchStatus: 'LOADING',
     dataDisabled: false,
   },
-  volumeData: [],
-  oraclePriceData: [],
-  baselinePriceData: [],
   lendTradesData: [],
   lendControllerData: [],
   activityFetchStatus: 'LOADING',
@@ -168,13 +178,13 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           state[sliceKey].chartLlammaOhlc = {
             fetchStatus: 'LOADING',
             data: DEFAULT_STATE.chartLlammaOhlc.data,
+            volumeData: DEFAULT_STATE.chartLlammaOhlc.volumeData,
+            oraclePriceData: DEFAULT_STATE.chartLlammaOhlc.oraclePriceData,
+            baselinePriceData: DEFAULT_STATE.chartLlammaOhlc.baselinePriceData,
             refetchingCapped: DEFAULT_STATE.chartLlammaOhlc.refetchingCapped,
             lastFetchEndTime: DEFAULT_STATE.chartLlammaOhlc.lastFetchEndTime,
             dataDisabled: DEFAULT_STATE.chartLlammaOhlc.dataDisabled,
           }
-          state[sliceKey].volumeData = DEFAULT_STATE.volumeData
-          state[sliceKey].oraclePriceData = DEFAULT_STATE.oraclePriceData
-          state[sliceKey].baselinePriceData = DEFAULT_STATE.baselinePriceData
         })
       )
       const network = networks[chainId].id.toLowerCase()
@@ -239,9 +249,9 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc.refetchingCapped = ohlcDataArray.length < 298
             state[sliceKey].chartLlammaOhlc.lastFetchEndTime = lendOhlcResponse.data[0].time
             state[sliceKey].chartLlammaOhlc.fetchStatus = 'READY'
-            state[sliceKey].volumeData = volumeArray
-            state[sliceKey].oraclePriceData = oraclePriceArray
-            state[sliceKey].baselinePriceData = baselinePriceArray
+            state[sliceKey].chartLlammaOhlc.volumeData = volumeArray
+            state[sliceKey].chartLlammaOhlc.oraclePriceData = oraclePriceArray
+            state[sliceKey].chartLlammaOhlc.baselinePriceData = baselinePriceArray
           })
         )
       } catch (error) {
@@ -250,13 +260,13 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc = {
               fetchStatus: 'ERROR',
               data: DEFAULT_STATE.chartLlammaOhlc.data,
+              volumeData: DEFAULT_STATE.chartLlammaOhlc.volumeData,
+              oraclePriceData: DEFAULT_STATE.chartLlammaOhlc.oraclePriceData,
+              baselinePriceData: DEFAULT_STATE.chartLlammaOhlc.baselinePriceData,
               refetchingCapped: DEFAULT_STATE.chartLlammaOhlc.refetchingCapped,
               lastFetchEndTime: DEFAULT_STATE.chartLlammaOhlc.lastFetchEndTime,
               dataDisabled: true,
             }
-            state[sliceKey].volumeData = DEFAULT_STATE.volumeData
-            state[sliceKey].oraclePriceData = DEFAULT_STATE.oraclePriceData
-            state[sliceKey].baselinePriceData = DEFAULT_STATE.baselinePriceData
           })
         )
         console.log(error)
@@ -347,6 +357,8 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           state[sliceKey].chartOraclePoolOhlc = {
             fetchStatus: 'LOADING',
             data: DEFAULT_STATE.chartOraclePoolOhlc.data,
+            oraclePriceData: DEFAULT_STATE.chartOraclePoolOhlc.oraclePriceData,
+            baselinePriceData: DEFAULT_STATE.chartOraclePoolOhlc.baselinePriceData,
             refetchingCapped: DEFAULT_STATE.chartOraclePoolOhlc.refetchingCapped,
             lastFetchEndTime: DEFAULT_STATE.chartOraclePoolOhlc.lastFetchEndTime,
             dataDisabled: DEFAULT_STATE.chartOraclePoolOhlc.dataDisabled,
@@ -372,17 +384,40 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           throw new Error('No oracle OHLC data found. Data may be unavailable for this pool.')
         }
 
-        const oracleOhlcFormatted = oracleOhlcResponse.data.map((data: any) => {
-          return {
-            ...data,
-            time: convertToLocaleTimestamp(data.time) as UTCTimestamp,
+        let baselinePriceArray: LlamaBaselinePriceData[] = []
+        let oraclePriceArray: OraclePriceData[] = []
+        let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
+
+        for (const item of oracleOhlcResponse.data) {
+          if (item.base_price) {
+            baselinePriceArray.push({
+              time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+              base_price: item.base_price,
+            })
           }
-        })
+
+          if (item.oracle_price) {
+            oraclePriceArray.push({
+              time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+              value: item.oracle_price,
+            })
+          }
+
+          ohlcDataArray.push({
+            time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+            open: item.open,
+            close: item.close,
+            high: item.high,
+            low: item.low,
+          })
+        }
 
         set(
           produce((state: State) => {
-            state[sliceKey].chartOraclePoolOhlc.data = oracleOhlcFormatted
-            state[sliceKey].chartOraclePoolOhlc.refetchingCapped = oracleOhlcFormatted.length < 299
+            state[sliceKey].chartOraclePoolOhlc.data = ohlcDataArray
+            state[sliceKey].chartOraclePoolOhlc.oraclePriceData = oraclePriceArray
+            state[sliceKey].chartOraclePoolOhlc.baselinePriceData = baselinePriceArray
+            state[sliceKey].chartOraclePoolOhlc.refetchingCapped = ohlcDataArray.length < 299
             state[sliceKey].chartOraclePoolOhlc.lastFetchEndTime = oracleOhlcResponse.data[0].time
             state[sliceKey].chartOraclePoolOhlc.fetchStatus = 'READY'
           })
@@ -393,6 +428,8 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartOraclePoolOhlc = {
               fetchStatus: 'ERROR',
               data: DEFAULT_STATE.chartOraclePoolOhlc.data,
+              oraclePriceData: DEFAULT_STATE.chartOraclePoolOhlc.oraclePriceData,
+              baselinePriceData: DEFAULT_STATE.chartOraclePoolOhlc.baselinePriceData,
               refetchingCapped: DEFAULT_STATE.chartOraclePoolOhlc.refetchingCapped,
               lastFetchEndTime: DEFAULT_STATE.chartOraclePoolOhlc.lastFetchEndTime,
               dataDisabled: true,
@@ -418,16 +455,40 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           `https://prices.curve.fi/v1/lending/oracle_ohlc/${network}/${checkSummedController}?agg_number=${interval}&agg_units=${timeUnit}&start=${start}&end=${end}`
         )
         const oracleOhlcResponse = await oracleOhlcDataFetch.json()
-        const oracleOhlcFormatted = oracleOhlcResponse.data.map((data: any) => {
-          return {
-            ...data,
-            time: convertToLocaleTimestamp(data.time) as UTCTimestamp,
+
+        let baselinePriceArray: LlamaBaselinePriceData[] = []
+        let oraclePriceArray: OraclePriceData[] = []
+        let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
+
+        for (const item of oracleOhlcResponse.data) {
+          if (item.base_price) {
+            baselinePriceArray.push({
+              time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+              base_price: item.base_price,
+            })
           }
-        })
+
+          if (item.oracle_price) {
+            oraclePriceArray.push({
+              time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+              value: item.oracle_price,
+            })
+          }
+
+          ohlcDataArray.push({
+            time: convertToLocaleTimestamp(item.time) as UTCTimestamp,
+            open: item.open,
+            close: item.close,
+            high: item.high,
+            low: item.low,
+          })
+        }
 
         return {
-          data: oracleOhlcFormatted,
-          refetchingCapped: oracleOhlcFormatted.length < 299,
+          data: ohlcDataArray,
+          oraclePriceData: oraclePriceArray,
+          baselinePriceData: baselinePriceArray,
+          refetchingCapped: ohlcDataArray.length < 299,
           lastFetchEndTime: oracleOhlcResponse.data[0].time,
         }
       } catch (error) {
@@ -470,7 +531,9 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           produce((state: State) => {
             state[sliceKey].chartOraclePoolOhlc = {
               fetchStatus: 'READY',
-              data: [...oracleData.data, ...state[sliceKey].chartOraclePoolOhlc.data],
+              data: [...oracleData.ohlcData, ...state[sliceKey].chartOraclePoolOhlc.data],
+              oraclePriceData: [...oracleData.oracleData, ...state[sliceKey].chartOraclePoolOhlc.oraclePriceData],
+              baselinePriceData: [...oracleData.baselineData, ...state[sliceKey].chartOraclePoolOhlc.baselinePriceData],
               refetchingCapped: oracleData.refetchingCapped,
               lastFetchEndTime: oracleData.lastFetchEndTime,
               dataDisabled: false,
@@ -479,13 +542,13 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc = {
               fetchStatus: 'READY',
               data: [...llammaData.ohlcData, ...state[sliceKey].chartLlammaOhlc.data],
+              volumeData: [...llammaData.volumeData, ...state[sliceKey].chartLlammaOhlc.volumeData],
+              oraclePriceData: [...llammaData.oracleData, ...state[sliceKey].chartLlammaOhlc.oraclePriceData],
+              baselinePriceData: [...llammaData.baselineData, ...state[sliceKey].chartLlammaOhlc.baselinePriceData],
               refetchingCapped: llammaData.refetchingCapped,
               lastFetchEndTime: llammaData.lastFetchEndTime,
               dataDisabled: false,
             }
-            state[sliceKey].volumeData = [...llammaData.volumeData, ...state[sliceKey].volumeData]
-            state[sliceKey].oraclePriceData = [...llammaData.oracleData, ...state[sliceKey].oraclePriceData]
-            state[sliceKey].baselinePriceData = [...llammaData.baselineData, ...state[sliceKey].baselinePriceData]
           })
         )
 
@@ -499,7 +562,9 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           produce((state: State) => {
             state[sliceKey].chartOraclePoolOhlc = {
               fetchStatus: 'READY',
-              data: [...oracleData.data, ...state[sliceKey].chartOraclePoolOhlc.data],
+              data: [...oracleData.ohlcData, ...state[sliceKey].chartOraclePoolOhlc.data],
+              oraclePriceData: [...oracleData.oracleData, ...state[sliceKey].chartOraclePoolOhlc.oraclePriceData],
+              baselinePriceData: [...oracleData.baselineData, ...state[sliceKey].chartOraclePoolOhlc.baselinePriceData],
               refetchingCapped: oracleData.refetchingCapped,
               lastFetchEndTime: oracleData.lastFetchEndTime,
               dataDisabled: false,
@@ -518,13 +583,13 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc = {
               fetchStatus: 'READY',
               data: [...llammaData.ohlcData, ...state[sliceKey].chartLlammaOhlc.data],
+              volumeData: [...llammaData.volumeData, ...state[sliceKey].chartLlammaOhlc.volumeData],
+              oraclePriceData: [...llammaData.oracleData, ...state[sliceKey].chartLlammaOhlc.oraclePriceData],
+              baselinePriceData: [...llammaData.baselineData, ...state[sliceKey].chartLlammaOhlc.baselinePriceData],
               refetchingCapped: llammaData.refetchingCapped,
               lastFetchEndTime: llammaData.lastFetchEndTime,
               dataDisabled: false,
             }
-            state[sliceKey].volumeData = [...llammaData.volumeData, ...state[sliceKey].volumeData]
-            state[sliceKey].oraclePriceData = [...llammaData.oracleData, ...state[sliceKey].oraclePriceData]
-            state[sliceKey].baselinePriceData = [...llammaData.baselineData, ...state[sliceKey].baselinePriceData]
           })
         )
 

--- a/apps/lend/src/store/createOhlcChartSlice.ts
+++ b/apps/lend/src/store/createOhlcChartSlice.ts
@@ -485,9 +485,9 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         }
 
         return {
-          data: ohlcDataArray,
-          oraclePriceData: oraclePriceArray,
-          baselinePriceData: baselinePriceArray,
+          ohlcData: ohlcDataArray,
+          oracleData: oraclePriceArray,
+          baselineData: baselinePriceArray,
           refetchingCapped: ohlcDataArray.length < 299,
           lastFetchEndTime: oracleOhlcResponse.data[0].time,
         }

--- a/apps/lend/src/store/createOhlcChartSlice.ts
+++ b/apps/lend/src/store/createOhlcChartSlice.ts
@@ -44,7 +44,6 @@ type SliceState = {
   lendControllerData: LlammaControllerEvent[]
   activityFetchStatus: FetchingStatus
   timeOption: TimeOptions
-  selectedChartIndex: number
   activityHidden: boolean
   chartExpanded: boolean
   oraclePriceVisible: boolean
@@ -106,7 +105,6 @@ export type OhlcChartSlice = {
       start: number,
       end: number
     ): Promise<void>
-    setChartSelectedIndex(index: number): void
     fetchPoolActivity(chainId: ChainId, poolAddress: string): Promise<void>
     setActivityHidden(bool?: boolean): void
     setChartExpanded(bool?: boolean): void
@@ -139,7 +137,6 @@ const DEFAULT_STATE: SliceState = {
   lendControllerData: [],
   activityFetchStatus: 'LOADING',
   timeOption: '1d',
-  selectedChartIndex: 0,
   activityHidden: false,
   chartExpanded: false,
   oraclePriceVisible: true,
@@ -605,13 +602,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         )
         console.log(error)
       }
-    },
-    setChartSelectedIndex: (index: number) => {
-      set(
-        produce((state: State) => {
-          state[sliceKey].selectedChartIndex = index
-        })
-      )
     },
     setActivityHidden: (bool?: boolean) => {
       set(

--- a/apps/lend/src/store/createOhlcChartSlice.ts
+++ b/apps/lend/src/store/createOhlcChartSlice.ts
@@ -499,7 +499,9 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         )
         console.log(error)
         return {
-          data: [],
+          ohlcData: [],
+          oracleData: [],
+          baselineData: [],
           refetchingCapped: false,
           lastFetchEndTime: 0,
         }

--- a/apps/main/src/components/PagePool/PoolDetails/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/components/PagePool/PoolDetails/ChartOhlcWrapper/index.tsx
@@ -25,7 +25,6 @@ const PoolInfoData = ({ rChainId, pricesApiPoolData }: Props) => {
     pricesApiState: {
       chartOhlcData,
       chartStatus,
-      selectedChartIndex,
       timeOption,
       chartExpanded,
       activityHidden,
@@ -33,7 +32,6 @@ const PoolInfoData = ({ rChainId, pricesApiPoolData }: Props) => {
       refetchingCapped,
       lastFetchEndTime,
     },
-    setChartSelectedIndex,
     setChartTimeOption,
     setChartExpanded,
     fetchPricesApiCharts,
@@ -44,6 +42,7 @@ const PoolInfoData = ({ rChainId, pricesApiPoolData }: Props) => {
 
   const [poolInfo, setPoolInfo] = useState<'chart' | 'poolActivity'>('chart')
   const [selectChartList, setSelectChartList] = useState<LabelList[]>([])
+  const [selectedChartIndex, setChartSelectedIndex] = useState<number>(0)
   const [isFlipped, setIsFlipped] = useState<boolean[]>([])
 
   const chartHeight = {

--- a/apps/main/src/store/createPoolsSlice.ts
+++ b/apps/main/src/store/createPoolsSlice.ts
@@ -61,7 +61,6 @@ type SliceState = {
     tradeEventsData: LpTradesData[]
     liquidityEventsData: LpLiquidityEventsData[]
     timeOption: TimeOptions
-    selectedChartIndex: number
     chartExpanded: boolean
     activityHidden: boolean
     chartStatus: FetchingStatus
@@ -96,7 +95,6 @@ export type PoolsSlice = {
     fetchMorePricesApiCharts: (chainId: ChainId, selectedChartIndex: number, poolAddress: string, interval: number, timeUnit: string, start: number, end: number, chartCombinations: PricesApiCoin[][], isFlipped: boolean[]) => void
     fetchPricesApiActivity: (chainId: ChainId, poolAddress: string, chartCombinations: PricesApiCoin[][]) => void
     setChartTimeOption: (timeOption: TimeOptions) => void
-    setChartSelectedIndex: (index: number) => void
     setChartExpanded: (expanded: boolean) => void
     setActivityHidden: (hidden: boolean) => void
 
@@ -131,7 +129,6 @@ const DEFAULT_STATE: SliceState = {
     tradeEventsData: [],
     liquidityEventsData: [],
     timeOption: '1d',
-    selectedChartIndex: 0,
     chartExpanded: false,
     activityHidden: false,
     chartStatus: 'LOADING',
@@ -796,13 +793,6 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
       set(
         produce((state: State) => {
           state.pools.pricesApiState.timeOption = timeOption
-        })
-      )
-    },
-    setChartSelectedIndex: (index: number) => {
-      set(
-        produce((state: State) => {
-          state.pools.pricesApiState.selectedChartIndex = index
         })
       )
     },


### PR DESCRIPTION
Changes:
- Add oracle price data fallback from "oracle" api data when "llamma" api data is unavailable to display oracle price line in lend ohlc chart