### PR TITLE
feat: hide crosscurve links on pools overview table

### DIFF
--- a/apps/main/src/dex/components/PoolLabel.tsx
+++ b/apps/main/src/dex/components/PoolLabel.tsx
@@ -129,7 +129,7 @@ const PoolLabel = ({ className = '', imageBaseUrl, isVisible = true, poolData, p
       </Wrapper>
 
       {tokenAlert && isMobile && <StyledAlertBox alertType={tokenAlert.alertType}>{tokenAlert.message}</StyledAlertBox>}
-      {poolAlert && (
+      {poolAlert && !poolAlert.isPoolPageOnly && (
         <>
           {!poolAlert.isInformationOnly && !poolAlert.isInformationOnlyAndShowInForm ? (
             <Box padding="0.5rem 0 0 0">{poolAlert.message}</Box>

--- a/apps/main/src/dex/hooks/usePoolAlert.tsx
+++ b/apps/main/src/dex/hooks/usePoolAlert.tsx
@@ -112,6 +112,7 @@ const usePoolAlert = (poolAddress: string | undefined, hasVyperVulnerability: bo
     // Fantom networks
     const crossCurveAlert = (externalLinks: { label: string; url: string }[]): PoolAlert => ({
       alertType: '',
+      isPoolPageOnly: true,
       message: (
         <PoolAlertCustomMessage title="CrossCurve links" titleIcon={<RCCrossCurve />} externalLinks={externalLinks} />
       ),

--- a/apps/main/src/dex/types/main.types.ts
+++ b/apps/main/src/dex/types/main.types.ts
@@ -292,6 +292,7 @@ export interface PoolAlert extends TooltipProps {
   isInformationOnly?: boolean
   isInformationOnlyAndShowInForm?: boolean
   isCloseOnTooltipOnly?: boolean
+  isPoolPageOnly?: boolean // Don't show the pools overview table
   address?: string
   message: string | React.ReactNode
 }


### PR DESCRIPTION
Crosscurve pools on fantom no longer show links on the pools overview table, only on the pool page itself.
That means, the links you see in screenshot attached are removed

![image](https://github.com/user-attachments/assets/e8a31c08-bae2-4a30-aea1-46aa8f9367ac)
