### PR TITLE
Fix old links for audit and whitepaper tabs on risk disclaimer page

### DIFF
--- a/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/CrvUsd.tsx
+++ b/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/CrvUsd.tsx
@@ -32,7 +32,7 @@ export const CrvUsd = () => (
       <Button
         component={Link}
         variant="link"
-        href="https://docs.curve.fi/assets/pdf/curve-stablecoin.pdf"
+        href="https://docs.curve.fi/assets/pdf/whitepaper_curve_stablecoin.pdf"
         target="_blank"
         endIcon={<ArrowOutwardIcon />}
         sx={{
@@ -46,7 +46,7 @@ export const CrvUsd = () => (
       <Button
         component={Link}
         variant="link"
-        href="https://docs.curve.fi/references/audits/#crvusd-and-lending"
+        href="https://docs.curve.fi/security/security/#stablecoin-and-lending"
         target="_blank"
         endIcon={<ArrowOutwardIcon />}
         sx={{

--- a/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/Dex.tsx
+++ b/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/Dex.tsx
@@ -44,7 +44,7 @@ export const Dex = () => (
       <Button
         component={Link}
         variant="link"
-        href="https://docs.curve.fi/security/security/#dao"
+        href="https://docs.curve.fi/security/security/#security-audits"
         target="_blank"
         endIcon={<ArrowOutwardIcon />}
         sx={{

--- a/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/Dex.tsx
+++ b/packages/curve-ui-kit/src/widgets/Disclaimer/Tabs/Dex.tsx
@@ -30,7 +30,7 @@ export const Dex = () => (
       <Button
         component={Link}
         variant="link"
-        href="https://docs.curve.fi/assets/pdf/CurveDAO.pdf"
+        href="https://docs.curve.fi/references/whitepaper"
         target="_blank"
         endIcon={<ArrowOutwardIcon />}
         sx={{
@@ -44,7 +44,7 @@ export const Dex = () => (
       <Button
         component={Link}
         variant="link"
-        href="https://docs.curve.fi/references/audits/#curve-dao"
+        href="https://docs.curve.fi/security/security/#dao"
         target="_blank"
         endIcon={<ArrowOutwardIcon />}
         sx={{


### PR DESCRIPTION
- replace old links which directs to a page not found with new ones