### PR TITLE
chore: remove disclaimer from menu

### DIFF
--- a/packages/curve-ui-kit/src/shared/routes.ts
+++ b/packages/curve-ui-kit/src/shared/routes.ts
@@ -51,16 +51,12 @@ export const APP_LINK: Record<AppName, AppRoutes> = {
       { route: CRVUSD_ROUTES.PAGE_MARKETS, label: () => t`Markets` },
       ...(isBeta ? [{ route: CRVUSD_ROUTES.BETA_PAGE_MARKETS, label: () => t`Llama (beta)` }] : []),
       { route: CRVUSD_ROUTES.PAGE_CRVUSD_STAKING, label: () => t`Savings crvUSD` },
-      { route: `${CRVUSD_ROUTES.PAGE_DISCLAIMER}?tab=crvusd`, label: () => t`Risk Disclaimer` },
     ],
   },
   lend: {
     root: getAppRoot('lend'),
     label: 'Lend',
-    pages: [
-      { route: LEND_ROUTES.PAGE_MARKETS, label: () => t`Markets` },
-      { route: `${LEND_ROUTES.PAGE_DISCLAIMER}?tab=lend`, label: () => t`Risk Disclaimer` },
-    ],
+    pages: [{ route: LEND_ROUTES.PAGE_MARKETS, label: () => t`Markets` }],
   },
   dao: {
     root: getAppRoot('dao'),


### PR DESCRIPTION
- the disclaimer is moved to the footer
- now we can remove it from the menu