### PR TITLE
fix: sort proposals on start date instead of voteId

### DIFF
--- a/apps/dao/src/store/createProposalsSlice.ts
+++ b/apps/dao/src/store/createProposalsSlice.ts
@@ -590,7 +590,7 @@ const sortProposals = (
     const activeProposals = proposals.filter((proposal) => proposal.startDate + SEVEN_DAYS > currentTimestamp)
     const passedProposals = orderBy(
       proposals.filter((proposal) => proposal.startDate + SEVEN_DAYS < currentTimestamp),
-      ['voteId'],
+      ['startDate'],
       ['desc'],
     )
 


### PR DESCRIPTION
Changes:
- Sort proposals on 'startDate' rather then 'voteId' to ensure parameter and ownership votes appear in correct order