### PR TITLE
refactor: prices api minor feedback

### DIFF
--- a/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
@@ -25,9 +25,7 @@ const CrvStats: React.FC = () => {
     }
   }, [veCrvData.totalCrv, veCrvData.fetchStatus, getVeCrvData, provider])
 
-  const veCrvApr = aprLoading
-    ? 0
-    : calculateApr(veCrvFees.fees[1].feesUsd, Number(veCrvData.totalVeCrv) / 10 ** 18, crv)
+  const veCrvApr = aprLoading ? 0 : calculateApr(veCrvFees.fees[1].feesUsd, veCrvData.totalVeCrv.fromWei(), crv)
 
   const loading = Boolean(provider && veCrvLoading)
   return (
@@ -40,7 +38,7 @@ const CrvStats: React.FC = () => {
             title={t`Total CRV`}
             data={
               <MetricsColumnData>
-                {noProvider ? '-' : formatNumber(Number(veCrvData.totalCrv) / 10 ** 18, { notation: 'compact' })}
+                {noProvider ? '-' : formatNumber(veCrvData.totalCrv.fromWei(), { notation: 'compact' })}
               </MetricsColumnData>
             }
           />
@@ -49,7 +47,7 @@ const CrvStats: React.FC = () => {
             title={t`Locked CRV`}
             data={
               <MetricsColumnData>
-                {noProvider ? '-' : formatNumber(Number(veCrvData.totalLockedCrv) / 10 ** 18, { notation: 'compact' })}
+                {noProvider ? '-' : formatNumber(veCrvData.totalLockedCrv.fromWei(), { notation: 'compact' })}
               </MetricsColumnData>
             }
           />
@@ -58,7 +56,7 @@ const CrvStats: React.FC = () => {
             title={t`veCRV`}
             data={
               <MetricsColumnData>
-                {noProvider ? '-' : formatNumber(Number(veCrvData.totalVeCrv) / 10 ** 18, { notation: 'compact' })}
+                {noProvider ? '-' : formatNumber(veCrvData.totalVeCrv.fromWei(), { notation: 'compact' })}
               </MetricsColumnData>
             }
           />

--- a/apps/main/src/dao/components/PageAnalytics/DailyLocksChart/PositiveAndNegativeBarChart.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/DailyLocksChart/PositiveAndNegativeBarChart.tsx
@@ -16,7 +16,7 @@ const PositiveAndNegativeBarChart: React.FC<PositiveAndNegativeBarChartProps> = 
     <BarChart
       width={500}
       height={300}
-      data={data.map((x) => ({ ...x, amount: Number(x.amount) / 10 ** 18 }))}
+      data={data.map((x) => ({ ...x, amount: x.amount.fromWei() }))}
       margin={{
         top: 16,
         right: 20,

--- a/apps/main/src/dao/components/PageAnalytics/HoldersTable/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/HoldersTable/index.tsx
@@ -50,10 +50,10 @@ const TopHoldersTable: React.FC = () => {
               </span>
             </StyledTableDataLink>
             <TableData className={allHoldersSortBy.key === 'weight' ? 'sortby-active right-padding' : 'right-padding'}>
-              {formatNumber(Number(holder.weight) / 10 ** 18, { notation: 'compact' })}
+              {formatNumber(holder.weight.fromWei(), { notation: 'compact' })}
             </TableData>
             <TableData className={allHoldersSortBy.key === 'locked' ? 'sortby-active right-padding' : 'right-padding'}>
-              {formatNumber(Number(holder.locked) / 10 ** 18, { notation: 'compact' })}
+              {formatNumber(holder.locked.fromWei(), { notation: 'compact' })}
             </TableData>
             <TableData
               className={allHoldersSortBy.key === 'weightRatio' ? 'sortby-active right-padding' : 'right-padding'}

--- a/apps/main/src/dao/components/PageAnalytics/TopHoldersChart/TopHoldersBarChartComponent.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/TopHoldersChart/TopHoldersBarChartComponent.tsx
@@ -42,8 +42,8 @@ const TopHoldersBarChart: React.FC<TopHoldersBarChartProps> = ({ data, filter })
 
   const dataFormatted = data.map((x) => ({
     ...x,
-    weight: Number(x.weight) / 10 ** 18,
-    locked: Number(x.locked) / 10 ** 18,
+    weight: x.weight.fromWei(),
+    locked: x.locked.fromWei(),
   }))
 
   return (

--- a/apps/main/src/dao/components/PageUser/UserStats/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserStats/index.tsx
@@ -20,7 +20,7 @@ const UserStats = ({ veCrvHolder, holdersLoading }: UserStatsProps) => (
         title={t`Total veCRV`}
         data={
           <MetricsColumnData>
-            {formatNumber(Number(veCrvHolder.weight) / 10 ** 18, { showDecimalIfSmallNumberOnly: true })}
+            {formatNumber(veCrvHolder.weight.fromWei(), { showDecimalIfSmallNumberOnly: true })}
           </MetricsColumnData>
         }
       />
@@ -29,7 +29,7 @@ const UserStats = ({ veCrvHolder, holdersLoading }: UserStatsProps) => (
         title={t`Locked CRV`}
         data={
           <MetricsColumnData>
-            {formatNumber(Number(veCrvHolder.locked) / 10 ** 18, { showDecimalIfSmallNumberOnly: true })}
+            {formatNumber(veCrvHolder.locked.fromWei(), { showDecimalIfSmallNumberOnly: true })}
           </MetricsColumnData>
         }
       />

--- a/apps/main/src/global-extensions.ts
+++ b/apps/main/src/global-extensions.ts
@@ -3,6 +3,7 @@ import type { UTCTimestamp } from 'lightweight-charts'
 declare global {
   interface Date {
     getUTCTimestamp(): UTCTimestamp
+    getLocalTimestamp(): UTCTimestamp
   }
 
   interface BigInt {
@@ -12,6 +13,10 @@ declare global {
 
 Date.prototype.getUTCTimestamp = function () {
   return (this.getTime() / 1000) as UTCTimestamp
+}
+
+Date.prototype.getLocalTimestamp = function () {
+  return ((this.getTime() - this.getTimezoneOffset() * 60000) / 1000) as UTCTimestamp
 }
 
 BigInt.prototype.fromWei = function () {

--- a/apps/main/src/global-extensions.ts
+++ b/apps/main/src/global-extensions.ts
@@ -4,10 +4,18 @@ declare global {
   interface Date {
     getUTCTimestamp(): UTCTimestamp
   }
+
+  interface BigInt {
+    fromWei(): number
+  }
 }
 
 Date.prototype.getUTCTimestamp = function () {
   return (this.getTime() / 1000) as UTCTimestamp
+}
+
+BigInt.prototype.fromWei = function () {
+  return Number(this) / 10 ** 18
 }
 
 export {}

--- a/apps/main/src/lend/store/createOhlcChartSlice.ts
+++ b/apps/main/src/lend/store/createOhlcChartSlice.ts
@@ -233,24 +233,26 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           volumeArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             value: item.volume,
             color: item.open < item.close ? '#26a69982' : '#ef53507e',
           })
 
           baselinePriceArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             base_price: item.basePrice,
           })
 
           oraclePriceArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             value: item.oraclePrice,
           })
 
           ohlcDataArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             open: item.open,
             close: item.close,
             high: item.high,
@@ -322,24 +324,26 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           volumeArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             value: item.volume,
             color: item.open < item.close ? '#26a69982' : '#ef53507e',
           })
 
           baselinePriceArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             base_price: item.basePrice,
           })
 
           oraclePriceArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             value: item.oraclePrice,
           })
 
           ohlcDataArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             open: item.open,
             close: item.close,
             high: item.high,
@@ -418,22 +422,24 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           if (item.basePrice) {
             baselinePriceArray.push({
-              time: item.time.getUTCTimestamp(),
+              time,
               base_price: item.basePrice,
             })
           }
 
           if (item.oraclePrice) {
             oraclePriceArray.push({
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.oraclePrice,
             })
           }
 
           ohlcDataArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             open: item.open,
             close: item.close,
             high: item.high,
@@ -504,22 +510,24 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           if (item.basePrice) {
             baselinePriceArray.push({
-              time: item.time.getUTCTimestamp(),
+              time,
               base_price: item.basePrice,
             })
           }
 
           if (item.oraclePrice) {
             oraclePriceArray.push({
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.oraclePrice,
             })
           }
 
           ohlcDataArray.push({
-            time: item.time.getUTCTimestamp(),
+            time,
             open: item.open,
             close: item.close,
             high: item.high,

--- a/apps/main/src/loan/store/createOhlcChartSlice.ts
+++ b/apps/main/src/loan/store/createOhlcChartSlice.ts
@@ -132,10 +132,12 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           volumeArray = [
             ...volumeArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.volume,
               color: item.open < item.close ? '#26a69982' : '#ef53507e',
             },
@@ -144,7 +146,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           baselinePriceArray = [
             ...baselinePriceArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               base_price: item.basePrice,
             },
           ]
@@ -152,7 +154,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           oraclePriceArray = [
             ...oraclePriceArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.oraclePrice,
             },
           ]
@@ -160,7 +162,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           ohlcDataArray = [
             ...ohlcDataArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               open: item.open,
               close: item.close,
               high: item.high,
@@ -223,10 +225,12 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         let ohlcDataArray: LpPriceOhlcDataFormatted[] = []
 
         for (const item of ohlc) {
+          const time = item.time.getLocalTimestamp()
+
           volumeArray = [
             ...volumeArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.volume,
               color: item.open < item.close ? '#26a69982' : '#ef53507e',
             },
@@ -235,7 +239,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           baselinePriceArray = [
             ...baselinePriceArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               base_price: item.basePrice,
             },
           ]
@@ -243,7 +247,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           oraclePriceArray = [
             ...oraclePriceArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               value: item.oraclePrice,
             },
           ]
@@ -251,7 +255,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
           ohlcDataArray = [
             ...ohlcDataArray,
             {
-              time: item.time.getUTCTimestamp(),
+              time,
               open: item.open,
               close: item.close,
               high: item.high,

--- a/packages/prices-api/src/chains/parsers.ts
+++ b/packages/prices-api/src/chains/parsers.ts
@@ -1,5 +1,5 @@
 import { chains, type Chain } from '..'
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -21,7 +21,7 @@ export const parseTxs = (x: Responses.GetTransactionsResponse): Models.Transacti
   x.data.flatMap((data) =>
     data.transactions.map((tx) => ({
       chain: data.chain,
-      timestamp: toUTC(tx.timestamp),
+      timestamp: toDate(tx.timestamp),
       type: tx.type,
       transactions: tx.transactions,
     })),
@@ -31,7 +31,7 @@ export const parseUsers = (x: Responses.GetUsersResponse): Models.Users[] =>
   x.data.flatMap((data) =>
     data.users.map((tx) => ({
       chain: data.chain,
-      timestamp: toUTC(tx.timestamp),
+      timestamp: toDate(tx.timestamp),
       type: tx.type,
       users: tx.users,
     })),

--- a/packages/prices-api/src/crvusd/parsers.ts
+++ b/packages/prices-api/src/crvusd/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -29,7 +29,7 @@ export const parseMarket = (x: Responses.GetMarketsResponse['data'][number]): Mo
 })
 
 export const parseSnapshot = (x: Responses.GetSnapshotsResponse['data'][number]): Models.Snapshot => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   rate: x.rate,
   nLoans: x.n_loans,
   minted: x.minted,
@@ -59,7 +59,7 @@ export const parseKeeper = (x: Responses.GetKeepersResponse['keepers'][number]):
 })
 
 export const parseSupply = (x: Responses.GetSupplyResponse['data'][number]): Models.CrvUsdSupply => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   market: x.market,
   supply: x.supply,
   borrowable: x.borrowable,
@@ -69,8 +69,8 @@ export const parseUserMarkets = (x: Responses.GetUserMarketsResponse): Models.Us
   x.markets.map((market) => ({
     collateral: market.collateral,
     controller: market.controller,
-    snapshotFirst: toUTC(market.first_snapshot),
-    snapshotLast: toUTC(market.last_snapshot),
+    snapshotFirst: toDate(market.first_snapshot),
+    snapshotLast: toDate(market.last_snapshot),
   }))
 
 export const parseUserMarketStats = (x: Responses.GetUserMarketStatsResponse) => ({
@@ -89,7 +89,7 @@ export const parseUserMarketStats = (x: Responses.GetUserMarketStatsResponse) =>
   lossPct: x.loss_pct,
   oraclePrice: x.oracle_price,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
 })
 
 export const parseUserMarketSnapshots = (x: Responses.GetUserMarketSnapshotsResponse): Models.UserMarketSnapshots =>
@@ -106,7 +106,7 @@ export const parseUserCollateralEvents = (
   totalBorrowed: x.total_borrowed,
   totalBorrowedPrecise: x.total_borrowed_precise,
   events: x.data.map((y) => ({
-    timestamp: toUTC(y.dt),
+    timestamp: toDate(y.dt),
     txHash: y.transaction_hash,
     type: y.type,
     user: y.user,

--- a/packages/prices-api/src/dao/parsers.ts
+++ b/packages/prices-api/src/dao/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -11,21 +11,21 @@ export const parseVotesOverview = (x: Responses.GetVotesOverviewResponse['data']
 })
 
 export const parseLocksDaily = (x: Responses.GetLocksDailyResponse['locks'][number]): Models.LocksDaily => ({
-  day: toUTC(x.day),
+  day: toDate(x.day),
   amount: BigInt(x.amount),
 })
 
 export const parseUserLock = (x: Responses.GetUserLocksResponse['locks'][number]): Models.UserLock => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   amount: BigInt(Math.round(parseFloat(x.amount))),
-  unlockTime: toUTC(x.unlock_time),
+  unlockTime: toDate(x.unlock_time),
   lockType: x.lock_type as Models.UserLock['lockType'],
   lockedBalance: BigInt(Math.round(parseFloat(x.locked_balance))),
   txHash: x.transaction_hash,
 })
 
 export const parseSupply = (x: Responses.GetSupplyResponse['supply'][number]): Models.Supply => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   veCrvTotal: BigInt(x.total_vecrv),
   crvEscrowed: BigInt(x.escrowed_crv),
   crvSupply: BigInt(x.crv_supply),
@@ -44,5 +44,5 @@ export const parseLockers = (x: Responses.GetLockersTopResponse['users'][number]
   locked: BigInt(Math.round(parseFloat(x.locked))),
   weight: BigInt(Math.round(parseFloat(x.weight))),
   weightRatio: parseFloat(x.weight_ratio.slice(0, -1)),
-  unlockTime: toUTC(x.unlock_time),
+  unlockTime: toDate(x.unlock_time),
 })

--- a/packages/prices-api/src/gauge/parsers.ts
+++ b/packages/prices-api/src/gauge/parsers.ts
@@ -1,5 +1,5 @@
 import type { Chain } from '..'
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -38,16 +38,16 @@ export const parseGauge = (x: Responses.GetGaugeResponse): Models.Gauge => ({
   weightRelativeDelta7d: x.gauge_relative_weight_7d_delta ? x.gauge_relative_weight_7d_delta : undefined,
   weightRelativeDelta60d: x.gauge_relative_weight_60d_delta ? x.gauge_relative_weight_60d_delta : undefined,
   creationTx: x.creation_tx,
-  creationDate: toUTC(x.creation_date),
+  creationDate: toDate(x.creation_date),
   lastVoteTx: x.last_vote_tx ?? undefined,
-  lastVoteDate: x.last_vote_date ? toUTC(x.last_vote_date) : undefined,
+  lastVoteDate: x.last_vote_date ? toDate(x.last_vote_date) : undefined,
 })
 
 export const parseVote = (x: Responses.GetVotesResponse['votes'][number]): Models.GaugeVote => ({
   user: x.user,
   weight: x.weight,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   tx: x.transaction,
 })
 
@@ -65,7 +65,7 @@ export const parseDeployment = (x: Responses.GetDeploymentResponse): Models.Depl
   calldata: x.calldata,
   calldataDecoded: x.decoded_calldata ?? undefined,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
 })
 
 export const parseUserGaugeVote = (x: Responses.GetUserGaugeVotesResponse['votes'][number]): Models.UserGaugeVote => ({
@@ -73,6 +73,6 @@ export const parseUserGaugeVote = (x: Responses.GetUserGaugeVotesResponse['votes
   gaugeName: x.gauge_name,
   weight: x.weight,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   txHash: x.transaction,
 })

--- a/packages/prices-api/src/lending/parsers.ts
+++ b/packages/prices-api/src/lending/parsers.ts
@@ -1,6 +1,6 @@
 import type * as Responses from './responses'
 import type * as Models from './models'
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 
 export const parseLoanDistribution = (x: Responses.GetLoanDistributionResponse): Models.LoanDistribution => ({
   stablecoin: x.stablecoin.map((x) => ({ value: x.value, label: x.label })),
@@ -22,7 +22,7 @@ export const parseOracle = (x: Responses.GetOracleResponse): Models.Oracle => ({
     collateralAddress: pool.collateral_address,
   })),
   ohlc: x.data.map((ohlc) => ({
-    time: toUTC(ohlc.time),
+    time: toDate(ohlc.time),
     open: ohlc.open,
     close: ohlc.close,
     high: ohlc.high,

--- a/packages/prices-api/src/liquidations/parsers.ts
+++ b/packages/prices-api/src/liquidations/parsers.ts
@@ -1,14 +1,14 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
 export const parseSoftLiqRatio = (x: Responses.GetSoftLiqRatiosResponse['data'][number]): Models.SoftLiqRatio => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   proportion: x.proportion / 100,
 })
 
 export const parseLiqsDetailed = (x: Responses.GetLiqsDetailedResponse['data'][number]): Models.LiquidationDetails => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   user: x.user,
   liquidator: x.liquidator,
   self: x.self,
@@ -26,7 +26,7 @@ export const parseLiqsDetailed = (x: Responses.GetLiqsDetailedResponse['data'][n
 export const parseLiqsAggregate = (
   x: Responses.GetLiqsAggregateResponse['data'][number],
 ): Models.LiquidationAggregate => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   selfCount: x.self_count,
   hardCount: x.hard_count,
   selfValue: x.self_value,
@@ -46,7 +46,7 @@ export const parseLiqOverview = (x: Responses.GetLiqOverviewResponse): Models.Li
 })
 
 export const parseLiqLosses = (x: Responses.GetLiqLossesResponse['data'][number]): Models.LiqLosses => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   pctLossAverage: x.avg_pct_loss,
   pctLossMedian: x.median_pct_loss,
   absoluteLossAverage: x.avg_abs_loss,

--- a/packages/prices-api/src/llamalend/parsers.ts
+++ b/packages/prices-api/src/llamalend/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -54,7 +54,7 @@ export const parseSnapshot = (x: Responses.GetSnapshotsResponse['data'][number])
   collateralBalanceUsd: parseFloat(x.collateral_balance_usd),
   borrowedBalance: parseFloat(x.borrowed_balance),
   borrowedBalanceUsd: parseFloat(x.borrowed_balance_usd),
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   discountLiquidation: x.liquidation_discount,
   discountLoan: x.loan_discount,
 })
@@ -63,8 +63,8 @@ export const parseUserMarkets = (x: Responses.GetUserMarketsResponse): Models.Us
   x.markets.map((market) => ({
     name: market.market_name,
     controller: market.controller,
-    snapshotFirst: toUTC(market.first_snapshot),
-    snapshotLast: toUTC(market.last_snapshot),
+    snapshotFirst: toDate(market.first_snapshot),
+    snapshotLast: toDate(market.last_snapshot),
   }))
 
 export const parseUserMarketStats = (x: Responses.GetUserMarketStatsResponse) => ({
@@ -83,7 +83,7 @@ export const parseUserMarketStats = (x: Responses.GetUserMarketStatsResponse) =>
   lossPct: x.loss_pct,
   oraclePrice: x.oracle_price,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
 })
 
 export const parseUserMarketSnapshots = (x: Responses.GetUserMarketSnapshotsResponse): Models.UserMarketSnapshots =>
@@ -102,7 +102,7 @@ export const parseUserCollateralEvents = (
   totalBorrowed: x.total_borrowed,
   totalBorrowedPrecise: x.total_borrowed_precise,
   events: x.data.map((y) => ({
-    timestamp: toUTC(y.dt),
+    timestamp: toDate(y.dt),
     txHash: y.transaction_hash,
     type: y.type,
     user: y.user,

--- a/packages/prices-api/src/llamma/parsers.ts
+++ b/packages/prices-api/src/llamma/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -18,7 +18,7 @@ export const parseEvents = (x: Responses.GetLlammaEventsResponse['data'][number]
       }
     : null,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   txHash: x.transaction_hash,
 })
 
@@ -40,12 +40,12 @@ export const parseTrades = (x: Responses.GetLlammaTradesResponse['data'][number]
   feeX: x.fee_x,
   feeY: x.fee_y,
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   txHash: x.transaction_hash,
 })
 
 export const parseOHLC = (x: Responses.GetLlammaOHLCResponse['data'][number]): Models.LlammaOHLC => ({
-  time: toUTC(x.time),
+  time: toDate(x.time),
   open: x.open,
   close: x.close,
   high: x.high,

--- a/packages/prices-api/src/ohlc/parsers.ts
+++ b/packages/prices-api/src/ohlc/parsers.ts
@@ -1,9 +1,9 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
 export const parseOHLC = (x: Responses.GetOHLCResponse['data'][number]): Models.OHLC => ({
-  time: toUTC(x.time),
+  time: toDate(x.time),
   open: x.open,
   high: x.high,
   low: x.low,

--- a/packages/prices-api/src/pools/parsers.ts
+++ b/packages/prices-api/src/pools/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -32,13 +32,13 @@ export const parsePool = (x: Responses.GetPoolsResponse['data'][number]): Models
 })
 
 export const parseVolume = (x: Responses.GetVolumeResponse['data'][number]): Models.Volume => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   volume: x.volume,
   fees: x.fees,
 })
 
 export const parseTvl = (x: Responses.GetTvlResponse['data'][number]): Models.Tvl => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   tvlUSD: x.tvl_usd ?? 0,
   balances: [...x.balances],
   tokenPrices: [...x.token_prices],

--- a/packages/prices-api/src/proposal/parsers.ts
+++ b/packages/prices-api/src/proposal/parsers.ts
@@ -1,9 +1,9 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
 export const parseProposal = (x: Responses.GetProposalsResponse['proposals'][number]): Models.Proposal => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   id: x.vote_id,
   type: x.vote_type.toLocaleLowerCase() === 'parameter' ? 'parameter' : 'ownership',
   metadata: x.metadata?.startsWith('"') // Remove weird starting quote, if present.

--- a/packages/prices-api/src/revenue/parsers.ts
+++ b/packages/prices-api/src/revenue/parsers.ts
@@ -1,5 +1,5 @@
 import type { Chain } from '..'
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -14,14 +14,14 @@ export const parseTopPools = (x: Responses.GetTopPoolsResponse['revenue'][number
 })
 
 export const parseCrvUsdWeekly = (x: Responses.GetCrvUsdWeeklyResponse['fees'][number]): Models.CrvUsdWeekly => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   controller: x.controller,
   collateral: x.collateral,
   feesUsd: x.fees_usd,
 })
 
 export const parsePoolsWeekly = (x: Responses.GetPoolsWeeklyResponse['fees'][number]): Models.PoolsWeekly => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   chain: x.chain as Chain,
   feesUsd: x.fees_usd,
 })
@@ -36,14 +36,14 @@ export const parseCushion = (x: Responses.GetCushionsResponse['data'][number]): 
 export const parseDistribution = (
   x: Responses.GetDistributionsResponse['distributions'][number],
 ): Models.Distribution => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   feesUsd: x.fees_usd,
 })
 
 export const parseCowSwapSettlement = (
   x: Responses.GetCowSwapSettlementsResponse['data'][number],
 ): Models.CowSwapSettlement => ({
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
   coin: {
     lpToken: x.coin.lp_token,
     symbol: x.coin.symbol,

--- a/packages/prices-api/src/savings/parsers.ts
+++ b/packages/prices-api/src/savings/parsers.ts
@@ -1,4 +1,4 @@
-import { toUTC } from '../timestamp'
+import { toDate } from '../timestamp'
 import type * as Responses from './responses'
 import type * as Models from './models'
 
@@ -10,12 +10,12 @@ export const parseEvent = (x: Responses.GetEventsResponse['events'][number]): Mo
   assets: BigInt(x.assets),
   supply: BigInt(x.shares),
   blockNumber: x.block_number,
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   txHash: x.transaction_hash,
 })
 
 export const parseYield = (x: Responses.GetYieldResponse['data'][number]): Models.Yield => ({
-  timestamp: toUTC(x.timestamp),
+  timestamp: toDate(x.timestamp),
   assets: x.assets,
   supply: x.supply,
   apyProjected: x.proj_apy,
@@ -30,11 +30,11 @@ export const parseRevenue = (x: Responses.GetRevenueResponse['history'][number])
   feesTotal: BigInt(x.total_fees),
   feesProtocol: BigInt(x.protocol_fees),
   txHash: x.tx_hash,
-  timestamp: toUTC(x.dt),
+  timestamp: toDate(x.dt),
 })
 
 export const parseStatistics = (x: Responses.GetStatisticsResponse): Models.Statistics => ({
-  lastUpdated: toUTC(x.last_updated),
+  lastUpdated: toDate(x.last_updated),
   lastUpdatedBlock: x.last_updated_block,
   aprProjected: x.proj_apr,
   supply: x.supply,

--- a/packages/prices-api/src/timestamp.ts
+++ b/packages/prices-api/src/timestamp.ts
@@ -2,15 +2,16 @@ const TZ_OFFSET = /[+-]\d{2}:?\d{2}$/
 
 /**
  * Converts a timestamp string or number to UTC Date object
- * @param timestamp - Timestamp as string (ISO format) or number (unix seconds)
+ * @param timestamp - Timestamp as string (ISO format or unix seconds) or number (unix seconds)
  * @returns UTC Date object
  * @example
- * toUTC(1234567890)
- * toUTC("2024-01-01T00:00:00.000Z")
- * toUTC("2024-01-01T00:00:00.000Z+01:00")
- * toUTC("2024-01-01T00:00:00") // (assumes UTC)
+ * toDate(1234567890) // Unix timestamp number
+ * toDate("1234567890") // Unix timestamp string
+ * toDate("2024-01-01T00:00:00.000Z") // ISO with UTC
+ * toDate("2024-01-01T00:00:00.000+01:00") // ISO with timezone
+ * toDate("2024-01-01T00:00:00") // ISO without timezone (assumes UTC)
  */
-export function toUTC(timestamp: string | number): Date {
+export function toDate(timestamp: string | number): Date {
   // Convert actual unix timestamp numbers to Date.
   if (typeof timestamp === 'number') {
     return new Date(timestamp * 1000)


### PR DESCRIPTION
* Turns out lightweight charts prefer to have the actual data adjusted to the local time zone as per https://tradingview.github.io/lightweight-charts/docs/time-zones#how-to-add-time-zone-support-to-your-chart.
* Adds `bigint.prototype.fromWei()` to easily convert bigints to a presentational number
* Renames 'toUTC' to 'toDate' such that the function's purposes is clearer
* Lodash doesn't have a suitable alternative for the `combinations` function we've implemented ourselves, so that has been kept untouched.
* Depends on https://github.com/curvefi/curve-frontend/pull/637