### PR TITLE
fix: other rewards are not shown if crv rewards are enabled

### DIFF
--- a/apps/main/src/dex/components/PagePoolList/components/TableRow.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableRow.tsx
@@ -85,16 +85,18 @@ const TableRow = ({
           {columnKey === COLUMN_KEYS.rewardsLite && (
             <Td className="right">
               <Box flex flexColumn style={{ gap: 'var(--spacing-1)' }}>
-                {rewardsApy &&
-                  (isCrvRewardsEnabled ? (
-                    <TableCellRewardsCrv
-                      isHighlight={sortBy === 'rewardsCrv'}
-                      poolData={poolData}
-                      rewardsApy={rewardsApy}
-                    />
-                  ) : (
+                {rewardsApy && (
+                  <>
+                    {isCrvRewardsEnabled && (
+                      <TableCellRewardsCrv
+                        isHighlight={sortBy === 'rewardsCrv'}
+                        poolData={poolData}
+                        rewardsApy={rewardsApy}
+                      />
+                    )}
                     <TableCellRewardsOthers isHighlight={sortBy === 'rewardsOther'} rewardsApy={rewardsApy} />
-                  ))}
+                  </>
+                )}
                 {poolData && campaignRewardsMapper[poolData.pool.address] && (
                   <CampaignRewardsRow rewardItems={campaignRewardsMapper[poolData.pool.address]} />
                 )}


### PR DESCRIPTION
1. crv rewards are enabled, but that means no other rewards are being shown
2. there are no crv rewards (yet?)
3. so you see nothing

In short, the ternary shouldn't have been a ternary