### PR TITLE
task: enable showing CRV rewards on FTM

### DIFF
--- a/apps/main/src/lib/curvejs.ts
+++ b/apps/main/src/lib/curvejs.ts
@@ -36,7 +36,6 @@ import useStore from '@/store/useStore'
 const multichainNetworks: { [chainId: string]: boolean } = {
   43114: true,
   42220: true,
-  250: true,
 }
 
 const helpers = {


### PR DESCRIPTION
Changes:
- Remove FTM from list of networks disabled from showing CRV rewards (list set after multichain debacle)