### PR TITLE
fix collateral token address

### DIFF
--- a/apps/lend/src/components/DetailsMarket/components/DetailsContracts.tsx
+++ b/apps/lend/src/components/DetailsMarket/components/DetailsContracts.tsx
@@ -39,7 +39,7 @@ const DetailsContracts = ({
     supply: [
       [
         { label: <TokenLabel isDisplayOnly rChainId={rChainId} token={borrowed_token} />, address: addresses?.borrowed_token },
-        { label: <TokenLabel isDisplayOnly rChainId={rChainId} token={collateral_token} />, address: addresses?.borrowed_token },
+        { label: <TokenLabel isDisplayOnly rChainId={rChainId} token={collateral_token} />, address: addresses?.collateral_token },
       ],
       [
         { label: t`Vault`, address: addresses?.vault },


### PR DESCRIPTION
the fe was displaying twice the address of the borrowed token (crvusd) instead of the address of the collateral token