### PR TITLE
chore: upgrade curve-js to 2.65.25 on /dao

### DIFF
--- a/apps/dao/package.json
+++ b/apps/dao/package.json
@@ -26,7 +26,7 @@
     "typescript": "*"
   },
   "dependencies": {
-    "@curvefi/api": "^2.65.23",
+    "@curvefi/api": "^2.65.25",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@lingui/react": "^4.6.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -26,7 +26,7 @@
     "typescript": "*"
   },
   "dependencies": {
-    "@curvefi/api": "^2.65.23",
+    "@curvefi/api": "^2.65.25",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^3.9.0",
     "@lingui/react": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,19 +3328,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:^2.65.23":
-  version: 2.65.23
-  resolution: "@curvefi/api@npm:2.65.23"
-  dependencies:
-    "@curvefi/ethcall": "npm:6.0.7"
-    axios: "npm:^0.21.1"
-    bignumber.js: "npm:^9.0.1"
-    ethers: "npm:^6.11.0"
-    memoizee: "npm:^0.4.15"
-  checksum: 10c0/71191c76bfd79cc9095335df3e430d54b1d9160fd5f53444c0baa836e77e8dedafbaada33a6a3f7095778947b896ccbbe616951f4daa7b969db7c8eeef89693a
-  languageName: node
-  linkType: hard
-
 "@curvefi/api@npm:^2.65.25":
   version: 2.65.25
   resolution: "@curvefi/api@npm:2.65.25"
@@ -21414,7 +21401,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:^2.65.23"
+    "@curvefi/api": "npm:^2.65.25"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^3.9.0"
     "@lingui/cli": "npm:^4.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@curvefi/api@npm:^2.65.25":
+  version: 2.65.25
+  resolution: "@curvefi/api@npm:2.65.25"
+  dependencies:
+    "@curvefi/ethcall": "npm:6.0.7"
+    axios: "npm:^0.21.1"
+    bignumber.js: "npm:^9.0.1"
+    ethers: "npm:^6.11.0"
+    memoizee: "npm:^0.4.15"
+  checksum: 10c0/457b62ed1a8a1ac8f910cf4be070b7a4a17ebc6992b4a1594dbc24c517d027c6f59f640ca73be89a75976e975be88db4b86175122200ebd2306a4ea8524457a7
+  languageName: node
+  linkType: hard
+
 "@curvefi/ethcall@npm:6.0.7":
   version: 6.0.7
   resolution: "@curvefi/ethcall@npm:6.0.7"
@@ -15355,7 +15368,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dao@workspace:apps/dao"
   dependencies:
-    "@curvefi/api": "npm:^2.65.23"
+    "@curvefi/api": "npm:^2.65.25"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^3.9.0"
     "@lingui/cli": "npm:^4.6.0"


### PR DESCRIPTION
Changes:
- Upgraded curve-js to 2.65.25 on /dao
- Upgraded curve-js to 2.65.25 on /main