### PR TITLE
fix: warning icon visibility

### DIFF
--- a/apps/loan/src/components/TokenLabel.tsx
+++ b/apps/loan/src/components/TokenLabel.tsx
@@ -55,7 +55,7 @@ const TokenLabel = ({
 }
 
 const Wrapper = styled(Box)<{ $minHeight?: number }>`
-  ${({ $minHeight }) => typeof $minHeight !== 'undefined' && `min-height: ${$minHeight}px;`};
+  ${({ $minHeight }) => typeof $minHeight !== 'undefined' && `min-height: ${$minHeight}px; gap: 0.25rem`};
 `
 
 const Label = styled.strong<Pick<Props, 'size'>>`

--- a/packages/ui/src/Tooltip/TooltipAlert.tsx
+++ b/packages/ui/src/Tooltip/TooltipAlert.tsx
@@ -1,31 +1,24 @@
+import WarningOutlinedIcon from '@mui/icons-material/WarningOutlined'
+
 import type { AlertType } from 'ui/src/AlertBox/types'
 import type { TooltipProps } from 'ui/src/Tooltip/types'
 
 import * as React from 'react'
-import Icon from 'ui/src/Icon'
 import IconTooltip from 'ui/src/Tooltip/TooltipIcon'
 
 const TooltipAlert = ({
   alertType,
+  isDeprecated,
   ...props
 }: React.PropsWithChildren<
   TooltipProps & {
     alertType: AlertType
+    isDeprecated?: boolean
   }
 >) => {
-  return (
-    <IconTooltip {...props} customIcon={<Icon name="WarningSquareFilled" size={24} fill={getColor(alertType)} />} />
-  )
-}
+  const color = isDeprecated ? 'error' : alertType === '' ? 'info' : alertType === 'danger' ? 'error' : alertType
 
-function getColor(alertType: AlertType) {
-  if (alertType === 'error' || alertType === 'danger') {
-    return `var(--danger-400)`
-  } else if (alertType === 'info') {
-    return `var(--info-400)`
-  } else if (alertType === 'warning') {
-    return `var(--warning-400)`
-  }
+  return <IconTooltip {...props} customIcon={<WarningOutlinedIcon color={color} />} />
 }
 
 export default TooltipAlert

--- a/packages/ui/src/Tooltip/TooltipButton.tsx
+++ b/packages/ui/src/Tooltip/TooltipButton.tsx
@@ -82,6 +82,7 @@ function TooltipButton({
 
 const StyledTooltipButton = styled.span`
   position: relative;
+  display: flex;
 `
 
 const Button = styled.span`


### PR DESCRIPTION
@0xtutti I've been struggling with making it visible with the yellow primary color, so I've settled with the red from error. This way it's way more in all themes compared to the warning's yellow. I've tried to find a different icon or add a black outline/stroke but wasn't able to find one that looks good.

@DanielSchiavini I've added a hardcoded gap of 0.125 to make it look nicer; I can't be arsed making it responsive with the mui theme given that this will prob get redesigned in the future anyway. In fact, the whole TooltipAlert probably gets replaced some time in the future. Consider this PR a quick fix until we get there.

https://mui.com/material-ui/material-icons/?query=warning

![image](https://github.com/user-attachments/assets/91af78df-a79b-47c7-87dc-7685d2fffe6f)
