### PR TITLE
refactor: remove unused theme variables

### DIFF
--- a/packages/curve-ui-kit/src/themes/design/2_theme.ts
+++ b/packages/curve-ui-kit/src/themes/design/2_theme.ts
@@ -1,4 +1,4 @@
-import { Blues, Grays, Greens, Reds, Violet, TransitionFunction } from './0_primitives'
+import { Blues, Grays, Greens, Reds, TransitionFunction, Violet } from './0_primitives'
 import { SurfacesAndText } from './1_surfaces_text'
 
 const { plain, inverted } = SurfacesAndText
@@ -148,13 +148,6 @@ export const createLightDesign = (Light: typeof plain.Light | typeof inverted.Li
     },
   } as const
 
-  const Feedback = {
-    Success: Greens[300],
-    Info: Layer[3].Fill,
-    Warning: Reds[400],
-    Error: Reds[500],
-  } as const
-
   const Tabs = {
     Transition,
     UnderLined: {
@@ -246,7 +239,7 @@ export const createLightDesign = (Light: typeof plain.Light | typeof inverted.Li
           Default: Grays[400],
           Active: Light.Text.highlight,
           Filled: Grays[850],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
       Nested: {
@@ -256,7 +249,7 @@ export const createLightDesign = (Light: typeof plain.Light | typeof inverted.Li
           Default: Grays[400],
           Active: Light.Text.highlight,
           Filled: Grays[850],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
     },
@@ -285,7 +278,6 @@ export const createLightDesign = (Light: typeof plain.Light | typeof inverted.Li
     Color,
     Text,
     Button,
-    Feedback,
     Layer,
     Tabs,
     Chips,
@@ -493,13 +485,6 @@ export const createDarkDesign = (Dark: typeof plain.Dark | typeof inverted.Dark)
     },
   } as const
 
-  const Feedback = {
-    Success: Greens[400],
-    Info: Layer[3].Fill,
-    Warning: Reds[300],
-    Error: Reds[500],
-  } as const
-
   const Tabs = {
     Transition,
     UnderLined: {
@@ -589,7 +574,7 @@ export const createDarkDesign = (Dark: typeof plain.Dark | typeof inverted.Dark)
           Default: color[600],
           Active: Dark.Text.highlight,
           Filled: color[75],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
       Nested: {
@@ -599,7 +584,7 @@ export const createDarkDesign = (Dark: typeof plain.Dark | typeof inverted.Dark)
           Default: color[600],
           Active: Dark.Text.highlight,
           Filled: color[75],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
     },
@@ -628,7 +613,6 @@ export const createDarkDesign = (Dark: typeof plain.Dark | typeof inverted.Dark)
     Color,
     Text,
     Button,
-    Feedback,
     Layer,
     Tabs,
     Chips,
@@ -779,13 +763,6 @@ export const createChadDesign = (Chad: typeof plain.Chad | typeof inverted.Chad)
     },
   } as const
 
-  const Feedback = {
-    Success: Greens[400],
-    Info: Layer[3].Fill,
-    Warning: Reds[400],
-    Error: Reds[500],
-  } as const
-
   const Tabs = {
     Transition,
     UnderLined: {
@@ -877,7 +854,7 @@ export const createChadDesign = (Chad: typeof plain.Chad | typeof inverted.Chad)
           Default: Violet[200],
           Active: Chad.Text.highlight,
           Filled: Violet[400],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
       Nested: {
@@ -887,7 +864,7 @@ export const createChadDesign = (Chad: typeof plain.Chad | typeof inverted.Chad)
           Default: Violet[200],
           Active: Chad.Text.highlight,
           Filled: Violet[400],
-          Error: Feedback.Error,
+          Error: Reds[500],
         },
       },
     },
@@ -916,7 +893,6 @@ export const createChadDesign = (Chad: typeof plain.Chad | typeof inverted.Chad)
     Color,
     Text,
     Button,
-    Feedback,
     Layer,
     Tabs,
     Chips,

--- a/packages/curve-ui-kit/src/themes/palette/palette.ts
+++ b/packages/curve-ui-kit/src/themes/palette/palette.ts
@@ -3,7 +3,7 @@ import { PaletteOptions } from '@mui/material'
 
 export const createPalette = (
   mode: 'light' | 'dark',
-  { Layer, Color, Feedback, Text: { TextColors } }: DesignSystem,
+  { Layer, Color, Text: { TextColors } }: DesignSystem,
 ): PaletteOptions => ({
   mode,
   primary: { main: Color.Primary[500] },


### PR DESCRIPTION
- `02_theme.Feedback` was removed from the design system in favor of `02_theme.Layer.Feedback` and `02_theme.Text.TextColors.Feedback`
- This PR removes the old, now unused, theme variables