### PR TITLE
task: increase offpeg fee multiplier to 5x in fiat redeemable stableswap preset

### DIFF
--- a/apps/main/src/components/PageCreatePool/constants.ts
+++ b/apps/main/src/components/PageCreatePool/constants.ts
@@ -70,7 +70,7 @@ export const POOL_PRESETS: PRESETS = {
       stableSwapFee: '0.01',
       stableA: '1000',
       maExpTime: '600',
-      offpegFeeMultiplier: '2',
+      offpegFeeMultiplier: '5',
     },
   },
   1: {


### PR DESCRIPTION
Changes:
- Increased offpeg fee multiplier to 5x (was 2x) in 'Fiat Redeemable Stablecoins' stableswap preset