### PR TITLE
fix: slippage management for stableswap routes in router swap

### DIFF
--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -90,7 +90,7 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
   const basePoolsLoading = useStore((state) => state.pools.basePoolsLoading)
   const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
-  const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage[chainIdPoolId])
+  const storeMaxSlippage = useUserProfileStore((state) => state.maxSlippage[chainIdPoolId])
 
   const { data: gaugeManager, isPending: isPendingGaugeManager } = useGaugeManager({
     chainId: rChainId,
@@ -121,11 +121,11 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
   }, [signerAddress, pricesApi, pricesApiPoolData, snapshotsMapper, poolData?.pool.address])
 
   const maxSlippage = useMemo(() => {
-    if (globalMaxSlippage) return globalMaxSlippage
+    if (storeMaxSlippage) return storeMaxSlippage
     if (!pool) return ''
 
     return pool.isCrypto ? '0.1' : '0.03'
-  }, [globalMaxSlippage, pool])
+  }, [storeMaxSlippage, pool])
 
   const navHeight = useMemo(() => layoutHeight.mainNav + layoutHeight.secondaryNav, [layoutHeight])
 

--- a/apps/main/src/dex/components/PageRouterSwap/Page.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/Page.tsx
@@ -124,7 +124,7 @@ const Page = (params: NetworkUrlParams) => {
         <IconButton testId="hidden" hidden />
         {t`Swap`}
         <AdvancedSettings
-          stateKey={isStableswapRoute ? 'stable' : 'global'}
+          stateKey={isStableswapRoute ? 'stable' : 'crypto'}
           testId="advance-settings"
           maxSlippage={storeMaxSlippage}
         />

--- a/apps/main/src/dex/components/PageRouterSwap/Page.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/Page.tsx
@@ -26,16 +26,20 @@ const Page = (params: NetworkUrlParams) => {
   const getNetworkConfigFromApi = useStore((state) => state.getNetworkConfigFromApi)
   const isLoadingCurve = useStore((state) => state.isLoadingCurve)
   const routerCached = useStore((state) => state.storeCache.routerFormValues[rChainId])
+  const activeKey = useStore((state) => state.quickSwap.activeKey)
+  const routesAndOutput = useStore((state) => state.quickSwap.routesAndOutput[activeKey])
   const { provider } = useWallet()
   const nativeToken = useStore((state) => state.networks.nativeToken[rChainId])
   const network = useStore((state) => state.networks.networks[rChainId])
   const connectWallet = useStore((s) => s.updateConnectState)
   const connectState = useStore((s) => s.connectState)
-  const { tokensMapper, tokensMapperStr } = useTokensMapper(rChainId)
-
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const stableMaxSlippage = useUserProfileStore((state) => state.maxSlippage.stable)
   const setMaxSlippage = useUserProfileStore((state) => state.setMaxSlippage)
+  const isStableswapRoute = routesAndOutput?.isStableswapRoute
+  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : globalMaxSlippage
 
+  const { tokensMapper, tokensMapperStr } = useTokensMapper(rChainId)
   const [loaded, setLoaded] = useState(false)
 
   const { hasRouter } = getNetworkConfigFromApi(rChainId)
@@ -119,7 +123,11 @@ const Page = (params: NetworkUrlParams) => {
       <BoxHeader className="title-text">
         <IconButton testId="hidden" hidden />
         {t`Swap`}
-        <AdvancedSettings stateKey="global" testId="advance-settings" maxSlippage={maxSlippage} />
+        <AdvancedSettings
+          stateKey={isStableswapRoute ? 'stable' : 'global'}
+          testId="advance-settings"
+          maxSlippage={storeMaxSlippage}
+        />
       </BoxHeader>
 
       <Box grid gridRowGap={3} padding>

--- a/apps/main/src/dex/components/PageRouterSwap/Page.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/Page.tsx
@@ -33,11 +33,11 @@ const Page = (params: NetworkUrlParams) => {
   const network = useStore((state) => state.networks.networks[rChainId])
   const connectWallet = useStore((s) => s.updateConnectState)
   const connectState = useStore((s) => s.connectState)
-  const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const cryptoMaxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
   const stableMaxSlippage = useUserProfileStore((state) => state.maxSlippage.stable)
   const setMaxSlippage = useUserProfileStore((state) => state.setMaxSlippage)
   const isStableswapRoute = routesAndOutput?.isStableswapRoute
-  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : globalMaxSlippage
+  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : cryptoMaxSlippage
 
   const { tokensMapper, tokensMapperStr } = useTokensMapper(rChainId)
   const [loaded, setLoaded] = useState(false)

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -80,10 +80,10 @@ const QuickSwap = ({
   const updateTokenList = useStore((state) => state.quickSwap.updateTokenList)
   const network = useStore((state) => (chainId ? state.networks.networks[chainId] : null))
 
-  const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const cryptoMaxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
   const stableMaxSlippage = useUserProfileStore((state) => state.maxSlippage.stable)
   const isStableswapRoute = routesAndOutput?.isStableswapRoute
-  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : globalMaxSlippage
+  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : cryptoMaxSlippage
 
   const [confirmedLoss, setConfirmedLoss] = useState(false)
   const [steps, setSteps] = useState<Step[]>([])
@@ -205,7 +205,7 @@ const QuickSwap = ({
           onClick: async () => {
             const notifyMessage = t`Please approve spending your ${fromToken}.`
             const { dismiss } = notify(notifyMessage, 'pending')
-            await fetchStepApprove(activeKey, curve, formValues, searchedParams, globalMaxSlippage)
+            await fetchStepApprove(activeKey, curve, formValues, searchedParams, storeMaxSlippage)
             if (typeof dismiss === 'function') dismiss()
           },
         },
@@ -281,7 +281,7 @@ const QuickSwap = ({
 
       return stepsKey.map((key) => stepsObj[key])
     },
-    [confirmedLoss, fetchStepApprove, globalMaxSlippage, handleBtnClickSwap, steps],
+    [confirmedLoss, fetchStepApprove, storeMaxSlippage, handleBtnClickSwap, steps],
   )
 
   const fetchData = useCallback(() => {
@@ -303,9 +303,9 @@ const QuickSwap = ({
 
   // maxSlippage
   useEffect(() => {
-    if (isReady) updateFormValues({}, false, globalMaxSlippage)
+    if (isReady) updateFormValues({}, false, cryptoMaxSlippage)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [globalMaxSlippage])
+  }, [cryptoMaxSlippage])
 
   // pageVisible re-fetch data
   useEffect(() => {

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -83,6 +83,7 @@ const QuickSwap = ({
   const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
   const stableMaxSlippage = useUserProfileStore((state) => state.maxSlippage.stable)
   const isStableswapRoute = routesAndOutput?.isStableswapRoute
+  const storeMaxSlippage = isStableswapRoute ? stableMaxSlippage : globalMaxSlippage
 
   const [confirmedLoss, setConfirmedLoss] = useState(false)
   const [steps, setSteps] = useState<Step[]>([])
@@ -128,12 +129,12 @@ const QuickSwap = ({
         updatedFormValues,
         searchedParams,
         isGetMaxFrom,
-        maxSlippage || globalMaxSlippage,
+        maxSlippage || storeMaxSlippage,
         isFullReset,
         isRefetch,
       )
     },
-    [curve, globalMaxSlippage, isLoadingApi, pageLoaded, searchedParams, setFormValues],
+    [curve, storeMaxSlippage, isLoadingApi, pageLoaded, searchedParams, setFormValues],
   )
 
   const handleBtnClickSwap = useCallback(
@@ -488,7 +489,7 @@ const QuickSwap = ({
           />
         )}
         <DetailInfoSlippageTolerance
-          maxSlippage={isStableswapRoute ? stableMaxSlippage : globalMaxSlippage}
+          maxSlippage={storeMaxSlippage}
           testId="slippage-tolerance"
           stateKey={isStableswapRoute ? 'stable' : 'global'}
         />

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -491,7 +491,7 @@ const QuickSwap = ({
         <DetailInfoSlippageTolerance
           maxSlippage={storeMaxSlippage}
           testId="slippage-tolerance"
-          stateKey={isStableswapRoute ? 'stable' : 'global'}
+          stateKey={isStableswapRoute ? 'stable' : 'crypto'}
         />
       </div>
 

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -81,6 +81,8 @@ const QuickSwap = ({
   const network = useStore((state) => (chainId ? state.networks.networks[chainId] : null))
 
   const globalMaxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const stableMaxSlippage = useUserProfileStore((state) => state.maxSlippage.stable)
+  const isStableswapRoute = routesAndOutput?.isStableswapRoute
 
   const [confirmedLoss, setConfirmedLoss] = useState(false)
   const [steps, setSteps] = useState<Step[]>([])
@@ -486,9 +488,9 @@ const QuickSwap = ({
           />
         )}
         <DetailInfoSlippageTolerance
-          maxSlippage={globalMaxSlippage || routesAndOutput?.maxSlippage}
+          maxSlippage={isStableswapRoute ? stableMaxSlippage : globalMaxSlippage}
           testId="slippage-tolerance"
-          stateKey="global"
+          stateKey={isStableswapRoute ? 'stable' : 'global'}
         />
       </div>
 

--- a/apps/main/src/dex/components/PageRouterSwap/types.ts
+++ b/apps/main/src/dex/components/PageRouterSwap/types.ts
@@ -43,6 +43,7 @@ export type RoutesAndOutput = {
   isExchangeRateLow: boolean
   isHighImpact: boolean
   isHighSlippage: boolean
+  isStableswapRoute: boolean
   maxSlippage: string
   priceImpact: number | null
   routes: Route[]

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -389,6 +389,7 @@ const router = {
       isExpectedToAmount: false,
       isHighImpact: false,
       isHighSlippage: false,
+      isStableswapRoute: false,
       maxSlippage: '',
       priceImpact: 0,
       routes: [] as Route[],

--- a/apps/main/src/dex/utils/utilsSwap.ts
+++ b/apps/main/src/dex/utils/utilsSwap.ts
@@ -111,6 +111,7 @@ export function _parseRoutesAndOutput(
       : getIsLowExchangeRate(haveCryptoRoutes, toAmount, fromAmount),
     isHighImpact: priceImpact > +parsedMaxSlippage,
     isHighSlippage: haveCryptoRoutes ? false : Number(exchangeRates[0]) > 0.98,
+    isStableswapRoute: !haveCryptoRoutes,
     maxSlippage: parsedMaxSlippage,
     priceImpact: priceImpact,
     routes: parsedRouterRoutes.routes,

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
@@ -43,7 +43,7 @@ const DetailInfoLeverage = ({
   const liqRanges = useStore((state) => state.loanCreate.liqRanges[activeKeyLiqRange])
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const { signerAddress } = api ?? {}
   const { minBands, maxBands, borrowed_token, collateral_token } = market ?? {}

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -65,7 +65,7 @@ const LoanCreate = ({
   const resetState = useStore((state) => state.loanCreate.resetState)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [{ isConfirming, confirmedWarning }, setConfirmWarning] = useState(DEFAULT_CONFIRM_WARNING)
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/components/DetailInfoLeverage.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/components/DetailInfoLeverage.tsx
@@ -39,7 +39,7 @@ const DetailInfoLeverage = ({
   const formValues = useStore((state) => state.loanBorrowMore.formValues)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const { signerAddress } = api ?? {}
   const { expectedCollateral, routeImage } = detailInfo ?? {}

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -61,7 +61,7 @@ const LoanBorrowMore = ({
   const setFormValues = useStore((state) => state.loanBorrowMore.setFormValues)
   const resetState = useStore((state) => state.loanBorrowMore.resetState)
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [{ isConfirming, confirmedWarning }, setConfirmWarning] = useState(DEFAULT_CONFIRM_WARNING)
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/components/DetailInfo.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/components/DetailInfo.tsx
@@ -35,7 +35,7 @@ const DetailInfo = ({
   const formValues = useStore((state) => state.loanRepay.formValues)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const detailInfo = detailInfoNonLeverage ?? detailInfoLeverage
 

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -62,7 +62,7 @@ const LoanRepay = ({
   const setFormValues = useStore((state) => state.loanRepay.setFormValues)
   const resetState = useStore((state) => state.loanRepay.resetState)
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [{ isConfirming, confirmedWarning }, setConfirmWarning] = useState(DEFAULT_CONFIRM_WARNING)
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -52,7 +52,7 @@ const LoanSelfLiquidation = ({
   const fetchStepLiquidate = useStore((state) => state.loanSelfLiquidation.fetchStepLiquidate)
   const resetState = useStore((state) => state.loanSelfLiquidation.resetState)
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [steps, setSteps] = useState<Step[]>([])
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
@@ -43,7 +43,7 @@ const DetailInfoLeverage = ({
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
   const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const LeverageDetail = () => (
     <DetailInfo label={t`Leverage:`} loading={!isReady || detailInfo.loading} loadingSkeleton={[50, 20]}>

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -65,7 +65,7 @@ const LoanCreate = ({
   const resetState = useStore((state) => state.loanCreate.resetState)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [confirmedHealthWarning, setConfirmHealthWarning] = useState(false)
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)

--- a/apps/main/src/loan/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/Page.tsx
@@ -56,7 +56,7 @@ const Page = (params: CollateralUrlParams) => {
   const { provider } = useWallet()
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [loaded, setLoaded] = useState(false)
 

--- a/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
@@ -68,7 +68,7 @@ const LoanDeleverage = ({
   const setFormValues = useStore((state) => state.loanDeleverage.setFormValues)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [confirmHighPriceImpact, setConfirmHighPriceImpact] = useState(false)
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -45,7 +45,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
   const setStateByKey = useStore((state) => state.loanLiquidate.setStateByKey)
   const resetState = useStore((state) => state.loanLiquidate.resetState)
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [steps, setSteps] = useState<Step[]>([])
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)

--- a/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
@@ -54,7 +54,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
   const setStateByKey = useStore((state) => state.loanSwap.setStateByKey)
   const resetState = useStore((state) => state.loanSwap.resetState)
 
-  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.global)
+  const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
   const [steps, setSteps] = useState<Step[]>([])
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)

--- a/packages/curve-ui-kit/src/features/user-profile/store.ts
+++ b/packages/curve-ui-kit/src/features/user-profile/store.ts
@@ -7,8 +7,8 @@ import type { ThemeKey } from '@ui-kit/themes/basic-theme'
 
 type State = {
   theme: ThemeKey
-  /** Key is either 'global', 'stable' or a chainIdPoolId from getChainPoolIdActiveKey. */
-  maxSlippage: { global: string; stable: string } & Partial<Record<string, string>>
+  /** Key is either 'crypto', 'stable' or a chainIdPoolId from getChainPoolIdActiveKey. */
+  maxSlippage: { crypto: string; stable: string } & Partial<Record<string, string>>
   isAdvancedMode: boolean
   hideSmallPools: boolean
 }
@@ -19,11 +19,11 @@ type Action = {
   /**
    * Sets or removes a max slippage value for a given key.
    * @param slippage - The slippage value as a string percentage (e.g. "0.1" for 0.1%), or null to remove
-   * @param key - Optional key to set slippage for (e.g. "global", "stable" or chainId-poolId). If omitted, sets slippage to all existing keys.
+   * @param key - Optional key to set slippage for (e.g. "crypto", "stable" or chainId-poolId). If omitted, sets slippage to all existing keys.
    * @returns boolean - True if slippage was successfully set/removed, false if invalid input
    * @example
    * // Set router slippage to 0.1%
-   * setMaxSlippage("0.1", "global")
+   * setMaxSlippage("0.1", "crypto")
    *
    * // Set router slippage to 0.03% for a stableswap pool
    * setMaxSlippage("0.03", "stable")
@@ -47,7 +47,7 @@ const INITIAL_THEME =
 
 const INITIAL_STATE: State = {
   theme: INITIAL_THEME,
-  maxSlippage: { global: '0.1', stable: '0.03' },
+  maxSlippage: { crypto: '0.1', stable: '0.03' },
   isAdvancedMode: false,
   hideSmallPools: true,
 }
@@ -60,7 +60,7 @@ const store: StateCreator<Store> = (set) => ({
     // Check if we want to delete a slippage value first.
     if (maxSlippage === null) {
       if (!key) return false
-      if (key === 'global' || key === 'stable') return false
+      if (key === 'crypto' || key === 'stable') return false
 
       set(
         produce((state) => {

--- a/packages/curve-ui-kit/src/features/user-profile/store.ts
+++ b/packages/curve-ui-kit/src/features/user-profile/store.ts
@@ -7,7 +7,7 @@ import type { ThemeKey } from '@ui-kit/themes/basic-theme'
 
 type State = {
   theme: ThemeKey
-  /** Key is either 'global' or a chainIdPoolId from getChainPoolIdActiveKey. */
+  /** Key is either 'global', 'stable' or a chainIdPoolId from getChainPoolIdActiveKey. */
   maxSlippage: { global: string; stable: string } & Partial<Record<string, string>>
   isAdvancedMode: boolean
   hideSmallPools: boolean

--- a/packages/curve-ui-kit/src/features/user-profile/store.ts
+++ b/packages/curve-ui-kit/src/features/user-profile/store.ts
@@ -8,7 +8,7 @@ import type { ThemeKey } from '@ui-kit/themes/basic-theme'
 type State = {
   theme: ThemeKey
   /** Key is either 'global' or a chainIdPoolId from getChainPoolIdActiveKey. */
-  maxSlippage: { global: string } & Partial<Record<string, string>>
+  maxSlippage: { global: string; stable: string } & Partial<Record<string, string>>
   isAdvancedMode: boolean
   hideSmallPools: boolean
 }
@@ -19,11 +19,14 @@ type Action = {
   /**
    * Sets or removes a max slippage value for a given key.
    * @param slippage - The slippage value as a string percentage (e.g. "0.1" for 0.1%), or null to remove
-   * @param key - Optional key to set slippage for (e.g. "global" or chainId-poolId). If omitted, sets slippage to all existing keys.
+   * @param key - Optional key to set slippage for (e.g. "global", "stable" or chainId-poolId). If omitted, sets slippage to all existing keys.
    * @returns boolean - True if slippage was successfully set/removed, false if invalid input
    * @example
    * // Set router slippage to 0.1%
    * setMaxSlippage("0.1", "global")
+   *
+   * // Set router slippage to 0.03% for a stableswap pool
+   * setMaxSlippage("0.03", "stable")
    *
    * // Remove slippage for specific pool
    * setMaxSlippage(null, "1-0x123...")
@@ -44,7 +47,7 @@ const INITIAL_THEME =
 
 const INITIAL_STATE: State = {
   theme: INITIAL_THEME,
-  maxSlippage: { global: '0.1' },
+  maxSlippage: { global: '0.1', stable: '0.03' },
   isAdvancedMode: false,
   hideSmallPools: true,
 }
@@ -57,7 +60,7 @@ const store: StateCreator<Store> = (set) => ({
     // Check if we want to delete a slippage value first.
     if (maxSlippage === null) {
       if (!key) return false
-      if (key === 'global') return false
+      if (key === 'global' || key === 'stable') return false
 
       set(
         produce((state) => {


### PR DESCRIPTION
Changes:
- Restore stableswap specific slippage settings for router swap routes that only use stableswap pools