### PR TITLE
fix: search any word in the pool name

### DIFF
--- a/packages/curve-ui-kit/src/utils/searchText.ts
+++ b/packages/curve-ui-kit/src/utils/searchText.ts
@@ -29,7 +29,7 @@ export function groupSearchTerms(searchText: string) {
 // should only return results if pool/market have all searched tokens
 function searchByTokens<T>(searchTerms: string[], datas: T[], keys: string[]) {
   const fuse = new Fuse<T>(datas, {
-    ignoreLocation: false,
+    ignoreLocation: true,
     includeMatches: true,
     minMatchCharLength: 2,
     threshold: 0.01,


### PR DESCRIPTION
- the fuse search was configured to only match the beginning of the pool name
- by passing `ignoreLocation: true` we can also search later parts of the pool name
- Note that this will also change the way tokens are searched, e.g. 'usr' will return 'wstUSR' as the first match