### PR TITLE
fix: cypress mobile test for dex

### DIFF
--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -116,7 +116,7 @@ describe('Header', () => {
       cy.get(`[data-testid='mobile-drawer']`).should('be.visible')
 
       cy.url().then((url) => {
-        const clickIndex = appPath == 'dao' ? 0 : 1
+        const clickIndex = ['dex', 'dao'].includes(appPath) ? 0 : 1
         cy.get('[data-testid^="sidebar-item-"]').eq(clickIndex).click()
         cy.get(`[data-testid='mobile-drawer']`).should('not.exist')
         cy.url().should('not.equal', url)


### PR DESCRIPTION
- Since the default page is now the pools page, clicking on the 2nd option in the menu doesn't do anything for the DEX app
- This caused Cypress tests to get flaky