### PR TITLE
feat: address checksums

### DIFF
--- a/apps/main/src/app/dao/[network]/user/[userAddress]/page.tsx
+++ b/apps/main/src/app/dao/[network]/user/[userAddress]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { getAddress } from 'viem'
 import PageUser from '@/dao/components/PageUser/Page'
 import type { UserUrlParams } from '@/dao/types/dao.types'
 import { t } from '@ui-kit/lib/i18n'
@@ -7,7 +8,7 @@ type UserPageProps = { params: Promise<UserUrlParams> }
 
 export async function generateMetadata({ params }: UserPageProps): Promise<Metadata> {
   const { userAddress } = await params
-  return { title: [t`veCRV Holder`, userAddress, 'Curve'].join(' - ') }
+  return { title: [t`veCRV Holder`, getAddress(userAddress), 'Curve'].join(' - ') }
 }
 
 const UserPage = async ({ params }: UserPageProps) => <PageUser {...await params} />

--- a/apps/main/src/dao/components/ComboBoxSelectGauge/ComboBoxListItem.tsx
+++ b/apps/main/src/dao/components/ComboBoxSelectGauge/ComboBoxListItem.tsx
@@ -5,7 +5,7 @@ import Box from '@ui/Box'
 import Button from '@ui/Button'
 import Chip from '@ui/Typography/Chip'
 import { focusVisible } from '@ui/utils'
-import { shortenTokenAddress } from '@ui/utils'
+import { shortenAddress } from '@ui-kit/utils'
 
 const ComboBoxListItem = ({
   testId,
@@ -26,7 +26,7 @@ const ComboBoxListItem = ({
       <LabelTextWrapper flex flexDirection="column" flexAlignItems="flex-start">
         <LabelText data-testid={`li-${testId}`}>{item.title}</LabelText>
         <Chip isMono opacity={0.5}>
-          {shortenTokenAddress(item.address)}
+          {shortenAddress(item.address)}
         </Chip>
       </LabelTextWrapper>
     </ItemButton>

--- a/apps/main/src/dao/components/CopyIconButton.tsx
+++ b/apps/main/src/dao/components/CopyIconButton.tsx
@@ -1,25 +1,19 @@
-import { copyToClipboard } from '@/dao/utils'
 import Icon from '@ui/Icon'
 import TooltipButton from '@ui/Tooltip'
+import { copyToClipboard } from '@ui-kit/utils'
 
 type CopyIconButtonProps = {
   copyContent: string
   tooltip: string
 }
 
-const CopyIconButton = ({ copyContent, tooltip }: CopyIconButtonProps) => {
-  const handleCopyClick = (copyContent: string) => {
-    copyToClipboard(copyContent)
-  }
-
-  return (
-    <TooltipButton
-      onClick={() => handleCopyClick(copyContent)}
-      noWrap
-      tooltip={tooltip}
-      customIcon={<Icon name="Copy" size={16} />}
-    />
-  )
-}
+const CopyIconButton = ({ copyContent, tooltip }: CopyIconButtonProps) => (
+  <TooltipButton
+    onClick={() => copyToClipboard(copyContent)}
+    noWrap
+    tooltip={tooltip}
+    customIcon={<Icon name="Copy" size={16} />}
+  />
+)
 
 export default CopyIconButton

--- a/apps/main/src/dao/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dao/components/DetailInfoEstGas.tsx
@@ -2,7 +2,7 @@ import isNaN from 'lodash/isNaN'
 import isUndefined from 'lodash/isUndefined'
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { NETWORK_TOKEN } from '@/dao/constants'
+import { ethAddress } from 'viem'
 import networks from '@/dao/networks'
 import useStore from '@/dao/store/useStore'
 import { CurveApi, ChainId, EstimatedGas } from '@/dao/types/dao.types'
@@ -34,7 +34,7 @@ const DetailInfoEstGas = ({
   stepProgress?: StepProgress | null
 }) => {
   const { gasPricesDefault } = networks[chainId]
-  const chainTokenUsdRate = useStore((state) => state.usdRates.usdRatesMapper[NETWORK_TOKEN])
+  const chainTokenUsdRate = useStore((state) => state.usdRates.usdRatesMapper[ethAddress])
   const gasInfo = useStore((state) => state.gas.gasInfo)
   const basePlusPriority = useStore((state) => state.gas.gasInfo?.basePlusPriority?.[gasPricesDefault])
 

--- a/apps/main/src/dao/components/ExternalLinkIconButton.tsx
+++ b/apps/main/src/dao/components/ExternalLinkIconButton.tsx
@@ -30,7 +30,6 @@ const StyledExternalLink = styled(ExternalLink)`
   color: var(--page--text-color);
   font-size: var(--font-size-2);
   font-weight: var(--bold);
-  text-transform: none;
   text-decoration: none;
   &:hover {
     cursor: pointer;

--- a/apps/main/src/dao/components/InternalLinkButton.tsx
+++ b/apps/main/src/dao/components/InternalLinkButton.tsx
@@ -38,7 +38,6 @@ const StyledInternalLink = styled(InternalLink)<{ smallSize?: boolean }>`
   padding: ${({ smallSize }) =>
     smallSize ? 'var(--spacing-1) var(--spacing-2)' : 'var(--spacing-2) var(--spacing-4)'};
   font-weight: var(--bold);
-  text-transform: none;
   text-decoration: none;
   border: ${({ smallSize }) => (smallSize ? 'none' : '1px solid var(--link--color)')};
   margin-left: auto;

--- a/apps/main/src/dao/components/PageAnalytics/HoldersTable/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/HoldersTable/index.tsx
@@ -7,9 +7,10 @@ import type { AllHoldersSortBy } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
 import type { Locker } from '@curvefi/prices-api/dao'
 import Box from '@ui/Box'
-import { shortenTokenAddress, formatNumber, formatDate } from '@ui/utils'
+import { formatNumber, formatDate } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 
 const TopHoldersTable = () => {
   const { veCrvHolders, allHoldersSortBy, setAllHoldersSortBy, getVeCrvHolders } = useStore((state) => state.analytics)
@@ -45,7 +46,7 @@ const TopHoldersTable = () => {
               <span style={{ textDecoration: 'underline' }}>
                 {TOP_HOLDERS[holder.user.toLowerCase()]
                   ? TOP_HOLDERS[holder.user.toLowerCase()].title
-                  : shortenTokenAddress(holder.user)}
+                  : shortenAddress(holder.user)}
               </span>
             </StyledTableDataLink>
             <TableData className={allHoldersSortBy.key === 'weight' ? 'sortby-active right-padding' : 'right-padding'}>

--- a/apps/main/src/dao/components/PageAnalytics/TopHoldersChart/TopHoldersBarChartComponent.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/TopHoldersChart/TopHoldersBarChartComponent.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components'
 import { TOP_HOLDERS } from '@/dao/constants'
 import type { TopHoldersSortBy } from '@/dao/types/dao.types'
 import type { Locker } from '@curvefi/prices-api/dao'
-import { formatNumber, shortenTokenAddress } from '@ui/utils'
+import { formatNumber } from '@ui/utils'
+import { shortenAddress } from '@ui-kit/utils'
 import CustomTooltip from './TopHoldersBarChartTooltip'
 
 type TopHoldersBarChartProps = {
@@ -35,7 +36,7 @@ const TopHoldersBarChart = ({ data, filter }: TopHoldersBarChartProps) => {
       return TOP_HOLDERS[address].title
     }
 
-    return user.length > 15 ? (shortenTokenAddress(user)?.toString() ?? user) : user
+    return user.length > 15 ? (shortenAddress(user)?.toString() ?? user) : user
   }
 
   const dataFormatted = data.map((x) => ({

--- a/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
@@ -8,8 +8,9 @@ import useStore from '@/dao/store/useStore'
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
 import Box from '@ui/Box'
-import { formatNumber, convertToLocaleTimestamp, formatDateFromTimestamp, shortenTokenAddress } from '@ui/utils/'
+import { formatNumber, convertToLocaleTimestamp, formatDateFromTimestamp } from '@ui/utils/'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface GaugeMetricsProps {
   gaugeData: GaugeFormattedData | undefined
@@ -35,7 +36,7 @@ const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
             title={t`Gauge`}
             data={
               <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-                <StyledMetricsColumnData>{shortenTokenAddress(gaugeData?.address || '')}</StyledMetricsColumnData>
+                <StyledMetricsColumnData>{shortenAddress(gaugeData?.address || '')}</StyledMetricsColumnData>
                 <BigScreenButtonsWrapper>
                   <ExternalLinkIconButton
                     href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData?.address || '')}
@@ -140,7 +141,7 @@ const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
               title={t`Pool`}
               data={
                 <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-                  <StyledMetricsColumnData>{shortenTokenAddress(gaugeData?.pool?.address)}</StyledMetricsColumnData>
+                  <StyledMetricsColumnData>{shortenAddress(gaugeData?.pool?.address)}</StyledMetricsColumnData>
                   <BigScreenButtonsWrapper>
                     <ExternalLinkIconButton
                       href={gaugeExternalLink}

--- a/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
@@ -66,7 +66,6 @@ const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) 
             {formatNumber(gaugeVote.weight, { notation: 'compact' })}
           </TableData>
           <TableDataLink
-            $noCap
             onClick={(e) => {
               e.preventDefault()
               push(getEthPath(`${DAO_ROUTES.PAGE_USER}/${gaugeVote.user}`))

--- a/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
@@ -6,9 +6,10 @@ import { TOP_HOLDERS } from '@/dao/constants'
 import useStore from '@/dao/store/useStore'
 import { GaugeVote, GaugeVotesSortBy } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
-import { convertToLocaleTimestamp, formatDateFromTimestamp, formatNumber, shortenTokenAddress } from '@ui/utils/'
+import { convertToLocaleTimestamp, formatDateFromTimestamp, formatNumber } from '@ui/utils/'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 import { GAUGE_VOTES_TABLE_LABELS } from './constants'
 
 interface GaugeVotesTableProps {
@@ -73,7 +74,7 @@ const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) 
           >
             {TOP_HOLDERS[gaugeVote.user.toLowerCase()]
               ? TOP_HOLDERS[gaugeVote.user.toLowerCase()].title
-              : shortenTokenAddress(gaugeVote.user)}
+              : shortenAddress(gaugeVote.user)}
           </TableDataLink>
         </TableRowWrapper>
       )}

--- a/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
@@ -66,6 +66,7 @@ const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) 
             {formatNumber(gaugeVote.weight, { notation: 'compact' })}
           </TableData>
           <TableDataLink
+            $noCap
             onClick={(e) => {
               e.preventDefault()
               push(getEthPath(`${DAO_ROUTES.PAGE_USER}/${gaugeVote.user}`))

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
@@ -27,7 +27,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
             <StatsRow>
               {gaugeData.pool?.address && (
                 <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-                  <StyledExternalLink href={networks[chainId].scanAddressPath(gaugeData.pool.address)}>
+                  <StyledExternalLink $noCap href={networks[chainId].scanAddressPath(gaugeData.pool.address)}>
                     {shortenAddress(gaugeData.pool.address)}
                   </StyledExternalLink>
                   <ExternalLinkIconButton
@@ -65,7 +65,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
         </StatsTitleRow>
         <StatsRow>
           <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-            <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
+            <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
               {shortenAddress(gaugeData.address)}
             </StyledExternalLink>
             <ExternalLinkIconButton

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
@@ -7,8 +7,9 @@ import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
 import Box from '@ui/Box'
 import { ExternalLink } from '@ui/Link'
-import { shortenTokenAddress, formatNumber, convertToLocaleTimestamp } from '@ui/utils'
+import { formatNumber, convertToLocaleTimestamp } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData; className?: string }) => {
   const chainId = getChainIdFromGaugeData(gaugeData)
@@ -27,7 +28,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
               {gaugeData.pool?.address && (
                 <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
                   <StyledExternalLink href={networks[chainId].scanAddressPath(gaugeData.pool.address)}>
-                    {shortenTokenAddress(gaugeData.pool.address)}
+                    {shortenAddress(gaugeData.pool.address)}
                   </StyledExternalLink>
                   <ExternalLinkIconButton
                     href={networks[chainId].scanAddressPath(gaugeData.pool.address)}
@@ -65,7 +66,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
         <StatsRow>
           <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
             <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
-              {shortenTokenAddress(gaugeData.address)}
+              {shortenAddress(gaugeData.address)}
             </StyledExternalLink>
             <ExternalLinkIconButton
               href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
@@ -27,7 +27,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
             <StatsRow>
               {gaugeData.pool?.address && (
                 <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-                  <StyledExternalLink $noCap href={networks[chainId].scanAddressPath(gaugeData.pool.address)}>
+                  <StyledExternalLink href={networks[chainId].scanAddressPath(gaugeData.pool.address)}>
                     {shortenAddress(gaugeData.pool.address)}
                   </StyledExternalLink>
                   <ExternalLinkIconButton
@@ -65,7 +65,7 @@ const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormattedData;
         </StatsTitleRow>
         <StatsRow>
           <Box flex flexAlignItems="center" flexGap="var(--spacing-1)">
-            <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
+            <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
               {shortenAddress(gaugeData.address)}
             </StyledExternalLink>
             <ExternalLinkIconButton
@@ -114,7 +114,6 @@ const StyledExternalLink = styled(ExternalLink)`
   color: var(--page--text-color);
   font-size: var(--font-size-2);
   font-weight: var(--bold);
-  text-transform: none;
   text-decoration: none;
 
   &:hover {

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
@@ -87,7 +87,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
         </StatsRow>
         <StatsRow>
           <StatTitle>{t`Contract Address`}</StatTitle>
-          <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
+          <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
             {shortenAddress(gaugeData.address)}
           </StyledExternalLink>
         </StatsRow>
@@ -126,7 +126,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
           <StatTitle>{t`Contract Address`}</StatTitle>
           {gaugeData.pool?.address && (
             <Box flex flexAlignItems="center">
-              <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.pool.address)}>
+              <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.pool.address)}>
                 {shortenAddress(gaugeData.pool.address)}
               </StyledExternalLink>
             </Box>
@@ -178,7 +178,6 @@ const StyledExternalLink = styled(ExternalLink)`
   color: var(--page--text-color);
   font-size: var(--font-size-2);
   font-weight: var(--bold);
-  text-transform: none;
   text-decoration: none;
 
   &:hover {

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
@@ -87,7 +87,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
         </StatsRow>
         <StatsRow>
           <StatTitle>{t`Contract Address`}</StatTitle>
-          <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
+          <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
             {shortenAddress(gaugeData.address)}
           </StyledExternalLink>
         </StatsRow>
@@ -126,7 +126,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
           <StatTitle>{t`Contract Address`}</StatTitle>
           {gaugeData.pool?.address && (
             <Box flex flexAlignItems="center">
-              <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.pool.address)}>
+              <StyledExternalLink $noCap href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.pool.address)}>
                 {shortenAddress(gaugeData.pool.address)}
               </StyledExternalLink>
             </Box>

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
@@ -4,8 +4,9 @@ import networks from '@/dao/networks'
 import { GaugeFormattedData, UserGaugeVoteWeight } from '@/dao/types/dao.types'
 import Box from '@ui/Box'
 import { ExternalLink } from '@ui/Link'
-import { shortenTokenAddress, formatNumber, convertToLocaleTimestamp } from '@ui/utils'
+import { formatNumber, convertToLocaleTimestamp } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type GaugeDetailsSmProps = {
   gaugeData: GaugeFormattedData
@@ -87,7 +88,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
         <StatsRow>
           <StatTitle>{t`Contract Address`}</StatTitle>
           <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.address)}>
-            {shortenTokenAddress(gaugeData.address)}
+            {shortenAddress(gaugeData.address)}
           </StyledExternalLink>
         </StatsRow>
       </Box>
@@ -126,7 +127,7 @@ const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }: Gauge
           {gaugeData.pool?.address && (
             <Box flex flexAlignItems="center">
               <StyledExternalLink href={networks[ETHEREUM_CHAIN_ID].scanAddressPath(gaugeData.pool.address)}>
-                {shortenTokenAddress(gaugeData.pool.address)}
+                {shortenAddress(gaugeData.pool.address)}
               </StyledExternalLink>
             </Box>
           )}

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/TitleComp.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/TitleComp.tsx
@@ -5,9 +5,9 @@ import SmallLabel from '@/dao/components/SmallLabel'
 import networks from '@/dao/networks'
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import Box from '@ui/Box'
-import { shortenTokenAddress } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcons } from '@ui-kit/shared/ui/TokenIcons'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface TitleCompProps {
   gaugeData: GaugeFormattedData
@@ -36,7 +36,7 @@ const TitleComp = ({ gaugeData, gaugeAddress }: TitleCompProps) => (
       )}
       {gaugeAddress && (
         <Box flex flexGap="var(--spacing-1)">
-          <GaugeAddress>{shortenTokenAddress(gaugeAddress)}</GaugeAddress>
+          <GaugeAddress>{shortenAddress(gaugeAddress)}</GaugeAddress>
           <ButtonsWrapper>
             <ExternalLinkIconButton
               href={networks[1].scanAddressPath(gaugeAddress ?? '')}

--- a/apps/main/src/dao/components/PageGauges/GaugeVoting/GaugeVotingStats.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeVoting/GaugeVotingStats.tsx
@@ -73,7 +73,6 @@ const UserDataWrapper = styled(Box)`
 const StyledInternalLink = styled(InternalLink)`
   text-decoration: none;
   color: inherit;
-  text-transform: none;
 `
 
 export default GaugeVotingStats

--- a/apps/main/src/dao/components/PageGauges/GaugeVoting/GaugeVotingStats.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeVoting/GaugeVotingStats.tsx
@@ -6,9 +6,10 @@ import { getEthPath } from '@/dao/utils'
 import AlertBox from '@ui/AlertBox'
 import Box from '@ui/Box'
 import InternalLink from '@ui/Link/InternalLink'
-import { formatNumber, shortenTokenAddress } from '@ui/utils'
+import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 import { calculateUserPowerStale } from './utils'
 
 const GaugeVotingStats = ({ userAddress }: { userAddress: string }) => {
@@ -27,7 +28,7 @@ const GaugeVotingStats = ({ userAddress }: { userAddress: string }) => {
           title="User"
           data={
             <StyledInternalLink href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${userAddress}`)}>
-              <MetricsColumnData>{userEns ?? shortenTokenAddress(userAddress)}</MetricsColumnData>
+              <MetricsColumnData>{userEns ?? shortenAddress(userAddress)}</MetricsColumnData>
             </StyledInternalLink>
           }
         />

--- a/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
@@ -5,9 +5,10 @@ import { ProposalData } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
 import Box from '@ui/Box'
 import { InternalLink } from '@ui/Link'
-import { convertToLocaleTimestamp, shortenTokenAddress } from '@ui/utils'
+import { convertToLocaleTimestamp } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 
 type ProposalInformationProps = {
   proposal: ProposalData
@@ -29,7 +30,7 @@ const ProposalInformation = ({ proposal, snapshotBlock }: ProposalInformationPro
       <Box>
         <MetricsTitle>{t`Proposer`}</MetricsTitle>
         <StyledInternalLink href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${proposal?.creator}`)}>
-          {shortenTokenAddress(proposal?.creator)}
+          {shortenAddress(proposal?.creator)}
         </StyledInternalLink>
       </Box>
       <Box>

--- a/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
@@ -29,7 +29,7 @@ const ProposalInformation = ({ proposal, snapshotBlock }: ProposalInformationPro
     <Wrapper>
       <Box>
         <MetricsTitle>{t`Proposer`}</MetricsTitle>
-        <StyledInternalLink $noCap href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${proposal?.creator}`)}>
+        <StyledInternalLink href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${proposal?.creator}`)}>
           {shortenAddress(proposal?.creator)}
         </StyledInternalLink>
       </Box>
@@ -71,7 +71,6 @@ const StyledInternalLink = styled(InternalLink)`
   color: var(--page--text-color);
   font-size: var(--font-size-2);
   font-weight: var(--bold);
-  text-transform: none;
 
   &:hover {
     cursor: pointer;

--- a/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/ProposalInformation/index.tsx
@@ -29,7 +29,7 @@ const ProposalInformation = ({ proposal, snapshotBlock }: ProposalInformationPro
     <Wrapper>
       <Box>
         <MetricsTitle>{t`Proposer`}</MetricsTitle>
-        <StyledInternalLink href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${proposal?.creator}`)}>
+        <StyledInternalLink $noCap href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${proposal?.creator}`)}>
           {shortenAddress(proposal?.creator)}
         </StyledInternalLink>
       </Box>

--- a/apps/main/src/dao/components/PageProposal/Voters/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/Voters/index.tsx
@@ -6,9 +6,10 @@ import { getEthPath } from '@/dao/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import { ExternalLink, InternalLink } from '@ui/Link'
-import { shortenTokenAddress, formatNumber } from '@ui/utils'
+import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   totalVotes: number
@@ -58,7 +59,7 @@ const Voters = ({ totalVotes, rProposalId, className }: Props) => {
                       push(getEthPath(`${DAO_ROUTES.PAGE_USER}/${vote.voter}`))
                     }}
                   >
-                    {vote.topHolder ? vote.topHolder : shortenTokenAddress(vote.voter)}
+                    {vote.topHolder ? vote.topHolder : shortenAddress(vote.voter)}
                   </StyledInternalLink>
                 </Box>
                 <StyledExternalLink href={networks[1].scanTxPath(vote.transaction_hash)}>

--- a/apps/main/src/dao/components/PageProposal/Voters/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/Voters/index.tsx
@@ -54,7 +54,6 @@ const Voters = ({ totalVotes, rProposalId, className }: Props) => {
                     <AgainstIcon name="Misuse" size={16} />
                   )}
                   <StyledInternalLink
-                    $noCap
                     onClick={(e) => {
                       e.preventDefault()
                       push(getEthPath(`${DAO_ROUTES.PAGE_USER}/${vote.voter}`))
@@ -135,7 +134,6 @@ const StyledInternalLink = styled(InternalLink)`
   font-weight: var(--semi-bold);
   font-size: var(--font-size-2);
   text-decoration: none;
-  text-transform: none;
   display: flex;
   flex-direction: column;
 `
@@ -145,7 +143,6 @@ const StyledExternalLink = styled(ExternalLink)`
   font-weight: var(--semi-bold);
   font-size: var(--font-size-2);
   text-decoration: none;
-  text-transform: none;
   display: flex;
   flex-direction: column;
 `

--- a/apps/main/src/dao/components/PageProposal/Voters/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/Voters/index.tsx
@@ -54,6 +54,7 @@ const Voters = ({ totalVotes, rProposalId, className }: Props) => {
                     <AgainstIcon name="Misuse" size={16} />
                   )}
                   <StyledInternalLink
+                    $noCap
                     onClick={(e) => {
                       e.preventDefault()
                       push(getEthPath(`${DAO_ROUTES.PAGE_USER}/${vote.voter}`))

--- a/apps/main/src/dao/components/PageProposal/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/index.tsx
@@ -6,7 +6,7 @@ import useProposalMapper from '@/dao/hooks/useProposalMapper'
 import useProposalsMapper from '@/dao/hooks/useProposalsMapper'
 import useStore from '@/dao/store/useStore'
 import { ProposalType, type ProposalUrlParams } from '@/dao/types/dao.types'
-import { copyToClipboard, getEthPath } from '@/dao/utils'
+import { getEthPath } from '@/dao/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
@@ -16,6 +16,7 @@ import { breakpoints } from '@ui/utils'
 import { useWallet } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { copyToClipboard } from '@ui-kit/utils'
 import BackButton from '../BackButton'
 import ProposalVoteStatusBox from '../ProposalVoteStatusBox'
 import UserBox from '../UserBox'
@@ -61,10 +62,6 @@ const Proposal = ({ routerParams: { proposalId: rProposalId } }: ProposalProps) 
         : undefined,
     [proposal?.status, proposal?.startDate],
   )
-
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-  }
 
   useEffect(() => {
     if (snapshotVeCrv === undefined && provider && userAddress && proposal?.snapshotBlock) {
@@ -123,7 +120,7 @@ const Proposal = ({ routerParams: { proposalId: rProposalId } }: ProposalProps) 
                   <Box flex flexJustifyContent="space-between" flexAlignItems="end">
                     <MetadataTitle>{t`Metadata`}</MetadataTitle>
                     <Tooltip tooltip={t`Copy to clipboard`} minWidth="135px">
-                      <StyledCopyButton size="medium" onClick={() => handleCopyClick(proposal?.ipfsMetadata)}>
+                      <StyledCopyButton size="medium" onClick={() => copyToClipboard(proposal?.ipfsMetadata)}>
                         {t`Raw IPFS`}
                         <Icon name="Copy" size={16} />
                       </StyledCopyButton>

--- a/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
@@ -62,7 +62,6 @@ const UserGaugeVotesTable = ({ userAddress, tableMinWidth }: UserGaugeVotesTable
             {(gaugeVote.weight / 100).toFixed(2)}%
           </TableData>
           <TableDataLink
-            $noCap
             onClick={(e) => {
               e.preventDefault()
               push(getEthPath(`${DAO_ROUTES.PAGE_GAUGES}/${gaugeVote.gauge}`))

--- a/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
@@ -5,9 +5,10 @@ import { TableRowWrapper, TableData, TableDataLink } from '@/dao/components/Pagi
 import useStore from '@/dao/store/useStore'
 import { UserGaugeVote, UserGaugeVotesSortBy } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
-import { formatDateFromTimestamp, convertToLocaleTimestamp, shortenTokenAddress } from '@ui/utils'
+import { formatDateFromTimestamp, convertToLocaleTimestamp } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 import { GAUGE_VOTES_LABELS } from '../constants'
 
 interface UserGaugeVotesTableProps {
@@ -67,7 +68,7 @@ const UserGaugeVotesTable = ({ userAddress, tableMinWidth }: UserGaugeVotesTable
             }}
             className="right-padding"
           >
-            {shortenTokenAddress(gaugeVote.gauge)}
+            {shortenAddress(gaugeVote.gauge)}
           </TableDataLink>
         </TableRowWrapper>
       )}

--- a/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
@@ -62,6 +62,7 @@ const UserGaugeVotesTable = ({ userAddress, tableMinWidth }: UserGaugeVotesTable
             {(gaugeVote.weight / 100).toFixed(2)}%
           </TableData>
           <TableDataLink
+            $noCap
             onClick={(e) => {
               e.preventDefault()
               push(getEthPath(`${DAO_ROUTES.PAGE_GAUGES}/${gaugeVote.gauge}`))

--- a/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import { TOP_HOLDERS } from '@/dao/constants'
 import networks from '@/dao/networks'
 import { UserMapper } from '@/dao/types/dao.types'
@@ -24,10 +25,10 @@ const UserHeader = ({ userAddress, userMapper }: UserHeaderProps) => {
     <Wrapper variant="secondary">
       <Box flex flexAlignItems="center">
         <Box flex flexColumn flexJustifyContent="center">
-          <h3>{TOP_HOLDERS[userAddress]?.title || user?.ens || userAddress}</h3>
+          <h3>{TOP_HOLDERS[userAddress]?.title || user?.ens || getAddress(userAddress)}</h3>
           {((TOP_HOLDERS[userAddress]?.title && userAddress) || (user?.ens && userAddress)) && (
             <Box flex flexAlignItems="center">
-              <UserAddress>{userAddress}</UserAddress>{' '}
+              <UserAddress>{getAddress(userAddress)}</UserAddress>{' '}
               <Box margin="0 0 0 var(--spacing-1)" flex>
                 <StyledCopyButton size="small" onClick={() => handleCopyClick(userAddress)}>
                   <Icon name="Copy" size={16} />

--- a/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
@@ -3,11 +3,11 @@ import { getAddress } from 'viem'
 import { TOP_HOLDERS } from '@/dao/constants'
 import networks from '@/dao/networks'
 import { UserMapper } from '@/dao/types/dao.types'
-import { copyToClipboard } from '@/dao/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import { ExternalLink } from '@ui/Link'
+import { copyToClipboard } from '@ui-kit/utils'
 
 interface UserHeaderProps {
   userAddress: string
@@ -16,10 +16,6 @@ interface UserHeaderProps {
 
 const UserHeader = ({ userAddress, userMapper }: UserHeaderProps) => {
   const user = userMapper[userAddress]
-
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-  }
 
   return (
     <Wrapper variant="secondary">
@@ -30,7 +26,7 @@ const UserHeader = ({ userAddress, userMapper }: UserHeaderProps) => {
             <Box flex flexAlignItems="center">
               <UserAddress>{getAddress(userAddress)}</UserAddress>{' '}
               <Box margin="0 0 0 var(--spacing-1)" flex>
-                <StyledCopyButton size="small" onClick={() => handleCopyClick(userAddress)}>
+                <StyledCopyButton size="small" onClick={() => copyToClipboard(userAddress)}>
                   <Icon name="Copy" size={16} />
                 </StyledCopyButton>
                 <StyledExternalLink size="small" href={networks[1].scanAddressPath(userAddress)}>
@@ -42,7 +38,7 @@ const UserHeader = ({ userAddress, userMapper }: UserHeaderProps) => {
         </Box>
         {!userMapper[userAddress]?.ens && !TOP_HOLDERS[userAddress]?.title && (
           <Box flex margin="0 0 0 var(--spacing-1)">
-            <StyledCopyButton size="small" onClick={() => handleCopyClick(userAddress)}>
+            <StyledCopyButton size="small" onClick={() => copyToClipboard(userAddress)}>
               <Icon name="Copy" size={16} />
             </StyledCopyButton>
             <StyledExternalLink size="small" href={networks[1].scanAddressPath(userAddress)}>

--- a/apps/main/src/dao/components/PageVeCrv/components/FieldLockedAmt.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FieldLockedAmt.tsx
@@ -67,7 +67,6 @@ const StyledInputProvider = styled(InputProvider)`
 export const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
   font-weight: var(--bold);
-  text-transform: none;
 
   &:hover {
     cursor: pointer;

--- a/apps/main/src/dao/components/PaginatedTable/TableRow.tsx
+++ b/apps/main/src/dao/components/PaginatedTable/TableRow.tsx
@@ -64,7 +64,6 @@ export const TableDataLink = styled(InternalLink)<InternalLinkProps>`
   gap: var(--spacing-1);
   text-decoration: none;
   color: inherit;
-  text-transform: none;
   margin-left: auto;
   text-decoration: underline;
   &.right-padding {

--- a/apps/main/src/dao/components/UserBox/UserInformation.tsx
+++ b/apps/main/src/dao/components/UserBox/UserInformation.tsx
@@ -7,9 +7,10 @@ import { getEthPath } from '@/dao/utils'
 import Box from '@ui/Box'
 import InternalLink from '@ui/Link/InternalLink'
 import { TooltipIcon } from '@ui/Tooltip'
-import { shortenTokenAddress, formatNumber } from '@ui/utils'
+import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   noLink?: boolean
@@ -50,9 +51,9 @@ const UserInformation = ({ noLink, snapshotVotingPower, activeProposal, votingPo
             {userEns ? (
               <UserIdentifier>{userEns}</UserIdentifier>
             ) : (
-              <UserIdentifier>{shortenTokenAddress(userAddress ?? '')}</UserIdentifier>
+              <UserIdentifier>{shortenAddress(userAddress ?? '')}</UserIdentifier>
             )}
-            {userEns && <SmallAddress>{shortenTokenAddress(userAddress ?? '')}</SmallAddress>}
+            {userEns && <SmallAddress>{shortenAddress(userAddress ?? '')}</SmallAddress>}
           </Box>
         ) : (
           <StyledInternalLink href={getEthPath(`${DAO_ROUTES.PAGE_USER}/${userAddress}`)}>
@@ -60,10 +61,10 @@ const UserInformation = ({ noLink, snapshotVotingPower, activeProposal, votingPo
               {userEns ? (
                 <UserIdentifier>{userEns}</UserIdentifier>
               ) : (
-                <UserIdentifier>{shortenTokenAddress(userAddress ?? '')}</UserIdentifier>
+                <UserIdentifier>{shortenAddress(userAddress ?? '')}</UserIdentifier>
               )}
             </Box>
-            {userEns && <SmallAddress>{shortenTokenAddress(userAddress ?? '')}</SmallAddress>}
+            {userEns && <SmallAddress>{shortenAddress(userAddress ?? '')}</SmallAddress>}
           </StyledInternalLink>
         )}
       </Box>

--- a/apps/main/src/dao/components/UserBox/UserInformation.tsx
+++ b/apps/main/src/dao/components/UserBox/UserInformation.tsx
@@ -115,7 +115,6 @@ const StyledInternalLink = styled(InternalLink)`
   color: inherit;
   font-weight: 500;
   text-decoration: none;
-  text-transform: none;
 `
 
 const UserIdentifier = styled.h4`

--- a/apps/main/src/dao/constants.ts
+++ b/apps/main/src/dao/constants.ts
@@ -1,7 +1,6 @@
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
 export { CONNECT_STAGE } from '@ui/utils/utilsConnectState'
 
-export const NETWORK_TOKEN = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 export const ETHEREUM_CHAIN_ID = 1
 
 export const ROUTE = {

--- a/apps/main/src/dao/store/createGaugesSlice.ts
+++ b/apps/main/src/dao/store/createGaugesSlice.ts
@@ -18,9 +18,9 @@ import {
   SortDirection,
   TransactionState,
 } from '@/dao/types/dao.types'
-import { shortenTokenAddress } from '@ui/utils'
 import { notify, useWallet } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type StateKey = keyof typeof DEFAULT_STATE
 
@@ -518,7 +518,7 @@ const formatGaugeTitle = (poolName: string | undefined, marketName: string | nul
       .replace(/\(FRAXBP\)/i, '')
       .trim()
   }
-  return marketName ?? shortenTokenAddress(address) ?? ''
+  return marketName ?? shortenAddress(address) ?? ''
 }
 
 export default createGaugesSlice

--- a/apps/main/src/dao/store/createUsdRatesSlice.ts
+++ b/apps/main/src/dao/store/createUsdRatesSlice.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep'
+import { ethAddress } from 'viem'
 import type { GetState, SetState } from 'zustand'
-import { NETWORK_TOKEN } from '@/dao/constants'
 import curvejsApi from '@/dao/lib/curvejs'
 import type { State } from '@/dao/store/useStore'
 import { CurveApi, UsdRatesMapper } from '@/dao/types/dao.types'
@@ -30,7 +30,7 @@ export type UsdRatesSlice = {
 
 const DEFAULT_STATE: SliceState = {
   usdRatesMapper: {
-    [NETWORK_TOKEN]: 0,
+    [ethAddress]: 0,
     crv: 0,
   },
   loading: true,

--- a/apps/main/src/dao/utils/index.ts
+++ b/apps/main/src/dao/utils/index.ts
@@ -5,27 +5,6 @@ import { Chain } from '@ui-kit/utils'
 export * from './utilsRouter'
 export * from './utilsDates'
 
-export function copyToClipboard(text: string) {
-  if (window.clipboardData && window.clipboardData.setData) {
-    // IE specific code path to prevent textarea being shown while dialog is visible.
-    return window.clipboardData.setData('Text', text)
-  } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-    const textarea = document.createElement('textarea')
-    textarea.textContent = text
-    textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      return document.execCommand('copy') // Security exception may be thrown by some browsers.
-    } catch (ex) {
-      console.warn('Copy to clipboard failed.', ex)
-      return false
-    } finally {
-      document.body.removeChild(textarea)
-    }
-  }
-}
-
 export function getErrorMessage(error: Error, errorMessage: AlertFormErrorKey | string) {
   if (error?.message) {
     const message = error.message.toString()

--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef } from 'react'
 import { useButton } from 'react-aria'
 import type { AriaButtonProps } from 'react-aria'
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import { copyToClipboard } from '@/dex/lib/utils'
 import Icon from '@ui/Icon'
 import TextEllipsis from '@ui/TextEllipsis'
@@ -62,7 +63,7 @@ const ChipPool = ({
     if (poolAddress) {
       return `${shortenAddress(poolAddress)}`
     }
-    return poolAddress
+    return getAddress(poolAddress)
   }, [poolAddress])
 
   return (

--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -3,10 +3,10 @@ import { useButton } from 'react-aria'
 import type { AriaButtonProps } from 'react-aria'
 import styled from 'styled-components'
 import { copyToClipboard } from '@/dex/lib/utils'
-import { shortenTokenAddress } from '@/dex/utils'
 import Icon from '@ui/Icon'
 import TextEllipsis from '@ui/TextEllipsis'
 import { breakpoints } from '@ui/utils/responsive'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -60,7 +60,7 @@ const ChipPool = ({
 
   const parsedPoolAddress = useMemo(() => {
     if (poolAddress) {
-      return `${shortenTokenAddress(poolAddress)}`
+      return `${shortenAddress(poolAddress)}`
     }
     return poolAddress
   }, [poolAddress])

--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -3,11 +3,10 @@ import { useButton } from 'react-aria'
 import type { AriaButtonProps } from 'react-aria'
 import styled from 'styled-components'
 import { getAddress } from 'viem'
-import { copyToClipboard } from '@/dex/lib/utils'
 import Icon from '@ui/Icon'
 import TextEllipsis from '@ui/TextEllipsis'
 import { breakpoints } from '@ui/utils/responsive'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -54,11 +53,6 @@ const ChipPool = ({
   poolAddress,
   ...props
 }: ChipPoolProps) => {
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   const parsedPoolAddress = useMemo(() => {
     if (poolAddress) {
       return `${shortenAddress(poolAddress)}`
@@ -72,7 +66,7 @@ const ChipPool = ({
         {isHighlightPoolName || isHighlightPoolAddress ? <strong>{poolName}</strong> : poolName}{' '}
       </ChipPoolName>
       <ChipPoolAdditionalInfo>
-        <Button {...props} onPress={() => handleCopyClick(poolAddress)}>
+        <Button {...props} onPress={() => copyToClipboard(poolAddress)}>
           <ChipPoolAddress>
             {isHighlightPoolAddress ? <mark>{parsedPoolAddress}</mark> : parsedPoolAddress}
           </ChipPoolAddress>

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -2,11 +2,11 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import Icon from '@ui/Icon'
 import Spinner from '@ui/Spinner'
 import { formatNumberUsdRate } from '@ui/utils'
+import { copyToClipboard } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -50,11 +50,6 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
   const fetchUsdRateByToken = useStore((state) => state.usdRates.fetchUsdRateByToken)
   const parsedUsdRate = formatNumberUsdRate(usdRate)
 
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   const handleMouseEnter = (foundUsdRate?: string) => {
     if (!foundUsdRate && curve) {
       fetchUsdRateByToken(curve, tokenAddress)
@@ -72,7 +67,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
     <ChipTokenWrapper className={className} onMouseEnter={() => handleMouseEnter(parsedUsdRate)}>
       <span>{isHighlight ? <strong>{parsedTokenName}</strong> : parsedTokenName} </span>
       <ChipTokenAdditionalInfo>
-        <Button {...props} onPress={() => handleCopyClick(tokenAddress)}>
+        <Button {...props} onPress={() => copyToClipboard(tokenAddress)}>
           <ChipTokenUsdRate>{typeof usdRate === 'undefined' ? <Spinner size={10} /> : parsedUsdRate}</ChipTokenUsdRate>
           <ChipTokenCopyButtonIcon name="Copy" size={16} />
         </Button>

--- a/apps/main/src/dex/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dex/components/DetailInfoEstGas.tsx
@@ -2,7 +2,7 @@ import isNaN from 'lodash/isNaN'
 import isUndefined from 'lodash/isUndefined'
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { NETWORK_TOKEN } from '@/dex/constants'
+import { ethAddress } from 'viem'
 import useStore from '@/dex/store/useStore'
 import { ChainId, EstimatedGas } from '@/dex/types/main.types'
 import DetailInfo from '@ui/DetailInfo'
@@ -33,7 +33,7 @@ const DetailInfoEstGas = ({
   const curve = useStore((state) => state.curve)
   const networks = useStore((state) => state.networks.networks)
   const { gasPricesDefault } = networks[chainId]
-  const chainTokenUsdRate = useStore((state) => state.usdRates.usdRatesMapper[NETWORK_TOKEN])
+  const chainTokenUsdRate = useStore((state) => state.usdRates.usdRatesMapper[ethAddress])
   const gasInfo = useStore((state) => state.gas.gasInfo)
   const basePlusPriority = useStore((state) => state.gas.gasInfo?.basePlusPriority?.[gasPricesDefault])
 

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -99,7 +99,7 @@ const Compensation = ({
         <Box grid margin="0 1rem 0 0" gridRowGap={1}>
           <div>
             <strong>{token}</strong>{' '}
-            <StyledExternalLink href={networks[rChainId].scanAddressPath(contractAddress)}>
+            <StyledExternalLink $noCap href={networks[rChainId].scanAddressPath(contractAddress)}>
               {shortenAddress(contractAddress)}
               <Icon name="Launch" size={16} />
             </StyledExternalLink>

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -98,7 +98,7 @@ const Compensation = ({
         <Box grid margin="0 1rem 0 0" gridRowGap={1}>
           <div>
             <strong>{token}</strong>{' '}
-            <StyledExternalLink $noCap href={networks[rChainId].scanAddressPath(contractAddress)}>
+            <StyledExternalLink href={networks[rChainId].scanAddressPath(contractAddress)}>
               {shortenAddress(contractAddress)}
               <Icon name="Launch" size={16} />
             </StyledExternalLink>

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -7,7 +7,7 @@ import curvejsApi from '@/dex/lib/curvejs'
 import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, CurveApi, Provider } from '@/dex/types/main.types'
-import { getErrorMessage, shortenTokenAddress } from '@/dex/utils'
+import { getErrorMessage } from '@/dex/utils'
 import Box from '@ui/Box'
 import Button from '@ui/Button'
 import Icon from '@ui/Icon'
@@ -16,6 +16,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { formatNumber } from '@ui/utils'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 const Compensation = ({
   rChainId,
@@ -99,7 +100,7 @@ const Compensation = ({
           <div>
             <strong>{token}</strong>{' '}
             <StyledExternalLink href={networks[rChainId].scanAddressPath(contractAddress)}>
-              {shortenTokenAddress(contractAddress)}
+              {shortenAddress(contractAddress)}
               <Icon name="Launch" size={16} />
             </StyledExternalLink>
             <StyledIconButton size="medium" onClick={() => copyToClipboard(contractAddress)}>

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -4,7 +4,6 @@ import AlertFormError from '@/dex/components/AlertFormError'
 import type { EtherContract } from '@/dex/components/PageCompensation/types'
 import { StyledIconButton } from '@/dex/components/PagePool/PoolDetails/PoolStats/styles'
 import curvejsApi from '@/dex/lib/curvejs'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, CurveApi, Provider } from '@/dex/types/main.types'
 import { getErrorMessage } from '@/dex/utils'
@@ -16,7 +15,7 @@ import TxInfoBar from '@ui/TxInfoBar'
 import { formatNumber } from '@ui/utils'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 const Compensation = ({
   rChainId,

--- a/apps/main/src/dex/components/PageCreatePool/Parameters/SelectPreset.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Parameters/SelectPreset.tsx
@@ -330,7 +330,6 @@ const PresetMessage = styled.div`
 `
 
 const StyledExternalLink = styled(ExternalLink)`
-  text-transform: none;
   color: var(--page--text-color);
   font-weight: var(--bold);
   margin: 0 var(--spacing-1);

--- a/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import {
   CategoryDataRow,
   SummaryDataTitle,
@@ -73,14 +74,14 @@ const OracleTokenSummary = ({ chainId, token, title }: OracleTokenSummaryProps) 
         ) : (
           <SummaryData>
             {token.oracleAddress.length === 42 ? (
-              <AddressLink href={network.scanAddressPath(token.oracleAddress)}>
+              <AddressLink $noCap href={network.scanAddressPath(token.oracleAddress)}>
                 {shortenAddress(token.oracleAddress)}
                 <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
               </AddressLink>
             ) : token.oracleAddress.length > 13 ? (
               shortenAddress(token.oracleAddress)
             ) : (
-              token.oracleAddress
+              getAddress(token.oracleAddress)
             )}
           </SummaryData>
         )}

--- a/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
@@ -74,7 +74,7 @@ const OracleTokenSummary = ({ chainId, token, title }: OracleTokenSummaryProps) 
         ) : (
           <SummaryData>
             {token.oracleAddress.length === 42 ? (
-              <AddressLink $noCap href={network.scanAddressPath(token.oracleAddress)}>
+              <AddressLink href={network.scanAddressPath(token.oracleAddress)}>
                 {shortenAddress(token.oracleAddress)}
                 <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
               </AddressLink>

--- a/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/OracleSummary.tsx
@@ -10,9 +10,9 @@ import {
 import type { TokenState } from '@/dex/components/PageCreatePool/types'
 import useStore from '@/dex/store/useStore'
 import { ChainId } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Icon from '@ui/Icon'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   chainId: ChainId
@@ -74,11 +74,11 @@ const OracleTokenSummary = ({ chainId, token, title }: OracleTokenSummaryProps) 
           <SummaryData>
             {token.oracleAddress.length === 42 ? (
               <AddressLink href={network.scanAddressPath(token.oracleAddress)}>
-                {shortenTokenAddress(token.oracleAddress)}
+                {shortenAddress(token.oracleAddress)}
                 <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
               </AddressLink>
             ) : token.oracleAddress.length > 13 ? (
-              shortenTokenAddress(token.oracleAddress)
+              shortenAddress(token.oracleAddress)
             ) : (
               token.oracleAddress
             )}

--- a/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
@@ -211,7 +211,7 @@ const TokenSummary = ({ blockchainId, token, chainId, swapType }: TokenSummary) 
           </TokenType>
         )}
       </Box>
-      <AddressLink href={scanAddressPath(token.address)}>
+      <AddressLink $noCap href={scanAddressPath(token.address)}>
         {shortenAddress(token.address)}
         <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
       </AddressLink>

--- a/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
@@ -27,11 +27,11 @@ import { SwapType, TokenState } from '@/dex/components/PageCreatePool/types'
 import { checkTokensInPoolUnset, containsOracle } from '@/dex/components/PageCreatePool/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import { Chip } from '@ui/Typography'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   blockchainId: string
@@ -212,7 +212,7 @@ const TokenSummary = ({ blockchainId, token, chainId, swapType }: TokenSummary) 
         )}
       </Box>
       <AddressLink href={scanAddressPath(token.address)}>
-        {shortenTokenAddress(token.address)}
+        {shortenAddress(token.address)}
         <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
       </AddressLink>
     </TokenRow>

--- a/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/Summary/TokensInPoolSummary.tsx
@@ -211,7 +211,7 @@ const TokenSummary = ({ blockchainId, token, chainId, swapType }: TokenSummary) 
           </TokenType>
         )}
       </Box>
-      <AddressLink $noCap href={scanAddressPath(token.address)}>
+      <AddressLink href={scanAddressPath(token.address)}>
         {shortenAddress(token.address)}
         <Icon name={'Launch'} size={16} aria-label={t`Link to address`} />
       </AddressLink>

--- a/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
@@ -4,7 +4,7 @@ import { STABLESWAP } from '@/dex/components/PageCreatePool/constants'
 import { CreateToken } from '@/dex/components/PageCreatePool/types'
 import useStore from '@/dex/store/useStore'
 import { ChainId, CurveApi } from '@/dex/types/main.types'
-import { delayAction, shortenTokenAddress } from '@/dex/utils'
+import { delayAction } from '@/dex/utils'
 import { useButton } from '@react-aria/button'
 import { useFilter } from '@react-aria/i18n'
 import { useOverlayTriggerState } from '@react-stately/overlays'
@@ -16,7 +16,7 @@ import { Chip } from '@ui/Typography'
 import { TokenSelectorModal } from '@ui-kit/features/select-token/ui/modal/TokenSelectorModal'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
-import { type Address, filterTokens } from '@ui-kit/utils'
+import { type Address, filterTokens, shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   curve: CurveApi
@@ -146,7 +146,7 @@ const SelectTokenButton = ({
                 {selectedToken.basePool && swapType === STABLESWAP && <BasepoolLabel>{t`BASE`}</BasepoolLabel>}
               </SelectedLabelText>
             </LabelTextWrapper>
-            <SelectedLabelAddress>{shortenTokenAddress(selectedToken.address)}</SelectedLabelAddress>
+            <SelectedLabelAddress>{shortenAddress(selectedToken.address)}</SelectedLabelAddress>
           </>
         ) : (
           <LabelTextWrapper>

--- a/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
@@ -198,7 +198,6 @@ const FormVecrv = () => {
 const AdjustVecrvLink = styled(InternalLink)`
   color: inherit;
   font-weight: bold;
-  text-transform: initial;
 `
 
 const StyledTitle = styled(Title)`

--- a/apps/main/src/dex/components/PageDeployGauge/InfoBox.tsx
+++ b/apps/main/src/dex/components/PageDeployGauge/InfoBox.tsx
@@ -38,7 +38,6 @@ const InfoText = styled.p`
 
 const StyledExternalLink = styled(ExternalLink)`
   color: var(--white);
-  text-transform: none;
   &:hover {
     text-decoration: none;
   }

--- a/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
+++ b/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
@@ -3,13 +3,13 @@ import styled from 'styled-components'
 import InfoBox from '@/dex/components/PageDeployGauge/InfoBox'
 import useStore from '@/dex/store/useStore'
 import { ChainId } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import InternalLinkButton from '@ui/InternalLinkButton'
 import ExternalLink from '@ui/Link/ExternalLink'
 import Spinner from '@ui/Spinner'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   chainId: ChainId
@@ -52,7 +52,7 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     href={networks[sidechain].scanTxPath(deploymentStatus.sidechain.transaction.hash)}
                   >
                     <p>{t`Transaction:`}</p>
-                    {shortenTokenAddress(deploymentStatus.sidechain.transaction.hash)}
+                    {shortenAddress(deploymentStatus.sidechain.transaction.hash)}
                     <StyledIcon name={'Launch'} size={16} />
                   </Transaction>
                 </SuccessfulTransactionInfo>
@@ -84,7 +84,7 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     href={networks[chainId].scanTxPath(deploymentStatus.mirror.transaction.hash)}
                   >
                     <p>{t`Transaction:`}</p>
-                    {shortenTokenAddress(deploymentStatus.mirror.transaction.hash)}
+                    {shortenAddress(deploymentStatus.mirror.transaction.hash)}
                     <StyledIcon name={'Launch'} size={16} />
                   </Transaction>
                 </SuccessfulTransactionInfo>

--- a/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
+++ b/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
@@ -48,7 +48,6 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     <SuccessMessage>{t`Sidechain gauge successfully deployed`}</SuccessMessage>
                   </Box>
                   <Transaction
-                    $noCap
                     variant={'contained'}
                     href={networks[sidechain].scanTxPath(deploymentStatus.sidechain.transaction.hash)}
                   >
@@ -81,7 +80,6 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     <SuccessMessage>{t`Mirror gauge successfully deployed`}</SuccessMessage>
                   </Box>
                   <Transaction
-                    $noCap
                     variant={'contained'}
                     href={networks[chainId].scanTxPath(deploymentStatus.mirror.transaction.hash)}
                   >
@@ -174,7 +172,6 @@ const Transaction = styled(ExternalLink)`
   font-size: var(--font-size-2);
   font-weight: var(--semi-bold);
   color: var(--page--text-color);
-  text-transform: none;
   text-decoration: none;
   margin-top: var(--spacing-3);
   background-color: var(--page--background-color);

--- a/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
+++ b/apps/main/src/dex/components/PageDeployGauge/ProcessSummary.tsx
@@ -48,6 +48,7 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     <SuccessMessage>{t`Sidechain gauge successfully deployed`}</SuccessMessage>
                   </Box>
                   <Transaction
+                    $noCap
                     variant={'contained'}
                     href={networks[sidechain].scanTxPath(deploymentStatus.sidechain.transaction.hash)}
                   >
@@ -80,6 +81,7 @@ const ProcessSummary = ({ chainId, isLite }: Props) => {
                     <SuccessMessage>{t`Mirror gauge successfully deployed`}</SuccessMessage>
                   </Box>
                   <Transaction
+                    $noCap
                     variant={'contained'}
                     href={networks[chainId].scanTxPath(deploymentStatus.mirror.transaction.hash)}
                   >

--- a/apps/main/src/dex/components/PageDeployGauge/components/DeployGaugeButton.tsx
+++ b/apps/main/src/dex/components/PageDeployGauge/components/DeployGaugeButton.tsx
@@ -12,12 +12,12 @@ import { CONNECT_STAGE } from '@/dex/constants'
 import { curveProps } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, CurveApi } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import { getPath, useNetworkFromUrl, useRestFullPathname } from '@/dex/utils/utilsRouter'
 import AlertBox from '@ui/AlertBox'
 import Button from '@ui/Button'
 import Spinner, { SpinnerWrapper } from '@ui/Spinner'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface Props {
   disabled: boolean
@@ -99,7 +99,7 @@ const DeployGaugeButton = ({ disabled, chainId, curve }: Props) => {
             deploymentStatus.sidechain.status === 'SUCCESS' && (
               <InfoLinkBarWrapper>
                 <StyledInfoLinkBar
-                  description={t`Tx: Gauge for ${shortenTokenAddress(lpTokenAddress)} deployed`}
+                  description={t`Tx: Gauge for ${shortenAddress(lpTokenAddress)} deployed`}
                   link={networks[chainId].scanTxPath(deploymentStatus.sidechain.transaction.hash)}
                 />
               </InfoLinkBarWrapper>
@@ -108,7 +108,7 @@ const DeployGaugeButton = ({ disabled, chainId, curve }: Props) => {
             deploymentStatus.mirror.status === 'SUCCESS' && (
               <InfoLinkBarWrapper>
                 <StyledInfoLinkBar
-                  description={t`Tx: Gauge for ${shortenTokenAddress(lpTokenAddress)} deployed`}
+                  description={t`Tx: Gauge for ${shortenAddress(lpTokenAddress)} deployed`}
                   link={networks[chainId].scanTxPath(deploymentStatus.mirror.transaction.hash)}
                 />
               </InfoLinkBarWrapper>
@@ -178,7 +178,7 @@ const DeployGaugeButton = ({ disabled, chainId, curve }: Props) => {
       {deploymentStatus.mainnet.transaction && deploymentStatus.mainnet.status === 'SUCCESS' && (
         <InfoLinkBarWrapper>
           <StyledInfoLinkBar
-            description={t`Tx: Gauge for ${shortenTokenAddress(lpTokenAddress)} deployed`}
+            description={t`Tx: Gauge for ${shortenAddress(lpTokenAddress)} deployed`}
             link={networks[chainId].scanTxPath(deploymentStatus.mainnet.transaction.hash)}
           />
         </InfoLinkBarWrapper>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import type { CurrencyReservesProps } from '@/dex/components/PagePool/PoolDetails/CurrencyReserves/types'
 import { StyledStats } from '@/dex/components/PagePool/PoolDetails/PoolStats/styles'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import ExternalLink from '@ui/Link/ExternalLink'
@@ -12,6 +11,7 @@ import Chip from '@ui/Typography/Chip'
 import { breakpoints, formatNumber, formatNumberUsdRate } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { shortenAddress } from '@ui-kit/utils'
 
 const CurrencyReservesContent = ({
   cr,
@@ -37,7 +37,7 @@ const CurrencyReservesContent = ({
           <ExternalLinkToken>{token}</ExternalLinkToken>{' '}
           {haveSameTokenName ? (
             <Chip opacity={0.7} size="xs">
-              {shortenTokenAddress(tokenAddress)}
+              {shortenAddress(tokenAddress)}
             </Chip>
           ) : null}
         </TokenLabelLink>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
@@ -33,7 +33,7 @@ const CurrencyReservesContent = ({
       />
 
       <Box grid gridGap={1}>
-        <TokenLabelLink $noStyles href={network.scanTokenPath(tokenAddress)}>
+        <TokenLabelLink $noCap $noStyles href={network.scanTokenPath(tokenAddress)}>
           <ExternalLinkToken>{token}</ExternalLinkToken>{' '}
           {haveSameTokenName ? (
             <Chip opacity={0.7} size="xs">

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
@@ -33,7 +33,7 @@ const CurrencyReservesContent = ({
       />
 
       <Box grid gridGap={1}>
-        <TokenLabelLink $noCap $noStyles href={network.scanTokenPath(tokenAddress)}>
+        <TokenLabelLink $noStyles href={network.scanTokenPath(tokenAddress)}>
           <ExternalLinkToken>{token}</ExternalLinkToken>{' '}
           {haveSameTokenName ? (
             <Chip opacity={0.7} size="xs">
@@ -83,7 +83,6 @@ const TokenLabelLink = styled(ExternalLink)`
   display: inline-flex;
   grid-gap: var(--spacing-1);
   text-decoration: none;
-  text-transform: initial;
 `
 
 export const TokenBalancePercent = styled(Chip)`
@@ -105,7 +104,6 @@ export const ExternalLinkToken = styled(TextEllipsis)`
 
 export const TokenLink = styled(ExternalLink)`
   color: inherit;
-  text-transform: initial;
 `
 
 export default CurrencyReservesContent

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/index.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import CurrencyReservesContent from '@/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent'
 import { StyledStats } from '@/dex/components/PagePool/PoolDetails/PoolStats/styles'
 import usePoolTokensLinksMapper from '@/dex/hooks/usePoolTokensLinksMapper'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, TokensMapper, Tvl } from '@/dex/types/main.types'
 import { getChainPoolIdActiveKey } from '@/dex/utils'
@@ -10,6 +9,7 @@ import IconTooltip from '@ui/Tooltip/TooltipIcon'
 import { Chip } from '@ui/Typography'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { copyToClipboard } from '@ui-kit/utils'
 
 interface Props {
   rChainId: ChainId
@@ -27,11 +27,6 @@ const CurrencyReserves = ({ rChainId, rPoolId, tokensMapper, tvl }: Props) => {
   const poolDataCachedOrApi = poolData ?? poolDataMapperCached
   const poolTokensLinks = usePoolTokensLinksMapper(rChainId, poolDataCachedOrApi)
 
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   return (
     <article>
       <StyledTitle>{t`Currency reserves`}</StyledTitle>
@@ -48,7 +43,7 @@ const CurrencyReserves = ({ rChainId, rPoolId, tokensMapper, tvl }: Props) => {
             token={token}
             tokenAddress={tokenAddress}
             tokenLink={poolTokensLinks?.[tokenAddress]}
-            handleCopyClick={handleCopyClick}
+            handleCopyClick={copyToClipboard}
           />
         )
       })}

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import { StyledIconButton, StyledInformationSquare16 } from '@/dex/components/PagePool/PoolDetails/PoolStats/styles'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, PoolData } from '@/dex/types/main.types'
 import Box from '@ui/Box'
@@ -14,7 +13,7 @@ import { breakpoints } from '@ui/utils/responsive'
 import dayjs from '@ui-kit/lib/dayjs'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 type PoolParametersProps = {
   pricesApi: boolean
@@ -59,10 +58,6 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
       }
     }
   }, [future_A, future_A_time, initial_A, initial_A_time])
-
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-  }
 
   const returnPoolType = (poolType: string, coins: number) => {
     const isCrypto = poolData.pool.isCrypto
@@ -135,7 +130,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
                         <ExternalLinkToken>{token}</ExternalLinkToken>
                       </ExternalLinkTokenWrapper>
                     </StyledExternalLink>
-                    <StyledIconButton size="medium" onClick={() => handleCopyClick(poolData.tokenAddresses[idx])}>
+                    <StyledIconButton size="medium" onClick={() => copyToClipboard(poolData.tokenAddresses[idx])}>
                       <Icon name="Copy" size={16} />
                     </StyledIconButton>
                   </>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -4,7 +4,6 @@ import { StyledIconButton, StyledInformationSquare16 } from '@/dex/components/Pa
 import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, PoolData } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import { ExternalLink } from '@ui/Link'
@@ -15,6 +14,7 @@ import { breakpoints } from '@ui/utils/responsive'
 import dayjs from '@ui-kit/lib/dayjs'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { shortenAddress } from '@ui-kit/utils'
 
 type PoolParametersProps = {
   pricesApi: boolean
@@ -101,7 +101,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
             <PoolParameter>
               <PoolParameterTitle>{t`Basepool:`}</PoolParameterTitle>
               <DataAddressLink href={network.scanTokenPath(pricesData.base_pool)}>
-                {shortenTokenAddress(pricesData.base_pool)}
+                {shortenAddress(pricesData.base_pool)}
               </DataAddressLink>
             </PoolParameter>
           )}
@@ -112,7 +112,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
           <PoolParameter>
             <PoolParameterTitle>{t`Registry:`}</PoolParameterTitle>
             <PoolParameterLink href={network.scanTokenPath(pricesData.registry)}>
-              {shortenTokenAddress(pricesData.registry)}
+              {shortenAddress(pricesData.registry)}
             </PoolParameterLink>
           </PoolParameter>
         </SectionWrapper>
@@ -150,7 +150,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
                       <Numeral>├─</Numeral>
                       <IndentDataTitle>{t`Oracle Address:`}</IndentDataTitle>
                       <IndentDataAddressLink href={network.scanTokenPath(pricesData.oracles[idx].oracle_address)}>
-                        {shortenTokenAddress(pricesData.oracles[idx].oracle_address)}
+                        {shortenAddress(pricesData.oracles[idx].oracle_address)}
                       </IndentDataAddressLink>
                     </Box>
                     <Box flex>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -95,7 +95,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
           {pricesData.base_pool && (
             <PoolParameter>
               <PoolParameterTitle>{t`Basepool:`}</PoolParameterTitle>
-              <DataAddressLink $noCap href={network.scanTokenPath(pricesData.base_pool)}>
+              <DataAddressLink href={network.scanTokenPath(pricesData.base_pool)}>
                 {shortenAddress(pricesData.base_pool)}
               </DataAddressLink>
             </PoolParameter>
@@ -106,7 +106,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
           </PoolParameter>
           <PoolParameter>
             <PoolParameterTitle>{t`Registry:`}</PoolParameterTitle>
-            <PoolParameterLink $noCap href={network.scanTokenPath(pricesData.registry)}>
+            <PoolParameterLink href={network.scanTokenPath(pricesData.registry)}>
               {shortenAddress(pricesData.registry)}
             </PoolParameterLink>
           </PoolParameter>
@@ -144,10 +144,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
                     <Box flex>
                       <Numeral>├─</Numeral>
                       <IndentDataTitle>{t`Oracle Address:`}</IndentDataTitle>
-                      <IndentDataAddressLink
-                        $noCap
-                        href={network.scanTokenPath(pricesData.oracles[idx].oracle_address)}
-                      >
+                      <IndentDataAddressLink href={network.scanTokenPath(pricesData.oracles[idx].oracle_address)}>
                         {shortenAddress(pricesData.oracles[idx].oracle_address)}
                       </IndentDataAddressLink>
                     </Box>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -100,7 +100,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
           {pricesData.base_pool && (
             <PoolParameter>
               <PoolParameterTitle>{t`Basepool:`}</PoolParameterTitle>
-              <DataAddressLink href={network.scanTokenPath(pricesData.base_pool)}>
+              <DataAddressLink $noCap href={network.scanTokenPath(pricesData.base_pool)}>
                 {shortenAddress(pricesData.base_pool)}
               </DataAddressLink>
             </PoolParameter>
@@ -111,7 +111,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
           </PoolParameter>
           <PoolParameter>
             <PoolParameterTitle>{t`Registry:`}</PoolParameterTitle>
-            <PoolParameterLink href={network.scanTokenPath(pricesData.registry)}>
+            <PoolParameterLink $noCap href={network.scanTokenPath(pricesData.registry)}>
               {shortenAddress(pricesData.registry)}
             </PoolParameterLink>
           </PoolParameter>
@@ -149,7 +149,10 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
                     <Box flex>
                       <Numeral>├─</Numeral>
                       <IndentDataTitle>{t`Oracle Address:`}</IndentDataTitle>
-                      <IndentDataAddressLink href={network.scanTokenPath(pricesData.oracles[idx].oracle_address)}>
+                      <IndentDataAddressLink
+                        $noCap
+                        href={network.scanTokenPath(pricesData.oracles[idx].oracle_address)}
+                      >
                         {shortenAddress(pricesData.oracles[idx].oracle_address)}
                       </IndentDataAddressLink>
                     </Box>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
@@ -5,7 +5,6 @@ import ChipVolatileBaseApy from '@/dex/components/PagePoolList/components/ChipVo
 import PoolRewardsCrv from '@/dex/components/PoolRewardsCrv'
 import { LARGE_APY } from '@/dex/constants'
 import useCampaignRewardsMapper from '@/dex/hooks/useCampaignRewardsMapper'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId, RewardsApy, PoolData } from '@/dex/types/main.types'
 import { shortenTokenName } from '@/dex/utils'
@@ -19,6 +18,7 @@ import IconTooltip from '@ui/Tooltip/TooltipIcon'
 import { Chip } from '@ui/Typography'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { copyToClipboard } from '@ui-kit/utils'
 
 type RewardsProps = {
   chainId: ChainId
@@ -37,10 +37,6 @@ const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
     { label: t`Daily`, value: base?.day ?? '' },
     { label: t`Weekly`, value: base?.week ?? '' },
   ]
-
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-  }
 
   if ((isLite ? true : !haveBase) && !poolData?.failedFetching24hOldVprice && !haveCrv && !haveOther) return null
 
@@ -118,7 +114,7 @@ const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
                       </TokenWrapper>
                     </StyledExternalLink>
 
-                    <StyledIconButton size="small" onClick={() => handleCopyClick(tokenAddress)}>
+                    <StyledIconButton size="small" onClick={() => copyToClipboard(tokenAddress)}>
                       <Icon name="Copy" size={16} />
                     </StyledIconButton>
                   </Box>

--- a/apps/main/src/dex/components/PagePool/Swap/index.tsx
+++ b/apps/main/src/dex/components/PagePool/Swap/index.tsx
@@ -3,6 +3,7 @@ import isNaN from 'lodash/isNaN'
 import isUndefined from 'lodash/isUndefined'
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
+import { ethAddress } from 'viem'
 import AlertFormError from '@/dex/components/AlertFormError'
 import AlertFormWarning from '@/dex/components/AlertFormWarning'
 import AlertSlippage from '@/dex/components/AlertSlippage'
@@ -18,7 +19,6 @@ import { DEFAULT_EST_GAS, DEFAULT_EXCHANGE_OUTPUT, getSwapTokens } from '@/dex/c
 import type { EstimatedGas as FormEstGas, PageTransferProps, Seed } from '@/dex/components/PagePool/types'
 import DetailInfoExchangeRate from '@/dex/components/PageRouterSwap/components/DetailInfoExchangeRate'
 import DetailInfoPriceImpact from '@/dex/components/PageRouterSwap/components/DetailInfoPriceImpact'
-import { NETWORK_TOKEN } from '@/dex/constants'
 import useStore from '@/dex/store/useStore'
 import { Balances, CurveApi, PoolAlert, PoolData, TokensMapper } from '@/dex/types/main.types'
 import { toTokenOption } from '@/dex/utils'
@@ -369,7 +369,7 @@ const Swap = ({
               <InputMaxBtn
                 disabled={isDisabled || isMaxLoading}
                 loading={isMaxLoading}
-                isNetworkToken={formValues.fromAddress.toLowerCase() === NETWORK_TOKEN}
+                isNetworkToken={formValues.fromAddress.toLowerCase() === ethAddress}
                 onClick={() => {
                   updateFormValues({ isFrom: true, fromAmount: '', toAmount: '' }, true, null)
                 }}

--- a/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
+++ b/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
@@ -4,7 +4,6 @@ import type { TransferProps } from '@/dex/components/PagePool/types'
 import PoolRewardsCrv from '@/dex/components/PoolRewardsCrv'
 import { getUserPoolActiveKey } from '@/dex/store/createUserSlice'
 import useStore from '@/dex/store/useStore'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Stats from '@ui/Stats'
 import Table from '@ui/Table'
@@ -147,7 +146,7 @@ const MySharesStats = ({
                   label={
                     tokenObj && poolData.tokensCountBy[token] > 1 ? (
                       <span>
-                        {token} <Chip>{shortenTokenAddress(tokenObj.address)}</Chip>
+                        {token} <Chip>{shortenAddress(tokenObj.address)}</Chip>
                       </span>
                     ) : (
                       token

--- a/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
+++ b/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
@@ -10,6 +10,7 @@ import Table from '@ui/Table'
 import { Chip } from '@ui/Typography'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 const MySharesStats = ({
   className,

--- a/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
+++ b/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
@@ -32,7 +32,7 @@ const ContractComp = ({
           <LabelWrapper flex flexDirection="row">
             <Box flex flexDirection="column">
               {label}
-              <StyledExternalLink $noCap href={network.scanAddressPath(address)}>
+              <StyledExternalLink href={network.scanAddressPath(address)}>
                 {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
@@ -45,7 +45,7 @@ const ContractComp = ({
           <>
             <Label>{label}</Label>
             <span>
-              <StyledExternalLink $noCap href={network.scanAddressPath(address)}>
+              <StyledExternalLink href={network.scanAddressPath(address)}>
                 {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>

--- a/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
+++ b/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
@@ -1,13 +1,12 @@
 import { ReactNode } from 'react'
 import styled from 'styled-components'
 import { StyledIconButton } from '@/dex/components/PagePool/PoolDetails/PoolStats/styles'
-import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId } from '@/dex/types/main.types'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import ExternalLink from '@ui/Link/ExternalLink'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 const ContractComp = ({
   address,
@@ -25,9 +24,6 @@ const ContractComp = ({
   action?: ReactNode
 }) => {
   const network = useStore((state) => state.networks.networks[rChainId])
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-  }
 
   return (
     <Wrapper haveAction={!!action}>
@@ -41,7 +37,7 @@ const ContractComp = ({
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
             </Box>
-            <StyledIconButton size="medium" onClick={() => handleCopyClick(address)}>
+            <StyledIconButton size="medium" onClick={() => copyToClipboard(address)}>
               <Icon name="Copy" size={16} />
             </StyledIconButton>
           </LabelWrapper>
@@ -53,7 +49,7 @@ const ContractComp = ({
                 {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
-              <StyledIconButton size="medium" onClick={() => handleCopyClick(address)}>
+              <StyledIconButton size="medium" onClick={() => copyToClipboard(address)}>
                 <Icon name="Copy" size={16} />
               </StyledIconButton>
             </span>

--- a/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
+++ b/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
@@ -36,7 +36,7 @@ const ContractComp = ({
           <LabelWrapper flex flexDirection="row">
             <Box flex flexDirection="column">
               {label}
-              <StyledExternalLink href={network.scanAddressPath(address)}>
+              <StyledExternalLink $noCap href={network.scanAddressPath(address)}>
                 {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
@@ -49,7 +49,7 @@ const ContractComp = ({
           <>
             <Label>{label}</Label>
             <span>
-              <StyledExternalLink href={network.scanAddressPath(address)}>
+              <StyledExternalLink $noCap href={network.scanAddressPath(address)}>
                 {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>

--- a/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
+++ b/apps/main/src/dex/components/PagePool/components/ContractComp.tsx
@@ -4,10 +4,10 @@ import { StyledIconButton } from '@/dex/components/PagePool/PoolDetails/PoolStat
 import { copyToClipboard } from '@/dex/lib/utils'
 import useStore from '@/dex/store/useStore'
 import { ChainId } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import ExternalLink from '@ui/Link/ExternalLink'
+import { shortenAddress } from '@ui-kit/utils'
 
 const ContractComp = ({
   address,
@@ -37,7 +37,7 @@ const ContractComp = ({
             <Box flex flexDirection="column">
               {label}
               <StyledExternalLink href={network.scanAddressPath(address)}>
-                {shortenTokenAddress(address)}
+                {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
             </Box>
@@ -50,7 +50,7 @@ const ContractComp = ({
             <Label>{label}</Label>
             <span>
               <StyledExternalLink href={network.scanAddressPath(address)}>
-                {shortenTokenAddress(address)}
+                {shortenAddress(address)}
                 <Icon name="Launch" size={16} />
               </StyledExternalLink>
               <StyledIconButton size="medium" onClick={() => handleCopyClick(address)}>

--- a/apps/main/src/dex/components/PagePool/components/FieldToken.tsx
+++ b/apps/main/src/dex/components/PagePool/components/FieldToken.tsx
@@ -1,4 +1,4 @@
-import { NETWORK_TOKEN } from '@/dex/constants'
+import { ethAddress } from 'viem'
 import { shortenTokenAddress, shortenTokenName } from '@/dex/utils'
 import Box from '@ui/Box'
 import InputProvider, { InputDebounced, InputMaxBtn } from '@ui/InputComp'
@@ -45,7 +45,7 @@ const FieldToken = ({
   handleMaxClick,
 }: Props) => {
   const value = typeof amount === 'undefined' ? '' : amount
-  const isNetworkToken = !isWithdraw && tokenAddress.toLowerCase() === NETWORK_TOKEN
+  const isNetworkToken = !isWithdraw && tokenAddress.toLowerCase() === ethAddress
   const showAvailableBalance = haveSigner && !isWithdraw
 
   return (

--- a/apps/main/src/dex/components/PagePool/components/FieldToken.tsx
+++ b/apps/main/src/dex/components/PagePool/components/FieldToken.tsx
@@ -1,9 +1,10 @@
 import { ethAddress } from 'viem'
-import { shortenTokenAddress, shortenTokenName } from '@/dex/utils'
+import { shortenTokenName } from '@/dex/utils'
 import Box from '@ui/Box'
 import InputProvider, { InputDebounced, InputMaxBtn } from '@ui/InputComp'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { shortenAddress } from '@ui-kit/utils'
 
 type Props = {
   idx: number
@@ -63,7 +64,7 @@ const FieldToken = ({
         type="number"
         value={value}
         labelProps={{
-          label: `${shortenTokenName(token)} ${haveSameTokenName ? shortenTokenAddress(tokenAddress) : ''} ${
+          label: `${shortenTokenName(token)} ${haveSameTokenName ? shortenAddress(tokenAddress) : ''} ${
             showAvailableBalance ? `${t`Avail.`} ` : ''
           }`,
           descriptionLoading: showAvailableBalance && balanceLoading,

--- a/apps/main/src/dex/components/PagePool/components/SelectedLpTokenExpected.tsx
+++ b/apps/main/src/dex/components/PagePool/components/SelectedLpTokenExpected.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import type { Amount } from '@/dex/components/PagePool/utils'
 import { TokensMapper, PoolDataCacheOrApi } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Box from '@ui/Box'
 import Loader from '@ui/Loader'
 import Spacer from '@ui/Spacer'
@@ -9,6 +8,7 @@ import TextEllipsis from '@ui/TextEllipsis'
 import { Chip } from '@ui/Typography'
 import { formatNumber } from '@ui/utils'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { shortenAddress } from '@ui-kit/utils'
 
 const SelectedLpTokenExpected = ({
   amounts,
@@ -40,7 +40,7 @@ const SelectedLpTokenExpected = ({
             address={tokensMapper[tokenAddress]?.ethAddress || tokenAddress}
           />{' '}
           {symbol}
-          {haveSameTokenName && <Chip>{shortenTokenAddress(tokenAddress)}</Chip>}
+          {haveSameTokenName && <Chip>{shortenAddress(tokenAddress)}</Chip>}
           <Spacer />
           {loading ? (
             <Loader skeleton={[90, 20]} />

--- a/apps/main/src/dex/components/PagePool/components/SelectedOneCoinExpected.tsx
+++ b/apps/main/src/dex/components/PagePool/components/SelectedOneCoinExpected.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import type { Amount } from '@/dex/components/PagePool/utils'
 import { TokensMapper, PoolDataCacheOrApi } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import Loader from '@ui/Loader'
 import { Radio, RadioGroup } from '@ui/Radio'
 import Spacer from '@ui/Spacer'
@@ -10,6 +9,7 @@ import TextEllipsis from '@ui/TextEllipsis'
 import { Chip } from '@ui/Typography'
 import { formatNumber } from '@ui/utils'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { shortenAddress } from '@ui-kit/utils'
 
 const SelectedOneCoinExpected = ({
   amounts,
@@ -58,7 +58,7 @@ const SelectedOneCoinExpected = ({
                 tooltip={symbol}
                 address={tokensMapper[tokenAddress]?.ethAddress || tokenAddress}
               />{' '}
-              {symbol} {haveSameTokenName && <StyledChip>{shortenTokenAddress(tokenAddress)}</StyledChip>}
+              {symbol} {haveSameTokenName && <StyledChip>{shortenAddress(tokenAddress)}</StyledChip>}
               <Spacer />
               {loading ? (
                 <Loader skeleton={[90, 20]} />

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -373,7 +373,6 @@ const Wrapper = styled(AppPageFormContainer)<{ chartExpanded: boolean }>`
 
 const StyledExternalLink = styled(ExternalLink)`
   color: var(--nav--page--color);
-  text-transform: none;
 `
 
 const Title = styled(TextEllipsis)`

--- a/apps/main/src/dex/components/PageRouterSwap/components/DetailInfoTradeRouteRoute.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/components/DetailInfoTradeRouteRoute.tsx
@@ -6,11 +6,11 @@ import type { Route } from '@/dex/components/PageRouterSwap/types'
 import { ROUTE } from '@/dex/constants'
 import useStore from '@/dex/store/useStore'
 import { ChainId, NetworkEnum, type UrlParams } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import { getPath } from '@/dex/utils/utilsRouter'
 import Icon from '@ui/Icon'
 import { ExternalLink } from '@ui/Link'
 import TextEllipsis from '@ui/TextEllipsis'
+import { shortenAddress } from '@ui-kit/utils'
 
 const DetailInfoTradeRouteRoute = ({
   params,
@@ -23,8 +23,8 @@ const DetailInfoTradeRouteRoute = ({
   routesLength: number
   tokensNameMapper: { [address: string]: string }
 }) => {
-  const inputToken = tokensNameMapper[route.inputCoinAddress] ?? shortenTokenAddress(route.inputCoinAddress) ?? ''
-  const outputToken = tokensNameMapper[route.outputCoinAddress] ?? shortenTokenAddress(route.outputCoinAddress) ?? ''
+  const inputToken = tokensNameMapper[route.inputCoinAddress] ?? shortenAddress(route.inputCoinAddress) ?? ''
+  const outputToken = tokensNameMapper[route.outputCoinAddress] ?? shortenAddress(route.outputCoinAddress) ?? ''
   const networks = useStore((state) => state.networks.networks)
   const networksIdMapper = useStore((state) => state.networks.networksIdMapper)
   const networkId = params?.network ? networksIdMapper[params.network.toLowerCase() as NetworkEnum] : null

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -1,5 +1,6 @@
 import isEmpty from 'lodash/isEmpty'
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ethAddress } from 'viem'
 import ChipInpHelper from '@/dex/components/ChipInpHelper'
 import DetailInfoEstGas from '@/dex/components/DetailInfoEstGas'
 import FieldHelperUsdRate from '@/dex/components/FieldHelperUsdRate'
@@ -17,7 +18,6 @@ import type {
   SearchedParams,
   StepKey,
 } from '@/dex/components/PageRouterSwap/types'
-import { NETWORK_TOKEN } from '@/dex/constants'
 import useTokensNameMapper from '@/dex/hooks/useTokensNameMapper'
 import useStore from '@/dex/store/useStore'
 import { ChainId, CurveApi, type NetworkUrlParams, TokensMapper } from '@/dex/types/main.types'
@@ -384,7 +384,7 @@ const QuickSwap = ({
               <InputMaxBtn
                 loading={isMaxLoading}
                 disabled={isDisable}
-                isNetworkToken={searchedParams.fromAddress === NETWORK_TOKEN}
+                isNetworkToken={searchedParams.fromAddress === ethAddress}
                 testId="max"
                 onClick={() => updateFormValues({ isFrom: true, toAmount: '' }, true)}
               />

--- a/apps/main/src/dex/components/PoolAlertCustomMessage.tsx
+++ b/apps/main/src/dex/components/PoolAlertCustomMessage.tsx
@@ -73,7 +73,6 @@ const Title = styled.div`
 
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
-  text-transform: initial;
 `
 
 const StyledChip = styled(Chip)`

--- a/apps/main/src/dex/constants.ts
+++ b/apps/main/src/dex/constants.ts
@@ -1,8 +1,6 @@
 import { DEX_ROUTES } from '@ui-kit/shared/routes'
 export { CONNECT_STAGE } from '@ui/utils/utilsConnectState'
 
-export const NETWORK_TOKEN = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-export const INVALID_ADDRESS = '0x0000000000000000000000000000000000000000'
 export const LARGE_APY = 5000
 
 export const MAIN_ROUTE = {

--- a/apps/main/src/dex/features/add-gauge-reward-token/ui/TokenSelector.tsx
+++ b/apps/main/src/dex/features/add-gauge-reward-token/ui/TokenSelector.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { type Address, isAddressEqual, zeroAddress } from 'viem'
-import { NETWORK_TOKEN } from '@/dex/constants'
+import { ethAddress } from 'viem'
 import { useGaugeRewardsDistributors } from '@/dex/entities/gauge'
 import type { AddRewardFormValues } from '@/dex/features/add-gauge-reward-token/types'
 import { FlexItemToken, SubTitle } from '@/dex/features/add-gauge-reward-token/ui'
@@ -40,7 +40,7 @@ export const TokenSelector = ({
           token !== undefined &&
           token.decimals === 18 &&
           !aliasesCrv &&
-          ![...gaugeRewardTokens, zeroAddress, NETWORK_TOKEN, aliasesCrv].some((rewardToken) =>
+          ![...gaugeRewardTokens, zeroAddress, ethAddress, aliasesCrv].some((rewardToken) =>
             isAddressEqual(rewardToken as Address, token.address as Address),
           ),
       )

--- a/apps/main/src/dex/features/deposit-gauge-reward/ui/AmountTokenInput.tsx
+++ b/apps/main/src/dex/features/deposit-gauge-reward/ui/AmountTokenInput.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent, useCallback, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { Address, isAddressEqual } from 'viem'
-import { NETWORK_TOKEN } from '@/dex/constants'
+import { ethAddress } from 'viem'
 import {
   useDepositRewardApproveIsMutating,
   useDepositRewardIsMutating,
@@ -137,7 +137,7 @@ export const AmountTokenInput = ({ chainId, poolId }: { chainId: ChainId; poolId
           <InputMaxBtn
             loading={isMaxLoading}
             disabled={isDisabled}
-            isNetworkToken={rewardTokenId === NETWORK_TOKEN}
+            isNetworkToken={rewardTokenId === ethAddress}
             testId="max"
             onClick={onMaxButtonClick}
           />

--- a/apps/main/src/dex/hooks/usePoolAlert.tsx
+++ b/apps/main/src/dex/hooks/usePoolAlert.tsx
@@ -64,7 +64,7 @@ const usePoolAlert = (poolAddress: string | undefined, hasVyperVulnerability: bo
             <div>
               This pool has been deprecated. Please use the{' '}
               {redirectPathname ? (
-                <InternalLink $noCap $noStyles href={redirectPathname}>
+                <InternalLink $noStyles href={redirectPathname}>
                   {redirectText}
                 </InternalLink>
               ) : (

--- a/apps/main/src/dex/hooks/usePoolAlert.tsx
+++ b/apps/main/src/dex/hooks/usePoolAlert.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components'
 import PoolAlertCustomMessage from '@/dex/components/PoolAlertCustomMessage'
 import { ROUTE } from '@/dex/constants'
 import { PoolAlert, type UrlParams } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import { getPath } from '@/dex/utils/utilsRouter'
 import Box from '@ui/Box'
 import { RCCrossCurve } from '@ui/images'
 import { ExternalLink, InternalLink } from '@ui/Link'
 import { breakpoints } from '@ui/utils'
+import { shortenAddress } from '@ui-kit/utils'
 
 const usePoolAlert = (poolAddress: string | undefined, hasVyperVulnerability: boolean | undefined) => {
   const params = useParams() as UrlParams
@@ -53,7 +53,7 @@ const usePoolAlert = (poolAddress: string | undefined, hasVyperVulnerability: bo
     })
     const yPrismaAlert = (): PoolAlert => {
       const redirectPathname = params && getPath(params, `${ROUTE.PAGE_POOLS}/factory-v2-372${ROUTE.PAGE_POOL_DEPOSIT}`)
-      const redirectText = `PRISMA/yPRISMA pool (${shortenTokenAddress('0x69833361991ed76f9e8dbbcdf9ea1520febfb4a7')})`
+      const redirectText = `PRISMA/yPRISMA pool (${shortenAddress('0x69833361991ed76f9e8dbbcdf9ea1520febfb4a7')})`
       return {
         isDisableDeposit: true,
         isInformationOnly: true,

--- a/apps/main/src/dex/hooks/usePoolAlert.tsx
+++ b/apps/main/src/dex/hooks/usePoolAlert.tsx
@@ -64,7 +64,7 @@ const usePoolAlert = (poolAddress: string | undefined, hasVyperVulnerability: bo
             <div>
               This pool has been deprecated. Please use the{' '}
               {redirectPathname ? (
-                <InternalLink $noStyles href={redirectPathname}>
+                <InternalLink $noCap $noStyles href={redirectPathname}>
                   {redirectText}
                 </InternalLink>
               ) : (

--- a/apps/main/src/dex/hooks/useTokenAlert.tsx
+++ b/apps/main/src/dex/hooks/useTokenAlert.tsx
@@ -54,7 +54,6 @@ const useTokenAlert = (tokenAddressAll: string[]): PoolAlert | null =>
 
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
-  text-transform: initial;
   word-break: break-word;
 `
 

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -25,7 +25,7 @@ import {
   UsdRatesMapper,
   UserBalancesMapper,
 } from '@/dex/types/main.types'
-import { fulfilledValue, getErrorMessage, isValidAddress, shortenTokenAddress } from '@/dex/utils'
+import { fulfilledValue, getErrorMessage, isValidAddress } from '@/dex/utils'
 import {
   filterCrvProfit,
   filterRewardsApy,
@@ -46,6 +46,7 @@ import PromisePool from '@supercharge/promise-pool/dist'
 import { BN } from '@ui/utils'
 import dayjs from '@ui-kit/lib/dayjs'
 import { log } from '@ui-kit/lib/logging'
+import { shortenAddress } from '@ui-kit/utils'
 
 const helpers = {
   fetchCustomGasFees: async (curve: CurveApi) => {
@@ -193,10 +194,10 @@ const pool = {
   },
   getPoolData: (p: Pool, network: NetworkConfig, storedPoolData: PoolData | undefined) => {
     const isWrappedOnly = network.poolIsWrappedOnly[p.id]
-    const tokensWrapped = p.wrappedCoins.map((token, idx) => token || shortenTokenAddress(p.wrappedCoinAddresses[idx])!)
+    const tokensWrapped = p.wrappedCoins.map((token, idx) => token || shortenAddress(p.wrappedCoinAddresses[idx])!)
     const tokens = isWrappedOnly
       ? tokensWrapped
-      : p.underlyingCoins.map((token, idx) => token || shortenTokenAddress(p.underlyingCoinAddresses[idx])!)
+      : p.underlyingCoins.map((token, idx) => token || shortenAddress(p.underlyingCoinAddresses[idx])!)
     const tokensLowercase = tokens.map((c) => c.toLowerCase())
     const tokensAll = isWrappedOnly ? tokensWrapped : [...tokens, ...tokensWrapped]
     const tokenAddresses = isWrappedOnly ? p.wrappedCoinAddresses : p.underlyingCoinAddresses

--- a/apps/main/src/dex/lib/utils.ts
+++ b/apps/main/src/dex/lib/utils.ts
@@ -3,27 +3,6 @@ import { CurveApi, NetworkConfig } from '@/dex/types/main.types'
 
 export const httpFetcher = (uri: string) => fetch(uri).then((res) => res.json())
 
-export function copyToClipboard(text: string) {
-  if (window.clipboardData && window.clipboardData.setData) {
-    // IE specific code path to prevent textarea being shown while dialog is visible.
-    return window.clipboardData.setData('Text', text)
-  } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-    const textarea = document.createElement('textarea')
-    textarea.textContent = text
-    textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      return document.execCommand('copy') // Security exception may be thrown by some browsers.
-    } catch (ex) {
-      console.warn('Copy to clipboard failed.', ex)
-      return false
-    } finally {
-      document.body.removeChild(textarea)
-    }
-  }
-}
-
 export function curveProps(curve: CurveApi | null, networks: Record<number, NetworkConfig>) {
   if (curve) {
     const { chainId, signerAddress } = curve

--- a/apps/main/src/dex/store/createDeployGaugeSlice.ts
+++ b/apps/main/src/dex/store/createDeployGaugeSlice.ts
@@ -4,9 +4,9 @@ import type { GetState, SetState } from 'zustand'
 import type { DeploymentType, GaugeType, PoolType, PoolTypes } from '@/dex/components/PageDeployGauge/types'
 import type { State } from '@/dex/store/useStore'
 import { ChainId, CurveApi } from '@/dex/types/main.types'
-import { shortenTokenAddress } from '@/dex/utils'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
+import { shortenAddress } from '@ui-kit/utils'
 
 type NetworkWithFactory = {
   chainId: ChainId
@@ -182,11 +182,11 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
       const chainId = curve.chainId
       const fetchGasInfo = get().gas.fetchGasInfo
       const tokenAddress = sidechainGauge ? lpTokenAddress : poolAddress
-      const shortenAddress = shortenTokenAddress(tokenAddress)
+      const shortAddress = shortenAddress(tokenAddress)
 
       let dismissNotificationHandler
 
-      const notifyPendingMessage = t`Please confirm to deploy gauge for ${shortenAddress}.`
+      const notifyPendingMessage = t`Please confirm to deploy gauge for ${shortAddress}.`
       const { dismiss: dismissConfirm } = notify(notifyPendingMessage, 'pending')
 
       dismissNotificationHandler = dismissConfirm
@@ -212,7 +212,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -249,7 +249,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -286,7 +286,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -323,7 +323,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -359,7 +359,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -405,7 +405,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -443,7 +443,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -481,7 +481,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -519,7 +519,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -557,7 +557,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying sidechain gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -608,7 +608,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -647,7 +647,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -686,7 +686,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -725,7 +725,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying
@@ -761,7 +761,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
               }),
             )
             dismissConfirm()
-            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortenAddress}...`
+            const deployingNotificationMessage = t`Deploying mirror gauge for ${shortAddress}...`
             const { dismiss: dismissDeploying } = notify(deployingNotificationMessage, 'pending')
 
             dismissNotificationHandler = dismissDeploying

--- a/apps/main/src/dex/store/createPoolDepositSlice.ts
+++ b/apps/main/src/dex/store/createPoolDepositSlice.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep'
+import { ethAddress } from 'viem'
 import type { GetState, SetState } from 'zustand'
 import { DEFAULT_ESTIMATED_GAS, DEFAULT_SLIPPAGE } from '@/dex/components/PagePool'
 import type {
@@ -16,7 +17,6 @@ import {
 import type { EstimatedGas as FormEstGas, Slippage } from '@/dex/components/PagePool/types'
 import { getAmountsError, parseAmountsForAPI } from '@/dex/components/PagePool/utils'
 import type { Amount } from '@/dex/components/PagePool/utils'
-import { NETWORK_TOKEN } from '@/dex/constants'
 import curvejsApi from '@/dex/lib/curvejs'
 import { getUserPoolActiveKey } from '@/dex/store/createUserSlice'
 import type { State } from '@/dex/store/useStore'
@@ -118,7 +118,7 @@ const createPoolDepositSlice = (set: SetState<State>, get: GetState<State>): Poo
       const cFormValues = cloneDeep(get()[sliceKey].formValues)
       const userBalance = get().userBalances.userBalancesMapper[tokenAddress] ?? ''
 
-      if (tokenAddress.toLowerCase() === NETWORK_TOKEN) {
+      if (tokenAddress.toLowerCase() === ethAddress) {
         // set loading
         cFormValues.amounts[idx].value = ''
         get()[sliceKey].setStateByKeys({

--- a/apps/main/src/dex/store/createPoolSwapSlice.ts
+++ b/apps/main/src/dex/store/createPoolSwapSlice.ts
@@ -1,5 +1,6 @@
 import { Contract, Interface, JsonRpcProvider } from 'ethers'
 import cloneDeep from 'lodash/cloneDeep'
+import { ethAddress } from 'viem'
 import type { GetState, SetState } from 'zustand'
 import type { ExchangeOutput, FormStatus, FormValues, RouterSwapOutput } from '@/dex/components/PagePool/Swap/types'
 import {
@@ -10,7 +11,6 @@ import {
 } from '@/dex/components/PagePool/Swap/utils'
 import type { EstimatedGas as FormEstGas } from '@/dex/components/PagePool/types'
 import type { RoutesAndOutput, RoutesAndOutputModal } from '@/dex/components/PageRouterSwap/types'
-import { NETWORK_TOKEN } from '@/dex/constants'
 import curvejsApi from '@/dex/lib/curvejs'
 import type { State } from '@/dex/store/useStore'
 import {
@@ -229,7 +229,7 @@ const createPoolSwapSlice = (set: SetState<State>, get: GetState<State>): PoolSw
 
       // get max amount for native token
       if (
-        formValues.fromAddress.toLowerCase() === NETWORK_TOKEN &&
+        formValues.fromAddress.toLowerCase() === ethAddress &&
         typeof basePlusPriority?.[0] !== 'undefined' &&
         +fromAmount > 0
       ) {

--- a/apps/main/src/dex/store/createPoolWithdrawSlice.ts
+++ b/apps/main/src/dex/store/createPoolWithdrawSlice.ts
@@ -18,8 +18,9 @@ import {
   Pool,
   PoolData,
 } from '@/dex/types/main.types'
-import { isBonus, isHighSlippage, shortenTokenAddress } from '@/dex/utils'
+import { isBonus, isHighSlippage } from '@/dex/utils'
 import { setMissingProvider, useWallet } from '@ui-kit/features/connect-wallet'
+import { shortenAddress } from '@ui-kit/utils'
 
 type StateKey = keyof typeof DEFAULT_STATE
 
@@ -638,7 +639,7 @@ export function getActiveKey(
   if (formType === 'WITHDRAW') {
     if (selected === 'token') {
       const selectedStr = `${selected}-${selectedToken}-${
-        selectedTokenAddress ? shortenTokenAddress(selectedTokenAddress) : ''
+        selectedTokenAddress ? shortenAddress(selectedTokenAddress) : ''
       }`
       activeKey += `${selectedStr}-${isWrapped}-${maxSlippage}-${lpToken}`
     } else if (selected === 'lpToken') {

--- a/apps/main/src/dex/store/createPoolsSlice.ts
+++ b/apps/main/src/dex/store/createPoolsSlice.ts
@@ -6,8 +6,8 @@ import countBy from 'lodash/countBy'
 import groupBy from 'lodash/groupBy'
 import isNaN from 'lodash/isNaN'
 import pick from 'lodash/pick'
+import { zeroAddress } from 'viem'
 import type { GetState, SetState } from 'zustand'
-import { INVALID_ADDRESS } from '@/dex/constants'
 import curvejsApi from '@/dex/lib/curvejs'
 import type { State } from '@/dex/store/useStore'
 import {
@@ -1002,7 +1002,7 @@ export function parsedTokensNameMapper(poolDatas: PoolData[]) {
       tokensNameMapper[address] = tokens[idx]
     })
 
-    if (lpToken !== INVALID_ADDRESS) {
+    if (lpToken !== zeroAddress) {
       tokensNameMapper[lpToken] = `${id} LP`
     }
   }

--- a/apps/main/src/dex/store/createQuickSwapSlice.ts
+++ b/apps/main/src/dex/store/createQuickSwapSlice.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep'
+import { ethAddress } from 'viem'
 import type { GetState, SetState } from 'zustand'
 import type {
   FormEstGas,
@@ -9,7 +10,6 @@ import type {
   SearchedParams,
 } from '@/dex/components/PageRouterSwap/types'
 import { DEFAULT_FORM_STATUS, DEFAULT_FORM_VALUES } from '@/dex/components/PageRouterSwap/utils'
-import { NETWORK_TOKEN } from '@/dex/constants'
 import curvejsApi from '@/dex/lib/curvejs'
 import type { State } from '@/dex/store/useStore'
 import { CurveApi, FnStepApproveResponse, FnStepResponse, TokensMapper } from '@/dex/types/main.types'
@@ -137,7 +137,7 @@ const createQuickSwapSlice = (set: SetState<State>, get: GetState<State>): Quick
         activeKey = getRouterActiveKey(curve, cFormValues, searchedParams, maxSlippage)
 
         // get max amount for native token
-        if (fromAddress.toLowerCase() === NETWORK_TOKEN) {
+        if (fromAddress.toLowerCase() === ethAddress) {
           await state.gas.fetchGasInfo(curve)
           const { basePlusPriority } = get().gas.gasInfo ?? {}
           const firstBasePlusPriority = basePlusPriority?.[0]
@@ -377,7 +377,7 @@ const createQuickSwapSlice = (set: SetState<State>, get: GetState<State>): Quick
       )
 
       // Get prices of user balance tokens
-      await state.usdRates.fetchUsdRateByTokens(curve, [...filteredUserBalancesList, NETWORK_TOKEN])
+      await state.usdRates.fetchUsdRateByTokens(curve, [...filteredUserBalancesList, ethAddress])
     },
 
     // steps

--- a/apps/main/src/dex/utils/index.ts
+++ b/apps/main/src/dex/utils/index.ts
@@ -1,8 +1,8 @@
 import type { AlertFormErrorKey } from '@/dex/components/AlertFormError'
-export { getStorageValue, setStorageValue } from '@/dex/utils/storage'
 import type { ChainId, Token } from '@/dex/types/main.types'
 import type { TokenOption } from '@ui-kit/features/select-token'
 import type { Address } from '@ui-kit/utils'
+export { getStorageValue, setStorageValue } from '@/dex/utils/storage'
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_device_detection
 export function isMobile() {
@@ -43,13 +43,6 @@ export function shortenTokenName(token: string) {
 
 export const isValidAddress = (address: string) =>
   address?.length === 42 && address !== '0x0000000000000000000000000000000000000000'
-
-export function shortenTokenAddress(tokenAddress: string, startOnly?: boolean) {
-  if (!tokenAddress) return
-  const start = tokenAddress.slice(0, 4)
-  const end = tokenAddress.slice(-4)
-  return startOnly ? start : `${start}...${end}`
-}
 
 export function removeExtraSpaces(str: string) {
   return str.replace(/ +(?= )/g, '').trim()

--- a/apps/main/src/lend/components/ChipCollateral.tsx
+++ b/apps/main/src/lend/components/ChipCollateral.tsx
@@ -3,10 +3,9 @@ import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
 import { getAddress } from 'viem'
-import { copyToClipboard } from '@/lend/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -53,11 +52,6 @@ const ChipCollateral = ({
   poolAddress,
   ...props
 }: ChipPoolProps) => {
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   const parsedPoolName = useMemo(() => {
     if (poolName && poolName.length > 24) {
       return `${poolName.slice(0, 18)}...`
@@ -78,7 +72,7 @@ const ChipCollateral = ({
         {isHighlightPoolName || isHighlightPoolAddress ? <mark>{parsedPoolName}</mark> : parsedPoolName}{' '}
       </ChipPoolName>
       <ChipPoolAdditionalInfo>
-        <Button {...props} onPress={() => handleCopyClick(poolAddress)}>
+        <Button {...props} onPress={() => copyToClipboard(poolAddress)}>
           <ChipPoolAddress>
             {isHighlightPoolAddress ? <mark>{parsedPoolAddress}</mark> : parsedPoolAddress}
           </ChipPoolAddress>

--- a/apps/main/src/lend/components/ChipCollateral.tsx
+++ b/apps/main/src/lend/components/ChipCollateral.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import { copyToClipboard } from '@/lend/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
@@ -68,7 +69,7 @@ const ChipCollateral = ({
     if (poolAddress) {
       return `${shortenAddress(poolAddress)}`
     }
-    return poolAddress
+    return getAddress(poolAddress)
   }, [poolAddress])
 
   return (

--- a/apps/main/src/lend/components/ChipCollateral.tsx
+++ b/apps/main/src/lend/components/ChipCollateral.tsx
@@ -2,9 +2,10 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
-import { copyToClipboard, shortenTokenAddress } from '@/lend/utils/helpers'
+import { copyToClipboard } from '@/lend/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -65,7 +66,7 @@ const ChipCollateral = ({
 
   const parsedPoolAddress = useMemo(() => {
     if (poolAddress) {
-      return `${shortenTokenAddress(poolAddress)}`
+      return `${shortenAddress(poolAddress)}`
     }
     return poolAddress
   }, [poolAddress])

--- a/apps/main/src/lend/components/DetailInfoCrvIncentives.tsx
+++ b/apps/main/src/lend/components/DetailInfoCrvIncentives.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { INVALID_ADDRESS } from '@/lend/constants'
+import { zeroAddress } from 'viem'
 import { useOneWayMarket } from '@/lend/entities/chain'
 import useAbiTotalSupply from '@/lend/hooks/useAbiTotalSupply'
 import useSupplyTotalApr from '@/lend/hooks/useSupplyTotalApr'
@@ -32,7 +32,7 @@ const DetailInfoCrvIncentives = ({
   const { tooltipValues } = useSupplyTotalApr(rChainId, rOwmId)
   const gaugeAddress = useOneWayMarket(rChainId, rOwmId).data?.addresses?.gauge
   const gaugeTotalSupply = useAbiTotalSupply(rChainId, gaugeAddress)
-  const isGaugeAddressInvalid = gaugeAddress === INVALID_ADDRESS
+  const isGaugeAddressInvalid = gaugeAddress === zeroAddress
 
   const { crvBase = '', incentivesObj = [] } = tooltipValues ?? {}
 

--- a/apps/main/src/lend/components/DetailInfoEstimateGas.tsx
+++ b/apps/main/src/lend/components/DetailInfoEstimateGas.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { NETWORK_TOKEN } from '@/lend/constants'
+import { ethAddress } from 'viem'
 import { useTokenUsdRate } from '@/lend/entities/token'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
@@ -26,7 +26,7 @@ interface Props {
 }
 
 const DetailInfoEstimateGas = ({ chainId, isDivider = false, loading, estimatedGas, stepProgress }: Props) => {
-  const { data: chainTokenUsdRate } = useTokenUsdRate({ chainId, tokenAddress: NETWORK_TOKEN })
+  const { data: chainTokenUsdRate } = useTokenUsdRate({ chainId, tokenAddress: ethAddress })
   const gasPricesDefault = chainId && networks[chainId].gasPricesDefault
   // TODO: allow gas prices priority adjustment
   const basePlusPriorities = useStore((state) => state.gas.gasInfo?.basePlusPriority)

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
@@ -4,10 +4,11 @@ import type { StatsProps } from '@/lend/components/DetailsMarket/styles'
 import { StyledStats } from '@/lend/components/DetailsMarket/styles'
 import networks from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
-import { copyToClipboard, shortenTokenAddress } from '@/lend/utils/helpers'
+import { copyToClipboard } from '@/lend/utils/helpers'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import ExternalLink from '@ui/Link/ExternalLink'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface Props extends StatsProps {
   chainId: ChainId
@@ -34,7 +35,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
             isNumber={isValidAddress}
             href={isValidAddress ? networks[chainId]?.scanAddressPath(address) : ''}
           >
-            <strong>{address === 'NaN' ? 'no gauge' : shortenTokenAddress(address)}</strong>
+            <strong>{address === 'NaN' ? 'no gauge' : shortenAddress(address)}</strong>
             <Icon name="Launch" size={16} />
           </StyledExternalLink>
           <CopyIconButton

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
@@ -30,6 +30,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
       {address && (
         <span>
           <StyledExternalLink
+            $noCap
             isValid={isValidAddress}
             isMono={isValidAddress}
             isNumber={isValidAddress}

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
@@ -26,7 +26,6 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
           <StyledExternalLink
             $noCap
             isValid={isValidAddress}
-            isMono={isValidAddress}
             isNumber={isValidAddress}
             href={isValidAddress ? networks[chainId]?.scanAddressPath(address) : ''}
           >

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
@@ -4,11 +4,10 @@ import type { StatsProps } from '@/lend/components/DetailsMarket/styles'
 import { StyledStats } from '@/lend/components/DetailsMarket/styles'
 import networks from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
-import { copyToClipboard } from '@/lend/utils/helpers'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import ExternalLink from '@ui/Link/ExternalLink'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface Props extends StatsProps {
   chainId: ChainId
@@ -17,11 +16,6 @@ interface Props extends StatsProps {
 }
 
 const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) => {
-  const handleBtnClickCopy = (address: string) => {
-    console.log(`copied ${address}`)
-    copyToClipboard(address)
-  }
-
   const isValidAddress = address ? address !== 'NaN' : true
 
   return (
@@ -42,7 +36,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
           <CopyIconButton
             isValid={isValidAddress}
             size="medium"
-            onClick={() => (isValidAddress ? handleBtnClickCopy(address) : {})}
+            onClick={() => (isValidAddress ? copyToClipboard(address) : {})}
           >
             <Icon name="Copy" size={16} />
           </CopyIconButton>

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailInfoAddressLookup.tsx
@@ -24,7 +24,6 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
       {address && (
         <span>
           <StyledExternalLink
-            $noCap
             isValid={isValidAddress}
             isNumber={isValidAddress}
             href={isValidAddress ? networks[chainId]?.scanAddressPath(address) : ''}
@@ -71,7 +70,6 @@ const CopyIconButton = styled(IconButton)<{ isValid: boolean }>`
 const StyledExternalLink = styled(ExternalLink)<{ isValid: boolean }>`
   color: inherit;
   font-size: var(--font-size-2);
-  text-transform: inherit;
 
   svg {
     padding-top: 0.3125rem;

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailsContracts.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailsContracts.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
+import { zeroAddress } from 'viem'
 import ChipInactive from '@/lend/components/ChipInactive'
 import DetailInfoAddressLookup from '@/lend/components/DetailsMarket/components/DetailInfoAddressLookup'
 import { SubTitle } from '@/lend/components/DetailsMarket/styles'
 import TokenLabel from '@/lend/components/TokenLabel'
-import { INVALID_ADDRESS } from '@/lend/constants'
 import { PageContentProps } from '@/lend/types/lend.types'
 import Box from '@ui/Box'
 import Chip from '@ui/Typography/Chip'
@@ -40,7 +40,7 @@ const DetailsContracts = ({
       ],
       [
         { label: t`Vault`, address: addresses?.vault },
-        { label: t`Gauge`, address: addresses?.gauge, invalidText: addresses?.gauge === INVALID_ADDRESS ? t`No gauge` : '' }
+        { label: t`Gauge`, address: addresses?.gauge, invalidText: addresses?.gauge === zeroAddress ? t`No gauge` : '' }
       ],
     ]
   }

--- a/apps/main/src/lend/components/DetailsMarket/components/DetailsSupplyRewards.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailsSupplyRewards.tsx
@@ -3,7 +3,7 @@ import ChipInactive from '@/lend/components/ChipInactive'
 import useSupplyTotalApr from '@/lend/hooks/useSupplyTotalApr'
 import networks from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
-import { handleClickCopy, shortenTokenName } from '@/lend/utils/helpers'
+import { shortenTokenName } from '@/lend/utils/helpers'
 import Box from '@ui/Box'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
@@ -13,6 +13,7 @@ import TextCaption from '@ui/TextCaption'
 import Chip from '@ui/Typography/Chip'
 import { breakpoints, FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { copyToClipboard } from '@ui-kit/utils'
 
 // TODO: refactor to UI
 const DetailsSupplyRewards = ({ rChainId, rOwmId }: { rChainId: ChainId; rOwmId: string }) => {
@@ -74,7 +75,7 @@ const DetailsSupplyRewards = ({ rChainId, rOwmId }: { rChainId: ChainId; rOwmId:
                   </TokenWrapper>
                 </StyledExternalLink>
 
-                <StyledIconButton size="small" onClick={() => handleClickCopy(tokenAddress)}>
+                <StyledIconButton size="small" onClick={() => copyToClipboard(tokenAddress)}>
                   <Icon name="Copy" size={16} />
                 </StyledIconButton>
               </Box>

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -234,7 +234,6 @@ const LoanSelfLiquidation = ({
 
 const StyledInternalLink = styled(InternalLink)`
   color: inherit;
-  text-transform: inherit;
 
   &:hover {
     color: var(--link_light--hover--color);

--- a/apps/main/src/lend/components/TokenLabel.tsx
+++ b/apps/main/src/lend/components/TokenLabel.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import networks from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
-import { copyToClipboard } from '@/lend/utils/helpers'
 import type { OneWayMarketTemplate } from '@curvefi/lending-api/lib/markets'
 import Box from '@ui/Box'
 import type { BoxProps } from '@ui/Box/types'
@@ -10,6 +9,7 @@ import IconButton from '@ui/IconButton'
 import ExternalLink from '@ui/Link/ExternalLink'
 import TextEllipsis from '@ui/TextEllipsis'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { copyToClipboard } from '@ui-kit/utils'
 
 const TokenLabel = ({
   rChainId,
@@ -49,7 +49,6 @@ const TokenLabel = ({
           <StyledIconButton
             size="medium"
             onClick={(evt) => {
-              console.log(`Copied ${address}`)
               evt.stopPropagation()
               copyToClipboard(address)
             }}

--- a/apps/main/src/lend/constants.ts
+++ b/apps/main/src/lend/constants.ts
@@ -1,9 +1,6 @@
 import { LEND_ROUTES } from '@ui-kit/shared/routes'
 export { CONNECT_STAGE } from '@ui/utils/utilsConnectState'
 
-export const INVALID_ADDRESS = '0x0000000000000000000000000000000000000000'
-export const NETWORK_TOKEN = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
-
 export const ROUTE = {
   ...LEND_ROUTES,
   PAGE_INTEGRATIONS: '/integrations',

--- a/apps/main/src/lend/hooks/useAbiTotalSupply.tsx
+++ b/apps/main/src/lend/hooks/useAbiTotalSupply.tsx
@@ -1,6 +1,6 @@
 import type { Contract } from 'ethers'
 import { useCallback, useEffect, useState } from 'react'
-import { INVALID_ADDRESS } from '@/lend/constants'
+import { zeroAddress } from 'viem'
 import useContract from '@/lend/hooks/useContract'
 import useStore from '@/lend/store/useStore'
 import { ChainId } from '@/lend/types/lend.types'
@@ -10,7 +10,7 @@ import { weiToEther } from '@ui-kit/utils'
 
 const useAbiTotalSupply = (rChainId: ChainId, contractAddress: string | undefined) => {
   const contract = useContract(rChainId, false, 'totalSupply', contractAddress)
-  const isValidAddress = contractAddress !== INVALID_ADDRESS
+  const isValidAddress = contractAddress !== zeroAddress
 
   const isPageVisible = useStore((state) => state.isPageVisible)
 

--- a/apps/main/src/lend/hooks/useSupplyTotalApr.ts
+++ b/apps/main/src/lend/hooks/useSupplyTotalApr.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { INVALID_ADDRESS } from '@/lend/constants'
+import { zeroAddress } from 'viem'
 import { useOneWayMarket } from '@/lend/entities/chain'
 import useStore from '@/lend/store/useStore'
 import { ChainId, MarketRates, RewardOther, MarketRewards } from '@/lend/types/lend.types'
@@ -23,7 +23,7 @@ function useSupplyTotalApr(rChainId: ChainId, rOwmId: string) {
   return {
     isReady: typeof marketRewardsResp !== 'undefined' && typeof marketRatesResp !== 'undefined',
     isError: rewardsError || ratesError,
-    invalidGaugeAddress: typeof gauge !== 'undefined' && gauge === INVALID_ADDRESS,
+    invalidGaugeAddress: typeof gauge !== 'undefined' && gauge === zeroAddress,
     totalApr,
     tooltipValues,
   }

--- a/apps/main/src/lend/lib/apiLending.ts
+++ b/apps/main/src/lend/lib/apiLending.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash/cloneDeep'
 import sortBy from 'lodash/sortBy'
-import { INVALID_ADDRESS } from '@/lend/constants'
+import { zeroAddress } from 'viem'
 import networks from '@/lend/networks'
 import { USE_API } from '@/lend/shared/config'
 import type { LiqRange } from '@/lend/store/types'
@@ -322,7 +322,7 @@ const market = {
       }
 
       // check if gauge is valid
-      if (market.addresses.gauge === INVALID_ADDRESS) {
+      if (market.addresses.gauge === zeroAddress) {
         return resp
       } else {
         const isRewardsOnly = market.vault.rewardsOnly()

--- a/apps/main/src/lend/utils/helpers.ts
+++ b/apps/main/src/lend/utils/helpers.ts
@@ -38,13 +38,6 @@ export function isMobile() {
 
 export const isDevelopment = process.env.NODE_ENV === 'development'
 
-export function shortenTokenAddress(tokenAddress: string, startOnly?: boolean) {
-  if (!tokenAddress) return
-  const start = tokenAddress.slice(0, 4)
-  const end = tokenAddress.slice(-4)
-  return startOnly ? start : `${start}...${end}`
-}
-
 export function removeExtraSpaces(str: string) {
   return str.replace(/ +(?= )/g, '').trim()
 }

--- a/apps/main/src/lend/utils/helpers.ts
+++ b/apps/main/src/lend/utils/helpers.ts
@@ -86,32 +86,6 @@ export function fulfilledValue<T>(result: PromiseSettledResult<T>) {
 
 export const httpFetcher = (uri: string) => fetch(uri).then((res) => res.json())
 
-export function copyToClipboard(text: string) {
-  if (window.clipboardData && window.clipboardData.setData) {
-    // IE specific code path to prevent textarea being shown while dialog is visible.
-    return window.clipboardData.setData('Text', text)
-  } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-    const textarea = document.createElement('textarea')
-    textarea.textContent = text
-    textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      return document.execCommand('copy') // Security exception may be thrown by some browsers.
-    } catch (ex) {
-      console.warn('Copy to clipboard failed.', ex)
-      return false
-    } finally {
-      document.body.removeChild(textarea)
-    }
-  }
-}
-
-export function handleClickCopy(text: string) {
-  console.log('copied', text)
-  copyToClipboard(text)
-}
-
 export function sleep(ms?: number) {
   const parsedMs = ms || Math.floor(Math.random() * (10000 - 1000 + 1) + 1000)
   return new Promise((resolve) => setTimeout(resolve, parsedMs))

--- a/apps/main/src/loan/components/ChipCollateral.tsx
+++ b/apps/main/src/loan/components/ChipCollateral.tsx
@@ -3,10 +3,9 @@ import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
 import { getAddress } from 'viem'
-import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -53,11 +52,6 @@ const ChipCollateral = ({
   poolAddress,
   ...props
 }: ChipPoolProps) => {
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   const parsedPoolName = useMemo(() => {
     if (poolName && poolName.length > 24) {
       return `${poolName.slice(0, 18)}...`
@@ -78,7 +72,7 @@ const ChipCollateral = ({
         {isHighlightPoolName || isHighlightPoolAddress ? <mark>{parsedPoolName}</mark> : parsedPoolName}{' '}
       </ChipPoolName>
       <ChipPoolAdditionalInfo>
-        <Button {...props} onPress={() => handleCopyClick(poolAddress)}>
+        <Button {...props} onPress={() => copyToClipboard(poolAddress)}>
           <ChipPoolAddress>
             {isHighlightPoolAddress ? <mark>{parsedPoolAddress}</mark> : parsedPoolAddress}
           </ChipPoolAddress>

--- a/apps/main/src/loan/components/ChipCollateral.tsx
+++ b/apps/main/src/loan/components/ChipCollateral.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
@@ -68,7 +69,7 @@ const ChipCollateral = ({
     if (poolAddress) {
       return `${shortenAddress(poolAddress)}`
     }
-    return poolAddress
+    return getAddress(poolAddress)
   }, [poolAddress])
 
   return (

--- a/apps/main/src/loan/components/ChipCollateral.tsx
+++ b/apps/main/src/loan/components/ChipCollateral.tsx
@@ -2,9 +2,10 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
-import { copyToClipboard, shortenTokenAddress } from '@/loan/utils/helpers'
+import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -65,7 +66,7 @@ const ChipCollateral = ({
 
   const parsedPoolAddress = useMemo(() => {
     if (poolAddress) {
-      return `${shortenTokenAddress(poolAddress)}`
+      return `${shortenAddress(poolAddress)}`
     }
     return poolAddress
   }, [poolAddress])

--- a/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
+++ b/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
+import { getAddress } from 'viem'
 import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
@@ -69,7 +70,7 @@ const CollateralLabelNameAddress = ({
     if (displayAddress) {
       return `${shortenAddress(displayAddress)}`
     }
-    return displayAddress
+    return getAddress(displayAddress)
   }, [displayAddress])
 
   return (

--- a/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
+++ b/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
@@ -3,10 +3,9 @@ import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
 import { getAddress } from 'viem'
-import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -54,11 +53,6 @@ const CollateralLabelNameAddress = ({
   displayAddress,
   ...props
 }: ChipPoolProps) => {
-  const handleCopyClick = (address: string) => {
-    copyToClipboard(address)
-    console.log(`Copied ${address}`)
-  }
-
   const parsedName = useMemo(() => {
     if (displayName && displayName.length > 24) {
       return `${displayName.slice(0, 18)}...`
@@ -77,7 +71,7 @@ const CollateralLabelNameAddress = ({
     <ChipWrapper className={className}>
       <ChipName>{isHighlightName || isHighlightAddress ? <mark>{parsedName}</mark> : parsedName} </ChipName>
       <ChipAdditionalInfo>
-        <Button {...props} onPress={() => handleCopyClick(displayAddress)}>
+        <Button {...props} onPress={() => copyToClipboard(displayAddress)}>
           <ChipAddress>{isHighlightAddress ? <mark>{parsedAddress}</mark> : parsedAddress}</ChipAddress>
           <ChipCopyButtonIcon name="Copy" size={16} />
         </Button>

--- a/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
+++ b/apps/main/src/loan/components/CollateralLabelNameAddress.tsx
@@ -2,9 +2,10 @@ import { useMemo, useRef } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import styled from 'styled-components'
-import { copyToClipboard, shortenTokenAddress } from '@/loan/utils/helpers'
+import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import { breakpoints } from '@ui/utils/responsive'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -66,7 +67,7 @@ const CollateralLabelNameAddress = ({
 
   const parsedAddress = useMemo(() => {
     if (displayAddress) {
-      return `${shortenTokenAddress(displayAddress)}`
+      return `${shortenAddress(displayAddress)}`
     }
     return displayAddress
   }, [displayAddress])

--- a/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
@@ -18,7 +18,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
   <StyledStats {...props}>
     <strong>{title}</strong>
     <span>
-      <StyledExternalLink $noCap isMono href={networks[chainId]?.scanAddressPath(address)}>
+      <StyledExternalLink $noCap href={networks[chainId]?.scanAddressPath(address)}>
         {shortenAddress(address)}
         <Icon name="Launch" size={16} />
       </StyledExternalLink>

--- a/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
@@ -18,7 +18,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
   <StyledStats {...props}>
     <strong>{title}</strong>
     <span>
-      <StyledExternalLink $noCap href={networks[chainId]?.scanAddressPath(address)}>
+      <StyledExternalLink href={networks[chainId]?.scanAddressPath(address)}>
         {shortenAddress(address)}
         <Icon name="Launch" size={16} />
       </StyledExternalLink>
@@ -48,7 +48,6 @@ const CopyIconButton = styled(IconButton)`
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
   font-size: var(--font-size-2);
-  text-transform: inherit;
 
   svg {
     padding-top: 0.3125rem;

--- a/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
@@ -24,7 +24,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
     <StyledStats {...props}>
       <strong>{title}</strong>
       <span>
-        <StyledExternalLink isMono href={networks[chainId]?.scanAddressPath(address)}>
+        <StyledExternalLink $noCap isMono href={networks[chainId]?.scanAddressPath(address)}>
           {shortenAddress(address)}
           <Icon name="Launch" size={16} />
         </StyledExternalLink>

--- a/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
@@ -3,11 +3,10 @@ import type { StatsProps } from '@/loan/components/LoanInfoLlamma/styles'
 import { StyledStats } from '@/loan/components/LoanInfoLlamma/styles'
 import networks from '@/loan/networks'
 import { ChainId } from '@/loan/types/loan.types'
-import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import ExternalLink from '@ui/Link/ExternalLink'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface Props extends StatsProps {
   chainId: ChainId
@@ -15,26 +14,20 @@ interface Props extends StatsProps {
   address: string
 }
 
-const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) => {
-  const handleBtnClickCopy = (tokenAddress: string) => {
-    copyToClipboard(tokenAddress)
-  }
-
-  return (
-    <StyledStats {...props}>
-      <strong>{title}</strong>
-      <span>
-        <StyledExternalLink $noCap isMono href={networks[chainId]?.scanAddressPath(address)}>
-          {shortenAddress(address)}
-          <Icon name="Launch" size={16} />
-        </StyledExternalLink>
-        <CopyIconButton size="medium" onClick={() => handleBtnClickCopy(address)}>
-          <Icon name="Copy" size={16} />
-        </CopyIconButton>
-      </span>
-    </StyledStats>
-  )
-}
+const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) => (
+  <StyledStats {...props}>
+    <strong>{title}</strong>
+    <span>
+      <StyledExternalLink $noCap isMono href={networks[chainId]?.scanAddressPath(address)}>
+        {shortenAddress(address)}
+        <Icon name="Launch" size={16} />
+      </StyledExternalLink>
+      <CopyIconButton size="medium" onClick={() => copyToClipboard(address)}>
+        <Icon name="Copy" size={16} />
+      </CopyIconButton>
+    </span>
+  </StyledStats>
+)
 
 const CopyIconButton = styled(IconButton)`
   align-items: center;

--- a/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/components/DetailInfoAddressLookup.tsx
@@ -3,10 +3,11 @@ import type { StatsProps } from '@/loan/components/LoanInfoLlamma/styles'
 import { StyledStats } from '@/loan/components/LoanInfoLlamma/styles'
 import networks from '@/loan/networks'
 import { ChainId } from '@/loan/types/loan.types'
-import { copyToClipboard, shortenTokenAddress } from '@/loan/utils/helpers'
+import { copyToClipboard } from '@/loan/utils/helpers'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import ExternalLink from '@ui/Link/ExternalLink'
+import { shortenAddress } from '@ui-kit/utils'
 
 interface Props extends StatsProps {
   chainId: ChainId
@@ -24,7 +25,7 @@ const DetailInfoAddressLookup = ({ chainId, title, address, ...props }: Props) =
       <strong>{title}</strong>
       <span>
         <StyledExternalLink isMono href={networks[chainId]?.scanAddressPath(address)}>
-          {shortenTokenAddress(address)}
+          {shortenAddress(address)}
           <Icon name="Launch" size={16} />
         </StyledExternalLink>
         <CopyIconButton size="medium" onClick={() => handleBtnClickCopy(address)}>

--- a/apps/main/src/loan/components/PageCrvUsdStaking/TransactionTracking/styles.ts
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/TransactionTracking/styles.ts
@@ -33,7 +33,6 @@ export const TransactionLink = styled(ExternalLink)`
   color: var(--primary-400);
   text-decoration: none;
   border: none;
-  text-transform: none;
 `
 
 export const IconWrapper = styled.div`

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -243,7 +243,6 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
 
 const StyledInternalLink = styled(InternalLink)`
   color: inherit;
-  text-transform: inherit;
 
   &:hover {
     color: var(--link_light--hover--color);

--- a/apps/main/src/loan/components/PageLoanManage/utils.ts
+++ b/apps/main/src/loan/components/PageLoanManage/utils.ts
@@ -1,5 +1,5 @@
+import { zeroAddress } from 'viem'
 import { FormDetailInfo, FormEstGas, FormStatus } from '@/loan/components/PageLoanManage/types'
-import { INVALID_ADDRESS } from '@/loan/constants'
 import { Llamma, HealthMode, UserWalletBalances } from '@/loan/types/loan.types'
 
 export const DEFAULT_HEALTH_MODE: HealthMode = {
@@ -38,5 +38,5 @@ export const DEFAULT_USER_WALLET_BALANCES: UserWalletBalances = {
 }
 
 export function hasDeleverage(llamma: Llamma | null) {
-  return !!llamma && llamma?.deleverageZap !== INVALID_ADDRESS
+  return !!llamma && llamma?.deleverageZap !== zeroAddress
 }

--- a/apps/main/src/loan/components/PagePegKeepers/Page.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/Page.tsx
@@ -98,7 +98,6 @@ const Title = styled.h1`
 
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
-  text-transform: initial;
 `
 
 const ConnectWalletWrapper = styled.div`

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperContent.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperContent.tsx
@@ -93,7 +93,6 @@ const StyledExternalLink = styled(ExternalLink)`
   font-size: var(--font-size-2);
   font-weight: bold;
   margin-left: var(--spacing-narrow);
-  text-transform: initial;
 `
 
 export default PegKeeperContent

--- a/apps/main/src/loan/constants.ts
+++ b/apps/main/src/loan/constants.ts
@@ -2,7 +2,6 @@ import { APP_LINK, CRVUSD_ROUTES } from '@ui-kit/shared/routes'
 
 export const CRVUSD_ADDRESS = '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e'
 export const SCRVUSD_VAULT_ADDRESS = '0x0655977FEb2f289A4aB78af67BAB0d17aAb84367' // same address as token
-export const INVALID_ADDRESS = '0x0000000000000000000000000000000000000000'
 export const ETHEREUM_CHAIN_ID = 1
 
 export const ROUTE = {

--- a/apps/main/src/loan/hooks/useTokenAlert.tsx
+++ b/apps/main/src/loan/hooks/useTokenAlert.tsx
@@ -44,7 +44,6 @@ const useTokenAlert = (tokenAddressAll: string[]): TokenAlert | null =>
 
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
-  text-transform: initial;
 `
 
 export default useTokenAlert

--- a/apps/main/src/loan/utils/helpers.ts
+++ b/apps/main/src/loan/utils/helpers.ts
@@ -85,27 +85,6 @@ export const shortenAccount = (account: string, visibleLength = 4): string =>
 
 export const httpFetcher = (uri: string) => fetch(uri).then((res) => res.json())
 
-export function copyToClipboard(text: string) {
-  if (window.clipboardData && window.clipboardData.setData) {
-    // IE specific code path to prevent textarea being shown while dialog is visible.
-    return window.clipboardData.setData('Text', text)
-  } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-    const textarea = document.createElement('textarea')
-    textarea.textContent = text
-    textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      return document.execCommand('copy') // Security exception may be thrown by some browsers.
-    } catch (ex) {
-      console.warn('Copy to clipboard failed.', ex)
-      return false
-    } finally {
-      document.body.removeChild(textarea)
-    }
-  }
-}
-
 export function sleep(ms?: number) {
   const parsedMs = ms || Math.floor(Math.random() * (10000 - 1000 + 1) + 1000)
   return new Promise((resolve) => setTimeout(resolve, parsedMs))

--- a/apps/main/src/loan/utils/helpers.ts
+++ b/apps/main/src/loan/utils/helpers.ts
@@ -40,13 +40,6 @@ export function isNumber<T>(val: T) {
 
 export const isDevelopment = process.env.NODE_ENV === 'development'
 
-export function shortenTokenAddress(tokenAddress: string, startOnly?: boolean) {
-  if (!tokenAddress) return
-  const start = tokenAddress.slice(0, 4)
-  const end = tokenAddress.slice(-4)
-  return startOnly ? start : `${start}...${end}`
-}
-
 export function removeExtraSpaces(str: string) {
   return str.replace(/ +(?= )/g, '').trim()
 }

--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
@@ -11,6 +11,6 @@ export type ConnectedWalletLabelProps = {
 
 export const ConnectedWalletLabel = ({ walletAddress, onDisconnectWallet, ...props }: ConnectedWalletLabelProps) => (
   <Button size="small" color="ghost" onClick={onDisconnectWallet} title={walletAddress} {...props}>
-    {shortenAddress(walletAddress, { includePrefix: false })}
+    {shortenAddress(walletAddress)}
   </Button>
 )

--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
@@ -1,6 +1,6 @@
 import Button from '@mui/material/Button'
 import type { SxProps, Theme } from '@mui/material/styles'
-import { addressShort, type Address } from '@ui-kit/utils'
+import { shortenAddress, type Address } from '@ui-kit/utils'
 
 export type ConnectedWalletLabelProps = {
   walletAddress: Address
@@ -11,6 +11,6 @@ export type ConnectedWalletLabelProps = {
 
 export const ConnectedWalletLabel = ({ walletAddress, onDisconnectWallet, ...props }: ConnectedWalletLabelProps) => (
   <Button size="small" color="ghost" onClick={onDisconnectWallet} title={walletAddress} {...props}>
-    {addressShort(walletAddress)}
+    {shortenAddress(walletAddress, 4, false)}
   </Button>
 )

--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectedWalletLabel.tsx
@@ -11,6 +11,6 @@ export type ConnectedWalletLabelProps = {
 
 export const ConnectedWalletLabel = ({ walletAddress, onDisconnectWallet, ...props }: ConnectedWalletLabelProps) => (
   <Button size="small" color="ghost" onClick={onDisconnectWallet} title={walletAddress} {...props}>
-    {shortenAddress(walletAddress, 4, false)}
+    {shortenAddress(walletAddress, { includePrefix: false })}
   </Button>
 )

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/ErrorAlert.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/ErrorAlert.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { copyToClipboard } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -16,7 +17,7 @@ export const ErrorAlert = ({ error }: Props) => (
     variant="filled"
     severity="error"
     action={
-      <Button color="ghost" size="extraSmall" onClick={() => navigator.clipboard.writeText(error)}>
+      <Button color="ghost" size="extraSmall" onClick={() => copyToClipboard(error)}>
         Copy
       </Button>
     }

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -9,7 +9,7 @@ import { InvertTheme } from '@ui-kit/shared/ui/ThemeProvider'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { addressShort } from '@ui-kit/utils'
+import { shortenAddress } from '@ui-kit/utils'
 import type { TokenOption as Option } from '../../types'
 
 const { IconSize } = SizesAndSpaces
@@ -98,7 +98,7 @@ export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice
 
           {showAddress && (
             <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textTertiary'}>
-              {addressShort(address)}
+              {shortenAddress(address, 4, false)}
             </Typography>
           )}
         </Stack>

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -98,7 +98,7 @@ export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice
 
           {showAddress && (
             <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textTertiary'}>
-              {shortenAddress(address, { includePrefix: false })}
+              {shortenAddress(address)}
             </Typography>
           )}
         </Stack>

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -98,7 +98,7 @@ export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice
 
           {showAddress && (
             <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textTertiary'}>
-              {shortenAddress(address, 4, false)}
+              {shortenAddress(address, { includePrefix: false })}
             </Typography>
           )}
         </Stack>

--- a/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
+++ b/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
@@ -28,7 +28,7 @@ export const UserProfileHeader = ({ walletAddress, onClose }: Props) => (
     />
 
     <Typography variant="headingMLight" flexGrow={1}>
-      {shortenAddress(walletAddress, 4, false)}
+      {shortenAddress(walletAddress, { includePrefix: false })}
     </Typography>
 
     <Box display="flex">

--- a/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
+++ b/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
@@ -28,7 +28,7 @@ export const UserProfileHeader = ({ walletAddress, onClose }: Props) => (
     />
 
     <Typography variant="headingMLight" flexGrow={1}>
-      {shortenAddress(walletAddress, { includePrefix: false })}
+      {shortenAddress(walletAddress)}
     </Typography>
 
     <Box display="flex">

--- a/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
+++ b/packages/curve-ui-kit/src/features/user-profile/home/Header.tsx
@@ -6,7 +6,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { LlamaImg } from '@ui/images'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { addressShort, type Address } from '@ui-kit/utils'
+import { shortenAddress, type Address } from '@ui-kit/utils'
 
 type Props = {
   walletAddress?: Address
@@ -28,7 +28,7 @@ export const UserProfileHeader = ({ walletAddress, onClose }: Props) => (
     />
 
     <Typography variant="headingMLight" flexGrow={1}>
-      {addressShort(walletAddress)}
+      {shortenAddress(walletAddress, 4, false)}
     </Typography>
 
     <Box display="flex">

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -10,7 +10,7 @@ import Typography from '@mui/material/Typography'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { shortenAddress } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -45,7 +45,7 @@ const ActionInfo = ({ label, address, linkAddress, size = 'medium', copiedText }
   const [isOpen, open, close] = useSwitch(false)
 
   const copyValue = () => {
-    navigator.clipboard.writeText(address)
+    copyToClipboard(address)
     open()
   }
 

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -1,4 +1,3 @@
-import { shortenTokenAddress } from 'ui/src/utils/'
 import CallMade from '@mui/icons-material/CallMade'
 import ContentCopy from '@mui/icons-material/ContentCopy'
 import { Stack } from '@mui/material'
@@ -11,6 +10,7 @@ import Typography from '@mui/material/Typography'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { shortenAddress } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -56,7 +56,7 @@ const ActionInfo = ({ label, address, linkAddress, size = 'medium', copiedText }
       </Typography>
       <Stack direction="row" alignItems="center">
         <Typography variant={addressSize[size]} color="textPrimary" sx={{ marginRight: Spacing.sm }}>
-          {shortenTokenAddress(address)}
+          {shortenAddress(address)}
         </Typography>
         <IconButton size="small" onClick={copyValue} color="primary">
           <ContentCopy />

--- a/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
@@ -7,6 +7,7 @@ import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { CopyIcon } from '@ui-kit/shared/icons/CopyIcon'
 import { InvertTheme } from '@ui-kit/shared/ui/ThemeProvider'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
+import { copyToClipboard } from '@ui-kit/utils'
 
 export function CopyIconButton({
   copyText,
@@ -28,7 +29,7 @@ export function CopyIconButton({
           className={className}
           size="extraSmall"
           onClick={async () => {
-            await navigator.clipboard.writeText(copyText)
+            copyToClipboard(copyText)
             showAlert()
           }}
         >

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -10,7 +10,7 @@ import Typography from '@mui/material/Typography'
 import { MAX_USD_VALUE } from '@ui/utils/utilsConstants'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { TypographyVariantKey } from '@ui-kit/themes/typography'
-import { abbreviateNumber, scaleSuffix } from '@ui-kit/utils'
+import { abbreviateNumber, copyToClipboard, scaleSuffix } from '@ui-kit/utils'
 import { Duration } from '../../themes/design/0_primitives'
 
 const { Spacing, IconSize } = SizesAndSpaces
@@ -213,7 +213,7 @@ export const Metric = ({
   const [openCopyAlert, setOpenCopyAlert] = useState(false)
 
   const copyValue = () => {
-    navigator.clipboard.writeText(value.toString())
+    copyToClipboard(value.toString())
     setOpenCopyAlert(true)
   }
 

--- a/packages/curve-ui-kit/src/utils/address.ts
+++ b/packages/curve-ui-kit/src/utils/address.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from 'viem'
+import { getAddress, zeroAddress } from 'viem'
 
 export type Address = `0x${string}`
 
@@ -15,9 +15,16 @@ export type Address = `0x${string}`
  *
  * // With 4 digits on each side, but not counting prefix (showing 6 chars after 0x at start)
  * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", 4, false) // "0x1234...5678"
+ *
+ * @remarks
+ * This function explicitly applies checksumming to the address for consistency.
+ * We actively discourage non-checksummed addresses and therefore don't provide an option to bypass it.
+ * The checksumming is applied as a precaution since we don't control the input address string.
+ * The `getAddress` function from viem applies checksumming to the address and has a checksum cache
+ * to optimize performance when the same address is used multiple times.
  */
 export function shortenAddress(address: string | undefined, digits = 4, includePrefix = true): string {
-  const addr = address || zeroAddress
+  const addr = getAddress(address || zeroAddress)
   const startChars = includePrefix ? digits : digits + 2
 
   return `${addr.slice(0, startChars)}...${addr.slice(-digits)}`

--- a/packages/curve-ui-kit/src/utils/address.ts
+++ b/packages/curve-ui-kit/src/utils/address.ts
@@ -2,19 +2,25 @@ import { getAddress, zeroAddress } from 'viem'
 
 export type Address = `0x${string}`
 
+type ShortenAddressOptions = {
+  /** Number of digits to show on each side of the shortened address (default: 4) */
+  digits?: number
+  /** Whether to count the "0x" prefix as part of the starting digits (default: true) */
+  includePrefix?: boolean
+}
+
 /**
  * Shortens an Ethereum address by displaying first and last few characters
  *
  * @param address - Ethereum address to shorten
- * @param digits - Number of digits to show on each side of the shortened address (default: 4)
- * @param includePrefix - Whether to count the "0x" prefix as part of the starting digits (default: true)
+ * @param options - Configuration options for shortening
  * @returns Shortened address string in format for example "0xAB...XY"
  * @example
  * // With default parameters (4 digits, prefix included)
  * shortenAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x12...5678"
  *
  * // With 4 digits on each side, but not counting prefix (showing 6 chars after 0x at start)
- * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", 4, false) // "0x1234...5678"
+ * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", { digits: 4, includePrefix: false }) // "0x1234...5678"
  *
  * @remarks
  * This function explicitly applies checksumming to the address for consistency.
@@ -23,7 +29,8 @@ export type Address = `0x${string}`
  * The `getAddress` function from viem applies checksumming to the address and has a checksum cache
  * to optimize performance when the same address is used multiple times.
  */
-export function shortenAddress(address: string | undefined, digits = 4, includePrefix = true): string {
+export function shortenAddress(address: string | undefined, options?: ShortenAddressOptions): string {
+  const { digits = 4, includePrefix = true } = options || {}
   const addr = getAddress(address || zeroAddress)
   const startChars = includePrefix ? digits : digits + 2
 

--- a/packages/curve-ui-kit/src/utils/address.ts
+++ b/packages/curve-ui-kit/src/utils/address.ts
@@ -5,8 +5,6 @@ export type Address = `0x${string}`
 type ShortenAddressOptions = {
   /** Number of digits to show on each side of the shortened address (default: 4) */
   digits?: number
-  /** Whether to count the "0x" prefix as part of the starting digits (default: true) */
-  includePrefix?: boolean
 }
 
 /**
@@ -16,11 +14,11 @@ type ShortenAddressOptions = {
  * @param options - Configuration options for shortening
  * @returns Shortened address string in format for example "0xAB...XY"
  * @example
- * // With default parameters (4 digits, prefix included)
- * shortenAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x12...5678"
+ * // With default parameters (4 digits)
+ * shortenAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x1234...5678"
  *
- * // With 4 digits on each side, but not counting prefix (showing 6 chars after 0x at start)
- * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", { digits: 4, includePrefix: false }) // "0x1234...5678"
+ * // With 6 digits on each side
+ * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", { digits: 6 }) // "0x123456...345678"
  *
  * @remarks
  * This function explicitly applies checksumming to the address for consistency.
@@ -28,11 +26,11 @@ type ShortenAddressOptions = {
  * The checksumming is applied as a precaution since we don't control the input address string.
  * The `getAddress` function from viem applies checksumming to the address and has a checksum cache
  * to optimize performance when the same address is used multiple times.
+ * To enforce consistency, there's no option to include the 0x prefix on the starting digits length.
  */
 export function shortenAddress(address: string | undefined, options?: ShortenAddressOptions): string {
-  const { digits = 4, includePrefix = true } = options || {}
+  const { digits = 4 } = options || {}
   const addr = getAddress(address || zeroAddress)
-  const startChars = includePrefix ? digits : digits + 2
 
-  return `${addr.slice(0, startChars)}...${addr.slice(-digits)}`
+  return `${addr.slice(0, digits + 2)}...${addr.slice(-digits)}`
 }

--- a/packages/curve-ui-kit/src/utils/address.ts
+++ b/packages/curve-ui-kit/src/utils/address.ts
@@ -1,22 +1,24 @@
+import { zeroAddress } from 'viem'
+
 export type Address = `0x${string}`
 
 /**
  * Shortens an Ethereum address by displaying first and last few characters
  *
  * @param address - Ethereum address to shorten
- * @param digits - Total number of address digits to show (default: 6)
- * @returns Shortened address string in format "0xAB...XY"
+ * @param digits - Number of digits to show on each side of the shortened address (default: 4)
+ * @param includePrefix - Whether to count the "0x" prefix as part of the starting digits (default: true)
+ * @returns Shortened address string in format for example "0xAB...XY"
  * @example
- * addressShort("0x1234567890abcdef1234567890abcdef12345678") // "0x1234...5678"
- * addressShort("0x1234567890abcdef1234567890abcdef12345678", 8) // "0x12345...5678"
+ * // With default parameters (4 digits, prefix included)
+ * shortenAddress("0x1234567890abcdef1234567890abcdef12345678") // "0x12...5678"
+ *
+ * // With 4 digits on each side, but not counting prefix (showing 6 chars after 0x at start)
+ * shortenAddress("0x1234567890abcdef1234567890abcdef12345678", 4, false) // "0x1234...5678"
  */
-export function addressShort(address?: string, digits = 6): string {
-  if (!address) {
-    return '0x000...000'
-  }
+export function shortenAddress(address: string | undefined, digits = 4, includePrefix = true): string {
+  const addr = address || zeroAddress
+  const startChars = includePrefix ? digits : digits + 2
 
-  const pre = digits / 2 + 2 // +2 for the "0x"
-  const post = address.length - digits / 2
-
-  return `${address.substring(0, pre)}...${address.substring(post)}`
+  return `${addr.slice(0, startChars)}...${addr.slice(-digits)}`
 }

--- a/packages/curve-ui-kit/src/utils/index.ts
+++ b/packages/curve-ui-kit/src/utils/index.ts
@@ -1,3 +1,5 @@
+import { isAddress, getAddress } from 'viem'
+
 export * from './address'
 export * from './BigDecimal'
 export * from './bigNumber'
@@ -11,3 +13,28 @@ export const isBeta =
   (window.localStorage.getItem('beta') !== null || !window.location.hostname.includes('curve.fi'))
 
 export const isCypress = typeof window !== 'undefined' && Boolean((window as { Cypress?: boolean }).Cypress)
+
+/**
+ * Copies text to clipboard with Ethereum address checksumming
+ * @param text - The text to copy to clipboard
+ * @returns Promise resolving to true if copy was successful, false otherwise
+ * @todo Potentially show a snackbar of the copied value
+ */
+export async function copyToClipboard(text: string) {
+  // Check if the text is an Ethereum address and apply checksumming if it is
+  if (isAddress(text)) {
+    try {
+      text = getAddress(text)
+    } catch (error) {
+      console.warn('Failed to checksum address', error)
+    }
+  }
+
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch (error) {
+    console.warn('Copy to clipboard failed', error)
+    return false
+  }
+}

--- a/packages/ui/src/Integration/IntegrationApp.tsx
+++ b/packages/ui/src/Integration/IntegrationApp.tsx
@@ -131,7 +131,6 @@ const AppExternalLink = styled(ExternalLink)`
   color: inherit;
   padding: 0.2rem 0.5rem;
   font-size: var(--font-size-2);
-  text-transform: initial;
   text-decoration: none;
 
   transition:

--- a/packages/ui/src/Link/styles.ts
+++ b/packages/ui/src/Link/styles.ts
@@ -6,7 +6,6 @@ export type LinkProps = {
   className?: string
   active?: boolean
   isDarkBg?: boolean
-  $noCap?: boolean
   $noStyles?: boolean
   size?: LinkSize
   variant?: LinkVariant
@@ -18,11 +17,6 @@ export const linkStyles = css<LinkProps>`
   color: var(--link--color);
   font: var(--link--font-weight) var(--link--font);
   text-decoration: underline;
-  ${({ $noCap }) => {
-    if (!$noCap) {
-      return `text-transform: uppercase;`
-    }
-  }}
 
   transition: color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 

--- a/packages/ui/src/Link/styles.ts
+++ b/packages/ui/src/Link/styles.ts
@@ -6,7 +6,6 @@ export type LinkProps = {
   className?: string
   active?: boolean
   isDarkBg?: boolean
-  isMono?: boolean
   $noCap?: boolean
   $noStyles?: boolean
   size?: LinkSize
@@ -75,12 +74,6 @@ export const linkStyles = css<LinkProps>`
           text-decoration-color: var(--link_light--hover--color);
         }
       `
-    }
-  }}
-
-  ${({ isMono }) => {
-    if (isMono) {
-      return `font-family: var(--font-mono);`
     }
   }}
 

--- a/packages/ui/src/ModalPendingTx/index.tsx
+++ b/packages/ui/src/ModalPendingTx/index.tsx
@@ -15,7 +15,7 @@ const ModalPendingTx = ({ transactionHash, txLink, pendingMessage }: Props) => (
     <PendingWrapper>
       <PendingMessage>{pendingMessage}</PendingMessage>
       <StyledPendingSpinner isDisabled size={24} />
-      <Transaction variant={'contained'} href={txLink}>
+      <Transaction $noCap variant={'contained'} href={txLink}>
         <p>Transaction:</p>
         {shortenAddress(transactionHash)}
         <StyledIcon name={'Launch'} size={16} />

--- a/packages/ui/src/ModalPendingTx/index.tsx
+++ b/packages/ui/src/ModalPendingTx/index.tsx
@@ -15,7 +15,7 @@ const ModalPendingTx = ({ transactionHash, txLink, pendingMessage }: Props) => (
     <PendingWrapper>
       <PendingMessage>{pendingMessage}</PendingMessage>
       <StyledPendingSpinner isDisabled size={24} />
-      <Transaction $noCap variant={'contained'} href={txLink}>
+      <Transaction variant={'contained'} href={txLink}>
         <p>Transaction:</p>
         {shortenAddress(transactionHash)}
         <StyledIcon name={'Launch'} size={16} />
@@ -53,7 +53,6 @@ const Transaction = styled(ExternalLink)`
   font-size: var(--font-size-2);
   font-weight: var(--semi-bold);
   color: var(--page--text-color);
-  text-transform: none;
   text-decoration: none;
   background-color: var(--page--background-color);
   padding: var(--spacing-2);

--- a/packages/ui/src/ModalPendingTx/index.tsx
+++ b/packages/ui/src/ModalPendingTx/index.tsx
@@ -1,8 +1,8 @@
+import { shortenAddress } from 'curve-ui-kit/src/utils'
 import styled from 'styled-components'
 import Icon from 'ui/src/Icon'
 import ExternalLink from 'ui/src/Link/ExternalLink'
 import Spinner from 'ui/src/Spinner'
-import { shortenTokenAddress } from 'ui/src/utils'
 
 type Props = {
   transactionHash: string
@@ -17,7 +17,7 @@ const ModalPendingTx = ({ transactionHash, txLink, pendingMessage }: Props) => (
       <StyledPendingSpinner isDisabled size={24} />
       <Transaction variant={'contained'} href={txLink}>
         <p>Transaction:</p>
-        {shortenTokenAddress(transactionHash)}
+        {shortenAddress(transactionHash)}
         <StyledIcon name={'Launch'} size={16} />
       </Transaction>
     </PendingWrapper>

--- a/packages/ui/src/Table/TrSearchedTextResult.tsx
+++ b/packages/ui/src/Table/TrSearchedTextResult.tsx
@@ -93,7 +93,6 @@ const CopyIconButton = styled(IconButton)`
 const StyledExternalLink = styled(ExternalLink)`
   color: inherit;
   font-size: var(--font-size-2);
-  text-transform: inherit;
   text-decoration: none;
 
   svg {

--- a/packages/ui/src/Table/TrSearchedTextResult.tsx
+++ b/packages/ui/src/Table/TrSearchedTextResult.tsx
@@ -1,9 +1,10 @@
+import { shortenAddress } from 'curve-ui-kit/src/utils'
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import Icon from 'ui/src/Icon'
 import IconButton from 'ui/src/IconButton'
 import ExternalLink from 'ui/src/Link/ExternalLink'
-import { breakpoints, handleClickCopy, shortenTokenAddress } from 'ui/src/utils'
+import { breakpoints, handleClickCopy } from 'ui/src/utils'
 
 type Result = { [key: string]: { value: string } }
 
@@ -41,7 +42,7 @@ const TrSearchedTextResult = ({
                   <strong>{label ?? ''}:</strong>{' '}
                   <span>
                     <StyledExternalLink href={scanAddressPath(value)}>
-                      {isMobile ? shortenTokenAddress(value) : value}
+                      {isMobile ? shortenAddress(value) : value}
                       <Icon name="Launch" size={16} />
                     </StyledExternalLink>
                     <CopyIconButton size="medium" onClick={() => handleClickCopy(value)}>

--- a/packages/ui/src/Table/TrSearchedTextResult.tsx
+++ b/packages/ui/src/Table/TrSearchedTextResult.tsx
@@ -1,10 +1,10 @@
-import { shortenAddress } from 'curve-ui-kit/src/utils'
+import { copyToClipboard, shortenAddress } from 'curve-ui-kit/src/utils'
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import Icon from 'ui/src/Icon'
 import IconButton from 'ui/src/IconButton'
 import ExternalLink from 'ui/src/Link/ExternalLink'
-import { breakpoints, handleClickCopy } from 'ui/src/utils'
+import { breakpoints } from 'ui/src/utils'
 
 type Result = { [key: string]: { value: string } }
 
@@ -45,7 +45,7 @@ const TrSearchedTextResult = ({
                       {isMobile ? shortenAddress(value) : value}
                       <Icon name="Launch" size={16} />
                     </StyledExternalLink>
-                    <CopyIconButton size="medium" onClick={() => handleClickCopy(value)}>
+                    <CopyIconButton size="medium" onClick={() => copyToClipboard(value)}>
                       <Icon name="Copy" size={16} />
                     </CopyIconButton>
                   </span>

--- a/packages/ui/src/utils/helpers.ts
+++ b/packages/ui/src/utils/helpers.ts
@@ -49,13 +49,6 @@ export function shortenAccount(account: string, visibleLength = 4) {
   }
 }
 
-export function shortenTokenAddress(tokenAddress: string, startOnly?: boolean) {
-  if (!tokenAddress) return
-  const start = tokenAddress.slice(0, 4)
-  const end = tokenAddress.slice(-4)
-  return startOnly ? start : `${start}...${end}`
-}
-
 export function copyToClipboard(text: string) {
   if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
     const textarea = document.createElement('textarea')

--- a/packages/ui/src/utils/helpers.ts
+++ b/packages/ui/src/utils/helpers.ts
@@ -48,26 +48,3 @@ export function shortenAccount(account: string, visibleLength = 4) {
     return account
   }
 }
-
-export function copyToClipboard(text: string) {
-  if (document.queryCommandSupported && document.queryCommandSupported('copy')) {
-    const textarea = document.createElement('textarea')
-    textarea.textContent = text
-    textarea.style.position = 'fixed' // Prevent scrolling to bottom of page in MS Edge.
-    document.body.appendChild(textarea)
-    textarea.select()
-    try {
-      return document.execCommand('copy') // Security exception may be thrown by some browsers.
-    } catch (ex) {
-      console.warn('Copy to clipboard failed.', ex)
-      return false
-    } finally {
-      document.body.removeChild(textarea)
-    }
-  }
-}
-
-export function handleClickCopy(text: string) {
-  console.log('copied', text)
-  copyToClipboard(text)
-}


### PR DESCRIPTION
This PR aims to consolidate how addresses are presented and copied; with checksums

* use ethAddress and zeroAddress from viem instead of duplicate hardcoded addresses
* consolidate short address formatting into a single util function in ui-kit
* always checksum when shortening (see docs for why, viem uses a cache to prevent duplicate checksum computations)
* consolidate copyToClipboard, apply potential checksumming, use modern clipboard API which is supported by all browsers, no need for legacy browser fallback anymore
* remove $noCap from link styles, in 80% of all links the uppercase transform was undone with either `text-transform: none / inherit / initial`. In the other 10% the link was just for a token anyway, the remaining cases were for addresses which we no longer want to show in uppercase

(I also tried to apply $noCap to most of the addresses but styled components seem to be borked in some way. For some apps it worked, for some it didn't... So I just decided to remove it instead)