### PR TITLE
refactor: prepare to redirect between domains

### DIFF
--- a/apps/main/src/pages/index.tsx
+++ b/apps/main/src/pages/index.tsx
@@ -2,7 +2,12 @@ import { useEffect } from 'react'
 
 export default function Index() {
   useEffect(() => {
-    location.href = `/dex${location.search}${location.hash}`
+    const subdomain = location.hostname.match(/(?:staging)?(?:(\w+).)?curve.fi/)?.[1]
+    if (subdomain) {
+      location.href = `https://curve.fi/${subdomain}${location.search}${location.hash}`
+    } else {
+      location.href = `/dex${location.search}${location.hash}`
+    }
   }, [])
   return null
 }


### PR DESCRIPTION
- accessing the app with domain `{subdomain}.curve.fi` should redirect to `curve.fi/subdomain`
- this will allow us to send all domains to the same application and still have it redirect properly

tested with the following snippet:
```javascript
const tests = [
  'https://lend.curve.fi',
  'https://staging.lend.curve.fi',
  'https://curve.fi',
  'https://crvusd.curve.fi',
  'https://lend.curve.fi/#/ethereum/pools',
  'https://staging.lend.curve.fi/#/ethereum/pools',
  'https://curve.fi/#/ethereum/pools',
  'https://crvusd.curve.fi/#/ethereum/pools',
].map(url => new URL(url))

const results = tests.map(({ hash, hostname, search }) => {
  const subdomain = hostname.match(/(?:staging)?(?:(\w+).)?curve.fi/)?.[1]
  return subdomain ? `https://curve.fi/${subdomain}${search}${hash}` : `/dex${search}${hash}`
})

console.log(results) 
// [
//   'https://curve.fi/lend',
//   'https://curve.fi/lend',
//   '/dex',
//   'https://curve.fi/crvusd',
//   'https://curve.fi/lend#/ethereum/pools',
//   'https://curve.fi/lend#/ethereum/pools',
//   '/dex#/ethereum/pools',
//   'https://curve.fi/crvusd#/ethereum/pools'
// ]


```