### PR TITLE
refactor: rename `notify` calls

### DIFF
--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
@@ -24,7 +24,7 @@ import FieldLockedAmt from '@/dao/components/PageVeCrv/components/FieldLockedAmt
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dao/types/dao.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -100,7 +100,7 @@ const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) =>
   const handleBtnClickApproval = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, rFormType, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -112,7 +112,7 @@ const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) =>
       if (formValues.utcDate) {
         const localUtcDate = formValues.calcdUtcDate || formatDisplayDate(formValues.utcDate.toString())
         const notifyMessage = t`Please confirm locking ${formatNumber(formValues.lockedAmt)} CRV until ${localUtcDate}.`
-        const { dismiss } = notifyNotification(notifyMessage, 'pending')
+        const { dismiss } = notify(notifyMessage, 'pending')
         const resp = await fetchStepCreate(activeKey, curve, formValues)
 
         if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
@@ -19,7 +19,7 @@ import FieldLockedAmt from '@/dao/components/PageVeCrv/components/FieldLockedAmt
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dao/types/dao.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -51,7 +51,7 @@ const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const handleBtnClickApproval = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, rFormType, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -61,7 +61,7 @@ const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const handleBtnClickIncrease = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please confirm increasing lock amount by ${formValues.lockedAmt} CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepIncreaseCrv(activeKey, curve, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
@@ -23,7 +23,7 @@ import FieldDatePicker from '@/dao/components/PageVeCrv/components/FieldDatePick
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dao/types/dao.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -116,7 +116,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       if (formValues.utcDate) {
         const localUtcDate = formValues.calcdUtcDate || formatDisplayDate(formValues.utcDate.toString())
         const notifyMessage = t`Please confirm changing unlock date to ${localUtcDate}.`
-        const { dismiss } = notifyNotification(notifyMessage, 'pending')
+        const { dismiss } = notify(notifyMessage, 'pending')
         const resp = await fetchStepIncreaseTime(activeKey, curve, formValues)
 
         if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -15,7 +15,7 @@ import ExternalLink from '@ui/Link/ExternalLink'
 import Icon from '@ui/Icon'
 import TxInfoBar from '@ui/TxInfoBar'
 import { ChainId, CurveApi, Provider } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const Compensation = ({
   rChainId,
@@ -56,7 +56,7 @@ const Compensation = ({
     async (activeKey: string, contract: EtherContract['contract'], balance: number) => {
       if (!curve) return
       const notifyMessage = t`Please confirm claim ${balance} compensation.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
 
       try {
         setStep('claiming')

--- a/apps/main/src/dex/components/PageCrvLocker/components/FormLockCreate.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/components/FormLockCreate.tsx
@@ -21,7 +21,7 @@ import FieldLockedAmt from '@/dex/components/PageCrvLocker/components/FieldLocke
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -96,7 +96,7 @@ const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) =>
   const handleBtnClickApproval = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, rFormType, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -108,7 +108,7 @@ const FormLockCreate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) =>
       if (formValues.utcDate) {
         const localUtcDate = formValues.calcdUtcDate || formatDisplayDate(formValues.utcDate.toString())
         const notifyMessage = t`Please confirm locking ${formatNumber(formValues.lockedAmt)} CRV until ${localUtcDate}.`
-        const { dismiss } = notifyNotification(notifyMessage, 'pending')
+        const { dismiss } = notify(notifyMessage, 'pending')
         const resp = await fetchStepCreate(activeKey, curve, formValues)
 
         if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dex/components/PageCrvLocker/components/FormLockCrv.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/components/FormLockCrv.tsx
@@ -15,7 +15,7 @@ import FieldLockedAmt from '@/dex/components/PageCrvLocker/components/FieldLocke
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -48,7 +48,7 @@ const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const handleBtnClickApproval = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, rFormType, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -58,7 +58,7 @@ const FormLockCrv = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const handleBtnClickIncrease = useCallback(
     async (activeKey: string, curve: CurveApi, formValues: FormValues) => {
       const notifyMessage = t`Please confirm increasing lock amount by ${formValues.lockedAmt} CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepIncreaseCrv(activeKey, curve, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dex/components/PageCrvLocker/components/FormLockDate.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/components/FormLockDate.tsx
@@ -20,7 +20,7 @@ import FieldDatePicker from '@/dex/components/PageCrvLocker/components/FieldDate
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   const isSubscribed = useRef(false)
@@ -112,7 +112,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       if (formValues.utcDate) {
         const localUtcDate = formValues.calcdUtcDate || formatDisplayDate(formValues.utcDate.toString())
         const notifyMessage = t`Please confirm changing unlock date to ${localUtcDate}.`
-        const { dismiss } = notifyNotification(notifyMessage, 'pending')
+        const { dismiss } = notify(notifyMessage, 'pending')
         const resp = await fetchStepIncreaseTime(activeKey, curve, formValues)
 
         if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dex/components/PageDashboard/components/FormClaimFeesButtons.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/FormClaimFeesButtons.tsx
@@ -9,7 +9,7 @@ import useStore from '@/dex/store/useStore'
 import Button from '@ui/Button'
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormClaimFeesButtons = ({
   activeKey,
@@ -61,7 +61,7 @@ const FormClaimFeesButtons = ({
 
       const { scanTxPath } = network
       const notifyMessage = t`Please approve claim veCRV rewards.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
 
       // loading state
       setClaimingKey(key)

--- a/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
@@ -23,7 +23,7 @@ import Button from '@ui/Button'
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 // TODO uncomment locker link code once it is ready
 const FormVecrv = () => {
@@ -61,7 +61,7 @@ const FormVecrv = () => {
   const handleBtnClickWithdraw = useCallback(
     async (activeKey: string, curve: CurveApi, lockedAmount: string) => {
       const notifyMessage = t`Please confirm withdraw of ${lockedAmount} CRV.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepWithdraw(activeKey, curve, walletAddress)
 
       if (isSubscribed.current && resp && resp.hash && resp.walletAddress === walletAddress && network) {

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
@@ -21,7 +21,7 @@ import Stepper from '@ui/Stepper'
 import TransferActions from '@/dex/components/PagePool/components/TransferActions'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormDeposit = ({
   chainIdPoolId,
@@ -86,7 +86,7 @@ const FormDeposit = ({
   const handleApproveClick = useCallback(
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your ${tokensDescription(formValues.amounts)}.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, 'DEPOSIT', poolData.pool, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -97,7 +97,7 @@ const FormDeposit = ({
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string) => {
       const tokenText = amountsDescription(formValues.amounts)
       const notifyMessage = t`Please confirm deposit of ${tokenText} at max ${maxSlippage}% slippage.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepDeposit(activeKey, curve, poolData, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
@@ -23,7 +23,7 @@ import Stepper from '@ui/Stepper'
 import TransferActions from '@/dex/components/PagePool/components/TransferActions'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi, Pool, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormDepositStake = ({
   chainIdPoolId,
@@ -89,7 +89,7 @@ const FormDepositStake = ({
   const handleApproveClick = useCallback(
     async (activeKey: string, curve: CurveApi, pool: Pool, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your ${tokensDescription(formValues.amounts)}.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, 'DEPOSIT_STAKE', pool, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -100,7 +100,7 @@ const FormDepositStake = ({
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string) => {
       const tokenText = amountsDescription(formValues.amounts)
       const notifyMessage = t`Please confirm deposit and staking of ${tokenText} LP Tokens at max ${maxSlippage}% slippage.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepDepositStake(activeKey, curve, poolData, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
@@ -19,7 +19,7 @@ import Stepper from '@ui/Stepper'
 import TransferActions from '@/dex/components/PagePool/components/TransferActions'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi, Pool, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormStake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, userPoolBalances }: TransferProps) => {
   const isSubscribed = useRef(false)
@@ -55,7 +55,7 @@ const FormStake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
   const handleApproveClick = useCallback(
     async (activeKey: string, curve: CurveApi, pool: Pool, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your LP Tokens.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, 'STAKE', pool, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -65,7 +65,7 @@ const FormStake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
   const handleStakeClick = useCallback(
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues) => {
       const notifyMessage = t`Please confirm staking of ${formValues.lpToken} LP Tokens`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepStake(activeKey, curve, poolData, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {

--- a/apps/main/src/dex/components/PagePool/Swap/index.tsx
+++ b/apps/main/src/dex/components/PagePool/Swap/index.tsx
@@ -35,7 +35,7 @@ import TransferActions from '@/dex/components/PagePool/components/TransferAction
 import TxInfoBar from '@ui/TxInfoBar'
 import WarningModal from '@/dex/components/PagePool/components/WarningModal'
 import { Balances, CurveApi, PoolAlert, PoolData, TokensMapper } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const Swap = ({
   chainIdPoolId,
@@ -126,7 +126,7 @@ const Swap = ({
     ) => {
       const { fromAmount, fromToken, toToken } = formValues
       const notifyMessage = t`Please confirm swap ${fromAmount} ${fromToken} for ${toToken} at max slippage ${maxSlippage}%.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepSwap(actionActiveKey, curve, poolData, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {
@@ -179,7 +179,7 @@ const Swap = ({
           content: isApprove ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${formValues.fromToken}.`
-            const { dismiss } = notifyNotification(notifyMessage, 'pending')
+            const { dismiss } = notify(notifyMessage, 'pending')
             await fetchStepApprove(actionActiveKey, curve, poolData.pool, formValues, maxSlippage)
             if (typeof dismiss === 'function') dismiss()
           },

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormClaim.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormClaim.tsx
@@ -18,7 +18,7 @@ import Stepper from '@ui/Stepper'
 import TransferActions from '@/dex/components/PagePool/components/TransferActions'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, userPoolBalances }: TransferProps) => {
   const isSubscribed = useRef(false)
@@ -60,7 +60,7 @@ const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
       rewardsNeedNudging: boolean | undefined,
     ) => {
       const notifyMessage = getClaimText(formValues, formStatus, 'notify', rewardsNeedNudging)
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepClaim(activeKey, curve, poolData)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
@@ -14,7 +14,7 @@ import TransferActions from '@/dex/components/PagePool/components/TransferAction
 import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { CurveApi, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormUnstake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, userPoolBalances }: TransferProps) => {
   const isSubscribed = useRef(false)
@@ -47,7 +47,7 @@ const FormUnstake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, 
   const handleUnstakeClick = useCallback(
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues) => {
       const notifyMessage = t`Please confirm unstaking of ${formValues.stakedLpToken} LP Tokens`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepUnstake(activeKey, curve, poolData, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
@@ -32,7 +32,7 @@ import TransferActions from '@/dex/components/PagePool/components/TransferAction
 import TxInfoBar from '@ui/TxInfoBar'
 import WarningModal from '@/dex/components/PagePool/components/WarningModal'
 import { CurveApi, Pool, PoolData } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const FormWithdraw = ({
   chainIdPoolId,
@@ -91,7 +91,7 @@ const FormWithdraw = ({
   const handleApproveClick = useCallback(
     async (activeKey: string, curve: CurveApi, pool: Pool, formValues: FormValues) => {
       const notifyMessage = t`Please approve spending your LP Tokens.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       await fetchStepApprove(activeKey, curve, 'WITHDRAW', pool, formValues)
       if (typeof dismiss === 'function') dismiss()
     },
@@ -102,7 +102,7 @@ const FormWithdraw = ({
     async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string) => {
       const tokenText = amountsDescription(formValues.amounts)
       const notifyMessage = t`Please confirm withdrawal of ${formValues.lpToken} LP Tokens at max ${maxSlippage}% slippage.`
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepWithdraw(activeKey, curve, poolData, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && network) {

--- a/apps/main/src/dex/components/PagePoolList/components/TableSettings/TableSettings.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableSettings/TableSettings.tsx
@@ -84,6 +84,7 @@ const TableSettings = ({
           searchText={searchParams.searchText}
           handleInputChange={(val) => updatePath({ searchText: val })}
           handleClose={() => updatePath({ searchText: '' })}
+          testId="search-pools"
         />
       </div>
 

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -39,7 +39,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import WarningModal from '@/dex/components/PagePool/components/WarningModal'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { ChainId, CurveApi, Token, TokensMapper } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const QuickSwap = ({
   pageLoaded,
@@ -163,7 +163,7 @@ const QuickSwap = ({
       const notifyMessage = t`swap ${fromAmount} ${fromToken} for ${
         isExpectedToAmount ? toAmountOutput : toAmount
       } ${toToken} at max slippage ${maxSlippage}%.`
-      const { dismiss } = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const { dismiss } = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepSwap(actionActiveKey, curve, formValues, searchedParams, maxSlippage)
@@ -213,7 +213,7 @@ const QuickSwap = ({
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${fromToken}.`
-            const { dismiss } = notifyNotification(notifyMessage, 'pending')
+            const { dismiss } = notify(notifyMessage, 'pending')
             await fetchStepApprove(activeKey, curve, formValues, searchedParams, globalMaxSlippage)
             if (typeof dismiss === 'function') dismiss()
           },

--- a/apps/main/src/dex/entities/gauge/lib/reward-actions.ts
+++ b/apps/main/src/dex/entities/gauge/lib/reward-actions.ts
@@ -24,7 +24,7 @@ import type {
 import { queryClient } from '@ui-kit/lib/api/query-client'
 import { GaugeParams } from '@ui-kit/lib/model/query'
 import useTokensMapper from '@/dex/hooks/useTokensMapper'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 export const useAddRewardToken = ({
   chainId,
@@ -37,7 +37,7 @@ export const useAddRewardToken = ({
     onSuccess: (resp, { rewardTokenId }) => {
       if (resp) {
         const txDescription = t`Added reward token ${rewardTokenId ? tokensMapper[rewardTokenId]?.symbol : ''}`
-        notifyNotification(txDescription, 'success')
+        notify(txDescription, 'success')
       }
 
       return Promise.all([
@@ -47,7 +47,7 @@ export const useAddRewardToken = ({
     },
     onError: (error) => {
       console.error('Error adding reward:', error)
-      notifyNotification(t`Failed to add reward token`, 'error')
+      notify(t`Failed to add reward token`, 'error')
     },
   })
 }
@@ -77,7 +77,7 @@ export const useDepositRewardApprove = ({
     onSuccess: (resp, { rewardTokenId, amount }) => {
       if (resp) {
         const notifyMessage = t`Approve spending ${rewardTokenId ? tokensMapper[rewardTokenId]?.symbol : ''}`
-        notifyNotification(notifyMessage, 'success', 15000)
+        notify(notifyMessage, 'success', 15000)
       }
       return queryClient.invalidateQueries({
         queryKey: keys.depositRewardIsApproved({ chainId, poolId, rewardTokenId, amount }),
@@ -85,7 +85,7 @@ export const useDepositRewardApprove = ({
     },
     onError: (error) => {
       console.error('Error approving deposit reward:', error)
-      notifyNotification(t`Failed to approve deposit reward`, 'error', 15000)
+      notify(t`Failed to approve deposit reward`, 'error', 15000)
     },
   })
 }
@@ -114,13 +114,13 @@ export const useDepositReward = ({
     onSuccess: (resp, { rewardTokenId }) => {
       if (resp) {
         const txDescription = t`Deposited reward token ${rewardTokenId ? tokensMapper[rewardTokenId]?.symbol : ''}`
-        notifyNotification(txDescription, 'success', 15000)
+        notify(txDescription, 'success', 15000)
       }
       return queryClient.invalidateQueries({ queryKey: keys.isDepositRewardAvailable({ chainId, poolId }) })
     },
     onError: (error) => {
       console.error('Error depositing reward:', error)
-      notifyNotification(t`Failed to deposit reward`, 'error', 15000)
+      notify(t`Failed to deposit reward`, 'error', 15000)
     },
   })
 }

--- a/apps/main/src/dex/store/createCreatePoolSlice.ts
+++ b/apps/main/src/dex/store/createCreatePoolSlice.ts
@@ -11,7 +11,7 @@ import type { GetState, SetState } from 'zustand'
 import produce from 'immer'
 import { BigNumber } from 'bignumber.js'
 import { t } from '@lingui/macro'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import type { State } from '@/dex/store/useStore'
 import {
   CRYPTOSWAP,
@@ -794,7 +794,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
       let dismissNotificationHandler
 
       const notifyPendingMessage = t`Please confirm to create pool ${poolName}.`
-      const { dismiss: dismissConfirm } = notifyNotification(notifyPendingMessage, 'pending')
+      const { dismiss: dismissConfirm } = notify(notifyPendingMessage, 'pending')
 
       dismissNotificationHandler = dismissConfirm
 
@@ -841,7 +841,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.tricryptoFactory.getDeployedPoolAddress(deployPoolTx)
@@ -858,7 +858,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.tricryptoFactory.fetchRecentlyDeployedPool(poolAddress)
             set(
@@ -922,7 +922,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.twocryptoFactory.getDeployedPoolAddress(deployPoolTx)
@@ -939,7 +939,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.twocryptoFactory.fetchRecentlyDeployedPool(poolAddress)
             set(
@@ -1020,7 +1020,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.stableNgFactory.getDeployedMetaPoolAddress(deployPoolTx)
@@ -1038,7 +1038,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.stableNgFactory.fetchRecentlyDeployedPool(poolAddress)
             set(
@@ -1091,7 +1091,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.factory.getDeployedMetaPoolAddress(deployPoolTx)
@@ -1108,7 +1108,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.factory.fetchRecentlyDeployedPool(poolAddress)
             set(
@@ -1180,7 +1180,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.stableNgFactory.getDeployedPlainPoolAddress(deployPoolTx)
@@ -1197,7 +1197,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.stableNgFactory.fetchRecentlyDeployedPool(poolAddress)
             set(
@@ -1259,7 +1259,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up deploying message
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying pool ${poolName}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
             dismissNotificationHandler = dismissDeploying
 
             const poolAddress = await curve.factory.getDeployedPlainPoolAddress(deployPoolTx)
@@ -1277,7 +1277,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
             // set up success message
             dismissDeploying()
             const successNotificationMessage = t`Pool ${poolName} deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
 
             const poolId = await curve.factory.fetchRecentlyDeployedPool(poolAddress)
             set(

--- a/apps/main/src/dex/store/createDeployGaugeSlice.ts
+++ b/apps/main/src/dex/store/createDeployGaugeSlice.ts
@@ -6,7 +6,7 @@ import produce from 'immer'
 import { t } from '@lingui/macro'
 import { shortenTokenAddress } from '@/dex/utils'
 import { ChainId, CurveApi } from '@/dex/types/main.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 type NetworkWithFactory = {
   chainId: ChainId
@@ -187,7 +187,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
       let dismissNotificationHandler
 
       const notifyPendingMessage = t`Please confirm to deploy gauge for ${shortenAddress}.`
-      const { dismiss: dismissConfirm } = notifyNotification(notifyPendingMessage, 'pending')
+      const { dismiss: dismissConfirm } = notify(notifyPendingMessage, 'pending')
 
       dismissNotificationHandler = dismissConfirm
 
@@ -213,7 +213,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -225,7 +225,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mainnet gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -250,7 +250,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -262,7 +262,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mainnet gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -287,7 +287,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -299,7 +299,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mainnet gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -324,7 +324,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -336,7 +336,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mainnet gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -360,7 +360,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -372,7 +372,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mainnet gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -406,7 +406,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -420,7 +420,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Sidechain gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -444,7 +444,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -458,7 +458,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Sidechain gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -482,7 +482,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -496,7 +496,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Sidechain gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -520,7 +520,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -534,7 +534,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Sidechain gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -558,7 +558,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -572,7 +572,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Sidechain gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -609,7 +609,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -621,7 +621,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mirror gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -648,7 +648,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -660,7 +660,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mirror gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -687,7 +687,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -699,7 +699,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mirror gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -726,7 +726,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -738,7 +738,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mirror gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(
@@ -762,7 +762,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissConfirm()
             const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
-            const { dismiss: dismissDeploying } = notifyNotification(deployingNotificationMessage, 'pending')
+            const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
 
@@ -774,7 +774,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
             )
             dismissDeploying()
             const successNotificationMessage = t`Mirror gauge deployment successful.`
-            notifyNotification(successNotificationMessage, 'success', 15000)
+            notify(successNotificationMessage, 'success', 15000)
           } catch (error) {
             dismissNotificationHandler()
             set(

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -110,7 +110,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={networks[rChainId].scanTxPath(resp.hash)} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepCreate, rChainId],
   )
@@ -175,7 +175,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, maxSlippage, formValues, isLeverage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         CREATE: {

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -102,7 +102,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
       maxSlippage: string,
       isLeverage: boolean,
     ) => {
-      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepCreate(payloadActiveKey, api, market, maxSlippage, formValues, isLeverage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -110,7 +110,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={networks[rChainId].scanTxPath(resp.hash)} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepCreate, rChainId],
   )
@@ -172,10 +172,10 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending your ${tokensMessage}.`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, maxSlippage, formValues, isLeverage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         CREATE: {

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -36,7 +36,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Api, HealthMode, PageContentProps } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { isLeverage?: boolean }) => {
   const { rChainId, rOwmId, isLoaded, api, market, userActiveKey } = pageProps
@@ -102,7 +102,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
       maxSlippage: string,
       isLeverage: boolean,
     ) => {
-      const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepCreate(payloadActiveKey, api, market, maxSlippage, formValues, isLeverage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -172,7 +172,7 @@ const LoanCreate = ({ isLeverage = false, ...pageProps }: PageContentProps & { i
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending your ${tokensMessage}.`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, maxSlippage, formValues, isLeverage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -120,7 +120,7 @@ const LoanBorrowMore = ({
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepIncrease, updateFormValues],
   )
@@ -188,7 +188,7 @@ const LoanBorrowMore = ({
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage, isLeverage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         BORROW_MORE: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -33,7 +33,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Api, HealthMode, PageContentProps } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const LoanBorrowMore = ({
   rChainId,
@@ -106,7 +106,7 @@ const LoanBorrowMore = ({
     ) => {
       const { chainId } = api
 
-      const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, api, market, formValues, maxSlippage, isLeverage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -185,7 +185,7 @@ const LoanBorrowMore = ({
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending of ${tokensMessage}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage, isLeverage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -106,7 +106,7 @@ const LoanBorrowMore = ({
     ) => {
       const { chainId } = api
 
-      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, api, market, formValues, maxSlippage, isLeverage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -120,7 +120,7 @@ const LoanBorrowMore = ({
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepIncrease, updateFormValues],
   )
@@ -185,10 +185,10 @@ const LoanBorrowMore = ({
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending of ${tokensMessage}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage, isLeverage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         BORROW_MORE: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -26,7 +26,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import { Api, PageContentProps } from '@/lend/types/lend.types'
 
 const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActiveKey }: PageContentProps) => {
@@ -64,7 +64,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
     async (payloadActiveKey: string, api: Api, market: OneWayMarketTemplate, formValues: FormValues) => {
       const { chainId } = api
 
-      const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, api, market, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -120,7 +120,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${market.collateral_token.symbol}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -73,7 +73,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => updateFormValues({}, true)} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepIncrease, updateFormValues],
   )
@@ -123,7 +123,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         ADD: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -64,7 +64,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
     async (payloadActiveKey: string, api: Api, market: OneWayMarketTemplate, formValues: FormValues) => {
       const { chainId } = api
 
-      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, api, market, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -73,7 +73,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => updateFormValues({}, true)} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepIncrease, updateFormValues],
   )
@@ -120,10 +120,10 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${market.collateral_token.symbol}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         ADD: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -84,7 +84,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepDecrease, network, updateFormValues],
   )

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -27,7 +27,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import { Api, HealthMode, PageContentProps } from '@/lend/types/lend.types'
 
 const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: PageContentProps) => {
@@ -69,7 +69,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
 
   const handleBtnClickRemove = useCallback(
     async (payloadActiveKey: string, api: Api, market: OneWayMarketTemplate, formValues: FormValues) => {
-      const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, api, market, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -69,7 +69,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
 
   const handleBtnClickRemove = useCallback(
     async (payloadActiveKey: string, api: Api, market: OneWayMarketTemplate, formValues: FormValues) => {
-      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, api, market, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -84,7 +84,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepDecrease, network, updateFormValues],
   )

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -36,7 +36,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Api, HealthMode, PageContentProps } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: PageContentProps) => {
   const isSubscribed = useRef(false)
@@ -94,7 +94,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
       formValues: FormValues,
       maxSlippage: string,
     ) => {
-      const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepRepay(payloadActiveKey, api, market, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -182,7 +182,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending your ${tokensMessage}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -115,7 +115,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepRepay, navigate, params, rChainId, updateFormValues],
   )
@@ -185,7 +185,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         REPAY: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -94,7 +94,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
       formValues: FormValues,
       maxSlippage: string,
     ) => {
-      const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+      const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
       const resp = await fetchStepRepay(payloadActiveKey, api, market, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey && !resp.error) {
@@ -115,7 +115,7 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepRepay, navigate, params, rChainId, updateFormValues],
   )
@@ -182,10 +182,10 @@ const LoanRepay = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: P
           onClick: async () => {
             const tokensMessage = getStepTokensStr(formValues, market).symbolList
             const notifyMessage = t`Please approve spending your ${tokensMessage}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, api, market, formValues, maxSlippage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         REPAY: {

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -112,7 +112,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(api, market, maxSlippage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         SELF_LIQUIDATE: {
@@ -142,7 +142,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
               )
             }
             if (resp?.error) setTxInfoBar(null)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
       }

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -109,10 +109,10 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${market.borrowed_token.symbol}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(api, market, maxSlippage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         SELF_LIQUIDATE: {
@@ -121,7 +121,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
           type: 'action',
           content: isComplete ? t`Self-liquidated` : t`Self-liquidate`,
           onClick: async () => {
-            const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
+            const notification = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
             const resp = await fetchStepLiquidate(api, market, liquidationAmt, maxSlippage)
 
             if (isSubscribed.current && resp && resp.hash && !resp.loanExists && !resp.error) {
@@ -142,7 +142,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
               )
             }
             if (resp?.error) setTxInfoBar(null)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
       }

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -32,7 +32,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Api, PageContentProps, UserLoanState } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActiveKey }: PageContentProps) => {
   const isSubscribed = useRef(false)
@@ -109,7 +109,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${market.borrowed_token.symbol}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(api, market, maxSlippage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()
@@ -121,7 +121,7 @@ const LoanSelfLiquidation = ({ rChainId, rOwmId, isLoaded, api, market, userActi
           type: 'action',
           content: isComplete ? t`Self-liquidated` : t`Self-liquidate`,
           onClick: async () => {
-            const notify = notifyNotification(NOFITY_MESSAGE.pendingConfirm, 'pending')
+            const notify = notify(NOFITY_MESSAGE.pendingConfirm, 'pending')
             const resp = await fetchStepLiquidate(api, market, liquidationAmt, maxSlippage)
 
             if (isSubscribed.current && resp && resp.hash && !resp.loanExists && !resp.error) {

--- a/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
@@ -22,7 +22,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { Api, MarketClaimable, PageContentProps } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) => {
   const isSubscribed = useRef(false)
@@ -64,7 +64,7 @@ const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) 
 
       const amount = type === 'crv' ? `${crv} CRV` : _getRewardsAmount(rewards)
       const notifyMessage = t`claim rewards ${amount}`
-      const notify = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepClaim(payloadActiveKey, api, market, type)

--- a/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
@@ -80,7 +80,7 @@ const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) 
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [fetchStepClaim, reset, userActiveKey],
   )

--- a/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
@@ -64,7 +64,7 @@ const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) 
 
       const amount = type === 'crv' ? `${crv} CRV` : _getRewardsAmount(rewards)
       const notifyMessage = t`claim rewards ${amount}`
-      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
+      const notification = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepClaim(payloadActiveKey, api, market, type)
@@ -80,7 +80,7 @@ const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) 
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [fetchStepClaim, reset, userActiveKey],
   )

--- a/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
@@ -79,7 +79,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
       const { amount } = formValues
 
       const notifyMessage = t`deposit ${amount} ${borrowed_token?.symbol}`
-      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
+      const notification = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepDepositMint(payloadActiveKey, rFormType, api, market, formValues)
@@ -95,7 +95,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, borrowed_token?.symbol, fetchStepDepositMint, reset],
   )
@@ -124,10 +124,10 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${symbol}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         DEPOSIT_MINT: {

--- a/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
@@ -1,4 +1,4 @@
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import type { FormStatus, FormValues, StepKey } from '@/lend/components/PageVault/VaultDepositMint/types'
 import type { Step } from '@ui/Stepper/types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -79,7 +79,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
       const { amount } = formValues
 
       const notifyMessage = t`deposit ${amount} ${borrowed_token?.symbol}`
-      const notify = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepDepositMint(payloadActiveKey, rFormType, api, market, formValues)
@@ -124,7 +124,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${symbol}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
@@ -95,7 +95,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, borrowed_token?.symbol, fetchStepDepositMint, reset],
   )
@@ -127,7 +127,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         DEPOSIT_MINT: {

--- a/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
@@ -71,7 +71,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
       const { amount } = formValues
 
       const notifyMessage = t`stake ${amount} vault shares`
-      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
+      const notification = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepStake(payloadActiveKey, rFormType, api, market, formValues)
@@ -82,7 +82,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => reset({})} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepStake, reset],
   )
@@ -111,10 +111,10 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of vault shares`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         STAKE: {

--- a/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
@@ -82,7 +82,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => reset({})} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepStake, reset],
   )
@@ -114,7 +114,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         STAKE: {

--- a/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
@@ -1,4 +1,4 @@
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import type { FormStatus, FormValues, StepKey } from '@/lend/components/PageVault/VaultStake/types'
 import type { Step } from '@ui/Stepper/types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -71,7 +71,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
       const { amount } = formValues
 
       const notifyMessage = t`stake ${amount} vault shares`
-      const notify = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepStake(payloadActiveKey, rFormType, api, market, formValues)
@@ -111,7 +111,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of vault shares`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, rFormType, api, market, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
@@ -69,7 +69,7 @@ const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, user
       const { amount } = formValues
 
       const notifyMessage = t`unstake ${amount} vault shares`
-      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
+      const notification = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepUnstake(payloadActiveKey, rFormType, api, market, formValues)
@@ -80,7 +80,7 @@ const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, user
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => reset({})} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepUnstake, reset],
   )

--- a/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
@@ -80,7 +80,7 @@ const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, user
         setTxInfoBar(<TxInfoBar description={txMessage} txHash={txHash} onClose={() => reset({})} />)
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepUnstake, reset],
   )

--- a/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
@@ -19,7 +19,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import { Api, PageContentProps } from '@/lend/types/lend.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userActiveKey }: PageContentProps) => {
   const isSubscribed = useRef(false)
@@ -69,7 +69,7 @@ const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, user
       const { amount } = formValues
 
       const notifyMessage = t`unstake ${amount} vault shares`
-      const notify = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">Pending {notifyMessage}</AlertBox>)
 
       const resp = await fetchStepUnstake(payloadActiveKey, rFormType, api, market, formValues)

--- a/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
@@ -1,4 +1,4 @@
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import type { FormStatus, FormValues, StepKey } from '@/lend/components/PageVault/VaultWithdrawRedeem/types'
 import type { Step } from '@ui/Stepper/types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
@@ -99,7 +99,7 @@ const VaultWithdrawRedeem = ({
         notifyMessage = t`a full withdraw of ${vaultShares} vault shares`
       }
 
-      const notify = notifyNotification(`Please confirm ${notifyMessage}`, 'pending')
+      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">{`Pending ${notifyMessage}`}</AlertBox>)
       const resp = await fetchStepWithdrawRedeem(payloadActiveKey, rFormType, api, market, formValues, vaultShares)
 

--- a/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
@@ -99,7 +99,7 @@ const VaultWithdrawRedeem = ({
         notifyMessage = t`a full withdraw of ${vaultShares} vault shares`
       }
 
-      const notify = notify(`Please confirm ${notifyMessage}`, 'pending')
+      const notification = notify(`Please confirm ${notifyMessage}`, 'pending')
       setTxInfoBar(<AlertBox alertType="info">{`Pending ${notifyMessage}`}</AlertBox>)
       const resp = await fetchStepWithdrawRedeem(payloadActiveKey, rFormType, api, market, formValues, vaultShares)
 
@@ -114,7 +114,7 @@ const VaultWithdrawRedeem = ({
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepWithdrawRedeem, fetchUserMarketBalances, reset],
   )

--- a/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
@@ -114,7 +114,7 @@ const VaultWithdrawRedeem = ({
         )
       }
       if (resp?.error) setTxInfoBar(null)
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepWithdrawRedeem, fetchUserMarketBalances, reset],
   )

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -126,7 +126,7 @@ const LoanCreate = ({
         const TxDescription = <Trans>Transaction complete.</Trans>
         setTxInfoBar(<TxInfoBar description={TxDescription} txHash={network.scanTxPath(resp.hash)} />)
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepCreate, network],
   )
@@ -164,7 +164,7 @@ const LoanCreate = ({
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, isLeverage, llamma, formValues, maxSlippage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         CREATE: {

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -29,7 +29,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import DialogHealthLeverageWarning from '@/loan/components/PageLoanCreate/LoanFormCreate/components/DialogHealthLeverageWarning'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { CollateralAlert, Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 const LoanCreate = ({
   collateralAlert,
@@ -119,7 +119,7 @@ const LoanCreate = ({
       maxSlippage: string,
     ) => {
       const notifyMessage = t`Please confirm deposit of ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
       const resp = await fetchStepCreate(payloadActiveKey, curve, isLeverage, llamma, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -161,7 +161,7 @@ const LoanCreate = ({
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${llamma.collateralSymbol}.`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, isLeverage, llamma, formValues, maxSlippage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -119,14 +119,14 @@ const LoanCreate = ({
       maxSlippage: string,
     ) => {
       const notifyMessage = t`Please confirm deposit of ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
       const resp = await fetchStepCreate(payloadActiveKey, curve, isLeverage, llamma, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
         const TxDescription = <Trans>Transaction complete.</Trans>
         setTxInfoBar(<TxInfoBar description={TxDescription} txHash={network.scanTxPath(resp.hash)} />)
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepCreate, network],
   )
@@ -161,10 +161,10 @@ const LoanCreate = ({
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${llamma.collateralSymbol}.`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, isLeverage, llamma, formValues, maxSlippage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         CREATE: {

--- a/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
@@ -27,7 +27,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 interface Props extends Pick<PageLoanManageProps, 'curve' | 'llamma' | 'llammaId' | 'rChainId'> {}
 
@@ -95,7 +95,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
   const handleBtnClickRemove = useCallback(
     async (payloadActiveKey: string, curve: Curve, llamma: Llamma, formValues: FormValues) => {
       const notifyMessage = t`Please confirm removal of ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
@@ -108,7 +108,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
           />,
         )
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepDecrease, network, reset],
   )

--- a/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
@@ -95,7 +95,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
   const handleBtnClickRemove = useCallback(
     async (payloadActiveKey: string, curve: Curve, llamma: Llamma, formValues: FormValues) => {
       const notifyMessage = t`Please confirm removal of ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -108,7 +108,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
           />,
         )
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepDecrease, network, reset],
   )

--- a/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
@@ -99,7 +99,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
     async (payloadActiveKey: string, curve: Curve, llamma: Llamma, formValues: FormValues) => {
       const chainId = curve.chainId
       const notifyMessage = t`Please confirm depositing ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -111,7 +111,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           />,
         )
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepIncrease, reset],
   )
@@ -140,10 +140,10 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${llamma.collateralSymbol}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         ADD: {

--- a/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
@@ -28,7 +28,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 interface Props extends Pick<PageLoanManageProps, 'curve' | 'isReady' | 'llamma' | 'llammaId'> {}
 
@@ -99,7 +99,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
     async (payloadActiveKey: string, curve: Curve, llamma: Llamma, formValues: FormValues) => {
       const chainId = curve.chainId
       const notifyMessage = t`Please confirm depositing ${formValues.collateral} ${llamma.collateralSymbol}`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
       const resp = await fetchStepIncrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -140,7 +140,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${llamma.collateralSymbol}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
@@ -111,7 +111,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           />,
         )
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepIncrease, reset],
   )
@@ -143,7 +143,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         ADD: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -131,7 +131,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
           />,
         )
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepDecrease, navigate, params, rChainId, reset],
   )
@@ -162,7 +162,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         PAY: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -29,7 +29,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 interface Props extends Pick<PageLoanManageProps, 'curve' | 'llamma' | 'llammaId' | 'params' | 'rChainId'> {}
 
@@ -109,7 +109,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
       const notifyMessage = isFullRepay
         ? t`Please approve full repay.`
         : t`Please approve a repayment of ${debt} ${getTokenName(llamma).stablecoin}.`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -159,7 +159,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${getTokenName(llamma).stablecoin}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -109,7 +109,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
       const notifyMessage = isFullRepay
         ? t`Please approve full repay.`
         : t`Please approve a repayment of ${debt} ${getTokenName(llamma).stablecoin}.`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
       const resp = await fetchStepDecrease(payloadActiveKey, curve, llamma, formValues)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {
@@ -131,7 +131,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
           />,
         )
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepDecrease, navigate, params, rChainId, reset],
   )
@@ -159,10 +159,10 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${getTokenName(llamma).stablecoin}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         PAY: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
@@ -45,7 +45,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 // Loan Deleverage
 const LoanDeleverage = ({
@@ -109,7 +109,7 @@ const LoanDeleverage = ({
       const fTokenName = `${collateral} ${collateralName}`
       const notifyMessage = t`Please approve deleverage with ${fTokenName} at ${maxSlippage}% max slippage.`
 
-      const { dismiss } = notifyNotification(notifyMessage, 'pending')
+      const { dismiss } = notify(notifyMessage, 'pending')
       const resp = await fetchStepRepay(payloadActiveKey, curve, llamma, formValues, maxSlippage)
 
       if (isSubscribed.current && resp && resp.hash && resp.activeKey === activeKey) {

--- a/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
@@ -120,7 +120,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
             } ${llamma.collateralSymbol}.`
           : t`Please confirm borrowing of ${formValues.debt} ${getTokenName(llamma).stablecoin}.`
 
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
 
       const resp = await fetchStepIncrease(payloadActiveKey, curve, llamma, formValues)
 
@@ -133,7 +133,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           />,
         )
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, fetchStepIncrease, reset],
   )
@@ -163,10 +163,10 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${formValues.collateral}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         BORROW: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
@@ -34,7 +34,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import AlertFormError from '@/loan/components/AlertFormError'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 interface Props extends Pick<PageLoanManageProps, 'curve' | 'isReady' | 'llamma' | 'llammaId'> {}
 
@@ -120,7 +120,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
             } ${llamma.collateralSymbol}.`
           : t`Please confirm borrowing of ${formValues.debt} ${getTokenName(llamma).stablecoin}.`
 
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
 
       const resp = await fetchStepIncrease(payloadActiveKey, curve, llamma, formValues)
 
@@ -163,7 +163,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${formValues.collateral}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
@@ -133,7 +133,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
           />,
         )
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, fetchStepIncrease, reset],
   )
@@ -166,7 +166,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(payloadActiveKey, curve, llamma, formValues)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         BORROW: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -104,7 +104,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(curve, llamma, maxSlippage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         LIQUIDATE: {
@@ -138,7 +138,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
                 />,
               )
             }
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
       }

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -101,10 +101,10 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${getTokenName(llamma).stablecoin}`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(curve, llamma, maxSlippage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         LIQUIDATE: {
@@ -115,7 +115,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
           onClick: async () => {
             const stablecoinName = getTokenName(llamma).stablecoin
             const notifyMessage = t`Please confirm ${stablecoinName} self-liquidation at max ${maxSlippage}% slippage.`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             const resp = await fetchStepLiquidate(curve, llamma, liquidationAmt, maxSlippage)
 
@@ -138,7 +138,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
                 />,
               )
             }
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
       }

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -25,7 +25,7 @@ import Stepper from '@ui/Stepper'
 import TxInfoBar from '@ui/TxInfoBar'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { Curve, Llamma, UserWalletBalances } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 interface Props extends Pick<PageLoanManageProps, 'curve' | 'llamma' | 'llammaId' | 'params' | 'rChainId'> {}
 
@@ -101,7 +101,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
           onClick: async () => {
             const notifyMessage = t`Please approve spending of ${getTokenName(llamma).stablecoin}`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(curve, llamma, maxSlippage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()
@@ -115,7 +115,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
           onClick: async () => {
             const stablecoinName = getTokenName(llamma).stablecoin
             const notifyMessage = t`Please confirm ${stablecoinName} self-liquidation at max ${maxSlippage}% slippage.`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             const resp = await fetchStepLiquidate(curve, llamma, liquidationAmt, maxSlippage)
 

--- a/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
@@ -111,7 +111,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
       const { item1Name } = getItemsName(llamma, formValues)
       const swapAmount = formValues.item1 === '' ? detailInfo.amount : formValues.item1
       const notifyMessage = t`Please confirm swapping ${swapAmount} ${item1Name} at max ${maxSlippage} slippage.`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
 
       const resp = await fetchStepSwap(
         payloadActiveKey,
@@ -130,7 +130,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
           />,
         )
       }
-      if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
     },
     [activeKey, detailInfo.amount, fetchStepSwap, rChainId, reset],
   )
@@ -163,10 +163,10 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
             const { item1Name } = getItemsName(llamma, formValues)
             const swapAmount = formValues.item1 === '' ? detailInfo.amount : formValues.item1
             const notifyMessage = t`Please approve spending your ${item1Name}.`
-            const notify = notify(notifyMessage, 'pending')
+            const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(activeKey, curve, llamma, { ...formValues, item1: swapAmount }, maxSlippage)
-            if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
           },
         },
         SWAP: {

--- a/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
@@ -1,7 +1,7 @@
 import type { FormStatus, FormValues, StepKey } from '@/loan/components/PageLoanManage/LoanSwap/types'
 import type { FormEstGas, PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import type { Step } from '@ui/Stepper/types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@lingui/macro'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { DEFAULT_DETAIL_INFO, DEFAULT_FORM_STATUS, DEFAULT_FORM_VALUES } from '@/loan/store/createLoanSwap'
@@ -111,7 +111,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
       const { item1Name } = getItemsName(llamma, formValues)
       const swapAmount = formValues.item1 === '' ? detailInfo.amount : formValues.item1
       const notifyMessage = t`Please confirm swapping ${swapAmount} ${item1Name} at max ${maxSlippage} slippage.`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
 
       const resp = await fetchStepSwap(
         payloadActiveKey,
@@ -163,7 +163,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
             const { item1Name } = getItemsName(llamma, formValues)
             const swapAmount = formValues.item1 === '' ? detailInfo.amount : formValues.item1
             const notifyMessage = t`Please approve spending your ${item1Name}.`
-            const notify = notifyNotification(notifyMessage, 'pending')
+            const notify = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(activeKey, curve, llamma, { ...formValues, item1: swapAmount }, maxSlippage)
             if (notify && typeof notify.dismiss === 'function') notify.dismiss()

--- a/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
@@ -130,7 +130,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
           />,
         )
       }
-      if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+      notification?.dismiss()
     },
     [activeKey, detailInfo.amount, fetchStepSwap, rChainId, reset],
   )
@@ -166,7 +166,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
             const notification = notify(notifyMessage, 'pending')
 
             await fetchStepApprove(activeKey, curve, llamma, { ...formValues, item1: swapAmount }, maxSlippage)
-            if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+            notification?.dismiss()
           },
         },
         SWAP: {

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
@@ -36,7 +36,7 @@ const PegKeeperForm = ({ rChainId, poolName, pegKeeperAddress }: Props) => {
       setTxInfoBar(null)
 
       const notifyMessage = t`Please confirm update ${poolName} pool`
-      const notify = notify(notifyMessage, 'pending')
+      const notification = notify(notifyMessage, 'pending')
       const resp = await fetchUpdate(curve, pegKeeperAddress)
 
       if (isSubscribed.current && resp) {
@@ -45,7 +45,7 @@ const PegKeeperForm = ({ rChainId, poolName, pegKeeperAddress }: Props) => {
           setTxInfoBar(<TxInfoBar description={txMessage} txHash={networks[rChainId].scanTxPath(resp.hash)} />)
         }
 
-        if (notify && typeof notify.dismiss === 'function') notify.dismiss()
+        if (notification && typeof notification.dismiss === 'function') notification.dismiss()
       }
     },
     [fetchUpdate, poolName, rChainId],

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
@@ -45,7 +45,7 @@ const PegKeeperForm = ({ rChainId, poolName, pegKeeperAddress }: Props) => {
           setTxInfoBar(<TxInfoBar description={txMessage} txHash={networks[rChainId].scanTxPath(resp.hash)} />)
         }
 
-        if (notification && typeof notification.dismiss === 'function') notification.dismiss()
+        notification?.dismiss()
       }
     },
     [fetchUpdate, poolName, rChainId],

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperForm.tsx
@@ -11,7 +11,7 @@ import IconTooltip from '@ui/Tooltip/TooltipIcon'
 import LoanFormConnect from '@/loan/components/LoanFormConnect'
 import TxInfoBar from '@ui/TxInfoBar'
 import { ChainId, Curve } from '@/loan/types/loan.types'
-import { notify as notifyNotification } from '@ui-kit/features/connect-wallet'
+import { notify } from '@ui-kit/features/connect-wallet'
 
 type Props = {
   rChainId: ChainId
@@ -36,7 +36,7 @@ const PegKeeperForm = ({ rChainId, poolName, pegKeeperAddress }: Props) => {
       setTxInfoBar(null)
 
       const notifyMessage = t`Please confirm update ${poolName} pool`
-      const notify = notifyNotification(notifyMessage, 'pending')
+      const notify = notify(notifyMessage, 'pending')
       const resp = await fetchUpdate(curve, pegKeeperAddress)
 
       if (isSubscribed.current && resp) {

--- a/packages/ui/src/SearchInput/SearchListInput.tsx
+++ b/packages/ui/src/SearchInput/SearchListInput.tsx
@@ -9,6 +9,7 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   searchText: string
   handleInputChange(val: string): void
   handleClose(): void
+  testId?: string
 }
 
 function SearchListInput({ className = '', searchText, handleInputChange, handleClose, ...inputProps }: Props) {

--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -75,7 +75,7 @@ describe('Header', () => {
     })
 
     it('should change chains', () => {
-      if (['loan', 'dao'].includes(appPath)) {
+      if (['crvusd', 'dao'].includes(appPath)) {
         cy.get(`[data-testid='btn-change-chain']`).click()
         cy.get(`[data-testid='alert-eth-only']`).should('be.visible')
         cy.get("[data-testid='app-link-main']").invoke('attr', 'href').should('eq', `${mainAppUrl}/#/ethereum`)
@@ -140,7 +140,7 @@ describe('Header', () => {
     })
 
     it('should change chains', () => {
-      if (['loan', 'dao'].includes(appPath)) {
+      if (['crvusd', 'dao'].includes(appPath)) {
         cy.get(`[data-testid='btn-change-chain']`).click()
         cy.get(`[data-testid='alert-eth-only']`).should('be.visible')
         cy.get(`[data-testid='menu-toggle']`).click()
@@ -157,7 +157,12 @@ describe('Header', () => {
   })
 
   function waitIsLoaded(appPath: AppPath) {
-    const testId = appPath == 'dao' ? 'proposal-title' : 'btn-connect-prompt'
+    const testId = {
+      dao: 'proposal-title',
+      crvusd: 'btn-connect-prompt',
+      lend: 'btn-connect-prompt',
+      dex: 'inp-search-pools',
+    }[appPath || 'dex']
     cy.get(`[data-testid='${testId}']`).should('be.visible') // wait for loading
   }
 


### PR DESCRIPTION
- simple refactor to replace `notify as notifyNotification` by `notify`
- based off https://github.com/curvefi/curve-frontend/pull/639