### PR TITLE
fix: always bold pool name

### DIFF
--- a/apps/main/src/components/PoolLabel.tsx
+++ b/apps/main/src/components/PoolLabel.tsx
@@ -102,9 +102,8 @@ const PoolLabel = ({ className = '', imageBaseUrl, isVisible = true, poolData, p
                 )}
               </>
             )}
-            {pool && (
-              <ChipPool poolAddress={pool.address} poolName={pool.name} isHighlightPoolName={isHighlightPoolName} />
-            )}
+            {/* isHighlightPoolName = default to true now, even if searched text is not same result */}
+            {pool && <ChipPool poolAddress={pool.address} poolName={pool.name} isHighlightPoolName />}
           </Box>
 
           <PoolLabelTokensWrapper>


### PR DESCRIPTION
Fix: Always bold Pool's name
![Screenshot 2024-11-19 at 8 47 59 AM](https://github.com/user-attachments/assets/0f8b78cf-dcba-4493-8638-28ea09db114f)

