### PR TITLE
task: updated stableswap default fee for fiat redeemable stableswap preset

### DIFF
--- a/apps/main/src/components/PageCreatePool/constants.ts
+++ b/apps/main/src/components/PageCreatePool/constants.ts
@@ -67,7 +67,7 @@ export const POOL_PRESETS: PRESETS = {
     description: t`Suitable for stablecoins that are fiat-redeemable`,
     defaultParams: {
       ...fillerParams,
-      stableSwapFee: '0.04',
+      stableSwapFee: '0.01',
       stableA: '200',
       maExpTime: '600',
       offpegFeeMultiplier: '2',

--- a/apps/main/src/components/PageCreatePool/constants.ts
+++ b/apps/main/src/components/PageCreatePool/constants.ts
@@ -68,7 +68,7 @@ export const POOL_PRESETS: PRESETS = {
     defaultParams: {
       ...fillerParams,
       stableSwapFee: '0.01',
-      stableA: '200',
+      stableA: '1000',
       maExpTime: '600',
       offpegFeeMultiplier: '2',
     },


### PR DESCRIPTION
Changes:
- Updated stableswap 'Fiat Redeemable Stablecoins' preset in pool creation:
    - Changed default fee to 0.01% (was 0.04%)
    - Changed default A to 1000 (was 200)