### PR TITLE
fix: slippage not being set in advanced settings

### DIFF
--- a/apps/main/src/components/PageRouterSwap/Page.tsx
+++ b/apps/main/src/components/PageRouterSwap/Page.tsx
@@ -125,7 +125,7 @@ const Page: NextPage = () => {
           <BoxHeader className="title-text">
             <IconButton testId="hidden" hidden />
             {t`Swap`}
-            <AdvancedSettings stateKey="router" testId="advance-settings" maxSlippage={maxSlippage} />
+            <AdvancedSettings stateKey="global" testId="advance-settings" maxSlippage={maxSlippage} />
           </BoxHeader>
 
           <Box grid gridRowGap={3} padding>

--- a/apps/main/src/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/components/PageRouterSwap/index.tsx
@@ -512,7 +512,7 @@ const QuickSwap = ({
         <DetailInfoSlippageTolerance
           maxSlippage={globalMaxSlippage || routesAndOutput?.maxSlippage}
           testId="slippage-tolerance"
-          stateKey="router"
+          stateKey="global"
         />
       </div>
 

--- a/packages/curve-ui-kit/src/features/user-profile/store.ts
+++ b/packages/curve-ui-kit/src/features/user-profile/store.ts
@@ -21,11 +21,11 @@ type Action = {
   /**
    * Sets or removes a max slippage value for a given key.
    * @param slippage - The slippage value as a string percentage (e.g. "0.1" for 0.1%), or null to remove
-   * @param key - Optional key to set slippage for (e.g. "router" or chainId-poolId). If omitted, sets slippage to all existing keys.
+   * @param key - Optional key to set slippage for (e.g. "global" or chainId-poolId). If omitted, sets slippage to all existing keys.
    * @returns boolean - True if slippage was successfully set/removed, false if invalid input
    * @example
    * // Set router slippage to 0.1%
-   * setMaxSlippage("0.1", "router")
+   * setMaxSlippage("0.1", "global")
    *
    * // Remove slippage for specific pool
    * setMaxSlippage(null, "1-0x123...")


### PR DESCRIPTION
Advanced settings modal was incorrectly using the old "router" localstorage key to save slippage settings, while the rest of the front-end was relying on the more appropriately named "global" key.