### PR TITLE
update footer links

### DIFF
--- a/packages/curve-ui-kit/src/widgets/Footer/Sections.tsx
+++ b/packages/curve-ui-kit/src/widgets/Footer/Sections.tsx
@@ -96,12 +96,12 @@ export const getSections = (): SectionProps[] => [
     links: [
       {
         label: t`Audits`,
-        href: 'https://docs.curve.fi/references/audits/',
+        href: 'https://docs.curve.fi/security/security/#security-audits',
         icon: <BeenhereOutlinedIcon />,
       },
       {
         label: t`Bug Bounty`,
-        href: 'https://docs.curve.fi/security/security/',
+        href: 'https://docs.curve.fi/security/security/#bug-bounty',
         icon: <BugReportOutlinedIcon />,
       },
       {


### PR DESCRIPTION
Updated footer links for improved accuracy. I hope it’s fine to update the links only in [packages/curve-ui-kit/src/widgets/Footer/Sections.tsx](https://github.com/curvefi/curve-frontend/blob/2ddb290f87cea7f22fada6c63870dedc39ddbbd3/packages/curve-ui-kit/src/widgets/Footer/Sections.tsx#L84) and not in all apps.