### PR TITLE
Fix/proposal vote vote standings decimals

### DIFF
--- a/apps/dao/src/components/ProposalVoteStatusBox/index.tsx
+++ b/apps/dao/src/components/ProposalVoteStatusBox/index.tsx
@@ -29,7 +29,9 @@ const ProposalVoteStatusBox = ({ proposalData, className }: ProposalVoteStatusBo
             <HighlightedData>{t`Quorum`} </HighlightedData>
           </Box>
           <Box flex flexGap="var(--spacing-1)" flexAlignItems="flex-end">
-            <HighlightedData>{formatNumber(currentQuorumPercentage, { notation: 'compact' })}%</HighlightedData>{' '}
+            <HighlightedData>
+              {formatNumber(currentQuorumPercentage, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+            </HighlightedData>{' '}
             <Data>of {formatNumber(minAcceptQuorumPercent, { notation: 'compact' })}%</Data>
             <TooltipIcon>{t`The minimum share of For votes required to reach quorum is ${minAcceptQuorumPercent}% for this proposal.`}</TooltipIcon>
           </Box>
@@ -48,7 +50,9 @@ const ProposalVoteStatusBox = ({ proposalData, className }: ProposalVoteStatusBo
             <HighlightedData>{t`Min Support`}</HighlightedData>
           </Box>
           <Box flex flexGap="var(--spacing-1)" flexAlignItems="flex-end">
-            <HighlightedData>{formatNumber(support, { notation: 'compact' })}%</HighlightedData>
+            <HighlightedData>
+              {formatNumber(support, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+            </HighlightedData>
             <Data>{t`of ${minSupport}%`}</Data>
             <TooltipIcon>{t`The minimum support required to pass this proposal is ${minSupport}%.`}</TooltipIcon>
           </Box>
@@ -58,12 +62,16 @@ const ProposalVoteStatusBox = ({ proposalData, className }: ProposalVoteStatusBo
           <Box flex flexGap="var(--spacing-1)" flexAlignItems="flex-end">
             <HighlightedData className="for">{t`For`}</HighlightedData>{' '}
             <Tooltip noWrap tooltip={`${formatNumber(votesFor, { notation: 'compact' })} veCRV`}>
-              <HighlightedData>{formatNumber(support, { notation: 'compact' })}%</HighlightedData>
+              <HighlightedData>
+                {formatNumber(support, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+              </HighlightedData>
             </Tooltip>
           </Box>
           <Box flex flexGap="var(--spacing-1)" flexAlignItems="flex-end">
             <Tooltip noWrap tooltip={`${formatNumber(votesAgainst, { notation: 'compact' })} veCRV`}>
-              <HighlightedData>{formatNumber(against, { notation: 'compact' })}%</HighlightedData>
+              <HighlightedData>
+                {formatNumber(against, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+              </HighlightedData>
             </Tooltip>
             <HighlightedData className="against">{t`Against`}</HighlightedData>
           </Box>

--- a/apps/dao/src/store/createProposalsSlice.ts
+++ b/apps/dao/src/store/createProposalsSlice.ts
@@ -165,7 +165,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
 
       try {
         const proposal = await fetch(
-          `https://prices.curve.fi/v1/dao/proposals/details/${voteType.toLowerCase()}/${voteId}${!!txHash ? `?tx_hash=${txHash}` : ''}`,
+          `https://prices.curve.fi/v1/dao/proposals/details/${voteType.toLowerCase()}/${voteId}${txHash ? `?tx_hash=${txHash}` : ''}`,
         )
         const data: PricesProposalResponse = await proposal.json()
 
@@ -218,9 +218,9 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
 
       try {
         const request = await fetch(
-          `https://prices.curve.fi/v1/dao/proposals/vote/user/${userAddress}/${voteType.toLowerCase()}/${voteId}${!!txHash ? `?tx_hash=${txHash}` : ''}`,
+          `https://prices.curve.fi/v1/dao/proposals/vote/user/${userAddress}/${voteType.toLowerCase()}/${voteId}${txHash ? `?tx_hash=${txHash}` : ''}`,
         )
-        const data: PricesProposalResponse = await request.json()
+        const data: UserProposalVoteResData = await request.json()
 
         // the api returns a detail object if the proposal is not found
         if ('detail' in data) {
@@ -229,15 +229,16 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
         }
 
         const proposalData = get()[sliceKey].proposalMapper[`${voteId}-${voteType}`]
+
         const formattedData = {
-          votes_for: +data.votes_for / 1e18,
-          votes_against: +data.votes_against / 1e18,
+          votes_for: +data.proposal.votes_for / 1e18,
+          votes_against: +data.proposal.votes_against / 1e18,
           votes: data.votes
             .map((vote) => ({
               ...vote,
               topHolder: TOP_HOLDERS[vote.voter.toLowerCase()]?.title ?? null,
               stake: +vote.voting_power / 1e18,
-              relativePower: (+vote.voting_power / +data.total_supply) * 100,
+              relativePower: (+vote.voting_power / +data.proposal.total_supply) * 100,
             }))
             .sort((a, b) => b.stake - a.stake),
         }


### PR DESCRIPTION
Changes:
- Display minimum two decimals for for/against number when reporting current proposal standings to be more accurate with min support/quorum goals
- Fix proposal data refetch number formatting and apply correct type to fetch response