### PR TITLE
feat: add discussion link to dao submenu

### DIFF
--- a/packages/curve-ui-kit/src/shared/routes.ts
+++ b/packages/curve-ui-kit/src/shared/routes.ts
@@ -29,6 +29,7 @@ export const DAO_ROUTES = {
   PAGE_VECRV: '/vecrv',
   PAGE_ANALYTICS: '/analytics',
   PAGE_USER: '/user',
+  DISCUSSION: 'https://gov.curve.fi/',
 }
 
 export const AppNames = ['main', 'lend', 'crvusd', 'dao'] as const
@@ -68,6 +69,7 @@ export const APP_LINK: Record<AppName, AppRoutes> = {
       { route: DAO_ROUTES.PAGE_PROPOSALS, label: () => t`Proposals` },
       { route: DAO_ROUTES.PAGE_GAUGES, label: () => t`Gauges` },
       { route: DAO_ROUTES.PAGE_ANALYTICS, label: () => t`Analytics` },
+      { route: DAO_ROUTES.DISCUSSION, label: () => t`Discussion`, target: '_blank' },
     ],
   },
 }

--- a/packages/curve-ui-kit/src/widgets/Header/PageTabs.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/PageTabs.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent, useMemo } from 'react'
 import type { AppPage } from './types'
 import { TabsSwitcher } from '@ui-kit/shared/ui/TabsSwitcher'
 import { APP_LINK, AppName, externalAppUrl } from '@ui-kit/shared/routes'
+import Link from '@mui/material/Link'
 import { Link as RouterLink } from 'react-router-dom'
 
 export type PageTabsProps = {
@@ -20,8 +21,8 @@ export const PageTabs: FunctionComponent<PageTabsProps> = ({ pages, currentApp, 
           ? pages.map((page) => ({
               label: page.label,
               value: page.route,
-              to: page.route,
-              component: RouterLink,
+              component: page.target ? Link : RouterLink,
+              ...(page.target ? { href: page.route, target: page.target } : { to: page.route }),
             }))
           : APP_LINK[selectedApp].pages.map(({ label, route }) => ({
               label: label(),

--- a/packages/curve-ui-kit/src/widgets/Header/types.ts
+++ b/packages/curve-ui-kit/src/widgets/Header/types.ts
@@ -16,6 +16,7 @@ export type AppPage = {
 export type AppRoute = {
   route: string
   label: () => string // lazy evaluation for translations
+  target?: '_self' | '_blank' // note this is only used for external routes
 }
 
 export type AppRoutes = {

--- a/packages/ui/src/utils/utilsAppNavigation.tsx
+++ b/packages/ui/src/utils/utilsAppNavigation.tsx
@@ -6,14 +6,15 @@ export const _parseRouteAndIsActive = (
   routerPathname: string,
   network: string | undefined,
 ) =>
-  pages.map(({ route, label }) => {
+  pages.map(({ route, label, target }) => {
     const rPathname = routerPathname.split('?')[0] ?? ''
     const routePathname = route.split('?')[0] ?? ''
     const parsedRouterNetwork = network || 'ethereum'
 
     return {
-      route: `${routerLocalePathname}/${parsedRouterNetwork}${route}`,
+      route: route.startsWith('http') ? route : `${routerLocalePathname}/${parsedRouterNetwork}${route}`,
       isActive: rPathname && routePathname ? rPathname.endsWith(routePathname) : false,
       label: label(),
+      target,
     }
   })


### PR DESCRIPTION
Not the prettiest PR, but now that the apps are merged we should probably revise routing and menu generation anyway in a different PR (and it's also a bit buggy as well)

Either way, this PR adds a link to the governance forum to the DAO app. It used to be a separate top level link, but it makes more sense to group it under the DAO app.
![image](https://github.com/user-attachments/assets/ea68d694-21a2-4c34-9f38-b7071cc7bb3c)