### PR TITLE
loan details paged changed to loan concepts

### DIFF
--- a/apps/lend/src/hooks/useTitleMapper.tsx
+++ b/apps/lend/src/hooks/useTitleMapper.tsx
@@ -33,7 +33,7 @@ const useTitleMapper = (): TitleMapper => {
           <p>{t`The loan metric indicates the current health of your position.`}</p>
           <p>
             {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
-            <ExternalLink href="https://resources.curve.fi/crvusd/loan-details/#hard-liquidations" $noStyles>
+            <ExternalLink href="https://resources.curve.fi/crvusd/loan-concepts/#hard-liquidations" $noStyles>
               Click here to learn more.
             </ExternalLink>
           </p>

--- a/apps/loan/src/components/DetailInfoHealth.tsx
+++ b/apps/loan/src/components/DetailInfoHealth.tsx
@@ -119,7 +119,7 @@ const DetailInfoHealth = ({
             <p>{t`The loan metric indicates the current health of your position.`}</p>
             <p>
               {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
-              <ExternalLink href="https://resources.curve.fi/crvusd/loan-details/#hard-liquidations" $noStyles>
+              <ExternalLink href="https://resources.curve.fi/crvusd/loan-concepts/#hard-liquidations" $noStyles>
                 Click here to learn more.
               </ExternalLink>
             </p>

--- a/apps/loan/src/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
+++ b/apps/loan/src/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
@@ -32,7 +32,7 @@ const AlertSoftLiquidation = ({ llammaId, llamma }: { llammaId: string; llamma: 
         <p>{t`You are in soft-liquidation mode. The amount currently at risk is ${softLiquidationAmountText}. In this mode, you cannot partially withdraw or add more collateral to your position. To reduce the risk of hard liquidation, you can repay or, to exit soft liquidation, you can close (self-liquidate).`}</p>
         <p>
           {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
-          <ExternalLink href="https://resources.curve.fi/crvusd/loan-details/#hard-liquidations" $noStyles>
+          <ExternalLink href="https://resources.curve.fi/crvusd/loan-concepts/#hard-liquidations" $noStyles>
             Click here to learn more.
           </ExternalLink>
         </p>

--- a/apps/loan/src/hooks/useTitleMapper.tsx
+++ b/apps/loan/src/hooks/useTitleMapper.tsx
@@ -28,7 +28,7 @@ const useTitleMapper = (): TitleMapper => {
           <p>{t`The loan metric indicates the current health of your position.`}</p>
           <p>
             {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
-            <ExternalLink href="https://resources.curve.fi/crvusd/loan-details/#hard-liquidations" $noStyles>
+            <ExternalLink href="https://resources.curve.fi/crvusd/loan-concepts/#hard-liquidations" $noStyles>
               Click here to learn more.
             </ExternalLink>
           </p>


### PR DESCRIPTION
Updated resources links as the loan details page changed to a loan concepts page.

Currently the links still work because I have a redirect on the resources website, but I will depreciate this after this is merged.

This fixes #369 