### PR TITLE
chore: add missing yarn build step for prices api

### DIFF
--- a/.github/workflows/prices-api.yaml
+++ b/.github/workflows/prices-api.yaml
@@ -25,4 +25,5 @@ jobs:
           yarn config set npmRegistryServer "https://registry.npmjs.org"
           yarn config set npmAuthToken "${{ secrets.NPM_TOKEN }}"
           yarn install --immutable
+          yarn build
           yarn npm publish --access public


### PR DESCRIPTION
It seems "prepublishOnly": "yarn run build" in the package.json doesn't really work when executed through github actions, so the published package ends up missing its `dist` folder. I can't really test it properly until Github Actions runs this in prod.