### PR TITLE
chore: add routes to eslint import rules

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -17,8 +17,13 @@ module.exports = {
         zones: [
           { target: 'packages', from: 'apps' },
           ...['dex', 'dao', 'lend', 'loan']
-            .map((app) => `apps/main/src/${app}`)
-            .map((from, _, paths) => ({ target: paths.filter((path) => path !== from), from })),
+            .map((app) => [`apps/main/src/${app}`, `apps/main/src/app/${app}`])
+            .map((from, index, paths) =>
+              ({
+                target: paths.filter((_, i) => i !== index).flat(),
+                from,
+              }),
+            ),
         ],
       },
     ],


### PR DESCRIPTION
Update the ESLint rules to make sure we don't import incorrect files. For example for `dex` the rule is now:
```json
{
    "target": [
        "apps/main/src/dao",
        "apps/main/src/app/dao",
        "apps/main/src/lend",
        "apps/main/src/app/lend",
        "apps/main/src/loan",
        "apps/main/src/app/loan"
    ],
    "from": [
        "apps/main/src/dex",
        "apps/main/src/app/dex"
    ]
}
```