### PR TITLE
chore: upgrade curvefi/api to 2.65.17 on /main

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -24,7 +24,7 @@
     "tsconfig": "*"
   },
   "dependencies": {
-    "@curvefi/api": "^2.65.13",
+    "@curvefi/api": "^2.65.17",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@lingui/react": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,16 +3328,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:^2.65.13":
-  version: 2.65.13
-  resolution: "@curvefi/api@npm:2.65.13"
+"@curvefi/api@npm:^2.65.17":
+  version: 2.65.17
+  resolution: "@curvefi/api@npm:2.65.17"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.7"
     axios: "npm:^0.21.1"
     bignumber.js: "npm:^9.0.1"
     ethers: "npm:^6.11.0"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/ff06c8d2541fb283822551ebe872f0be9ba5d0b261a4d0f403e4c63d386e39ea3becca9b9d129bc2d2f4e36841b9a86a8e70cef1cce9164ae54922a7d80ec829
+  checksum: 10c0/18ab0576d99bd6a0418701d0990a6eacf7d8f04706a8c285bc964aeb15e2c22c7ce258f4f6c80261b134665f4282177b33c6d710c47a3be2035036094a959f84
   languageName: node
   linkType: hard
 
@@ -21227,7 +21227,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:^2.65.13"
+    "@curvefi/api": "npm:^2.65.17"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^3.9.0"
     "@lingui/cli": "npm:^4.6.0"


### PR DESCRIPTION
Changes:
- Upgrade curvefi/api to 2.65.17 on /main