### PR TITLE
feat: retrieve vault data from contract when connected

### DIFF
--- a/apps/loan/src/components/PageCrvUsdStaking/StatsBanner/index.tsx
+++ b/apps/loan/src/components/PageCrvUsdStaking/StatsBanner/index.tsx
@@ -18,8 +18,9 @@ const StatsBanner: React.FC<StatsBannerProps> = ({ className }) => {
 
   const exampleBalance = 100000
 
-  const isLoadingPricesYieldData = isLoading(pricesYieldData.fetchStatus)
-  const scrvUsdApy = pricesYieldData.data?.proj_apr ?? 0
+  const isLoadingPricesYieldData = !isReady(pricesYieldData.fetchStatus)
+
+  const scrvUsdApy = pricesYieldData.data?.proj_apr || 0
   const oneMonthProjYield = formatNumber((scrvUsdApy / 100 / 12) * exampleBalance, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/apps/loan/src/components/PageCrvUsdStaking/index.tsx
+++ b/apps/loan/src/components/PageCrvUsdStaking/index.tsx
@@ -20,7 +20,7 @@ const CrvUsdStaking = ({ mobileBreakpoint }: { mobileBreakpoint: string }) => {
     stakingModule,
   } = useStore((state) => state.scrvusd)
   const lendApi = useStore((state) => state.lendApi)
-  const onboardInstance = useStore((state) => state.wallet.onboard)
+  const {onboard: onboardInstance, provider } = useStore((state) => state.wallet)
   const signerAddress = onboardInstance?.state.get().wallets?.[0]?.accounts?.[0]?.address
   const chainId = useStore((state) => state.curve?.chainId)
   const userScrvUsdBalance = useStore((state) => state.scrvusd.userBalances[signerAddress ?? '']?.scrvUSD) ?? '0'
@@ -41,12 +41,8 @@ const CrvUsdStaking = ({ mobileBreakpoint }: { mobileBreakpoint: string }) => {
 
   // none library fetches
   useEffect(() => {
-    const fetchData = async () => {
-      fetchSavingsYield()
-    }
-
-    fetchData()
-  }, [fetchSavingsYield])
+    fetchSavingsYield(provider)
+  }, [fetchSavingsYield, provider])
 
   useEffect(() => {
     if (!lendApi || !chainId || !signerAddress || inputAmount === '0') return

--- a/apps/loan/src/store/createScrvUsdSlice.ts
+++ b/apps/loan/src/store/createScrvUsdSlice.ts
@@ -1,15 +1,12 @@
 import type { DepositWithdrawModule } from '@/components/PageCrvUsdStaking/types'
-import type { PricesYieldDataResponse, PricesYieldData } from '@/store/types'
-
+import type { PricesYieldData, PricesYieldDataResponse, Provider } from '@/store/types'
 import type { GetState, SetState } from 'zustand'
 import type { State } from '@/store/useStore'
-
 import BigNumber from 'bignumber.js'
 import { t } from '@lingui/macro'
-
 import { SCRVUSD_GAS_ESTIMATE } from '@/constants'
 import networks from '@/networks'
-
+import { Contract } from 'ethers'
 import cloneDeep from 'lodash/cloneDeep'
 
 type StateKey = keyof typeof DEFAULT_STATE
@@ -93,7 +90,7 @@ export type ScrvUsdSlice = {
     fetchUserBalances: () => void
     fetchExchangeRate: () => void
     fetchCrvUsdSupplies: () => void
-    fetchSavingsYield: () => void
+    fetchSavingsYield: (provider?: Provider | null) => void
     setMax: (userAddress: string, stakingModule: DepositWithdrawModule) => void
     setStakingModule: (stakingModule: DepositWithdrawModule) => void
     setInputAmount: (amount: string) => void
@@ -157,6 +154,36 @@ const DEFAULT_STATE: SliceState = {
     fetchStatus: 'loading',
     data: null,
   },
+}
+
+const VAULT_ADDRESS = '0x0655977FEb2f289A4aB78af67BAB0d17aAb84367'
+const YEAR = 86400 * 365.25 * 100
+const VAULT_ABI = [
+  { stateMutability: 'view', type: 'function', name: 'profitUnlockingRate', inputs: [], outputs: [{ name: '', type: 'uint256' }] },
+  { stateMutability: 'view', type: 'function', name: 'totalSupply', inputs: [], outputs: [{ name: '', type: 'uint256' }] },
+]
+
+/**
+ * Fetches the savings yield data from the Curve API.
+ * If a provider is provided, the data is fetched from the vault contract directly.
+ * That provides more accurate data and works even if our servers are down.
+ */
+async function _fetchSavingsYield(provider?: Provider | null): Promise<PricesYieldDataResponse> {
+  if (provider) {
+    const vault = new Contract(VAULT_ADDRESS, VAULT_ABI, provider)
+    const [unlock_amount, supply, block] = await Promise.all([
+      vault.profitUnlockingRate(), vault.totalSupply(), provider.getBlock('latest')
+    ])
+    return {
+      last_updated: new Date(block.timestamp).toISOString(),
+      last_updated_block: block.number,
+      proj_apr: supply > 0 ? (unlock_amount * 1e-12 * YEAR) / supply : 0,
+      supply,
+    }
+  }
+
+  const response = await fetch(`https://prices.curve.fi/v1/crvusd/savings/statistics`)
+  return await response.json()
 }
 
 const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
@@ -560,14 +587,11 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
         get()[sliceKey].setStateByKey('crvUsdSupplies', { fetchStatus: 'error', crvUSD: '', scrvUSD: '' })
       }
     },
-    fetchSavingsYield: async () => {
+    fetchSavingsYield: async (provider?: Provider | null) => {
       get()[sliceKey].setStateByKey('pricesYieldData', { fetchStatus: 'loading', data: null })
 
       try {
-        const response = await fetch(`https://prices.curve.fi/v1/crvusd/savings/statistics`)
-
-        const data: PricesYieldDataResponse = await response.json()
-
+        const data = await _fetchSavingsYield(provider)
         get()[sliceKey].setStateByKey('pricesYieldData', { fetchStatus: 'success', data })
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
- Fetch the savings yield data from the Curve API. If a provider is provided, the data is fetched from the vault contract directly.
- That provides more accurate data and works even if our servers are down.