### PR TITLE
chore: enable tanstack devtools when running locally

### DIFF
--- a/packages/ui/src/QueryProvider/index.tsx
+++ b/packages/ui/src/QueryProvider/index.tsx
@@ -1,6 +1,7 @@
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { type Persister, PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
-import React, { ReactNode } from 'react'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { ReactNode } from 'react'
 
 type QueryProviderWrapperProps = {
   children: ReactNode
@@ -9,7 +10,16 @@ type QueryProviderWrapperProps = {
 }
 
 export function QueryProvider({ children, persister, queryClient }: QueryProviderWrapperProps) {
-  // children = (<>{children}<ReactQueryDevtools buttonPosition="bottom-left" /></>)
+  // Cypress runs in dev mode which means the devtools button is visible, which may break tests.
+  const isCypress = typeof window !== 'undefined' && (window as any).Cypress
+
+  children = (
+    <>
+      {children}
+      {!isCypress && <ReactQueryDevtools />}
+    </>
+  )
+
   if (persister) {
     return (
       <PersistQueryClientProvider client={queryClient} persistOptions={{ persister }}>
@@ -17,5 +27,6 @@ export function QueryProvider({ children, persister, queryClient }: QueryProvide
       </PersistQueryClientProvider>
     )
   }
+
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 }

--- a/packages/ui/src/QueryProvider/index.tsx
+++ b/packages/ui/src/QueryProvider/index.tsx
@@ -9,10 +9,10 @@ type QueryProviderWrapperProps = {
   queryClient: QueryClient
 }
 
-export function QueryProvider({ children, persister, queryClient }: QueryProviderWrapperProps) {
-  // Cypress runs in dev mode which means the devtools button is visible, which may break tests.
-  const isCypress = typeof window !== 'undefined' && (window as any).Cypress
+// Cypress runs in dev mode which means the devtools button is visible, which may break tests.
+const isCypress = typeof window !== 'undefined' && (window as any).Cypress
 
+export function QueryProvider({ children, persister, queryClient }: QueryProviderWrapperProps) {
   children = (
     <>
       {children}


### PR DESCRIPTION
I think we can enable TanStack Devtools again; not sure why it was disabled in the first place in fd3f719333b6d405defefaccbe6b0bf3852eb01e as I find it very helpful, and in production builds it gets completely excluded by default (it only gets included if `process.env.NODE_ENV === 'development'`)

Because Cypress tests run with development mode enabled, I've added an extra check to not use the devtools in case Cypress is running. This is because the devtool button's positioning may break some tests. It's not really a big deal as in production the devtools get omitted anyway.