### PR TITLE
refactor: Remove TableCellReferenceAsset from PoolLabel

### DIFF
--- a/apps/main/src/dex/components/PoolLabel.tsx
+++ b/apps/main/src/dex/components/PoolLabel.tsx
@@ -83,11 +83,6 @@ const PoolLabel = ({ className = '', imageBaseUrl, isVisible = true, poolData, p
           {isVisible && <TokenIcons imageBaseUrl={imageBaseUrl} tokens={tokens} tokenAddresses={tokenAddresses} />}
         </IconsWrapper>
         <Box fillWidth>
-          <TableCellReferenceAsset
-            isCrypto={poolData?.pool?.isCrypto}
-            referenceAsset={poolData?.pool?.referenceAsset}
-          />
-
           <Box flex flexAlignItems="center">
             {!isMobile && (
               <>


### PR DESCRIPTION
Removed "pool type label" from pools rows in pool list

Before:
<img width="362" alt="SCR-20250216-rdlr" src="https://github.com/user-attachments/assets/b443b943-db79-4877-949f-894402c2b96b" />

After:
<img width="408" alt="SCR-20250216-rdct" src="https://github.com/user-attachments/assets/7f483544-f67d-46d0-a3d5-dfe0f08d8e36" />
