### PR TITLE
fix: set correct swapToSymbol in lend borrow more

### DIFF
--- a/apps/lend/src/components/PageLoanManage/LoanBorrowMore/components/DetailInfoLeverage.tsx
+++ b/apps/lend/src/components/PageLoanManage/LoanBorrowMore/components/DetailInfoLeverage.tsx
@@ -98,7 +98,7 @@ const DetailInfoLeverage = ({
         <DetailInfoLeverageExpected
           loading={expectedLoading}
           total={expectedCollateral?.totalCollateral}
-          swapToSymbol={borrowed_token?.symbol}
+          swapToSymbol={collateral_token?.symbol}
         />
       )}
 


### PR DESCRIPTION
The wrong "expected" token symbol was being set when not in 'advanced' mode.

<img width="508" alt="SCR-20250116-qxse" src="https://github.com/user-attachments/assets/ccb61b96-a7bd-4c2c-b440-d887ea6cf1ee" />
