### PR TITLE
feat: new color of the table header in chad

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable.tsx
@@ -147,7 +147,7 @@ export const DataTable = <T extends unknown>({
           zIndex: t.zIndex.appBar - 1,
           position: 'sticky',
           top: headerHeight,
-          backgroundColor: t.design.Table.Header_Fill,
+          backgroundColor: t.design.Table.Header.Fill,
         })}
         data-testid="data-table-head"
       >

--- a/packages/curve-ui-kit/src/themes/design/1_surfaces_text.ts
+++ b/packages/curve-ui-kit/src/themes/design/1_surfaces_text.ts
@@ -30,7 +30,7 @@ export const SurfacesAndText = {
         },
       },
       Tables: {
-        Header_Fill: Grays[200],
+        Header: { Fill: Grays[200] },
       },
     },
     Dark: {
@@ -61,7 +61,7 @@ export const SurfacesAndText = {
         },
       },
       Tables: {
-        Header_Fill: Grays[800],
+        Header: { Fill: Grays[800] },
       },
     },
     Chad: {
@@ -73,7 +73,7 @@ export const SurfacesAndText = {
         highlight: Violet[600],
       },
       Tables: {
-        Header_Fill: Violet[400],
+        Header: { Fill: Violet[50] },
       },
       Layer: {
         '1': {
@@ -125,7 +125,7 @@ export const SurfacesAndText = {
         },
       },
       Tables: {
-        Header_Fill: Grays[800],
+        Header: { Fill: Grays[800] },
       },
     },
     Dark: {
@@ -156,7 +156,7 @@ export const SurfacesAndText = {
         },
       },
       Tables: {
-        Header_Fill: Grays[200],
+        Header: { Fill: Grays[200] },
       },
     },
     Chad: {
@@ -168,7 +168,7 @@ export const SurfacesAndText = {
         highlight: Violet[400],
       },
       Tables: {
-        Header_Fill: Violet[800],
+        Header: { Fill: Violet[800] },
       },
       Layer: {
         '1': {

--- a/packages/curve-ui-kit/src/themes/design/2_theme.ts
+++ b/packages/curve-ui-kit/src/themes/design/2_theme.ts
@@ -231,7 +231,7 @@ export const createLightDesign = (Light: typeof plain.Light | typeof inverted.Li
       },
     },
     Table: {
-      Header_Fill: Light.Tables.Header_Fill,
+      Header: { Fill: Light.Tables.Header.Fill },
     },
     Inputs: {
       Base: {
@@ -557,7 +557,7 @@ export const createDarkDesign = (Dark: typeof plain.Dark | typeof inverted.Dark)
       },
     },
     Table: {
-      Header_Fill: Dark.Tables.Header_Fill,
+      Header: { Fill: Dark.Tables.Header.Fill },
     },
     Inputs: {
       Base: {
@@ -828,7 +828,7 @@ export const createChadDesign = (Chad: typeof plain.Chad | typeof inverted.Chad)
       },
     },
     Table: {
-      Header_Fill: Chad.Tables.Header_Fill,
+      Header: { Fill: Chad.Tables.Header.Fill },
     },
     Inputs: {
       Base: {


### PR DESCRIPTION
The table header did not have enough contrast in chad mode. This was fixed in the design system:
![image](https://github.com/user-attachments/assets/c7ca893f-4e20-46a7-af23-5a85f63a6d39)

Before: 
![image](https://github.com/user-attachments/assets/fdc06910-367a-42f1-bd0b-6b2de3fbcf76)

After:
![image](https://github.com/user-attachments/assets/77e80e97-1f66-490a-b640-99cdd3dace53)
