### PR TITLE
fix: token selector bugs

### DIFF
--- a/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
@@ -168,6 +168,7 @@ const SelectTokenButton = ({
           disabledTokens={disabledKeys ?? []}
           disableSorting={true}
           disableMyTokens={false}
+          compact={false}
           customOptions={
             swapType === STABLESWAP && (
               <Checkbox

--- a/apps/main/src/dex/components/PagePool/Swap/index.tsx
+++ b/apps/main/src/dex/components/PagePool/Swap/index.tsx
@@ -381,6 +381,7 @@ const Swap = ({
                 disabled={isDisabled || selectList.length === 0}
                 showSearch={false}
                 showManageList={false}
+                compact={true}
                 onToken={(token) => {
                   const val = token.address
                   const cFormValues = cloneDeep(formValues)
@@ -463,6 +464,7 @@ const Swap = ({
               disabled={isDisabled || selectList.length === 0}
               showSearch={false}
               showManageList={false}
+              compact={true}
               onToken={(token) => {
                 const val = token.address
                 const cFormValues = cloneDeep(formValues)

--- a/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
@@ -242,7 +242,10 @@ const meta: Meta<typeof TokenSelector> = {
       control: false,
       description: 'Adds extra custom options to the modal, below the favorites',
     },
-
+    disableMyTokens: {
+      control: 'boolean',
+      description: 'Disables the "My Tokens" tab in the token selector modal',
+    },
     onToken: {
       action: 'token selected',
       description: 'Callback when a token is selected',
@@ -285,6 +288,22 @@ export const WithError: Story = {
     docs: {
       description: {
         story: 'Token selector displaying an error message',
+      },
+    },
+  },
+}
+
+export const CompactMode: Story = {
+  args: {
+    compact: true,
+    favorites: [],
+    tokens: defaultTokens.slice(0, 3),
+    disableMyTokens: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Token selector in compact mode with reduced size modal',
       },
     },
   },

--- a/packages/curve-ui-kit/src/features/select-token/ui/TokenSelector.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/TokenSelector.tsx
@@ -30,6 +30,7 @@ export const TokenSelector = ({
   disableSorting = false,
   disableMyTokens = false,
   customOptions,
+  compact = false,
   onToken,
   onSearch,
   sx,
@@ -52,6 +53,7 @@ export const TokenSelector = ({
         disableSorting={disableSorting}
         disableMyTokens={disableMyTokens}
         customOptions={customOptions}
+        compact={compact}
         onClose={closeModal}
         onToken={(token) => {
           toggleModal()

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -48,7 +48,7 @@ const TokenSection = ({
   if (!tokens.length) return null
 
   const displayTokens = preview.length === 0 ? tokens : preview
-  const hasMore = preview.length > 0
+  const hasMore = preview.length > 0 && preview.length < tokens.length
 
   // If there's a list of preview tokens, show that with a 'Show more' button.
   // If not, then just display all tokens from the list.

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
@@ -20,11 +20,13 @@ export type TokenSelectorModalProps = {
   isOpen: boolean
   /** Shows token list management options (currently disabled in UI but wired for future use) */
   showManageList: boolean
+  /** Controls whether the modal should use a compact layout with fixed height */
+  compact: boolean
 }
 
 export type Props = TokenListProps & TokenSelectorModalCallbacks & TokenSelectorModalProps
 
-export const TokenSelectorModal = ({ isOpen, showManageList, onClose, ...tokenListProps }: Props) => {
+export const TokenSelectorModal = ({ isOpen, showManageList, compact, onClose, ...tokenListProps }: Props) => {
   const [isManageListOpen, openManageList, closeManageList] = useSwitch()
 
   return (
@@ -50,7 +52,7 @@ export const TokenSelectorModal = ({ isOpen, showManageList, onClose, ...tokenLi
           overflowY: 'hidden',
           maxHeight: MaxHeight.tokenSelector,
           height: 'auto',
-          minHeight: 'auto',
+          minHeight: compact ? 'auto' : MaxHeight.tokenSelector,
         },
       }}
     >

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
@@ -48,7 +48,7 @@ export const TokenSelectorModal = ({ isOpen, showManageList, compact, onClose, .
         false && showManageList && !isManageListOpen && <ModalSettingsButton onClick={openManageList} />
       }
       sx={{
-        '& .MuiPaper-root': {
+        '& .MuiPaper-root:not(.MuiAlert-root)': {
           overflowY: 'hidden',
           maxHeight: MaxHeight.tokenSelector,
           height: 'auto',


### PR DESCRIPTION
Fixes three smol bugs that appear in edge cases. Brought back compact mode I removed earlier, turns it was a bad idea to make bake it in by default. Whenever you searched and you had only 1 result the entire modal would shrink in height. Oops!