### PR TITLE
feat: show dust

### DIFF
--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -27,6 +27,8 @@ export type TokenSectionProps = Required<
 > &
   Required<Pick<TokenListCallbacks, 'onToken'>> & {
     title?: string
+    /** The label to show on the button that expands the section to show all */
+    showAllLabel?: string
     showAll: boolean
     /**
      * Controls which tokens are visible before "Show more".
@@ -39,6 +41,7 @@ export type TokenSectionProps = Required<
 const TokenSection = ({
   title,
   showAll,
+  showAllLabel,
   preview,
   tokens,
   balances,
@@ -96,7 +99,7 @@ const TokenSection = ({
             // Override variant button height to match menu list item height, so !important is required over '&'.
             sx={{ height: `${ButtonSize.md} !important` }}
           >
-            {t`Show more`}
+            {showAllLabel || t`Show more`}
           </Button>
         )}
       </MenuList>
@@ -244,6 +247,7 @@ export const TokenList = ({
             disabledTokens={disabledTokens}
             preview={myTokensPreview}
             showAll={sections.my || !!search}
+            showAllLabel={t`Show dust`}
             onShowAll={() => setSections((prev) => ({ ...prev, my: true }))}
             onToken={onToken}
           />

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -207,8 +207,9 @@ export const TokenList = ({
       const balance = +(balances[token.address] ?? 0)
       const price = tokenPrices[token.address] ?? 0
 
-      // Rare, but also show tokens with a balance but no $ price.
-      return balance > 0 && (price === 0 || balance * price > threshold)
+      // We used to include tokens with a balance > 0, but no $ price (0),
+      // but it turns out that way quite a few scam tokens show up in the preview.
+      return balance * price > threshold
     }
   }, [myTokens, balances, tokenPrices])
 

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -28,8 +28,8 @@ export type Props = Option & TokenOptionCallbacks & TokenOptionsProps
 
 export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice, disabled, onToken }: Props) => {
   const hasBalance = +(balance ?? '0') > 0
-  const hasBalanceUsd = hasBalance && (tokenPrice ?? 0 > 0)
-  const showAddress = !hasBalance
+  const hasBalanceUsd = hasBalance && (tokenPrice ?? 0) > 0
+  const showAddress = !hasBalanceUsd
 
   const menuItem = useRef<HTMLLIElement>(null)
   const isFocusVisible = useClassObserver(menuItem, 'Mui-focusVisible')


### PR DESCRIPTION
* rename 'show more' to 'show dust' under 'my tokens'
* tokens with a balance but zero usd balance are no longer the exception and are hidden under 'show dust'
* if a token has a balance but no usd balance, it shows the address instead for verification
* 
![image](https://github.com/user-attachments/assets/0ff01d75-f4c9-4620-9f0a-fdc669266ab0)
![image](https://github.com/user-attachments/assets/8d8b34da-3dd3-4240-8d76-fae60586c722)
