### PR TITLE
feat: add MuiCheckbox component and related stories to curve-ui-kit

### DIFF
--- a/packages/curve-ui-kit/src/themes/checkbox/index.ts
+++ b/packages/curve-ui-kit/src/themes/checkbox/index.ts
@@ -1,0 +1,1 @@
+export * from './mui-checkbox'

--- a/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
+++ b/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
@@ -65,6 +65,7 @@ export const defineMuiCheckbox = (design: DesignSystem): Components['MuiCheckbox
   defaultProps: {
     icon: createIconWrapper(<EmptyIcon />),
     checkedIcon: createIconWrapper(<CheckIcon />),
+    disableRipple: true,
   },
   styleOverrides: {
     root: { ...buttonSize({ size: 'sm' }) },

--- a/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
+++ b/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
@@ -1,0 +1,51 @@
+import type { Components } from '@mui/material/styles'
+import { createSvgIcon } from '@mui/material/utils'
+import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { handleBreakpoints } from '../basic-theme'
+import type { DesignSystem } from '../design'
+
+const { Sizing } = SizesAndSpaces
+
+/**
+ * Using standard Sizing instead of ButtonSize because:
+ * 1. ButtonSize is not responsive
+ * 2. ButtonSize has larger gaps between size levels
+ * 3. Checkbox buttons need more precise size control
+ */
+const buttonSize = ({ size }: { size: keyof typeof Sizing }) => ({
+  '& .MuiSvgIcon-root': handleBreakpoints({ fontSize: Sizing[size] }),
+})
+
+// Empty icon that will only show the border defined the root style
+const EmptyIcon = createSvgIcon(<svg viewBox="0 0 24 24" />, 'Empty')
+
+/**
+ * Checkbox sizes are slightly larger than in Figma to match radio button sizes
+ * for better usability in practice.
+ *
+ * The default MUI icons are replaced with custom ones. Unlike MUI's default where
+ * the checkbox background is filled with color and the checkmark is white, our design
+ * keeps the checkbox fill transparent while coloring the checkmark and outline.
+ *
+ * Note: For checked and disabled checkboxes, we use MUI's default disabled color
+ * as custom color properties with reduced opacity don't render consistently.
+ *
+ * This is a limitation as attempts to maintain the original color with reduced opacity
+ * don't work well with custom color properties.
+ */
+export const defineMuiCheckbox = (design: DesignSystem): Components['MuiCheckbox'] => ({
+  defaultProps: {
+    icon: <EmptyIcon />,
+    checkedIcon: <CheckIcon />,
+  },
+  styleOverrides: {
+    root: {
+      ...buttonSize({ size: 'sm' }),
+      '& .MuiSvgIcon-root': { outline: '1px solid currentColor' },
+    },
+
+    sizeSmall: { ...buttonSize({ size: 'xs' }) },
+    sizeLarge: { ...buttonSize({ size: 'md' }) },
+  },
+})

--- a/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
+++ b/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+import Box from '@mui/material/Box'
 import type { Components } from '@mui/material/styles'
 import { createSvgIcon } from '@mui/material/utils'
 import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
@@ -7,6 +9,34 @@ import type { DesignSystem } from '../design'
 
 const { Sizing } = SizesAndSpaces
 
+// Empty icon that will only show the border defined the root style
+const EmptyIcon = createSvgIcon(<svg viewBox="0 0 24 24" />, 'Empty')
+
+const createIconWrapper = (icon: ReactNode) => (
+  <Box
+    className="icon-wrapper"
+    display="flex"
+    sx={{
+      outline: '1px solid currentColor',
+
+      // Animate the checkbox as it appears. It's not possible to animate it when unchecking.
+      '& svg': {
+        animation: 'checkmark-appear 300ms cubic-bezier(0.4, 0, 0.2, 1) forwards',
+      },
+      '@keyframes checkmark-appear': {
+        from: {
+          transform: 'scale(0)',
+        },
+        to: {
+          transform: 'scale(1)',
+        },
+      },
+    }}
+  >
+    {icon}
+  </Box>
+)
+
 /**
  * Using standard Sizing instead of ButtonSize because:
  * 1. ButtonSize is not responsive
@@ -14,11 +44,8 @@ const { Sizing } = SizesAndSpaces
  * 3. Checkbox buttons need more precise size control
  */
 const buttonSize = ({ size }: { size: keyof typeof Sizing }) => ({
-  '& .MuiSvgIcon-root': handleBreakpoints({ fontSize: Sizing[size] }),
+  '& .icon-wrapper svg': handleBreakpoints({ fontSize: Sizing[size] }),
 })
-
-// Empty icon that will only show the border defined the root style
-const EmptyIcon = createSvgIcon(<svg viewBox="0 0 24 24" />, 'Empty')
 
 /**
  * Checkbox sizes are slightly larger than in Figma to match radio button sizes
@@ -36,14 +63,11 @@ const EmptyIcon = createSvgIcon(<svg viewBox="0 0 24 24" />, 'Empty')
  */
 export const defineMuiCheckbox = (design: DesignSystem): Components['MuiCheckbox'] => ({
   defaultProps: {
-    icon: <EmptyIcon />,
-    checkedIcon: <CheckIcon />,
+    icon: createIconWrapper(<EmptyIcon />),
+    checkedIcon: createIconWrapper(<CheckIcon />),
   },
   styleOverrides: {
-    root: {
-      ...buttonSize({ size: 'sm' }),
-      '& .MuiSvgIcon-root': { outline: '1px solid currentColor' },
-    },
+    root: { ...buttonSize({ size: 'sm' }) },
 
     sizeSmall: { ...buttonSize({ size: 'xs' }) },
     sizeLarge: { ...buttonSize({ size: 'md' }) },

--- a/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
+++ b/packages/curve-ui-kit/src/themes/checkbox/mui-checkbox.tsx
@@ -68,7 +68,10 @@ export const defineMuiCheckbox = (design: DesignSystem): Components['MuiCheckbox
     disableRipple: true,
   },
   styleOverrides: {
-    root: { ...buttonSize({ size: 'sm' }) },
+    root: {
+      ...buttonSize({ size: 'sm' }),
+      '&:hover .icon-wrapper': { outlineWidth: '2px' },
+    },
 
     sizeSmall: { ...buttonSize({ size: 'xs' }) },
     sizeLarge: { ...buttonSize({ size: 'md' }) },

--- a/packages/curve-ui-kit/src/themes/checkbox/override-checkbox.d.ts
+++ b/packages/curve-ui-kit/src/themes/checkbox/override-checkbox.d.ts
@@ -1,0 +1,11 @@
+import '@mui/material/CheckBox'
+
+declare module '@mui/material/Checkbox' {
+  export interface CheckboxPropsSizeOverrides {
+    large: true
+  }
+
+  export interface CheckboxClasses {
+    sizeLarge: string
+  }
+}

--- a/packages/curve-ui-kit/src/themes/components.ts
+++ b/packages/curve-ui-kit/src/themes/components.ts
@@ -4,6 +4,7 @@ import { alpha } from '@mui/system'
 import { basicMuiTheme } from './basic-theme'
 import { defineMuiButton, defineMuiIconButton, defineMuiToggleButton } from './button'
 import { defineMuiCardHeader } from './card-header'
+import { defineMuiCheckbox } from './checkbox'
 import { defineMuiChip } from './chip/mui-chip'
 import { DesignSystem } from './design'
 import { TransitionFunction } from './design/0_primitives'
@@ -38,6 +39,7 @@ export const createComponents = (design: DesignSystem, typography: TypographyOpt
       },
     },
   },
+  MuiCheckbox: defineMuiCheckbox(design),
   MuiChip: defineMuiChip(design, typography),
   MuiContainer: {
     styleOverrides: { root: { display: 'flex', maxWidth: 'var(--width)' } },

--- a/packages/curve-ui-kit/src/themes/stories/Checkbox.stories.tsx
+++ b/packages/curve-ui-kit/src/themes/stories/Checkbox.stories.tsx
@@ -1,0 +1,135 @@
+import { useState, useEffect } from 'react'
+import Checkbox, { CheckboxProps } from '@mui/material/Checkbox'
+import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
+
+const CheckboxStory = ({ checked, onChange, ...props }: CheckboxProps) => {
+  const [isChecked, setIsChecked] = useState(checked)
+
+  // Update internal state when the checked prop changes
+  useEffect(() => {
+    setIsChecked(checked)
+  }, [checked])
+
+  return (
+    <Checkbox
+      {...props}
+      checked={isChecked}
+      onChange={(event, value) => {
+        setIsChecked(value)
+        onChange?.(event, value)
+      }}
+    />
+  )
+}
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'UI Kit/Primitives/Checkbox',
+  component: CheckboxStory,
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+      description: 'The color of the component',
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+      description: 'The size of the component',
+    },
+    checked: {
+      control: 'boolean',
+      description: 'The checked state of the component',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'The disabled state of the component',
+    },
+  },
+  args: {
+    checked: true,
+    size: 'medium',
+    disabled: false,
+    onClick: fn(),
+  },
+}
+
+type Story = StoryObj<typeof Checkbox>
+
+export const Primary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Primary checkbox',
+      },
+    },
+  },
+}
+
+export const Secondary: Story = {
+  args: { color: 'secondary' },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Secondary checkbox',
+      },
+    },
+  },
+}
+
+export const Small: Story = {
+  args: { size: 'small' },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Small-sized checkbox (xs)',
+      },
+    },
+  },
+}
+
+export const Medium: Story = {
+  args: { size: 'medium' },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Medium-sized checkbox (sm)',
+      },
+    },
+  },
+}
+
+export const Large: Story = {
+  args: { size: 'large' },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Large-sized checkbox (md)',
+      },
+    },
+  },
+}
+
+export const Disabled: Story = {
+  args: { disabled: true },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Disabled checkbox',
+      },
+    },
+  },
+}
+
+export const Unchecked: Story = {
+  args: { checked: false },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Unchecked checkbox',
+      },
+    },
+  },
+}
+
+export default meta


### PR DESCRIPTION
Very similar to the radio button PR. Adds some sizing, but also replaces the checkbox icons so we can style invert the colors when checked as per the Figma design.