### PR TITLE
chore: redirect on app button click

### DIFF
--- a/packages/curve-common/src/widgets/Header/AppButtonLinks.tsx
+++ b/packages/curve-common/src/widgets/Header/AppButtonLinks.tsx
@@ -15,6 +15,7 @@ export const AppButtonLinks = ({ selectedApp, onChange }: AppNavAppsProps) => (
         className={selectedApp === appName ? 'current' : ''}
         component={Link}
         onClick={() => onChange(appName)}
+        href={APP_LINK[appName].root}
       >
         {APP_LINK[appName].label}
       </Button>


### PR DESCRIPTION
Users find it confusing to require to choose the sub-menu. Therefore we will return to the old behavior, for now.