### PR TITLE
chore: add husky pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ yarn-error.log*
 .cursorignore
 
 # husky
-.husky
+.husky/_
 
 # lingui compiled translation files
 src/locales/_build/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. "$(dirname "$0")/_/husky.sh"
+npx lint-staged
+git add .


### PR DESCRIPTION
- run lint in the staged files before committing
- this should result in less prettier errors in github