### PR TITLE
fix: wcm z-index override

### DIFF
--- a/packages/ui/src/styles/layout.css
+++ b/packages/ui/src/styles/layout.css
@@ -66,3 +66,9 @@
   --z-index-tab: 1;
   --z-index-tooltip: 1;
 }
+
+body {
+  --wcm-z-index: 101; /* Wallet Connect has an option to override its theme, but this object is not exposed in Onboard, so the override is handled in the UI library. See https://docs.reown.com/advanced/walletconnectmodal/theming for more overrides*/
+}
+
+


### PR DESCRIPTION
-fix Wallet connect mobile view `view all` button
<img width="558" alt="Screenshot 2024-10-24 at 1 51 00 PM" src="https://github.com/user-attachments/assets/02879e9b-d16e-43bb-a916-25c209008120">

