### PR TITLE
chore: bump prices-api to 1.0.1

### DIFF
--- a/packages/prices-api/package.json
+++ b/packages/prices-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/prices-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
forgot to bump version in the previous PR, oopsie