### PR TITLE
chore: bump curvefi/api to 2.66.8

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -25,7 +25,7 @@
     "typescript": "*"
   },
   "dependencies": {
-    "@curvefi/api": "^2.66.7",
+    "@curvefi/api": "^2.66.8",
     "@curvefi/lending-api": "^2.5.5",
     "@curvefi/stablecoin-api": "^1.5.9",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,15 +1562,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:^2.66.7":
-  version: 2.66.7
-  resolution: "@curvefi/api@npm:2.66.7"
+"@curvefi/api@npm:^2.66.8":
+  version: 2.66.8
+  resolution: "@curvefi/api@npm:2.66.8"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.12"
     bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.13.4"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/dcdd339f6125dc9122f02f0ad8ac2cac895a747f85ed737cd118beb528d7ab8347f0b5646b845afdbc9ccd47a4842831b58f6cef666049bfef30c9adf3a629ee
+  checksum: 10c0/07c958c9ddac49be1244ece9df68b749f495117454afb6c8c7ccc90a463336d5b25baa72229d3a7ecd7c0a0bad09e041dc97eda15ca48673d9355d1757444b85
   languageName: node
   linkType: hard
 
@@ -17478,7 +17478,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:^2.66.7"
+    "@curvefi/api": "npm:^2.66.8"
     "@curvefi/lending-api": "npm:^2.5.5"
     "@curvefi/stablecoin-api": "npm:^1.5.9"
     "@hookform/error-message": "npm:^2.0.1"


### PR DESCRIPTION
- https://github.com/curvefi/curve-js/pull/449