### PR TITLE
fix: broken typography variant typing

### DIFF
--- a/packages/curve-ui-kit/src/themes/typography/override-typography.d.ts
+++ b/packages/curve-ui-kit/src/themes/typography/override-typography.d.ts
@@ -1,22 +1,14 @@
-declare module 'global' {
-  type TypographyConfig = import('./create-typography')
-  type TypographyVariantKey = TypographyConfig['TypographyVariantKey']
+import type { CSSProperties } from 'react'
+import type { TypographyVariantKey, DisabledTypographyVariantKey } from './create-typography'
 
-  type NewTypographyVariants<T> = { [key in TypographyVariantKey]: T }
-  type DisabledTypographyVariants = { [key in TypographyConfig['DisabledTypographyVariantKey']]: false }
+type NewTypographyVariants<T> = { [key in TypographyVariantKey]: T }
+type DisabledTypographyVariants = { [key in DisabledTypographyVariantKey[number]]: false }
 
-  // type TypographyVariants = {[key in TypographyVariantKey]: CSSProperties}
+declare module '@mui/material/styles' {
+  interface TypographyVariants extends NewTypographyVariants<React.CSSProperties> {}
+  interface TypographyVariantsOptions extends Partial<NewTypographyVariants<React.CSSProperties>> {}
+}
 
-  module '@mui/material/styles' {
-    interface TypographyVariants extends NewTypographyVariants<React.CSSProperties> {}
-    interface TypographyVariantsOptions extends Partial<NewTypographyVariants<React.CSSProperties>> {}
-  }
-
-  module '@mui/material/Typography' {
-    interface TypographyPropsVariantOverrides extends NewTypographyVariants<true>, DisabledTypographyVariants {}
-  }
-
-  // module '@mui/system' {
-  //   interface Typography extends TypographyVariants {}
-  // }
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides extends NewTypographyVariants<true>, DisabledTypographyVariants {}
 }

--- a/packages/curve-ui-kit/src/themes/typography/override-typography.d.ts
+++ b/packages/curve-ui-kit/src/themes/typography/override-typography.d.ts
@@ -5,8 +5,8 @@ type NewTypographyVariants<T> = { [key in TypographyVariantKey]: T }
 type DisabledTypographyVariants = { [key in DisabledTypographyVariantKey[number]]: false }
 
 declare module '@mui/material/styles' {
-  interface TypographyVariants extends NewTypographyVariants<React.CSSProperties> {}
-  interface TypographyVariantsOptions extends Partial<NewTypographyVariants<React.CSSProperties>> {}
+  interface TypographyVariants extends NewTypographyVariants<CSSProperties> {}
+  interface TypographyVariantsOptions extends Partial<NewTypographyVariants<CSSProperties>> {}
 }
 
 declare module '@mui/material/Typography' {


### PR DESCRIPTION
I've managed to fix the typing for typography variants. However, I've not been able to fix the typing for typography colors, I think it needs a different approach given that the colors can be used for much more than just colors.