### PR TITLE
feat: format gauge vote weight as percentage in GaugeVotesTable

### DIFF
--- a/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
@@ -6,7 +6,7 @@ import { TOP_HOLDERS } from '@/dao/constants'
 import useStore from '@/dao/store/useStore'
 import { GaugeVote, GaugeVotesSortBy } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
-import { convertToLocaleTimestamp, formatDateFromTimestamp, formatNumber } from '@ui/utils/'
+import { convertToLocaleTimestamp, formatDateFromTimestamp } from '@ui/utils/'
 import { t } from '@ui-kit/lib/i18n'
 import { DAO_ROUTES } from '@ui-kit/shared/routes'
 import { shortenAddress } from '@ui-kit/utils'
@@ -16,6 +16,9 @@ interface GaugeVotesTableProps {
   gaugeAddress: string
   tableMinWidth: number
 }
+
+// weight is formatted in bps, 10000 = 100%
+const formatGaugeVoteWeight = (weight: number) => weight / 100
 
 const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) => {
   const getGaugeVotes = useStore((state) => state.gauges.getGaugeVotes)
@@ -66,7 +69,7 @@ const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) 
             {formatDateFromTimestamp(convertToLocaleTimestamp(gaugeVote.timestamp / 1000))}
           </TableData>
           <TableData className={gaugeVotesSortBy.key === 'weight' ? 'sortby-active right-padding' : 'right-padding'}>
-            {formatNumber(gaugeVote.weight, { notation: 'compact' })}
+            {formatGaugeVoteWeight(gaugeVote.weight)}%
           </TableData>
           <TableDataLink
             onClick={(e) => {


### PR DESCRIPTION
Changes:
- Formatted gauge vote weight to percentage instead of bps in gauge votes table on gauge page in DAO