### PR TITLE
fix: pool list non-lite TVL column width

### DIFF
--- a/apps/main/src/components/PagePoolList/components/TableHead.tsx
+++ b/apps/main/src/components/PagePoolList/components/TableHead.tsx
@@ -67,7 +67,8 @@ const TableHead: React.FC<Props> = ({
               )}
               {columnKey === COLUMN_KEYS.rewardsMobile && <Col className="right rewards" />}
               {columnKey === COLUMN_KEYS.volume && <col className="right" />}
-              {columnKey === COLUMN_KEYS.tvl && <Col className={`right ${isLite ? 'tvl' : ''}`} />}
+              {columnKey === COLUMN_KEYS.tvl && isLite && <Col className="right tvl" />}
+              {columnKey === COLUMN_KEYS.tvl && !isLite && <col className="right" />}
             </React.Fragment>
           )
         })}


### PR DESCRIPTION
1. Reduce width for TVL when not on Lite network

![Screenshot 2024-11-21 at 3 36 28 PM](https://github.com/user-attachments/assets/2b050281-74ac-47d8-b2c9-41e20b29e1a4)
