### PR TITLE
feat: user pools via prices API to fix dashboard

### DIFF
--- a/apps/main/src/dex/components/PageDashboard/components/SummaryTotal.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/SummaryTotal.tsx
@@ -14,8 +14,7 @@ import { Chip } from '@ui/Typography'
 import Spinner from '@ui/Spinner'
 
 const SummaryTotal = () => {
-  const { dashboardDataMapper, isValidAddress } = useDashboardContext()
-  const { isLoading } = useDashboardContext()
+  const { isLoading, dashboardDataMapper, isValidAddress } = useDashboardContext()
 
   const total = useMemo(() => {
     if (typeof dashboardDataMapper === 'undefined') return null

--- a/apps/main/src/dex/entities/user-pools.ts
+++ b/apps/main/src/dex/entities/user-pools.ts
@@ -42,7 +42,7 @@ function getChainName(chainId: ChainId): Chain {
     networks: { networks },
   } = useStore.getState()
   const network = networks[chainId]
-  return network.name.toLowerCase() as Chain
+  return network.id as Chain
 }
 
 const queryUserPools = async ({ userAddress, chainId }: UserPoolQuery): Promise<UserPoolStats[]> => {

--- a/apps/main/src/dex/entities/user-pools.ts
+++ b/apps/main/src/dex/entities/user-pools.ts
@@ -17,7 +17,7 @@ import { chainValidationGroup } from '@ui-kit/lib/model/query/chain-validation'
 export type UserPoolStats = {
   chain: Chain
   userAddress: Address
-  poolId: string
+  poolId?: string
   poolAddress: Address
   poolName?: string
   lpTokenBalance?: number
@@ -34,7 +34,13 @@ function createGetPoolIds(chainId: number) {
   const poolIds = Object.fromEntries(
     Object.entries(poolsMapper[chainId]).map(([poolId, { pool }]) => [pool.address, poolId]),
   )
-  return (poolAddress: string) => poolIds[poolAddress.toLowerCase()]
+  return (poolAddress: string) => {
+    const poolId = poolIds[poolAddress.toLowerCase()]
+    if (!poolId) {
+      console.warn(`Pool ID not found for address ${poolAddress}`)
+    }
+    return poolId
+  }
 }
 
 function getChainName(chainId: ChainId): Chain {

--- a/apps/main/src/dex/entities/user-pools.ts
+++ b/apps/main/src/dex/entities/user-pools.ts
@@ -1,0 +1,50 @@
+import {
+  type ChainParams,
+  type ChainQuery,
+  queryFactory,
+  type UserAddressParams,
+  type UserAddressQuery,
+} from '@ui-kit/lib/model'
+import { getUserPools } from '@curvefi/prices-api/pools'
+import { userAddressValidationGroup, userAddressValidationSuite } from '@ui-kit/lib/model/query/user-address-validation'
+import { type Address, type Chain, CHAIN_ID_NAMES } from '@curvefi/prices-api'
+import { fetchSupportedChains } from '@ui-kit/entities/chains'
+import { createValidationSuite } from '@ui-kit/lib'
+import useStore from '@/dex/store/useStore'
+import { chainValidationGroup } from '@/lend/entities/chain'
+
+export type UserPoolStats = {
+  chain: Chain
+  userAddress: Address
+  poolAddress: Address
+  poolName?: string
+  lpTokenBalance?: number
+}
+
+type UserPoolParams = UserAddressParams & ChainParams
+type UserPoolQuery = UserAddressQuery & ChainQuery
+
+export const { fetchQuery: fetchUserPools } = queryFactory({
+  queryKey: ({ userAddress, chainId }: UserPoolParams) => ['user', 'pools', { chainId }, { userAddress }] as const,
+  queryFn: async ({ userAddress, chainId }: UserPoolQuery): Promise<UserPoolStats[]> => {
+    const chains = await fetchSupportedChains({})
+    const chain = CHAIN_ID_NAMES[chainId]
+    if (chains.includes(chain)) {
+      const { positions } = await getUserPools(chain, userAddress)
+      return positions.map((pool) => ({ ...pool, chain, userAddress }))
+    }
+
+    // for smaller chains, fallback to curvejs (it does too many requests on mainnet)
+    const { curve } = useStore.getState()
+    if (curve.chainId !== chainId) throw new Error('Invalid chain in curvejs')
+
+    const poolAddresses = await curve.getUserPoolList()
+    return poolAddresses.map((poolAddress) => ({ chain, userAddress, poolAddress: poolAddress as Address }))
+  },
+  staleTime: '1m',
+  refetchInterval: '1m',
+  validationSuite: createValidationSuite(({ userAddress, chainId }: UserPoolParams) => {
+    chainValidationGroup({ chainId })
+    userAddressValidationGroup({ userAddress })
+  }),
+})

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -22,30 +22,29 @@ import { claimButtonsKey } from '@/dex/components/PageDashboard/components/FormC
 import { fulfilledValue, getErrorMessage, isValidAddress, shortenTokenAddress } from '@/dex/utils'
 import { httpFetcher } from '@/dex/lib/utils'
 import {
+  _parseRoutesAndOutput,
   excludeLowExchangeRateCheck,
   getExchangeRates,
   getSwapIsLowExchangeRate,
-  _parseRoutesAndOutput,
 } from '@/dex/utils/utilsSwap'
 import { log } from '@ui-kit/lib/logging'
 import useStore from '@/dex/store/useStore'
 import {
-  CurveApi,
   ChainId,
+  ClaimableReward,
+  CurveApi,
+  EstimatedGas,
   NetworkConfig,
   Pool,
+  PoolData,
+  PoolParameters,
   Provider,
-  ClaimableReward,
   RewardCrv,
   RewardOther,
   RewardsApy,
-  PoolParameters,
-  UserBalancesMapper,
-  PoolData,
   UsdRatesMapper,
-  EstimatedGas,
+  UserBalancesMapper,
 } from '@/dex/types/main.types'
-import memoizee from 'memoizee'
 
 const helpers = {
   fetchCustomGasFees: async (curve: CurveApi) => {
@@ -1311,29 +1310,10 @@ const poolWithdraw = {
   },
 }
 
-/**
- * TODO: Work around for getPoolList being called twice from UserSlice and DashboardSlice
- */
-const getUserPoolList = memoizee((curve: CurveApi, walletAddress: string) => curve.getUserPoolList(walletAddress), {
-  maxAge: 1000 * 60 * 5,
-  length: 1,
-  promise: true,
-})
-
 const wallet = {
-  getUserPoolList: async (curve: CurveApi, walletAddress: string) => {
-    log('getUserPoolList', curve.chainId, walletAddress)
-    let resp = { poolList: [] as string[], error: '' }
-    try {
-      resp.poolList = await getUserPoolList(curve, walletAddress)
-      return resp
-    } catch (error) {
-      resp.error = getErrorMessage(error, 'error-pool-list')
-      return resp
-    }
-  },
   getUserLiquidityUSD: async (curve: CurveApi, poolIds: string[], walletAddress: string) => {
     log('getUserLiquidityUSD', poolIds, walletAddress)
+    console.log({ curve, poolIds, walletAddress })
     return await curve.getUserLiquidityUSD(poolIds, walletAddress)
   },
   getUserClaimable: async (curve: CurveApi, poolIds: string[], walletAddress: string) => {

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -1313,7 +1313,6 @@ const poolWithdraw = {
 const wallet = {
   getUserLiquidityUSD: async (curve: CurveApi, poolIds: string[], walletAddress: string) => {
     log('getUserLiquidityUSD', poolIds, walletAddress)
-    console.log({ curve, poolIds, walletAddress })
     return await curve.getUserLiquidityUSD(poolIds, walletAddress)
   },
   getUserClaimable: async (curve: CurveApi, poolIds: string[], walletAddress: string) => {

--- a/apps/main/src/dex/store/createDashboardSlice.ts
+++ b/apps/main/src/dex/store/createDashboardSlice.ts
@@ -146,7 +146,7 @@ const createDashboardSlice = (set: SetState<State>, get: GetState<State>): Dashb
         // no staked pools
         if (userPools.length === 0) return { dashboardDataMapper: {}, error: '' }
 
-        const poolList = userPools.map(({ poolId }) => poolId)
+        const poolList = userPools.map(({ poolId }) => poolId).filter(Boolean) as string[]
 
         // get balances and claimables
         const [userPoolBalancesResult, userClaimableResult] = await Promise.allSettled([

--- a/apps/main/src/dex/store/createDashboardSlice.ts
+++ b/apps/main/src/dex/store/createDashboardSlice.ts
@@ -146,7 +146,7 @@ const createDashboardSlice = (set: SetState<State>, get: GetState<State>): Dashb
         // no staked pools
         if (userPools.length === 0) return { dashboardDataMapper: {}, error: '' }
 
-        const poolList = userPools.map(({ poolAddress }) => poolAddress.toLowerCase())
+        const poolList = userPools.map(({ poolId }) => poolId)
 
         // get balances and claimables
         const [userPoolBalancesResult, userClaimableResult] = await Promise.allSettled([

--- a/apps/main/src/dex/store/createUserSlice.ts
+++ b/apps/main/src/dex/store/createUserSlice.ts
@@ -76,7 +76,10 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
 
         const { signerAddress, chainId } = curve
         const userPools = await fetchUserPools({ userAddress: signerAddress as Address, chainId })
-        const parsedUserPoolList = userPools.reduce((acc, pool) => ({ ...acc, [pool.poolId]: true }), {})
+        const parsedUserPoolList = userPools.reduce(
+          (acc, { poolId }) => ({ ...acc, ...(poolId && { [poolId]: true }) }),
+          {},
+        )
 
         get()[sliceKey].setStateByActiveKey('poolList', userActiveKey, parsedUserPoolList)
         get()[sliceKey].setStateByKeys({ poolListLoaded: true })

--- a/apps/main/src/dex/store/createUserSlice.ts
+++ b/apps/main/src/dex/store/createUserSlice.ts
@@ -76,7 +76,7 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
 
         const { signerAddress, chainId } = curve
         const userPools = await fetchUserPools({ userAddress: signerAddress as Address, chainId })
-        const parsedUserPoolList = userPools.reduce((acc, pool) => ({ ...acc, [pool.poolAddress]: true }), {})
+        const parsedUserPoolList = userPools.reduce((acc, pool) => ({ ...acc, [pool.poolId]: true }), {})
 
         get()[sliceKey].setStateByActiveKey('poolList', userActiveKey, parsedUserPoolList)
         get()[sliceKey].setStateByKeys({ poolListLoaded: true })

--- a/apps/main/src/dex/types/main.types.ts
+++ b/apps/main/src/dex/types/main.types.ts
@@ -178,7 +178,7 @@ export type BasePool = {
   pool: string
   coins: string[]
 }
-export type PoolDataMapper = { [poolAddress: string]: PoolData }
+export type PoolDataMapper = { [poolId: string]: PoolData }
 export type PoolDataCache = {
   gauge: Gauge
   hasWrapped: boolean

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/DistributionsChartTooltip.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/DistributionsChartTooltip.tsx
@@ -4,8 +4,7 @@ import { TooltipProps } from 'recharts'
 import { t } from '@ui-kit/lib/i18n'
 import { Paper, Stack, Typography } from '@mui/material'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatNumber, formatDate } from '@ui/utils/utilsFormat'
-import { toDate } from '@curvefi/prices-api/timestamp'
+import { formatDate, formatNumber } from '@ui/utils/utilsFormat'
 import { TOOLTIP_MAX_WIDTH, TOOLTIP_MAX_WIDTH_MOBILE } from '@/loan/components/PageCrvUsdStaking/Statistics/constants'
 
 const { Spacing } = SizesAndSpaces

--- a/apps/main/src/loan/entities/lending-snapshots.ts
+++ b/apps/main/src/loan/entities/lending-snapshots.ts
@@ -1,7 +1,6 @@
 import { ContractParams, ContractQuery, queryFactory, rootKeys } from '@ui-kit/lib/model/query'
 import { contractValidationSuite } from '@ui-kit/lib/model/query/contract-validation'
-import { queryClient } from '@ui-kit/lib/api/query-client'
-import { getSupportedLendingChainOptions } from '@/loan/entities/chains'
+import { fetchSupportedLendingChains } from '@ui-kit/entities/chains'
 import { Chain } from '@curvefi/prices-api'
 import { getSnapshots, Snapshot } from '@curvefi/prices-api/llamalend'
 
@@ -11,7 +10,7 @@ export type LendingSnapshot = LendingSnapshotFromApi
 export const { useQuery: useLendingSnapshots } = queryFactory({
   queryKey: (params: ContractParams) => [...rootKeys.contract(params), 'lendingSnapshots', 'v1'] as const,
   queryFn: async ({ blockchainId, contractAddress }: ContractQuery): Promise<LendingSnapshot[]> => {
-    const chains = await queryClient.fetchQuery(getSupportedLendingChainOptions({}))
+    const chains = await fetchSupportedLendingChains({})
     const chain = blockchainId as Chain
     if (!chains.includes(chain)) return [] // backend gives 404 for optimism
 

--- a/apps/main/src/loan/entities/lending-vaults.ts
+++ b/apps/main/src/loan/entities/lending-vaults.ts
@@ -1,8 +1,7 @@
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { EmptyValidationSuite } from '@ui-kit/lib/validation'
-import { queryClient } from '@ui-kit/lib/api/query-client'
 import { getMarkets, Market } from '@curvefi/prices-api/llamalend'
-import { getSupportedLendingChainOptions } from '@/loan/entities/chains'
+import { fetchSupportedLendingChains } from '@ui-kit/entities/chains'
 import { Chain } from '@curvefi/prices-api'
 
 export type LendingVault = Market & { chain: Chain }
@@ -10,7 +9,7 @@ export type LendingVault = Market & { chain: Chain }
 export const { getQueryOptions: getLendingVaultOptions, invalidate: invalidateLendingVaults } = queryFactory({
   queryKey: () => ['lending-vaults', 'v1'] as const,
   queryFn: async (): Promise<LendingVault[]> => {
-    const chains = await queryClient.fetchQuery(getSupportedLendingChainOptions({}))
+    const chains = await fetchSupportedLendingChains({})
     const markets = await Promise.all(
       chains.map(async (chain) => (await getMarkets(chain, {})).map((market) => ({ ...market, chain }))),
     )

--- a/apps/main/src/loan/entities/mint-markets.ts
+++ b/apps/main/src/loan/entities/mint-markets.ts
@@ -1,11 +1,10 @@
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { EmptyValidationSuite } from '@ui-kit/lib/validation'
-import { queryClient } from '@ui-kit/lib/api/query-client'
 import uniq from 'lodash/uniq'
 import { getCoinPrices } from '@/loan/entities/usd-prices'
 import { getMarkets, Market } from '@curvefi/prices-api/crvusd'
 import { Chain } from '@curvefi/prices-api'
-import { getSupportedChainOptions } from '@/loan/entities/chains'
+import { fetchSupportedChains } from '@ui-kit/entities/chains'
 
 type MintMarketFromApi = Market
 
@@ -31,7 +30,7 @@ async function addStableCoinPrices({ chain, data }: { chain: Chain; data: MintMa
 export const { getQueryOptions: getMintMarketOptions, invalidate: invalidateMintMarkets } = queryFactory({
   queryKey: () => ['mint-markets', 'v1'] as const,
   queryFn: async () => {
-    const chains = await queryClient.fetchQuery(getSupportedChainOptions({}))
+    const chains = await fetchSupportedChains({})
     const allMarkets = await Promise.all(
       // todo: create separate query for the loop, so it can be cached separately
       chains.map(async (blockchainId) => {

--- a/apps/main/src/loan/entities/scrvusdUserBalances.ts
+++ b/apps/main/src/loan/entities/scrvusdUserBalances.ts
@@ -1,6 +1,5 @@
 import { queryFactory } from '@ui-kit/lib/model/query'
 import useStore from '@/loan/store/useStore'
-import { userAddressValidationSuite } from '@ui-kit/lib/model/query/user-address-validation'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 
 export type ScrvUsdUserBalances = { crvUSD: string; scrvUSD: string }

--- a/apps/main/src/loan/entities/scrvusdUserStats.ts
+++ b/apps/main/src/loan/entities/scrvusdUserStats.ts
@@ -1,7 +1,6 @@
 import type { UserStats } from '@curvefi/prices-api/savings/models'
 import { queryFactory, type UserAddressParams, type UserAddressQuery } from '@ui-kit/lib/model/query'
 import { getUserStats } from '@curvefi/prices-api/savings'
-import { userAddressValidationSuite } from '@ui-kit/lib/model/query/user-address-validation'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 
 export const { useQuery: useScrvUsdUserStats } = queryFactory({

--- a/apps/main/src/loan/entities/scrvusdUserStats.ts
+++ b/apps/main/src/loan/entities/scrvusdUserStats.ts
@@ -1,17 +1,11 @@
 import type { UserStats } from '@curvefi/prices-api/savings/models'
-import { queryFactory } from '@ui-kit/lib/model/query'
+import { queryFactory, type UserAddressParams, type UserAddressQuery } from '@ui-kit/lib/model/query'
 import { getUserStats } from '@curvefi/prices-api/savings'
 import { userAddressValidationSuite } from '@ui-kit/lib/model/query/user-address-validation'
 
-async function _fetchScrvUsdUserStats({ userAddress }: { userAddress: string }): Promise<UserStats> {
-  const data = await getUserStats(userAddress)
-
-  return data
-}
-
 export const { useQuery: useScrvUsdUserStats } = queryFactory({
-  queryKey: (params: { userAddress: string }) => ['scrvUsdUserStats', { userAddress: params.userAddress }] as const,
-  queryFn: _fetchScrvUsdUserStats,
+  queryKey: (params: UserAddressParams) => ['scrvUsdUserStats', { userAddress: params.userAddress }] as const,
+  queryFn: ({ userAddress }: UserAddressQuery): Promise<UserStats> => getUserStats(userAddress),
   staleTime: '5m',
   validationSuite: userAddressValidationSuite,
 })

--- a/apps/main/src/loan/entities/scrvusdYield.ts
+++ b/apps/main/src/loan/entities/scrvusdYield.ts
@@ -2,7 +2,6 @@ import type { TimeOption } from '@ui-kit/lib/types/scrvusd'
 import type { Yield } from '@curvefi/prices-api/savings/models'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { EmptyValidationSuite } from '@ui-kit/lib'
-import { timeOptionValidationSuite } from '@ui-kit/lib/model/query/time-option-validation'
 import { getYield } from '@curvefi/prices-api/savings'
 
 export type ScrvUsdYieldWithAverages = Yield & { proj_apy_7d_avg: number; proj_apy_total_avg: number }

--- a/apps/main/src/loan/entities/usd-prices.ts
+++ b/apps/main/src/loan/entities/usd-prices.ts
@@ -1,8 +1,7 @@
 import { ContractParams, queryFactory, rootKeys } from '@ui-kit/lib/model'
 import { contractValidationSuite } from '@ui-kit/lib/model/query/contract-validation'
-import { queryClient } from '@ui-kit/lib/api/query-client'
 
-export const { getQueryOptions: getCoinPriceOptions } = queryFactory({
+export const { fetchQuery: fetchCoinPrices } = queryFactory({
   queryKey: (params: ContractParams) => [...rootKeys.contract(params), 'usd-price'] as const,
   queryFn: async ({ blockchainId, contractAddress }: ContractParams) => {
     const response = await fetch(`https://prices.curve.fi/v1/usd_price/${blockchainId}/${contractAddress}`)
@@ -18,7 +17,7 @@ export const getCoinPrices = async (stablecoinAddresses: string[], chain: string
     await Promise.all(
       stablecoinAddresses.map(async (contractAddress) => [
         contractAddress,
-        await queryClient.fetchQuery(getCoinPriceOptions({ blockchainId: chain, contractAddress })),
+        await fetchCoinPrices({ blockchainId: chain, contractAddress }),
       ]),
     ),
   )

--- a/packages/curve-ui-kit/src/entities/chains.ts
+++ b/packages/curve-ui-kit/src/entities/chains.ts
@@ -1,16 +1,16 @@
 import { queryFactory } from '@ui-kit/lib/model'
 import { EmptyValidationSuite } from '@ui-kit/lib'
-import { getChains } from '@curvefi/prices-api/llamalend'
-import { getSupportedChains } from '@curvefi/prices-api/chains'
+import { getChains } from '@curvefi/prices-api/src/llamalend'
+import { getSupportedChains } from '@curvefi/prices-api/src/chains'
 
-export const { getQueryOptions: getSupportedChainOptions } = queryFactory({
+export const { fetchQuery: fetchSupportedChains } = queryFactory({
   queryKey: () => ['prices-api', 'supported-chains'] as const,
   queryFn: getSupportedChains,
   staleTime: '1d',
   validationSuite: EmptyValidationSuite,
 })
 
-export const { getQueryOptions: getSupportedLendingChainOptions } = queryFactory({
+export const { fetchQuery: fetchSupportedLendingChains } = queryFactory({
   queryKey: () => ['prices-api', 'supported-lending-chains'] as const,
   queryFn: getChains,
   staleTime: '1d',

--- a/packages/curve-ui-kit/src/lib/model/query/factory.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/factory.ts
@@ -14,7 +14,6 @@ export function getParamsFromQueryKey<TKey extends readonly unknown[], TParams, 
   const queryParams = Object.fromEntries(
     queryKey.flatMap((i) => (i && typeof i === 'object' ? Object.entries(i) : [])),
   ) as TParams
-  console.log(queryParams)
   return assertValidity(queryParams)
 }
 

--- a/packages/curve-ui-kit/src/lib/model/query/factory.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/factory.ts
@@ -14,6 +14,7 @@ export function getParamsFromQueryKey<TKey extends readonly unknown[], TParams, 
   const queryParams = Object.fromEntries(
     queryKey.flatMap((i) => (i && typeof i === 'object' ? Object.entries(i) : [])),
   ) as TParams
+  console.log(queryParams)
   return assertValidity(queryParams)
 }
 
@@ -40,7 +41,6 @@ export function queryFactory<
   TData,
   TParams
 > {
-  // todo: get rid of ValidatedData<T> use NonValidatedFields<T> instead
   const assertValidity = (data: TParams, fields?: TField[]) =>
     sharedAssertValidity(validationSuite, data, fields) as unknown as TQuery
 
@@ -73,6 +73,7 @@ export function queryFactory<
     getQueryData: (params) => queryClient.getQueryData(queryKey(params)),
     prefetchQuery: (params, staleTime = 0) =>
       queryClient.prefetchQuery({ queryKey: queryKey(params), queryFn, staleTime }),
+    fetchQuery: (params) => queryClient.fetchQuery(getQueryOptions(params, true)),
     useQuery: createQueryHook(getQueryOptions),
     invalidate: (params) => queryClient.invalidateQueries({ queryKey: queryKey(params) }),
   }

--- a/packages/curve-ui-kit/src/lib/model/query/root-keys.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/root-keys.ts
@@ -1,14 +1,17 @@
 import { FieldsOf } from '@ui-kit/lib'
+import type { Address } from 'viem'
 
 export type ChainQuery<T = number> = { chainId: T }
-export type ChainNameQuery = { blockchainId: string }
+export type ChainNameQuery<T = string> = { blockchainId: T }
+export type UserAddressQuery = { userAddress: Address }
 
 export type ContractQuery = ChainNameQuery & { contractAddress: string }
 export type PoolQuery<T = number> = ChainQuery<T> & { poolId: string }
 export type GaugeQuery<T = number> = PoolQuery<T>
 
 export type ChainParams<T = number> = FieldsOf<ChainQuery<T>>
-export type ChainNameParams = FieldsOf<ChainNameQuery>
+export type ChainNameParams<T = string> = FieldsOf<ChainNameQuery<T>>
+export type UserAddressParams = FieldsOf<UserAddressQuery>
 
 export type ContractParams = FieldsOf<ContractQuery>
 export type PoolParams<T = number> = FieldsOf<PoolQuery<T>>

--- a/packages/curve-ui-kit/src/lib/model/query/user-address-validation.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/user-address-validation.ts
@@ -1,15 +1,16 @@
-import { group, test } from 'vest'
+import { enforce, group, test } from 'vest'
 import { createValidationSuite } from '@ui-kit/lib/validation'
 import type { UserAddressParams } from '@ui-kit/lib/model'
+import { isAddress } from 'ethers'
 
 export const userAddressValidationGroup = ({ userAddress }: UserAddressParams) =>
   group('userAddressValidation', () => {
     test('userAddress', () => {
-      // enforce(userAddress)
-      //   .message('Address is required')
-      //   .isNotEmpty()
-      //   .message('Invalid EVM address')
-      //   .satisfy(() => isAddress(userAddress!))
+      enforce(userAddress)
+        .message('Address is required')
+        .isNotEmpty()
+        .message('Invalid EVM address')
+        .satisfy(() => isAddress(userAddress!))
     })
   })
 

--- a/packages/curve-ui-kit/src/lib/model/query/user-address-validation.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/user-address-validation.ts
@@ -1,18 +1,15 @@
-import type { Address } from 'viem'
-import { enforce, group, test } from 'vest'
+import { group, test } from 'vest'
 import { createValidationSuite } from '@ui-kit/lib/validation'
-import { isAddress } from 'viem'
-
-type UserAddressParams = { userAddress: Address }
+import type { UserAddressParams } from '@ui-kit/lib/model'
 
 export const userAddressValidationGroup = ({ userAddress }: UserAddressParams) =>
   group('userAddressValidation', () => {
     test('userAddress', () => {
-      enforce(userAddress)
-        .message('Address is required')
-        .isNotEmpty()
-        .message('Invalid EVM address')
-        .satisfy(() => isAddress(userAddress))
+      // enforce(userAddress)
+      //   .message('Address is required')
+      //   .isNotEmpty()
+      //   .message('Invalid EVM address')
+      //   .satisfy(() => isAddress(userAddress!))
     })
   })
 

--- a/packages/curve-ui-kit/src/lib/types/factory.ts
+++ b/packages/curve-ui-kit/src/lib/types/factory.ts
@@ -63,6 +63,7 @@ export type QueryFactoryOutput<
   assertValidity: (data: TParams) => TValidParams
   useQuery: (params: TParams, enabled?: boolean) => UseQueryResult<TData, TError>
   getQueryData: (params: TParams) => TData | undefined
+  fetchQuery: (params: TParams) => Promise<TData>
   prefetchQuery: (params: TParams, staleTime?: number) => Promise<void>
   invalidate: (params: TParams) => void
 }

--- a/packages/curve-ui-kit/src/lib/validation/lib.ts
+++ b/packages/curve-ui-kit/src/lib/validation/lib.ts
@@ -18,6 +18,7 @@ export function assertValidity<D extends object, S extends Suite<any, any>>(
   const result = suite(data, fields)
   const entries = Object.entries(result.getErrors())
   if (entries.length > 0) {
+    debugger
     throw new Error(`Validation failed: ${entries.map(([field, error]) => `${field}: ${error}`).join(', ')}`)
   }
   return data as D

--- a/packages/curve-ui-kit/src/lib/validation/lib.ts
+++ b/packages/curve-ui-kit/src/lib/validation/lib.ts
@@ -4,11 +4,16 @@ import { FieldName, FieldsOf } from './types'
 
 extendEnforce(enforce)
 
+const getErrors = (result: ReturnType<Suite<any, any>>) =>
+  Object.entries(result.getErrors())
+    .filter(([, errors]) => errors.length > 0)
+    .map(([field, errors]) => `${field}: ${errors.join(',')}`)
+
 export const checkValidity = <D extends object, S extends Suite<any, any>>(
   suite: S,
   data: FieldsOf<D>,
   fields?: FieldName<D>[],
-): boolean => Object.keys(suite(data, fields).getErrors()).length === 0
+): boolean => getErrors(suite(data, fields)).length === 0
 
 export function assertValidity<D extends object, S extends Suite<any, any>>(
   suite: S,
@@ -16,10 +21,9 @@ export function assertValidity<D extends object, S extends Suite<any, any>>(
   fields?: FieldName<D>[],
 ): D {
   const result = suite(data, fields)
-  const entries = Object.entries(result.getErrors())
-  if (entries.length > 0) {
-    debugger
-    throw new Error(`Validation failed: ${entries.map(([field, error]) => `${field}: ${error}`).join(', ')}`)
+  const errors = getErrors(result)
+  if (errors.length > 0) {
+    throw new Error(`Validation failed: ${errors.join(';')}`)
   }
   return data as D
 }

--- a/packages/prices-api/src/chains/models.ts
+++ b/packages/prices-api/src/chains/models.ts
@@ -1,7 +1,7 @@
 import type { Chain } from '..'
 
 export type ChainInfo = {
-  chain: string
+  chain: Chain
   total: {
     tvl: number
     tradingVolume24h: number

--- a/packages/prices-api/src/gauge/responses.ts
+++ b/packages/prices-api/src/gauge/responses.ts
@@ -1,4 +1,4 @@
-import type { Address } from '..'
+import type { Address, Chain } from '..'
 
 type Gauge = {
   address: Address
@@ -9,7 +9,7 @@ type Gauge = {
   pool: {
     address: Address
     name: string
-    chain: string
+    chain: Chain
     tvl_usd: number
     trading_volume_24h: number
   } | null
@@ -22,7 +22,7 @@ type Gauge = {
     | null
   market: {
     name: string
-    chain: string
+    chain: Chain
   } | null
   is_killed: boolean
   emissions: number

--- a/packages/prices-api/src/index.ts
+++ b/packages/prices-api/src/index.ts
@@ -42,9 +42,7 @@ export const chains = [
 
 export type Chain = (typeof chains)[number]
 
-export function isChain(chain: string): chain is Chain {
-  return chains.includes(chain as Chain)
-}
+export const isChain = (chain: Chain): chain is Chain => chains.includes(chain as Chain)
 
 // Copied from Viem such that you don't actually need a Viem dependency but may also use Ethers.
 export type Address = `0x${string}`

--- a/packages/prices-api/src/index.ts
+++ b/packages/prices-api/src/index.ts
@@ -46,22 +46,3 @@ export const isChain = (chain: Chain): chain is Chain => chains.includes(chain a
 
 // Copied from Viem such that you don't actually need a Viem dependency but may also use Ethers.
 export type Address = `0x${string}`
-
-export const CHAIN_IDS: Record<Chain, number> = {
-  ethereum: 1,
-  optimism: 10,
-  xdai: 100,
-  polygon: 137,
-  fantom: 250,
-  fraxtal: 252,
-  moonbeam: 1284,
-  base: 8453,
-  arbitrum: 42161,
-  avalanche: 43114,
-  matic: 137,
-  harmony: 1666600000,
-}
-
-export const CHAIN_ID_NAMES: Record<number, Chain> = Object.fromEntries(
-  Object.entries(CHAIN_IDS).map(([chain, id]) => [id, chain as Chain]),
-)

--- a/packages/prices-api/src/index.ts
+++ b/packages/prices-api/src/index.ts
@@ -48,3 +48,22 @@ export function isChain(chain: string): chain is Chain {
 
 // Copied from Viem such that you don't actually need a Viem dependency but may also use Ethers.
 export type Address = `0x${string}`
+
+export const CHAIN_IDS: Record<Chain, number> = {
+  ethereum: 1,
+  optimism: 10,
+  xdai: 100,
+  polygon: 137,
+  fantom: 250,
+  fraxtal: 252,
+  moonbeam: 1284,
+  base: 8453,
+  arbitrum: 42161,
+  avalanche: 43114,
+  matic: 137,
+  harmony: 1666600000,
+}
+
+export const CHAIN_ID_NAMES: Record<number, Chain> = Object.fromEntries(
+  Object.entries(CHAIN_IDS).map(([chain, id]) => [id, chain as Chain]),
+)

--- a/packages/prices-api/src/llamalend/responses.ts
+++ b/packages/prices-api/src/llamalend/responses.ts
@@ -117,7 +117,7 @@ export type GetUserMarketSnapshotsResponse = {
 }
 
 export type GetUserCollateralEventsResponse = {
-  chain: string
+  chain: Chain
   controller: Address
   user: Address
   total_deposit: number

--- a/packages/prices-api/src/ohlc/responses.ts
+++ b/packages/prices-api/src/ohlc/responses.ts
@@ -1,5 +1,7 @@
+import type { Chain } from '../index'
+
 export type GetOHLCResponse = {
-  chain: string
+  chain: Chain
   address: string
   data: {
     time: number

--- a/packages/prices-api/src/pools/api.ts
+++ b/packages/prices-api/src/pools/api.ts
@@ -1,4 +1,4 @@
-import { getHost, type Options, type Chain } from '..'
+import { getHost, type Options, type Chain, type Address } from '..'
 import { fetchJson as fetch } from '../fetch'
 import { getTimeRange } from '../timestamp'
 import type * as Responses from './responses'
@@ -13,6 +13,12 @@ export async function getPools(chain: Chain, page: number = 1, perPage: number =
     totals: Parsers.parsePoolTotals(resp.total),
     pools: resp.data.map(Parsers.parsePool),
   }
+}
+
+export async function getUserPools(chain: Chain, userAddress: Address, options?: Options) {
+  const host = getHost(options)
+  const resp = await fetch<Responses.GetUserPoolsResponse>(`${host}/v1/liquidity/${chain}/${userAddress}/positions`)
+  return { chain, positions: resp.positions.map(Parsers.parseUserPool) }
 }
 
 export async function getPool(chain: Chain, poolAddr: string, options?: Options) {

--- a/packages/prices-api/src/pools/models.ts
+++ b/packages/prices-api/src/pools/models.ts
@@ -30,6 +30,12 @@ export type Pool = {
   poolMethods: string[]
 }
 
+export type UserPool = {
+  poolName: string
+  poolAddress: Address
+  lpTokenBalance: number
+}
+
 export type Volume = {
   timestamp: Date
   volume: number

--- a/packages/prices-api/src/pools/parsers.ts
+++ b/packages/prices-api/src/pools/parsers.ts
@@ -35,7 +35,7 @@ export const parseUserPool = ({
   pool_name,
   pool_address,
   lp_token_balance,
-}: Responses.GetUserPoolsResponse['data'][number]): Models.UserPool => ({
+}: Responses.GetUserPoolsResponse['positions'][number]): Models.UserPool => ({
   poolName: pool_name,
   poolAddress: pool_address,
   lpTokenBalance: Number(lp_token_balance),

--- a/packages/prices-api/src/pools/parsers.ts
+++ b/packages/prices-api/src/pools/parsers.ts
@@ -31,6 +31,16 @@ export const parsePool = (x: Responses.GetPoolsResponse['data'][number]): Models
   poolMethods: x.pool_methods?.map((x) => x) ?? [],
 })
 
+export const parseUserPool = ({
+  pool_name,
+  pool_address,
+  lp_token_balance,
+}: Responses.GetUserPoolsResponse['data'][number]): Models.UserPool => ({
+  poolName: pool_name,
+  poolAddress: pool_address,
+  lpTokenBalance: Number(lp_token_balance),
+})
+
 export const parseVolume = (x: Responses.GetVolumeResponse['data'][number]): Models.Volume => ({
   timestamp: toDate(x.timestamp),
   volume: x.volume,

--- a/packages/prices-api/src/pools/responses.ts
+++ b/packages/prices-api/src/pools/responses.ts
@@ -34,6 +34,15 @@ export type GetPoolsResponse = {
   data: Pool[]
 }
 
+export type GetUserPoolsResponse = {
+  chain: string
+  positions: {
+    pool_name: string
+    pool_address: Address
+    lp_token_balance: string
+  }[]
+}
+
 export type GetPoolResponse = Pool
 
 export type GetVolumeResponse = {

--- a/packages/prices-api/src/pools/responses.ts
+++ b/packages/prices-api/src/pools/responses.ts
@@ -1,4 +1,4 @@
-import type { Address } from '..'
+import type { Address, Chain } from '..'
 
 type Coin = {
   pool_index: number
@@ -23,7 +23,7 @@ type Pool = {
 }
 
 export type GetPoolsResponse = {
-  chain: string
+  chain: Chain
   total: {
     total_tvl: number
     trading_volume_24h: number
@@ -35,7 +35,7 @@ export type GetPoolsResponse = {
 }
 
 export type GetUserPoolsResponse = {
-  chain: string
+  chain: Chain
   positions: {
     pool_name: string
     pool_address: Address

--- a/packages/prices-api/src/revenue/api.ts
+++ b/packages/prices-api/src/revenue/api.ts
@@ -1,4 +1,4 @@
-import { getHost, type Options } from '..'
+import { type Chain, getHost, type Options } from '..'
 import { fetchJson as fetch } from '../fetch'
 import { paginate } from '../paginate'
 import type * as Responses from './responses'
@@ -13,7 +13,7 @@ export async function getByChain(options?: Options) {
   return resp.revenue.map(Parsers.parseChainRevenue)
 }
 
-export async function getTopPools(chain: string, numPools = 10, options?: Options) {
+export async function getTopPools(chain: Chain, numPools = 10, options?: Options) {
   const chainStr = chain === 'ethereum' ? 'mainnet' : chain
   const host = getHost(options?.host ? options : { host: API_URL_OLD })
 
@@ -36,7 +36,7 @@ export async function getPoolsWeekly(options?: Options) {
   return resp.fees.map(Parsers.parsePoolsWeekly)
 }
 
-export async function getCushions(chain: string, options?: Options) {
+export async function getCushions(chain: Chain, options?: Options) {
   const host = getHost(options)
   const resp = await fetch<Responses.GetCushionsResponse>(`${host}/v1/dao/fees/${chain}/pending`)
 

--- a/packages/prices-api/src/revenue/models.ts
+++ b/packages/prices-api/src/revenue/models.ts
@@ -1,7 +1,7 @@
 import type { Address, Chain } from '..'
 
 export type ChainRevenue = {
-  chain: string
+  chain: Chain
   totalDailyFeesUSD: number
 }
 

--- a/packages/prices-api/src/revenue/responses.ts
+++ b/packages/prices-api/src/revenue/responses.ts
@@ -1,4 +1,4 @@
-import type { Address } from '..'
+import type { Address, Chain } from '..'
 
 export type GetCushionsResponse = {
   data: {
@@ -11,7 +11,7 @@ export type GetCushionsResponse = {
 
 export type GetByChainResponse = {
   revenue: {
-    chain: string
+    chain: Chain
     totalDailyFeesUSD: number
   }[]
 }
@@ -34,7 +34,7 @@ export type GetCrvUsdWeeklyResponse = {
 
 export type GetPoolsWeeklyResponse = {
   fees: {
-    chain: string
+    chain: Chain
     fees_usd: number
     timestamp: string
   }[]


### PR DESCRIPTION
- curve-js calls every single pool on chain, that results in too many RPC calls
- instead we can use the new prices API endpoint to find the pools that a user is part of
- lib is still used for unsupported chains
- add `fetchQuery` to factory to remove some duplication