### PR TITLE
mich requests for token selector

### DIFF
--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -445,9 +445,7 @@ const QuickSwap = ({
             <TokenSelector
               selectedToken={toToken}
               tokens={tokens}
-              balances={userBalancesMapper}
               disabled={isDisable || !toToken}
-              tokenPrices={usdRatesMapper}
               onToken={(token) => {
                 const toAddress = token.address
                 const fromAddress =

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -255,8 +255,9 @@ export const TokenList = ({
           <TokenSection
             title={myTokens.length > 0 ? t`Tokens by 24h volume` : undefined}
             tokens={allTokens}
-            balances={balances}
-            tokenPrices={tokenPrices}
+            // Balances and token prices are not relevant, given they go into the 'My tokens' section
+            balances={{}}
+            tokenPrices={{}}
             disabledTokens={disabledTokens}
             preview={300}
             showAll={sections.all || !!search}

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -295,9 +295,8 @@ export const TokenList = ({
           <TokenSection
             title={myTokens.length > 0 ? t`Tokens by 24h volume` : undefined}
             tokens={allTokens}
-            // Balances and token prices are not relevant, given they go into the 'My tokens' section
-            balances={{}}
-            tokenPrices={{}}
+            balances={balances}
+            tokenPrices={tokenPrices}
             disabledTokens={disabledTokens}
             preview={previewAll}
             onShowAll={() => setShowPreviewAll(false)}

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -149,7 +149,7 @@ export const TokenList = ({
 
   const showFavorites = favorites.length > 0 && !search
 
-  const tokensFiltered = useMemo(() => {
+  const tokensSearched = useMemo(() => {
     if (!search) return tokens
 
     const { addressesResult, tokensResult } = searchByText(search, tokens, ['symbol'], {
@@ -161,8 +161,8 @@ export const TokenList = ({
   }, [tokens, search])
 
   const { myTokens, allTokens } = useMemo(() => {
-    const myTokens = tokensFiltered.filter((token) => +(balances[token.address] ?? 0) > 0)
-    const allTokens = tokensFiltered.filter((token) => +(balances[token.address] ?? 0) === 0)
+    const myTokens = tokensSearched.filter((token) => +(balances[token.address] ?? 0) > 0)
+    const allTokens = tokensSearched.filter((token) => +(balances[token.address] ?? 0) === 0)
 
     if (!disableSorting) {
       // Sort tokens with balance by balance (USD then raw)
@@ -180,7 +180,7 @@ export const TokenList = ({
     }
 
     return { myTokens, allTokens }
-  }, [tokensFiltered, disableSorting, balances, tokenPrices])
+  }, [tokensSearched, disableSorting, balances, tokenPrices])
 
   /**
    * Filters tokens to show only those with significant value.


### PR DESCRIPTION
1. In quickswap, the 'to' token list no longer uses user balances and token prices. Just a list sorted by volume now.

2. In the 'from' token list, the 'tokens by 24h volume' will now include tokens hidden away as 'dust' if there's a 'my tokens' section. The list is still sorted by volume and ignores user balances. If the user clicks on 'show dust', the very same dust tokens will no longer show up in the '24h volume' section to avoid duplicate entries.

I've been internally debating about whether or not we should show token balances in the bottom section if they're hidden behind the 'show dust' button. I've opted to show balances, even though you can argue it breaks consistency with the other tokens in the list. This way the user can be sure that the token is really the token they're expecting. It would only be confusing if a user has a balance of $0.01 but it wouldn't show; is it the same token or not?