### PR TITLE
feat: add new metric widget

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -13,6 +13,7 @@ import { TypographyVariantKey, TYPOGRAPHY_VARIANTS } from 'curve-ui-kit/src/them
 import { abbreviateNumber, scaleSuffix } from 'curve-ui-kit/src/utils'
 
 const { Spacing } = SizesAndSpaces
+const COPY_ALERT_DURATION = 6000
 
 // Correspond to flexbox align items values.
 export const ALIGNMENTS = ['start', 'center', 'end'] as const
@@ -223,7 +224,7 @@ export const Metric = ({
         </Typography>
       )}
 
-      <Snackbar open={openCopyAlert} autoHideDuration={6000} onClose={() => setOpenCopyAlert(false)}>
+      <Snackbar open={openCopyAlert} autoHideDuration={COPY_ALERT_DURATION} onClose={() => setOpenCopyAlert(false)}>
         <Alert variant="filled" severity="success">
           Copied metric value: {value}
         </Alert>

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 
 import { SizesAndSpaces } from 'curve-ui-kit/src/themes/design/1_sizes_spaces'
@@ -143,28 +144,32 @@ export const Metric = ({
           }}
         />
       ) : (
-        <Box display="flex" alignItems="baseline" gap={Spacing.xxs}>
-          {unit?.position === 'prefix' && (
-            <Typography variant={MetricSize[size]} color="textSecondary">
-              {unit.symbol}
-            </Typography>
-          )}
+        <Box display="flex" gap={Spacing.xs} alignItems="baseline">
+          <Tooltip arrow title={value.toLocaleString()}>
+            <Box display="flex" gap={Spacing.xxs} alignItems="baseline">
+              {unit?.position === 'prefix' && (
+                <Typography variant={MetricSize[size]} color="textSecondary">
+                  {unit.symbol}
+                </Typography>
+              )}
 
-          <Typography variant={MetricSize[size]} color="textPrimary">
-            {formatter(abbreviate ? abbreviateNumber(value) : value)}
-          </Typography>
+              <Typography variant={MetricSize[size]} color="textPrimary">
+                {formatter(abbreviate ? abbreviateNumber(value) : value)}
+              </Typography>
 
-          {abbreviate && (
-            <Typography variant={MetricSize[size]} color="textPrimary" textTransform="capitalize">
-              {scaleSuffix(value)}
-            </Typography>
-          )}
+              {abbreviate && (
+                <Typography variant={MetricSize[size]} color="textPrimary" textTransform="capitalize">
+                  {scaleSuffix(value)}
+                </Typography>
+              )}
 
-          {unit?.position === 'suffix' && (
-            <Typography variant={MetricSize[size]} color="textSecondary">
-              {unit.symbol}
-            </Typography>
-          )}
+              {unit?.position === 'suffix' && (
+                <Typography variant={MetricSize[size]} color="textSecondary">
+                  {unit.symbol}
+                </Typography>
+              )}
+            </Box>
+          </Tooltip>
 
           {(change || change === 0) && (
             <Typography

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -151,7 +151,7 @@ export const Metric = ({
         {tooltip && (
           <Tooltip arrow placement="top" title={tooltip}>
             <span>
-              &nbsp;
+              {' '}
               <InfoOutlinedIcon sx={{ fontSize: '1.25em' }} />
             </span>
           </Tooltip>

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -149,7 +149,7 @@ export const Metric = ({
       <Typography variant="bodyXsRegular" color="textTertiary">
         {label}
         {tooltip && (
-          <Tooltip title={tooltip}>
+          <Tooltip arrow placement="top" title={tooltip}>
             <span>
               &nbsp;
               <InfoOutlinedIcon sx={{ fontSize: '1.25em' }} />
@@ -170,6 +170,7 @@ export const Metric = ({
         <Box display="flex" gap={Spacing.xs} alignItems="baseline">
           <Tooltip
             arrow
+            placement="bottom"
             title={value.toLocaleString()}
             onClick={copyValue}
             sx={{

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -6,6 +6,7 @@ import Skeleton from '@mui/material/Skeleton'
 import Snackbar from '@mui/material/Snackbar'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
 import { SizesAndSpaces } from 'curve-ui-kit/src/themes/design/1_sizes_spaces'
 import { TypographyVariantKey, TYPOGRAPHY_VARIANTS } from 'curve-ui-kit/src/themes/typography'
@@ -79,6 +80,8 @@ const formatChange = (value: number) => {
 type Props = {
   /** Label that goes above the value */
   label: string
+  /** Optional tooltip content shown next to the label */
+  tooltip?: string
 
   /** The actual metric value to display */
   value: number
@@ -108,6 +111,7 @@ type Props = {
 
 export const Metric = ({
   label,
+  tooltip,
 
   value,
   formatter = (value: number) => formatValue(value, decimals),
@@ -144,6 +148,14 @@ export const Metric = ({
     <Box display="flex" flexDirection="column" alignItems={alignment} gap={Spacing.xs}>
       <Typography variant="bodyXsRegular" color="textTertiary">
         {label}
+        {tooltip && (
+          <Tooltip title={tooltip}>
+            <span>
+              &nbsp;
+              <InfoOutlinedIcon sx={{ fontSize: '1.25em' }} />
+            </span>
+          </Tooltip>
+        )}
       </Typography>
 
       {loading ? (

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -48,20 +48,18 @@ const UNIT_MAP: Record<(typeof UNITS)[number], UnitOptions> = {
 } as const
 
 // Default value formatter.
-const formatValue = (value: number, decimals?: number): string => {
-  return value.toLocaleString(undefined, {
+const formatValue = (value: number, decimals?: number): string =>
+  value.toLocaleString(undefined, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   })
-}
 
 // Default notional value formatter.
-const formatNotionalValue = (value: number, decimals?: number): string => {
-  return value.toLocaleString(undefined, {
+const formatNotionalValue = (value: number, decimals?: number): string =>
+  value.toLocaleString(undefined, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   })
-}
 
 const formatChange = (value: number) => {
   // Looks aesthetically more pleasing without decimals.

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
+
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
+import Snackbar from '@mui/material/Snackbar'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 
@@ -129,6 +133,13 @@ export const Metric = ({
   notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit] : notionalUnit
   notionalAbbreviate ??= notionalUnit?.abbreviate ?? false
 
+  const [openCopyAlert, setOpenCopyAlert] = useState(false)
+
+  const copyValue = () => {
+    navigator.clipboard.writeText(value.toString())
+    setOpenCopyAlert(true)
+  }
+
   return (
     <Box display="flex" flexDirection="column" alignItems={alignment} gap={Spacing.xs}>
       <Typography variant="bodyXsRegular" color="textTertiary">
@@ -148,7 +159,7 @@ export const Metric = ({
           <Tooltip
             arrow
             title={value.toLocaleString()}
-            onClick={() => navigator.clipboard.writeText(value.toString())}
+            onClick={copyValue}
             sx={{
               cursor: 'pointer',
             }}
@@ -198,6 +209,12 @@ export const Metric = ({
           {notionalUnit?.position === 'suffix' && notionalUnit.symbol}
         </Typography>
       )}
+
+      <Snackbar open={openCopyAlert} autoHideDuration={6000} onClose={() => setOpenCopyAlert(false)}>
+        <Alert variant="filled" severity="success">
+          Copied metric value: {value}
+        </Alert>
+      </Snackbar>
     </Box>
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -122,10 +122,10 @@ export const Metric = ({
   alignment = 'start',
   loading = false,
 }: Props) => {
-  unit = typeof unit === 'string' ? UNIT_MAP[unit as keyof typeof UNIT_MAP] : unit
+  unit = typeof unit === 'string' ? UNIT_MAP[unit] : unit
   const valueAbbr = abbreviate ?? unit?.abbreviate ?? false
 
-  notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit as keyof typeof UNIT_MAP] : notionalUnit
+  notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit] : notionalUnit
   const notionalAbbr = notionalAbbreviate ?? notionalUnit?.abbreviate ?? false
 
   return (

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -1,0 +1,193 @@
+import Box from '@mui/material/Box'
+import Skeleton from '@mui/material/Skeleton'
+import Typography from '@mui/material/Typography'
+
+import { SizesAndSpaces } from 'curve-ui-kit/src/themes/design/1_sizes_spaces'
+import { TypographyVariantKey, TYPOGRAPHY_VARIANTS } from 'curve-ui-kit/src/themes/typography'
+import { abbr, suffix } from 'curve-ui-kit/src/utils'
+
+const { Spacing } = SizesAndSpaces
+
+// Correspond to flexbox align items values.
+export const ALIGNMENTS = ['start', 'center', 'end'] as const
+type Alignment = (typeof ALIGNMENTS)[number]
+
+const MetricSize = {
+  small: 'highlightM',
+  medium: 'highlightL',
+  large: 'highlightXl',
+  extraLarge: 'highlightXxl',
+} as const satisfies Record<string, TypographyVariantKey>
+
+export const SIZES = Object.keys(MetricSize) as (keyof typeof MetricSize)[]
+
+type UnitOptions = {
+  symbol: string
+  position: 'prefix' | 'suffix'
+  abbreviate: boolean
+}
+
+const dollar: UnitOptions = {
+  symbol: '$',
+  position: 'prefix',
+  abbreviate: true,
+}
+
+const percentage: UnitOptions = {
+  symbol: '%',
+  position: 'suffix',
+  abbreviate: false,
+}
+
+export const UNITS = ['dollar', 'percentage'] as const
+type Unit = (typeof UNITS)[number] | UnitOptions
+
+const UNIT_MAP: Record<(typeof UNITS)[number], UnitOptions> = {
+  dollar,
+  percentage,
+} as const
+
+// Default value formatter.
+const formatValue = (value: number, decimals?: number): string => {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  })
+}
+
+// Default notional value formatter.
+const formatNotionalValue = (value: number, decimals?: number): string => {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  })
+}
+
+const formatChange = (value: number) => {
+  // Looks aesthetically more pleasing without decimals.
+  if (value === 0) return '0'
+
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+type Props = {
+  /** Label that goes above the value */
+  label: string
+
+  /** The actual metric value to display */
+  value: number
+  /** Optional formatter for metric value */
+  formatter?: (value: number) => string
+  /** If the value should be abbreviated to 1.23k or 3.45m */
+  abbreviate?: boolean
+  /** The number of decimals the value should contain */
+  decimals?: number
+  /** A unit can be a currency symbol or percentage, prefix or suffix */
+  unit?: Unit
+
+  /** Optional value that denotes a change in metric value since 'last' time */
+  change?: number
+
+  /** Notional values give extra context to the metric, like underlying value */
+  notional?: number
+  notionalFormatter?: (value: number) => string
+  notionalAbbreviate?: boolean
+  notionalDecimals?: number
+  notionalUnit?: Unit
+
+  size?: keyof typeof MetricSize
+  alignment?: Alignment
+  loading?: boolean
+}
+
+export const Metric = ({
+  label,
+
+  value,
+  formatter = (value: number) => formatValue(value, decimals),
+  abbreviate,
+  unit,
+  decimals = 1,
+
+  change,
+
+  notional,
+  notionalFormatter = (value: number) => formatNotionalValue(value, notionalDecimals),
+  notionalAbbreviate,
+  notionalUnit,
+  notionalDecimals,
+
+  size = 'medium',
+  alignment = 'start',
+  loading = false,
+}: Props) => {
+  unit = typeof unit === 'string' ? UNIT_MAP[unit as keyof typeof UNIT_MAP] : unit
+  const valueAbbr = abbreviate ?? unit?.abbreviate ?? false
+
+  notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit as keyof typeof UNIT_MAP] : notionalUnit
+  const notionalAbbr = notionalAbbreviate ?? notionalUnit?.abbreviate ?? false
+
+  return (
+    <Box display="flex" flexDirection="column" alignItems={alignment} gap={Spacing.xs}>
+      <Typography variant="bodyXsRegular" color="textTertiary">
+        {label}
+      </Typography>
+
+      {loading ? (
+        <Skeleton
+          variant="text"
+          width="100%"
+          sx={{
+            fontSize: TYPOGRAPHY_VARIANTS[MetricSize[size]],
+          }}
+        />
+      ) : (
+        <Box display="flex" alignItems="baseline" gap={Spacing.xxs}>
+          {unit?.position === 'prefix' && (
+            <Typography variant={MetricSize[size]} color="textSecondary">
+              {unit.symbol}
+            </Typography>
+          )}
+
+          <Typography variant={MetricSize[size]} color="textPrimary">
+            {formatter(valueAbbr ? abbr(value) : value)}
+          </Typography>
+
+          {valueAbbr && (
+            <Typography variant={MetricSize[size]} color="textPrimary" textTransform="capitalize">
+              {suffix(value)}
+            </Typography>
+          )}
+
+          {unit?.position === 'suffix' && (
+            <Typography variant={MetricSize[size]} color="textSecondary">
+              {unit.symbol}
+            </Typography>
+          )}
+
+          {(change || change === 0) && (
+            <Typography
+              variant="highlightM"
+              color={change > 0 ? 'success' : change < 0 ? 'error' : 'textHighlight'}
+              sx={{ marginInlineStart: Spacing.xs }} // Not part of Figma, but my own addition
+            >
+              {formatChange(change)}%
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {notional !== undefined && (
+        <Typography variant="highlightXsNotional" color="textTertiary">
+          {notionalUnit?.position === 'prefix' && notionalUnit.symbol}
+          {notionalFormatter(notionalAbbr ? abbr(notional) : notional)}
+          {notionalAbbr && suffix(notional)}
+          {notionalUnit?.position === 'suffix' && notionalUnit.symbol}
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography'
 
 import { SizesAndSpaces } from 'curve-ui-kit/src/themes/design/1_sizes_spaces'
 import { TypographyVariantKey, TYPOGRAPHY_VARIANTS } from 'curve-ui-kit/src/themes/typography'
-import { abbr, suffix } from 'curve-ui-kit/src/utils'
+import { abbreviateNumber, scaleSuffix } from 'curve-ui-kit/src/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -151,12 +151,12 @@ export const Metric = ({
           )}
 
           <Typography variant={MetricSize[size]} color="textPrimary">
-            {formatter(abbreviate ? abbr(value) : value)}
+            {formatter(abbreviate ? abbreviateNumber(value) : value)}
           </Typography>
 
           {abbreviate && (
             <Typography variant={MetricSize[size]} color="textPrimary" textTransform="capitalize">
-              {suffix(value)}
+              {scaleSuffix(value)}
             </Typography>
           )}
 
@@ -181,8 +181,8 @@ export const Metric = ({
       {notional !== undefined && (
         <Typography variant="highlightXsNotional" color="textTertiary">
           {notionalUnit?.position === 'prefix' && notionalUnit.symbol}
-          {notionalFormatter(notionalAbbreviate ? abbr(notional) : notional)}
-          {notionalAbbreviate && suffix(notional)}
+          {notionalFormatter(notionalAbbreviate ? abbreviateNumber(notional) : notional)}
+          {notionalAbbreviate && scaleSuffix(notional)}
           {notionalUnit?.position === 'suffix' && notionalUnit.symbol}
         </Typography>
       )}

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -145,7 +145,14 @@ export const Metric = ({
         />
       ) : (
         <Box display="flex" gap={Spacing.xs} alignItems="baseline">
-          <Tooltip arrow title={value.toLocaleString()}>
+          <Tooltip
+            arrow
+            title={value.toLocaleString()}
+            onClick={() => navigator.clipboard.writeText(value.toString())}
+            sx={{
+              cursor: 'pointer',
+            }}
+          >
             <Box display="flex" gap={Spacing.xxs} alignItems="baseline">
               {unit?.position === 'prefix' && (
                 <Typography variant={MetricSize[size]} color="textSecondary">

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -123,10 +123,10 @@ export const Metric = ({
   loading = false,
 }: Props) => {
   unit = typeof unit === 'string' ? UNIT_MAP[unit] : unit
-  const valueAbbr = abbreviate ?? unit?.abbreviate ?? false
+  abbreviate ??= unit?.abbreviate ?? false
 
   notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit] : notionalUnit
-  const notionalAbbr = notionalAbbreviate ?? notionalUnit?.abbreviate ?? false
+  notionalAbbreviate ??= notionalUnit?.abbreviate ?? false
 
   return (
     <Box display="flex" flexDirection="column" alignItems={alignment} gap={Spacing.xs}>
@@ -151,10 +151,10 @@ export const Metric = ({
           )}
 
           <Typography variant={MetricSize[size]} color="textPrimary">
-            {formatter(valueAbbr ? abbr(value) : value)}
+            {formatter(abbreviate ? abbr(value) : value)}
           </Typography>
 
-          {valueAbbr && (
+          {abbreviate && (
             <Typography variant={MetricSize[size]} color="textPrimary" textTransform="capitalize">
               {suffix(value)}
             </Typography>
@@ -181,8 +181,8 @@ export const Metric = ({
       {notional !== undefined && (
         <Typography variant="highlightXsNotional" color="textTertiary">
           {notionalUnit?.position === 'prefix' && notionalUnit.symbol}
-          {notionalFormatter(notionalAbbr ? abbr(notional) : notional)}
-          {notionalAbbr && suffix(notional)}
+          {notionalFormatter(notionalAbbreviate ? abbr(notional) : notional)}
+          {notionalAbbreviate && suffix(notional)}
           {notionalUnit?.position === 'suffix' && notionalUnit.symbol}
         </Typography>
       )}

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -206,7 +206,7 @@ export const Metric = ({
             <Typography
               variant="highlightM"
               color={change > 0 ? 'success' : change < 0 ? 'error' : 'textHighlight'}
-              sx={{ marginInlineStart: Spacing.xs }} // Not part of Figma, but my own addition
+              sx={{ marginInlineStart: Spacing.xs }}
             >
               {formatChange(change)}%
             </Typography>

--- a/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
@@ -19,6 +19,10 @@ const meta: Meta<typeof Metric> = {
       control: 'text',
       description: 'The label on top of the value describing it',
     },
+    tooltip: {
+      control: 'text',
+      description: 'Optional tooltip shown next to the label',
+    },
     value: {
       control: 'number',
       description: 'The value of the component',
@@ -72,7 +76,7 @@ export const Default: Story = {
     docs: {
       description: {
         component: 'Metric',
-        story: 'Metric widget with all value properties in use',
+        story: 'Simple metric widget showing a dollar value with no special features',
       },
     },
   },
@@ -83,6 +87,12 @@ export const Percentage: Story = {
     value: 1337.42,
     decimals: 2,
     unit: 'percentage',
+  },
+}
+
+export const Tooltip: Story = {
+  args: {
+    tooltip: "Alu's future portfolio value",
   },
 }
 

--- a/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
@@ -1,0 +1,135 @@
+import { Metric, SIZES, ALIGNMENTS, UNITS } from '../Metric'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof Metric> = {
+  title: 'UI Kit/Widgets/Metric',
+  component: Metric,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: SIZES,
+      description: 'The size of the component',
+    },
+    alignment: {
+      control: 'select',
+      options: ALIGNMENTS,
+      description: 'The alignment of the component',
+    },
+    label: {
+      control: 'text',
+      description: 'The label on top of the value describing it',
+    },
+    value: {
+      control: 'number',
+      description: 'The value of the component',
+    },
+    decimals: {
+      control: 'number',
+      description: 'The number of decimals used in value rounding when using the default value formatter',
+    },
+    abbreviate: {
+      control: 'boolean',
+      description: 'Should the value be abbreviated together with a suffix? Does not work with a postfix unit.',
+    },
+    unit: {
+      control: 'select',
+      options: UNITS,
+      description: 'Optional unit like dollars or percentage to give context to the number',
+    },
+    change: {
+      control: 'number',
+      description: 'Optional value to denote a change in percentage since last time, whenever that may be',
+    },
+    notional: {
+      control: 'number',
+      description: 'Optional notional value that gives context or underlying value of the key metric',
+    },
+    notionalAbbreviate: {
+      control: 'boolean',
+    },
+    notionalDecimals: {
+      control: 'number',
+    },
+    notionalUnit: {
+      control: 'select',
+      options: UNITS,
+    },
+  },
+  args: {
+    size: 'medium',
+    alignment: 'start',
+    value: 26539422,
+    decimals: 1,
+    label: 'Metrics label',
+    unit: 'dollar',
+  },
+}
+
+type Story = StoryObj<typeof Metric>
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        component: 'Metric',
+        story: 'Metric widget with all value properties in use',
+      },
+    },
+  },
+}
+
+export const Percentage: Story = {
+  args: {
+    value: 1337.42,
+    decimals: 2,
+    unit: 'percentage',
+  },
+}
+
+export const LargeCenter: Story = {
+  args: {
+    size: 'large',
+    alignment: 'center',
+    change: -5,
+  },
+}
+
+export const ExtraLargeRight: Story = {
+  args: {
+    size: 'extraLarge',
+    alignment: 'end',
+    change: 5,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+}
+
+export const Notional: Story = {
+  args: {
+    notional: 50012345.345353,
+    notionalAbbreviate: true,
+    notionalDecimals: 2,
+    notionalUnit: {
+      symbol: ' ETH',
+      position: 'suffix',
+      abbreviate: true,
+    },
+  },
+}
+
+export const CustomUnit: Story = {
+  args: {
+    unit: {
+      symbol: '¥',
+      position: 'prefix',
+      abbreviate: true,
+    },
+    change: 0,
+  },
+}
+
+export default meta

--- a/packages/curve-ui-kit/src/utils/index.ts
+++ b/packages/curve-ui-kit/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './number'

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -1,0 +1,36 @@
+/**
+ * Returns the appropriate unit suffix for a given number value.
+ *
+ * @param value - The number to determine the unit for.
+ * @returns The unit suffix as a string ('t' for trillion, 'b' for billion, 'm' for million, 'k' for thousand, or '' for smaller values).
+ *
+ * @example
+ * unit(1500000000000) // Returns 't'
+ * unit(2000000000) // Returns 'b'
+ * unit(3000000) // Returns 'm'
+ * unit(4000) // Returns 'k'
+ * unit(500) // Returns ''
+ * unit(-1000000) // Returns 'm'
+ * unit(0) // Returns ''
+ */
+export function suffix(value: number): string {
+  const units = ['', 'k', 'm', 'b', 't']
+  const index = Math.max(0, Math.min(units.length - 1, Math.floor(Math.log10(Math.abs(value)) / 3)))
+
+  return units[index]
+}
+
+/**
+ * Abbreviates a number such that it can go along with a suffix like k, m, b or t.
+ *
+ * @example
+ * round(1234.5678) // Returns "1.23", goes with suffix "k"
+ * round(1000000) // Returns "1.0", goes with suffix "m"
+ */
+export function abbr(value: number): number {
+  const exp = Math.floor(Math.log10(Math.abs(value)) / 3) * 3
+  // Only apply the scaling if exp is positive
+  value /= exp > 0 ? 10 ** exp : 1
+
+  return value
+}

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -13,7 +13,7 @@
  * unit(-1000000) // Returns 'm'
  * unit(0) // Returns ''
  */
-export function suffix(value: number): string {
+export function scaleSuffix(value: number): string {
   const units = ['', 'k', 'm', 'b', 't']
   const index = Math.max(0, Math.min(units.length - 1, Math.floor(Math.log10(Math.abs(value)) / 3)))
 
@@ -27,7 +27,7 @@ export function suffix(value: number): string {
  * round(1234.5678) // Returns "1.23", goes with suffix "k"
  * round(1000000) // Returns "1.0", goes with suffix "m"
  */
-export function abbr(value: number): number {
+export function abbreviateNumber(value: number): number {
   const exp = Math.floor(Math.log10(Math.abs(value)) / 3) * 3
   // Only apply the scaling if exp is positive
   value /= exp > 0 ? 10 ** exp : 1

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -1,4 +1,23 @@
 /**
+ * Calculates the exponent (in base 10) divided by 3 for a given number.
+ * Used to determine the scale/magnitude of a number in terms of thousands.
+ * Corresponds to indices for an array of unit suffix like ['', 'k', 'm', 'b', 't'].
+ *
+ * @param value - The number to calculate the exponent for
+ * @returns The floor of log10(abs(value))/3
+ *
+ * @example
+ * log10Exp(1000) // Returns 1 (10^3 = 1000)
+ * log10Exp(1000000) // Returns 2 (10^6 = 1000000)
+ * log10Exp(1000000000) // Returns 3 (10^9 = 1000000000)
+ * log10Exp(123) // Returns 0 (less than 1000)
+ * log10Exp(-1000000) // Returns 2 (uses absolute value)
+ */
+export function log10Exp(value: number): number {
+  return Math.floor(Math.log10(Math.abs(value)) / 3)
+}
+
+/**
  * Returns the appropriate unit suffix for a given number value.
  *
  * @param value - The number to determine the unit for.
@@ -15,7 +34,7 @@
  */
 export function scaleSuffix(value: number): string {
   const units = ['', 'k', 'm', 'b', 't']
-  const index = Math.max(0, Math.min(units.length - 1, Math.floor(Math.log10(Math.abs(value)) / 3)))
+  const index = Math.max(0, Math.min(units.length - 1, log10Exp(value)))
 
   return units[index]
 }
@@ -28,7 +47,7 @@ export function scaleSuffix(value: number): string {
  * round(1000000) // Returns "1.0", goes with suffix "m"
  */
 export function abbreviateNumber(value: number): number {
-  const exp = Math.floor(Math.log10(Math.abs(value)) / 3) * 3
+  const exp = log10Exp(value) * 3
   // Only apply the scaling if exp is positive
   value /= exp > 0 ? 10 ** exp : 1
 


### PR DESCRIPTION
* New Metric widget as per Figma, to be used in for example the user profile. Started working on this as part of that feature, but spinned off into a new PR for earlier discussion & merging.
* I've decided not to implement the progress bar and icon yet as there's no need for them yet. I'd rather implement them when a specific use case arises.
* The `abbr` and `suffix` functions are number helper functions I've decided to use instead of `formatNumber`, because of the way we make them stand out in the UI with slightly different styling. I'd rather not dwell too much on the specifics; decimal number harmonization can become a tedious discussion.
* I couldn't decide between one prop for object vs multiple properties, like one `notionalConfig` prop vs multiple like `notionalAbbreviate` and `notionalDecimals`. I've chosen for a flat structure to make using the component easier as many are optional. The unit property however is an object property, as all of them are required when you want a custom unit.
* You can find many examples in the Storybook. There's no cypress tests as the new widget will not yet be used anywhere on the website.

![image](https://github.com/user-attachments/assets/fb9e11df-1777-49d5-b394-db0db7120d00)