### PR TITLE
feat: new function that considers number precision

### DIFF
--- a/apps/lend/src/hooks/useVaultShares.ts
+++ b/apps/lend/src/hooks/useVaultShares.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import useStore from '@/store/useStore'
 
-import { FORMAT_OPTIONS, formatNumber } from '@/ui/utils'
+import { FORMAT_OPTIONS, formatNumber, formatNumberWithPrecision } from '@/ui/utils'
 import { useTokenUsdRate } from '@/entities/token'
 import { useOneWayMarket } from '@/entities/chain'
 
@@ -24,7 +24,7 @@ function useVaultShares(rChainId: ChainId, rOwmId: string, vaultShares: string |
       const borrowedAmtUsd = +pricePerShare * +vaultShares * +usdRate
 
       return {
-        borrowedAmount: `${formatNumber(borrowedAmt, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${symbol}`,
+        borrowedAmount: `${formatNumberWithPrecision(borrowedAmt, 6)} ${symbol}`,
         borrowedAmountUsd: formatNumber(borrowedAmtUsd, FORMAT_OPTIONS.USD),
       }
     }

--- a/packages/ui/src/utils/utilsFormat.ts
+++ b/packages/ui/src/utils/utilsFormat.ts
@@ -173,6 +173,17 @@ export function formatNumberUsdRate(usdRate: number | string | undefined, hideCu
   return parsedUsdRate
 }
 
+/**
+ * Format number with the given precision digits, without rounding the whole part of the number.
+ * @param value number to format
+ * @param precisionDigits number of decimal digits to show. This will be the maximum number of decimal digits.
+ */
+export function formatNumberWithPrecision(value: number, precisionDigits: number) {
+  const valueDigits = Math.max(0, Math.floor(Math.log10(value)))
+  const fractionDigits = precisionDigits - Math.min(precisionDigits, valueDigits)
+  return formatNumber(value, { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits })
+}
+
 export const formatDateFromTimestamp = (unixTime: number) => {
   const date = new Date(unixTime * 1000)
   const day = String(date.getDate()).padStart(2, '0')

--- a/packages/ui/src/utils/utilsFormat.ts
+++ b/packages/ui/src/utils/utilsFormat.ts
@@ -181,7 +181,8 @@ export function formatNumberUsdRate(usdRate: number | string | undefined, hideCu
 export function formatNumberWithPrecision(value: number, precisionDigits: number) {
   const valueDigits = Math.max(0, Math.floor(Math.log10(value)))
   const fractionDigits = precisionDigits - Math.min(precisionDigits, valueDigits)
-  return formatNumber(value, { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits })
+  const opts = { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }
+  return _formatNumber(value, opts)
 }
 
 export const formatDateFromTimestamp = (unixTime: number) => {
@@ -192,8 +193,4 @@ export const formatDateFromTimestamp = (unixTime: number) => {
   return `${day}/${month}/${year}`
 }
 
-export const convertToLocaleTimestamp = (unixTime: number) => {
-  const offsetInSeconds = new Date().getTimezoneOffset() * 60
-  const localTimestamp = unixTime - offsetInSeconds
-  return localTimestamp
-}
+export const convertToLocaleTimestamp = (unixTime: number) => unixTime - new Date().getTimezoneOffset() * 60


### PR DESCRIPTION
![Screenshot from 2024-12-13 16-33-10](https://github.com/user-attachments/assets/f3a58a0c-f3e5-4671-bb22-4bee936a2a93)

Some other examples:
```
formatNumberWithPrecision(123456789123456780, 6) == 123,456,789,123,456,780
formatNumberWithPrecision(12345678912345678, 6) == 12,345,678,912,345,678
formatNumberWithPrecision(1234567891234567.8, 6) == 1,234,567,891,234,568
formatNumberWithPrecision(123456789123456.78, 6) == 123,456,789,123,457
formatNumberWithPrecision(12345678912345.678, 6) == 12,345,678,912,346
formatNumberWithPrecision(1234567891234.5679, 6) == 1,234,567,891,235
formatNumberWithPrecision(123456789123.45679, 6) == 123,456,789,123
formatNumberWithPrecision(12345678912.345678, 6) == 12,345,678,912
formatNumberWithPrecision(1234567891.2345679, 6) == 1,234,567,891
formatNumberWithPrecision(123456789.12345679, 6) == 123,456,789
formatNumberWithPrecision(12345678.91234568, 6) == 12,345,679
formatNumberWithPrecision(1234567.8912345679, 6) == 1,234,568
formatNumberWithPrecision(123456.78912345678, 6) == 123,456.8
formatNumberWithPrecision(12345.678912345678, 6) == 12,345.68
formatNumberWithPrecision(1234.567891234568, 6) == 1,234.568
formatNumberWithPrecision(123.45678912345679, 6) == 123.4568
formatNumberWithPrecision(12.34567891234568, 6) == 12.34568
formatNumberWithPrecision(1.234567891234568, 6) == 1.234568
formatNumberWithPrecision(0.12345678912345678, 6) == 0.123457
formatNumberWithPrecision(0.012345678912345679, 6) == 0.012346
formatNumberWithPrecision(0.001234567891234568, 6) == 0.001235
formatNumberWithPrecision(0.0001234567891234568, 6) == 0.000123
formatNumberWithPrecision(0.00001234567891234568, 6) == 0.000012
formatNumberWithPrecision(0.000001234567891234568, 6) == 0.000001
formatNumberWithPrecision(1.2345678912345682e-7, 6) == 0.000000
formatNumberWithPrecision(1.2345678912345683e-8, 6) == 0.000000
```