### PR TITLE
fix: bolster curve-lite checks in gauge deployments

### DIFF
--- a/apps/main/src/components/PageDeployGauge/components/DeployGaugeButton.tsx
+++ b/apps/main/src/components/PageDeployGauge/components/DeployGaugeButton.tsx
@@ -27,7 +27,7 @@ interface Props {
 const DeployGaugeButton = ({ disabled, chainId, curve }: Props) => {
   const networks = useStore((state) => state.networks.networks)
   const { haveSigner } = curveProps(curve, networks)
-  const isLite = networks[chainId].isLite ?? false
+  const isLite = networks[chainId]?.isLite ?? false
   const navigate = useNavigate()
   const { rChainId, rNetwork } = useNetworkFromUrl()
 

--- a/apps/main/src/components/PageDeployGauge/components/DeployGaugeButton.tsx
+++ b/apps/main/src/components/PageDeployGauge/components/DeployGaugeButton.tsx
@@ -27,7 +27,7 @@ interface Props {
 const DeployGaugeButton = ({ disabled, chainId, curve }: Props) => {
   const networks = useStore((state) => state.networks.networks)
   const { haveSigner } = curveProps(curve, networks)
-  const isLite = networks[chainId].isLite
+  const isLite = networks[chainId].isLite ?? false
   const navigate = useNavigate()
   const { rChainId, rNetwork } = useNetworkFromUrl()
 

--- a/apps/main/src/components/PageDeployGauge/index.tsx
+++ b/apps/main/src/components/PageDeployGauge/index.tsx
@@ -26,7 +26,7 @@ type Props = {
 const DeployGauge = ({ curve }: Props) => {
   const networks = useStore((state) => state.networks.networks)
   const { chainId } = curveProps(curve, networks) as { chainId: ChainId; haveSigner: boolean }
-  const isLite = networks[chainId].isLite ?? false
+  const isLite = networks[chainId]?.isLite ?? false
 
   const isLoadingApi = useStore((state) => state.isLoadingApi)
   const {

--- a/apps/main/src/components/PageDeployGauge/index.tsx
+++ b/apps/main/src/components/PageDeployGauge/index.tsx
@@ -26,7 +26,7 @@ type Props = {
 const DeployGauge = ({ curve }: Props) => {
   const networks = useStore((state) => state.networks.networks)
   const { chainId } = curveProps(curve, networks) as { chainId: ChainId; haveSigner: boolean }
-  const isLite = networks[chainId].isLite
+  const isLite = networks[chainId].isLite ?? false
 
   const isLoadingApi = useStore((state) => state.isLoadingApi)
   const {


### PR DESCRIPTION
Changes:
- Assume false for curve-lite checks in gauge deployment module
- Assumes false if networks store is not initialised