### PR TITLE
chore: update curve-js

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -24,7 +24,7 @@
     "tsconfig": "*"
   },
   "dependencies": {
-    "@curvefi/api": "^2.65.13",
+    "@curvefi/api": "^2.65.16",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@lingui/react": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,16 +3328,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:^2.65.13":
-  version: 2.65.13
-  resolution: "@curvefi/api@npm:2.65.13"
+"@curvefi/api@npm:^2.65.16":
+  version: 2.65.16
+  resolution: "@curvefi/api@npm:2.65.16"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.7"
     axios: "npm:^0.21.1"
     bignumber.js: "npm:^9.0.1"
     ethers: "npm:^6.11.0"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/ff06c8d2541fb283822551ebe872f0be9ba5d0b261a4d0f403e4c63d386e39ea3becca9b9d129bc2d2f4e36841b9a86a8e70cef1cce9164ae54922a7d80ec829
+  checksum: 10c0/1917b28a556c1ea5e9107502ef8593fec3e9d299ba803a0594d628054840fac5d2e89c3bd49d38a74af1558e727570e7039f2587e8533f3570ec392087f8a481
   languageName: node
   linkType: hard
 
@@ -21227,7 +21227,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:^2.65.13"
+    "@curvefi/api": "npm:^2.65.16"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^3.9.0"
     "@lingui/cli": "npm:^4.6.0"


### PR DESCRIPTION
- Update CurveJS to [v2.65.16](https://github.com/curvefi/curve-js/releases/tag/v2.65.16) ([Changes](https://github.com/curvefi/curve-js/compare/v2.65.13...v2.65.16))