### PR TITLE
bump max A to 20,000

### DIFF
--- a/apps/main/src/dex/components/PageCreatePool/constants.ts
+++ b/apps/main/src/dex/components/PageCreatePool/constants.ts
@@ -244,7 +244,7 @@ export const STABLESWAP_MIN_MAX_PARAMETERS = (swapFee: number) => ({
   },
   a: {
     min: 1,
-    max: 5000,
+    max: 20000,
   },
   maExpTime: {
     min: 60,


### PR DESCRIPTION
The current max in the pool implementation contract is 10**6: https://github.com/curvefi/stableswap-ng/blob/fd54b9a1a110d0e2e4f962583761d9e236b70967/contracts/main/CurveStableSwapNG.vy#L177

I propose we bump to 20,000 to allow for more concentrated pools from the pool creation component

current max:

<img width="210" alt="image" src="https://github.com/user-attachments/assets/640763bc-1f89-485a-a638-63c6cc84bcf5" />
