### PR TITLE
chore: update fantom explorer

### DIFF
--- a/packages/ui/src/utils/utilsNetworks.ts
+++ b/packages/ui/src/utils/utilsNetworks.ts
@@ -83,7 +83,7 @@ export const NETWORK_BASE_CONFIG: Record<number, any> = {
     chainId: Chain.Fantom,
     rpcUrl: 'https://rpc.ftm.tools/',
     nativeCurrencySymbol: 'FTM',
-    explorerUrl: 'https://ftmscan.com/',
+    explorerUrl: 'https://explorer.fantom.network/',
     orgUIPath: 'https://ftm.curve.fi',
   },
   [Chain.Arbitrum]: {


### PR DESCRIPTION
Note that the new explorer does not seem to have a token page, so that results in 404.