### PR TITLE
feat: enhance Chip component with icon size support

### DIFF
--- a/packages/curve-ui-kit/src/themes/chip/mui-chip.ts
+++ b/packages/curve-ui-kit/src/themes/chip/mui-chip.ts
@@ -12,16 +12,20 @@ const invertPrimary = (color: DesignSystem['Color']) => color.Neutral[50]
 
 const { Sizing, Spacing, IconSize } = SizesAndSpaces
 
-type ChipSizeDefinition = { font: TypographyVariantKey; height: Responsive }
+type ChipSizeDefinition = {
+  font: TypographyVariantKey
+  height: Responsive
+  iconSize: Responsive
+}
 
 type ChipSizes = NonNullable<ChipProps['size']>
 
 const chipSizes: Record<ChipSizes, ChipSizeDefinition> = {
-  extraSmall: { font: 'bodyXsBold', height: IconSize.md },
-  small: { font: 'buttonXs', height: IconSize.md },
-  medium: { font: 'buttonXs', height: Sizing.md },
-  large: { font: 'buttonM', height: Sizing.md },
-  extraLarge: { font: 'headingSBold', height: Sizing.xl },
+  extraSmall: { font: 'bodyXsBold', height: IconSize.md, iconSize: IconSize.xs },
+  small: { font: 'buttonXs', height: IconSize.md, iconSize: IconSize.sm },
+  medium: { font: 'buttonXs', height: Sizing.md, iconSize: IconSize.md },
+  large: { font: 'buttonM', height: Sizing.md, iconSize: IconSize.lg },
+  extraLarge: { font: 'headingSBold', height: Sizing.xl, iconSize: IconSize.xl },
 }
 
 // overrides for clickable chips
@@ -126,9 +130,15 @@ export const defineMuiChip = (
       },
     },
 
-    ...Object.entries(chipSizes).map(([size, { font, ...rest }]) => ({
+    ...Object.entries(chipSizes).map(([size, { font, iconSize, ...rest }]) => ({
       props: { size: size as ChipSizes },
-      style: handleBreakpoints({ ...typography[font], ...rest }),
+      style: {
+        ...handleBreakpoints({ ...typography[font], ...rest }),
+        '& .MuiChip-deleteIcon': handleBreakpoints({ width: iconSize, height: iconSize }),
+        '&:has(.MuiChip-icon)': {
+          '& .MuiChip-icon': handleBreakpoints({ width: iconSize, height: iconSize }),
+        },
+      },
     })),
     ...Object.entries(chipSizeClickable).map(([size, { font, ...rest }]) => ({
       props: { size: size as ChipSizes, clickable: true },


### PR DESCRIPTION
Looking at the new llama market page filters I noticed the icons were too big, so I made them adjust to the chip size as per the Badge page on the Figma design. I'm using the sizes of the Badges page, as the sizes on Chips page look rather inconsistent.