### PR TITLE
feat: enable points for crvusd loans

### DIFF
--- a/apps/main/src/lend/components/CampaignRewardsRow.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsRow.tsx
@@ -24,7 +24,7 @@ const Container = styled.div<{ mobile: boolean }>`
   flex-wrap: wrap;
   max-width: 12rem;
   gap: var(--spacing-1);
-  margin-left: var(--spacing-1);
+  margin-left: var(--spacing-2);
 `
 
 export default CampaignRewardsRow

--- a/apps/main/src/loan/components/CampaignRewardsRow.tsx
+++ b/apps/main/src/loan/components/CampaignRewardsRow.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+import CampaignRewardsComp from 'ui/src/CampaignRewards/CampaignRewardsComp'
+import type { RewardsPool } from 'ui/src/CampaignRewards/types'
+
+interface Props {
+  rewardItems: RewardsPool[]
+  mobile?: boolean
+}
+
+const CampaignRewardsRow = ({ rewardItems, mobile = false }: Props) => (
+  <Container mobile={mobile}>
+    {rewardItems.map((rewardItem: RewardsPool, index: number) => (
+      <CampaignRewardsComp
+        key={`${rewardItem.platform}-${rewardItem.description}-${index}`}
+        rewardsPool={rewardItem}
+        mobile={mobile}
+      />
+    ))}
+  </Container>
+)
+
+const Container = styled.div<{ mobile: boolean }>`
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 12rem;
+  gap: var(--spacing-1);
+  margin-left: var(--spacing-2);
+`
+
+export default CampaignRewardsRow

--- a/apps/main/src/loan/components/PageLlamaMarkets/cells/MarketTitleCell/MarketBadges.tsx
+++ b/apps/main/src/loan/components/PageLlamaMarkets/cells/MarketTitleCell/MarketBadges.tsx
@@ -30,6 +30,7 @@ const getRewardsDescription = ({ action, description, multiplier }: PoolRewards)
       lp: description ?? t`Earn points by providing liquidity.`,
       supply: t`Earn points by supplying liquidity.`,
       borrow: t`Earn points by borrowing.`,
+      loan: t`Earn points by borrowing.`,
     }[action]
   }`
 

--- a/apps/main/src/loan/components/TokenLabel.tsx
+++ b/apps/main/src/loan/components/TokenLabel.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
+import CampaignRewardsRow from '@/loan/components/CampaignRewardsRow'
 import useCollateralAlert from '@/loan/hooks/useCollateralAlert'
+import useStore from '@/loan/store/useStore'
 import { CollateralData, CollateralDataCache } from '@/loan/types/loan.types'
 import Box from '@ui/Box'
 import { TooltipAlert as AlertTooltipIcon } from '@ui/Tooltip'
@@ -27,6 +29,8 @@ const TokenLabel = ({
   onClick,
 }: Props) => {
   const collateralAlert = useCollateralAlert(collateralDataCachedOrApi?.llamma?.address)
+  const campaignRewardsMapper = useStore((state) => state.campaigns.campaignRewardsMapper)
+  const campaignRewards = campaignRewardsMapper[collateralDataCachedOrApi?.llamma?.controller ?? '']
 
   const { coins, coinAddresses } = collateralDataCachedOrApi?.llamma ?? {}
   const symbol = coins?.[type === 'collateral' ? 1 : 0] ?? ''
@@ -49,6 +53,7 @@ const TokenLabel = ({
       )}
       <TokenIcon blockchainId={blockchainId} tooltip={symbol} address={tokenAddress} />{' '}
       <Label size={size}>{symbol}</Label>
+      {campaignRewards && type === 'collateral' && <CampaignRewardsRow rewardItems={campaignRewards} />}
     </Wrapper>
   )
 }

--- a/apps/main/src/loan/hooks/usePageOnMount.ts
+++ b/apps/main/src/loan/hooks/usePageOnMount.ts
@@ -25,6 +25,8 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
   const updateConnectState = useStore((state) => state.updateConnectState)
   const updateCurveJs = useStore((state) => state.updateCurveJs)
   const updateGlobalStoreByKey = useStore((state) => state.updateGlobalStoreByKey)
+  const initCampaignRewards = useStore((state) => state.campaigns.initCampaignRewards)
+  const initiated = useStore((state) => state.campaigns.initiated)
 
   const walletChainId = getWalletChainId(wallet)
   const walletSignerAddress = getWalletSignerAddress(wallet)
@@ -270,6 +272,15 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname])
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!curve) return
+
+    if (!initiated) {
+      initCampaignRewards(curve.chainId)
+    }
+  }, [initCampaignRewards, curve, initiated])
 
   return {
     pageLoaded: connectState.status === 'success',

--- a/apps/main/src/loan/store/createCampaignRewardsSlice.ts
+++ b/apps/main/src/loan/store/createCampaignRewardsSlice.ts
@@ -1,0 +1,94 @@
+import produce from 'immer'
+import { CampaignRewardsItem, CampaignRewardsPool, CampaignRewardsMapper } from 'ui/src/CampaignRewards/types'
+import type { GetState, SetState } from 'zustand'
+import networks from '@/loan/networks'
+import type { State } from '@/loan/store/useStore'
+import { ChainId } from '@/loan/types/loan.types'
+import { CURVE_ASSETS_URL } from '@ui/utils'
+import campaigns from '@external-rewards'
+
+type StateKey = keyof typeof DEFAULT_STATE
+
+type SliceState = {
+  initiated: boolean
+  campaignRewardsMapper: CampaignRewardsMapper
+}
+
+const sliceKey = 'campaigns'
+
+// prettier-ignore
+export type CampaignRewardsSlice = {
+  [sliceKey]: SliceState & {
+    initCampaignRewards(chainId: ChainId): void
+
+    setStateByActiveKey<T>(key: StateKey, activeKey: string, value: T): void
+    setStateByKey<T>(key: StateKey, value: T): void
+    setStateByKeys(SliceState: Partial<SliceState>): void
+    resetState(): void
+  }
+}
+
+const DEFAULT_STATE: SliceState = {
+  initiated: false,
+  campaignRewardsMapper: {},
+}
+
+const createCampaignsSlice = (set: SetState<State>, get: GetState<State>): CampaignRewardsSlice => ({
+  [sliceKey]: {
+    ...DEFAULT_STATE,
+    initCampaignRewards: (chainId: ChainId) => {
+      const campaignRewardsMapper: CampaignRewardsMapper = {}
+      const network = networks[chainId].id
+
+      // compile a list of pool/markets using pool/vault address as key
+      campaigns.forEach((campaign: CampaignRewardsItem) => {
+        campaign.pools.forEach((pool: CampaignRewardsPool) => {
+          if (pool.network.toLowerCase() === network.toLowerCase()) {
+            if (!campaignRewardsMapper[pool.address.toLowerCase()]) {
+              campaignRewardsMapper[pool.address.toLowerCase()] = []
+            }
+
+            campaignRewardsMapper[pool.address.toLowerCase()].push({
+              campaignName: campaign.campaignName,
+              platform: campaign.platform,
+              platformImageSrc: `${CURVE_ASSETS_URL}/platforms/${campaign.platformImageId}`,
+              dashboardLink: campaign.dashboardLink,
+              ...pool,
+              description: pool.description !== 'null' ? pool.description : campaign.description,
+              address: pool.address.toLowerCase(),
+              lock: pool.lock === 'true',
+            })
+          }
+        })
+      })
+
+      // sort pools by multiplier to prepare for pool list sorting
+      Object.keys(campaignRewardsMapper).forEach((address: string) => {
+        campaignRewardsMapper[address].sort((a, b) => +a.multiplier - +b.multiplier)
+      })
+
+      set(
+        produce((state: State) => {
+          state[sliceKey].initiated = true
+          state[sliceKey].campaignRewardsMapper = campaignRewardsMapper
+        }),
+      )
+    },
+
+    // slice helpers
+    setStateByActiveKey: (key, activeKey, value) => {
+      get().setAppStateByActiveKey(sliceKey, key, activeKey, value)
+    },
+    setStateByKey: (key, value) => {
+      get().setAppStateByKey(sliceKey, key, value)
+    },
+    setStateByKeys: (sliceState) => {
+      get().setAppStateByKeys(sliceKey, sliceState)
+    },
+    resetState: () => {
+      get().resetAppState(sliceKey, DEFAULT_STATE)
+    },
+  },
+})
+
+export default createCampaignsSlice

--- a/apps/main/src/loan/store/useStore.ts
+++ b/apps/main/src/loan/store/useStore.ts
@@ -5,6 +5,7 @@ import { devtools, persist } from 'zustand/middleware'
 import type { PersistOptions } from 'zustand/middleware/persist'
 import createAppSlice, { AppSlice } from '@/loan/store/createAppSlice'
 import createCacheSlice, { CacheSlice } from '@/loan/store/createCacheSlice'
+import createCampaignRewardsSlice, { CampaignRewardsSlice } from '@/loan/store/createCampaignRewardsSlice'
 import createChartBandsSlice, { ChartBandsSlice } from '@/loan/store/createChartBandsStore'
 import createCollateralListSlice, { CollateralListSlice } from '@/loan/store/createCollateralListSlice'
 import createCollateralsSlice, { CollateralsSlice } from '@/loan/store/createCollateralsSlice'
@@ -49,7 +50,8 @@ export type State = CacheSlice &
   IntegrationsSlice &
   OhlcChartSlice &
   PegKeepersSlice &
-  ScrvUsdSlice
+  ScrvUsdSlice &
+  CampaignRewardsSlice
 
 const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createCacheSlice(set, get),
@@ -73,6 +75,7 @@ const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createOhlcChartSlice(set, get),
   ...createPegKeepersSlice(set, get),
   ...createScrvUsdSlice(set, get),
+  ...createCampaignRewardsSlice(set, get),
 })
 
 // cache all items in CacheSlice store

--- a/packages/external-rewards/src/README.md
+++ b/packages/external-rewards/src/README.md
@@ -38,7 +38,7 @@ Only Campaigns listed in [`campaign-list.json`](https://github.com/curvefi/curve
   - `description`: Pool/market specific description or `null` (will overwrite the campaign description in tooltip if set)
   - `campaignStart`: Start of the rewards, as UTC timestamp
   - `campaignEnd`: End of the rewards, as UTC timestamp
-  - `address`: Address of the pool/market (use address identified as `controller` for lending markets and action: `borrow`, use address identified as `vault` for action: `supply`)
+  - `address`: Address of the pool/market (use address identified as `controller` for lending markets and action: `borrow`, use address identified as `vault` for action: `supply`, use address identified as `controller` for crvUSD mint markets and action: `loan`)
   - `network`: Network of the pool/market
   - `multiplier`: Multiplier, or `null`
   - `tags`: Array of pool/market specific tags (any of the tags ids listed here: [`rewards-tags.json`](https://github.com/curvefi/curve-frontend/blob/main/packages/external-rewards/src/reward-tags.json))

--- a/packages/external-rewards/src/actions.json
+++ b/packages/external-rewards/src/actions.json
@@ -10,5 +10,9 @@
   {
     "id": "lp",
     "displayName": "LP"
+  },
+  {
+    "id": "loan",
+    "displayName": "Loan"
   }
 ]

--- a/packages/external-rewards/src/campaigns/Etherfi.json
+++ b/packages/external-rewards/src/campaigns/Etherfi.json
@@ -124,6 +124,18 @@
       "multiplier": "4x",
       "tags": ["points"],
       "lock": "false"
+    },
+    {
+      "id": "null",
+      "action": "loan",
+      "description": "null",
+      "campaignStart": "0",
+      "campaignEnd": "1770000000",
+      "address": "0x652aEa6B22310C89DCc506710CaD24d2Dba56B11",
+      "network": "ethereum",
+      "multiplier": "2x",
+      "tags": ["points"],
+      "lock": "false"
     }
   ]
 }

--- a/packages/ui/src/CampaignRewards/types.ts
+++ b/packages/ui/src/CampaignRewards/types.ts
@@ -52,4 +52,4 @@ export interface CampaignRewardsBannerCompProps {
 }
 
 export type RewardsTags = 'points' | 'merkle' | 'tokens'
-export type RewardsAction = 'supply' | 'borrow' | 'lp'
+export type RewardsAction = 'supply' | 'borrow' | 'lp' | 'loan'


### PR DESCRIPTION
Changes:
- Added new option for field action, "loan", to campaign rewards for crvusd mint markets
- Added campaign rewards support for loan app
- Added weETH mint market data to Etherfi.json