### PR TITLE
fix: crash in lend when switching networks

### DIFF
--- a/apps/lend/src/entities/chain/chain-hooks.ts
+++ b/apps/lend/src/entities/chain/chain-hooks.ts
@@ -10,16 +10,17 @@ export const useOneWayMarketMapping = (params: ChainParams<ChainId>) => {
   const { data: marketNames, ...rest } = useOneWayMarketNames(params)
   const api = useStore((state) => state.api)
   const isLoadingApi = useStore((state) => state.isLoadingApi)
+  const apiChainId = api?.chainId
   const data: Record<string, OneWayMarketTemplate> | undefined = useMemo(
     () =>
-      marketNames && chainId && api && !isLoadingApi
+      marketNames && api && chainId == apiChainId && !isLoadingApi
         ? Object.fromEntries(
             marketNames
-              .filter((marketName) => !networks[chainId].hideMarketsInUI[marketName])
+              .filter((marketName) => !networks[chainId!].hideMarketsInUI[marketName])
               .map((name) => [name, api.getOneWayMarket(name)]),
           )
         : undefined,
-    [api, chainId, marketNames, isLoadingApi],
+    [api, apiChainId, chainId, marketNames, isLoadingApi],
   )
   return { data, ...rest }
 }


### PR DESCRIPTION
a mismatch between the UI chain and the one in the lending lib caused the library to crash