### PR TITLE
chore: bump @curvefi/stablecoin-api to 1.5.17

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.14",
+    "@curvefi/stablecoin-api": "^1.5.15",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.15",
+    "@curvefi/stablecoin-api": "^1.5.16",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.9",
+    "@curvefi/stablecoin-api": "^1.5.12",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.16",
+    "@curvefi/stablecoin-api": "^1.5.17",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.12",
+    "@curvefi/stablecoin-api": "^1.5.13",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@curvefi/api": "^2.66.7",
     "@curvefi/lending-api": "^2.5.5",
-    "@curvefi/stablecoin-api": "^1.5.13",
+    "@curvefi/stablecoin-api": "^1.5.14",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^4.0.0",
     "@supercharge/promise-pool": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.12":
-  version: 1.5.12
-  resolution: "@curvefi/stablecoin-api@npm:1.5.12"
+"@curvefi/stablecoin-api@npm:^1.5.13":
+  version: 1.5.13
+  resolution: "@curvefi/stablecoin-api@npm:1.5.13"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/169b6b14bec2147d51090a8ee6f61b42b4db3c7ee87b725719ce075e6b3c9ed026c903ce577e71317b31a8da124ba91e906f0dbf582ddd44b8b322a976de0d18
+  checksum: 10c0/c78e703b479d86a1e022bb4aa45abf947f3d1d7c615a42b783be1f0be499f9a3a219627d25051ea785525734ee5105b7616df927da65090ca9c219297f138b9c
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.12"
+    "@curvefi/stablecoin-api": "npm:^1.5.13"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.9":
-  version: 1.5.9
-  resolution: "@curvefi/stablecoin-api@npm:1.5.9"
+"@curvefi/stablecoin-api@npm:^1.5.12":
+  version: 1.5.12
+  resolution: "@curvefi/stablecoin-api@npm:1.5.12"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/d04b78335b125a8790d5aadbe51110692db3b513b0058721479554c4a76e73fb7c9c46db77cb6c8d250a8099c63148f3e150d4bf73aff47087e308b1aea61e26
+  checksum: 10c0/169b6b14bec2147d51090a8ee6f61b42b4db3c7ee87b725719ce075e6b3c9ed026c903ce577e71317b31a8da124ba91e906f0dbf582ddd44b8b322a976de0d18
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.9"
+    "@curvefi/stablecoin-api": "npm:^1.5.12"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.16":
-  version: 1.5.16
-  resolution: "@curvefi/stablecoin-api@npm:1.5.16"
+"@curvefi/stablecoin-api@npm:^1.5.17":
+  version: 1.5.17
+  resolution: "@curvefi/stablecoin-api@npm:1.5.17"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/161cee8645c74547f7dd22abaef40f3396f8446c0ba08ae97202059bfaa7791461bbd8b8a416443b471b3399a57a80d694f5d15ba14a067326047809af138452
+  checksum: 10c0/f14d525ab052f9d94ed5e5eb9be05fb236e24968709e2e777f994dc4dfcd5f200a2b9e64bd8a7e74df852c4ac8636ffd0e5631dbc631338a6e9a5971ef2c67fb
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.16"
+    "@curvefi/stablecoin-api": "npm:^1.5.17"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.14":
-  version: 1.5.14
-  resolution: "@curvefi/stablecoin-api@npm:1.5.14"
+"@curvefi/stablecoin-api@npm:^1.5.15":
+  version: 1.5.15
+  resolution: "@curvefi/stablecoin-api@npm:1.5.15"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/5eb941daa98b4e00a3ab259c153041f7e9a98988d009fc530647a4c26cd1fdbd5b9b3f58e8ec27e74f6586a315644efeb641b7be93986dc902c8254c9f12eff2
+  checksum: 10c0/20b59fc906e3662430a9581c49ff9d777bdf4afb125a1fbdf73fc31c11cf32eabbedb873e4ed1e6897fc4fff1ea5bf054c426b77c497cabaa36b723b21b81487
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.14"
+    "@curvefi/stablecoin-api": "npm:^1.5.15"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.13":
-  version: 1.5.13
-  resolution: "@curvefi/stablecoin-api@npm:1.5.13"
+"@curvefi/stablecoin-api@npm:^1.5.14":
+  version: 1.5.14
+  resolution: "@curvefi/stablecoin-api@npm:1.5.14"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/c78e703b479d86a1e022bb4aa45abf947f3d1d7c615a42b783be1f0be499f9a3a219627d25051ea785525734ee5105b7616df927da65090ca9c219297f138b9c
+  checksum: 10c0/5eb941daa98b4e00a3ab259c153041f7e9a98988d009fc530647a4c26cd1fdbd5b9b3f58e8ec27e74f6586a315644efeb641b7be93986dc902c8254c9f12eff2
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.13"
+    "@curvefi/stablecoin-api": "npm:^1.5.14"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/stablecoin-api@npm:^1.5.15":
-  version: 1.5.15
-  resolution: "@curvefi/stablecoin-api@npm:1.5.15"
+"@curvefi/stablecoin-api@npm:^1.5.16":
+  version: 1.5.16
+  resolution: "@curvefi/stablecoin-api@npm:1.5.16"
   dependencies:
     "@ethersproject/networks": "npm:^5.5.0"
     bignumber.js: "npm:^9.0.1"
     ethcall: "npm:^4.2.5"
     ethers: "npm:^5.4.6"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/20b59fc906e3662430a9581c49ff9d777bdf4afb125a1fbdf73fc31c11cf32eabbedb873e4ed1e6897fc4fff1ea5bf054c426b77c497cabaa36b723b21b81487
+  checksum: 10c0/161cee8645c74547f7dd22abaef40f3396f8446c0ba08ae97202059bfaa7791461bbd8b8a416443b471b3399a57a80d694f5d15ba14a067326047809af138452
   languageName: node
   linkType: hard
 
@@ -17480,7 +17480,7 @@ __metadata:
   dependencies:
     "@curvefi/api": "npm:^2.66.7"
     "@curvefi/lending-api": "npm:^2.5.5"
-    "@curvefi/stablecoin-api": "npm:^1.5.15"
+    "@curvefi/stablecoin-api": "npm:^1.5.16"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^4.0.0"
     "@next/bundle-analyzer": "npm:^15.1.6"


### PR DESCRIPTION
- https://github.com/curvefi/curve-stablecoin-js/pull/31/
- https://github.com/curvefi/curve-stablecoin-js/pull/32/
- https://github.com/curvefi/curve-stablecoin-js/pull/33/
- https://github.com/curvefi/curve-stablecoin-js/pull/34/
- https://github.com/curvefi/curve-stablecoin-js/pull/35/
- https://github.com/curvefi/curve-stablecoin-js/pull/36
- https://github.com/curvefi/curve-stablecoin-js/pull/37
- https://github.com/curvefi/curve-stablecoin-js/pull/38