### PR TITLE
fix: convert on chain response to number from bigint before calc

### DIFF
--- a/apps/loan/src/store/createScrvUsdSlice.ts
+++ b/apps/loan/src/store/createScrvUsdSlice.ts
@@ -188,11 +188,15 @@ async function _fetchSavingsYield(provider?: Provider | null): Promise<PricesYie
       vault.totalSupply(),
       provider.getBlock('latest'),
     ])
+
+    const unlockAmountNum = Number(unlock_amount)
+    const supplyNum = Number(supply)
+
     return {
       last_updated: new Date(block?.timestamp ?? 0).toISOString(),
       last_updated_block: block?.number ?? 0,
-      proj_apr: supply > 0 ? (unlock_amount * 1e-12 * YEAR) / supply : 0,
-      supply: supply / 1e18,
+      proj_apr: supplyNum > 0 ? (unlockAmountNum * 1e-12 * YEAR) / supplyNum : 0,
+      supply: supplyNum / 1e18,
     }
   }
 


### PR DESCRIPTION
Changes:
- Convert unlock_amount and supply to Number (from BigInt) before calculating projected apr