### PR TITLE
fix: unnecessary console warning

### DIFF
--- a/packages/curve-ui-kit/src/shared/routes.ts
+++ b/packages/curve-ui-kit/src/shared/routes.ts
@@ -85,7 +85,7 @@ function getAppRoot(productionHost: string, previewPrefix: string, developmentPo
       return `https://curve-${previewPrefix}-${branchPrefix}-curvefi.vercel.app`
     }
   }
-  if (windowHost && !windowHost?.endsWith(productionHost)) {
+  if (windowHost && !windowHost.endsWith('curve.fi')) {
     console.warn(`Unexpected host: ${windowHost}`)
   }
   return `https://${productionHost}`


### PR DESCRIPTION
The getAppRoot method gets called with every separate app, so the application host will not always match the window host. Currently, we are incorrectly logging a warning.