### PR TITLE
fix: band width factor

### DIFF
--- a/apps/main/src/lend/components/DetailsMarket/components/MarketParameters.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/MarketParameters.tsx
@@ -40,7 +40,7 @@ const MarketParameters = ({
       [
         { label: t`AMM swap fee`, value: parameters?.fee, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 3 }, isError: parametersError },
         { label: t`Admin fee`, value: parameters?.admin_fee, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 3 }, isError: parametersError },
-        { label: t`A`, value: parameters?.A, formatOptions: { useGrouping: false }, isError: parametersError },
+        { label: t`Band width factor`, value: parameters?.A, formatOptions: { useGrouping: false }, isError: parametersError },
         { label: t`Loan discount`, value: parameters?.loan_discount, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 2 }, isError: parametersError },
         { label: t`Liquidation discount`, value: parameters?.liquidation_discount, formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 2 }, isError: parametersError },
         { label: t`Max LTV`, value: _getMaxLTV( parameters?.A, parameters?.loan_discount), formatOptions: { ...FORMAT_OPTIONS.PERCENT, maximumSignificantDigits: 2 }, isError: parametersError, isAdvance: true, tooltip: t`Max possible loan at N=4` },

--- a/apps/main/src/loan/components/LoanInfoLlamma/LoanInfoParameters.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/LoanInfoParameters.tsx
@@ -32,7 +32,7 @@ const LoanInfoParameters = ({ llamma, llammaId }: Props) => {
           </Chip>
         )}
       </DetailInfo>
-      <DetailInfo label={t`Oracle Price`} size="md">
+      <DetailInfo label={t`Oracle price`} size="md">
         {typeof priceInfo?.oraclePrice !== 'undefined' && (
           <Chip
             size="md"

--- a/apps/main/src/loan/components/LoanInfoLlamma/LoanInfoParameters.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/LoanInfoParameters.tsx
@@ -18,7 +18,7 @@ const LoanInfoParameters = ({ llamma, llammaId }: Props) => {
 
   return (
     <Box grid gridRowGap="1">
-      <DetailInfo label={t`A`} size="md">
+      <DetailInfo label={t`Band width factor`} size="md">
         <span>{formatNumber(llamma?.A, { useGrouping: false })}</span>
       </DetailInfo>
       <DetailInfo label={t`Base price`} size="md">

--- a/packages/ui/src/Chart/CandleChart.tsx
+++ b/packages/ui/src/Chart/CandleChart.tsx
@@ -1,6 +1,5 @@
 import type {
   LpPriceOhlcDataFormatted,
-  ChartType,
   ChartHeight,
   VolumeData,
   OraclePriceData,
@@ -34,7 +33,6 @@ function hslaToRgb(hsla: string) {
 }
 
 type Props = {
-  chartType: ChartType
   chartHeight: ChartHeight
   ohlcData: LpPriceOhlcDataFormatted[]
   volumeData?: VolumeData[]
@@ -55,7 +53,6 @@ type Props = {
 }
 
 const CandleChart = ({
-  chartType,
   chartHeight,
   ohlcData,
   volumeData,

--- a/packages/ui/src/Chart/CandleChart.tsx
+++ b/packages/ui/src/Chart/CandleChart.tsx
@@ -14,6 +14,25 @@ import { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { debounce } from 'lodash'
 
+/**
+ * Converts an HSLA color string to RGB format
+ * Lightweight Cahrts v5 adds support for HSLA, but until then we need to convert to RGB
+ * @param hsla - HSLA color string (e.g. "hsla(230, 60%, 29%, 1)")
+ * @returns RGB color string (e.g. "rgb(44, 57, 118)")
+ * @example
+ * hslaToRgb("hsla(230, 60%, 29%, 1)") // returns "rgb(44, 57, 118)"
+ * hslaToRgb("hsl(230, 60%, 29%)") // returns "rgb(44, 57, 118)"
+ */
+function hslaToRgb(hsla: string) {
+  return hsla.replace(/hsla?\((\d+),\s*(\d+)%,\s*(\d+)%(?:,\s*[\d.]+)?\)/, (_, h, s, l) => {
+    const a = s / 100
+    const b = l / 100
+    const k = (n: number) => (n + h / 30) % 12
+    const f = (n: number) => b - a * Math.min(b, 1 - b) * Math.max(-1, Math.min(k(n) - 3, 9 - k(n), 1))
+    return `rgb(${Math.round(255 * f(0))}, ${Math.round(255 * f(8))}, ${Math.round(255 * f(4))})`
+  })
+}
+
 type Props = {
   chartType: ChartType
   chartHeight: ChartHeight
@@ -97,8 +116,8 @@ const CandleChart = ({
 
     chartRef.current = createChart(chartContainerRef.current, {
       layout: {
-        background: { type: ColorType.Solid, color: colors.backgroundColor },
-        textColor: colors.textColor,
+        background: { type: ColorType.Solid, color: hslaToRgb(colors.backgroundColor) },
+        textColor: hslaToRgb(colors.textColor),
       },
       width: wrapperRef.current.clientWidth,
       height: chartExpanded ? chartHeight.expanded : chartHeight.standard,

--- a/packages/ui/src/Chart/ChartWrapper.tsx
+++ b/packages/ui/src/Chart/ChartWrapper.tsx
@@ -237,7 +237,6 @@ const ChartWrapper = ({
         {chartStatus === 'READY' && (
           <ResponsiveContainer ref={wrapperRef} chartExpanded={chartExpanded} chartHeight={chartHeight}>
             <CandleChart
-              chartType={chartType}
               chartHeight={chartHeight}
               ohlcData={clonedOhlcData}
               volumeData={volumeData}


### PR DESCRIPTION
Renames 'A' to 'Band width factor' for loans. Also fixed some casing and lightweight charts color issues. 

I thought it would be nice to add a tooltip explaining the band width factor, but couldn't get it to work nicely. Fixing this and replacing the tooltip component is outside the scope of this PR

![image](https://github.com/user-attachments/assets/71dc6791-dfb9-4ec0-b2f0-10d5d5090a13)