### PR TITLE
chore: fetch server data in background

### DIFF
--- a/apps/main/src/app/crvusd/[network]/beta-markets/page.tsx
+++ b/apps/main/src/app/crvusd/[network]/beta-markets/page.tsx
@@ -1,36 +1,14 @@
-import memoizee from 'memoizee'
 import type { Metadata } from 'next'
 import { cookies } from 'next/headers'
-import { LlamaMarketsPage, type LlamaMarketsPageProps } from '@/loan/components/PageLlamaMarkets/Page'
-import { fetchSupportedChains, fetchSupportedLendingChains } from '@/loan/entities/chains'
-import { fetchLendingVaults } from '@/loan/entities/lending-vaults'
-import { fetchMintMarkets } from '@/loan/entities/mint-markets'
-import { fetchAppStatsDailyVolume } from '@/loan/entities/appstats-daily-volume'
+import { LlamaMarketsPage } from '@/loan/components/PageLlamaMarkets/Page'
+import { LlamaMarketsServerSideData } from './server-side-data'
 
 export const metadata: Metadata = { title: 'Llamalend Markets - Curve' }
-
-const getServerData = memoizee(
-  async (): Promise<LlamaMarketsPageProps> => {
-    const [lendingVaults, mintMarkets, supportedChains, supportedLendingChains, dailyVolume] = await Promise.all([
-      fetchLendingVaults({}),
-      fetchMintMarkets({}),
-      fetchSupportedChains({}),
-      fetchSupportedLendingChains({}),
-      fetchAppStatsDailyVolume({}),
-    ])
-    return { lendingVaults, mintMarkets, supportedChains, supportedLendingChains, dailyVolume }
-  },
-  {
-    promise: true,
-    preFetch: true,
-    maxAge: 5 * 60 * 1000, // 5 minutes
-  },
-)
 
 const Page = async () => {
   const requestCookies = await cookies()
   const isCypress = requestCookies.get('cypress') ?? false // skip server data fetching in Cypress so we can mock it
-  return <LlamaMarketsPage {...(!isCypress && (await getServerData()))} />
+  return <LlamaMarketsPage {...(!isCypress && LlamaMarketsServerSideData.result)} />
 }
 
 export default Page

--- a/apps/main/src/app/crvusd/[network]/beta-markets/page.tsx
+++ b/apps/main/src/app/crvusd/[network]/beta-markets/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import { LlamaMarketsPage } from '@/loan/components/PageLlamaMarkets/Page'
-import { LlamaMarketsServerSideData } from './server-side-data'
+import { LlamaMarketsServerSideCache } from '../../server-side-data'
 
 export const metadata: Metadata = { title: 'Llamalend Markets - Curve' }
 
 const Page = async () => {
   const requestCookies = await cookies()
   const isCypress = requestCookies.get('cypress') ?? false // skip server data fetching in Cypress so we can mock it
-  return <LlamaMarketsPage {...(!isCypress && LlamaMarketsServerSideData.result)} />
+  return <LlamaMarketsPage {...(!isCypress && LlamaMarketsServerSideCache.result)} />
 }
 
 export default Page

--- a/apps/main/src/app/crvusd/[network]/beta-markets/server-side-data.ts
+++ b/apps/main/src/app/crvusd/[network]/beta-markets/server-side-data.ts
@@ -1,0 +1,18 @@
+import type { LlamaMarketsPageProps } from '@/loan/components/PageLlamaMarkets/Page'
+import { fetchAppStatsDailyVolume } from '@/loan/entities/appstats-daily-volume'
+import { fetchSupportedChains, fetchSupportedLendingChains } from '@/loan/entities/chains'
+import { fetchLendingVaults } from '@/loan/entities/lending-vaults'
+import { fetchMintMarkets } from '@/loan/entities/mint-markets'
+
+export const LlamaMarketsServerSideData: { result: LlamaMarketsPageProps } = { result: {} }
+
+export const getLlamaMarketsServerSideData = async (): Promise<LlamaMarketsPageProps> => {
+  const [lendingVaults, mintMarkets, supportedChains, supportedLendingChains, dailyVolume] = await Promise.all([
+    fetchLendingVaults({}),
+    fetchMintMarkets({}),
+    fetchSupportedChains({}),
+    fetchSupportedLendingChains({}),
+    fetchAppStatsDailyVolume({}),
+  ])
+  return { lendingVaults, mintMarkets, supportedChains, supportedLendingChains, dailyVolume }
+}

--- a/apps/main/src/app/crvusd/[network]/markets/[collateralId]/collateral.utils.ts
+++ b/apps/main/src/app/crvusd/[network]/markets/[collateralId]/collateral.utils.ts
@@ -1,12 +1,7 @@
-'use server'
-import memoizee from 'memoizee'
+import { LlamaMarketsServerSideCache } from '@/app/crvusd/server-side-data'
 import type { CollateralUrlParams } from '@/loan/types/loan.types'
-import { Chain } from '@curvefi/prices-api'
-import { getMarkets } from '@curvefi/prices-api/crvusd'
 
-const getCrvUsdMarkets = memoizee(getMarkets, { promise: true, preFetch: true, maxAge: 1000 * 60 * 5 })
-
-export async function getCollateralName({ network, collateralId }: CollateralUrlParams) {
-  const markets = await getCrvUsdMarkets(network as Chain)
-  return markets.find((m) => m.collateralToken.symbol.toLowerCase() === collateralId)?.name ?? collateralId
-}
+export const getCollateralName = async ({ network, collateralId }: CollateralUrlParams) =>
+  LlamaMarketsServerSideCache.result.mintMarkets?.find(
+    (m) => m.chain === network && m.collateralToken.symbol.toLowerCase() === collateralId,
+  )?.name ?? collateralId

--- a/apps/main/src/app/crvusd/server-side-data.ts
+++ b/apps/main/src/app/crvusd/server-side-data.ts
@@ -4,7 +4,7 @@ import { fetchSupportedChains, fetchSupportedLendingChains } from '@/loan/entiti
 import { fetchLendingVaults } from '@/loan/entities/lending-vaults'
 import { fetchMintMarkets } from '@/loan/entities/mint-markets'
 
-export const LlamaMarketsServerSideData: { result: LlamaMarketsPageProps } = { result: {} }
+export const LlamaMarketsServerSideCache: { result: LlamaMarketsPageProps } = { result: {} }
 
 export const getLlamaMarketsServerSideData = async (): Promise<LlamaMarketsPageProps> => {
   const [lendingVaults, mintMarkets, supportedChains, supportedLendingChains, dailyVolume] = await Promise.all([

--- a/apps/main/src/app/dex/[network]/InjectServeSideData.tsx
+++ b/apps/main/src/app/dex/[network]/InjectServeSideData.tsx
@@ -5,9 +5,9 @@ import type { ChainId, PoolDataCacheMapper, ValueMapperCached } from '@/dex/type
 
 type ServerSideStoreProps = {
   chainId: ChainId
-  pools: PoolDataCacheMapper
-  tvl: ValueMapperCached
-  volume: ValueMapperCached
+  pools?: PoolDataCacheMapper
+  tvl?: ValueMapperCached
+  volume?: ValueMapperCached
   children: ReactNode
 }
 

--- a/apps/main/src/app/dex/[network]/compensation/page.tsx
+++ b/apps/main/src/app/dex/[network]/compensation/page.tsx
@@ -3,6 +3,6 @@ import PageCompensation from '@/dex/components/PageCompensation/Page'
 
 export const metadata: Metadata = { title: 'Compensation - Curve' }
 
-const CompensationPage = async () => <PageCompensation />
+const CompensationPage = () => <PageCompensation />
 
 export default CompensationPage

--- a/apps/main/src/app/dex/[network]/create-pool/page.tsx
+++ b/apps/main/src/app/dex/[network]/create-pool/page.tsx
@@ -3,6 +3,6 @@ import CreatePool from '@/dex/components/PageCreatePool/Page'
 
 export const metadata: Metadata = { title: 'Create Pool - Curve' } // todo: get rid of one metadata
 
-const CreatePoolPage = async () => <CreatePool />
+const CreatePoolPage = () => <CreatePool />
 
 export default CreatePoolPage

--- a/apps/main/src/app/dex/[network]/deploy-gauge/page.tsx
+++ b/apps/main/src/app/dex/[network]/deploy-gauge/page.tsx
@@ -3,6 +3,6 @@ import DeployGauge from '@/dex/components/PageDeployGauge/Page'
 
 export const metadata: Metadata = { title: 'Deploy Gauge - Curve' }
 
-const DeployGaugePage = async () => <DeployGauge />
+const DeployGaugePage = () => <DeployGauge />
 
 export default DeployGaugePage

--- a/apps/main/src/app/dex/[network]/layout.tsx
+++ b/apps/main/src/app/dex/[network]/layout.tsx
@@ -1,8 +1,9 @@
 import { notFound } from 'next/navigation'
 import type { ReactNode } from 'react'
 import type { NetworkUrlParams } from '@/dex/types/main.types'
+import { DexServerSideCache } from '@/server-side-data'
 import { InjectServeSideData } from './InjectServeSideData'
-import { getNetworkConfig, getServerSideCache } from './pools.util'
+import { getNetworkConfig } from './pools.util'
 
 type NetworkLayoutProps = { params: Promise<NetworkUrlParams>; children: ReactNode }
 
@@ -13,7 +14,7 @@ const Layout = async ({ children, params }: NetworkLayoutProps) => {
     return notFound()
   }
   return (
-    <InjectServeSideData chainId={network.chainId} {...await getServerSideCache(network)}>
+    <InjectServeSideData chainId={network.chainId} {...DexServerSideCache[network.id]}>
       {children}
     </InjectServeSideData>
   )

--- a/apps/main/src/app/dex/[network]/pools.util.ts
+++ b/apps/main/src/app/dex/[network]/pools.util.ts
@@ -13,13 +13,13 @@ import {
 
 const options = { maxAge: 5 * 1000 * 60, promise: true, preFetch: true } as const
 
-const getAllNetworks = memoizee(getNetworks, options)
+export const getAllNetworks = memoizee(getNetworks, options)
 
 /**
  * Retrieves a mapping of pool IDs and addresses to pool names.
  * Unfortunately we cannot use an API as the pool names are generated in CurveJS
  */
-export const getServerSideCache = memoizee(async (network: NetworkConfig) => {
+export const getServerSideCache = async (network: NetworkConfig) => {
   const curveJS = cloneDeep((await import('@curvefi/api')).default) as CurveApi
   await curveJS.init('NoRPC', 'NoRPC', { chainId: network.chainId })
   await Promise.all([
@@ -33,7 +33,7 @@ export const getServerSideCache = memoizee(async (network: NetworkConfig) => {
   const { poolsMapper, poolsMapperCache } = await getPools(curveJS, curveJS.getPoolList(), network, {})
   const [tvl, volume] = await Promise.all([getTvlCache(network, poolsMapper), getVolumeCache(network, poolsMapper)])
   return { pools: poolsMapperCache, tvl, volume }
-}, options)
+}
 
 export async function getNetworkConfig(networkName: string) {
   const networks = await getAllNetworks()

--- a/apps/main/src/app/lend/[network]/markets/[market]/market-name.utils.ts
+++ b/apps/main/src/app/lend/[network]/markets/[market]/market-name.utils.ts
@@ -1,30 +1,17 @@
 'use server'
-import memoizee from 'memoizee'
+import { lendServerSideCache } from '@/app/lend/server-side.data'
 import type { MarketUrlParams } from '@/lend/types/lend.types'
-import type { Chain } from '@curvefi/prices-api'
-import { fetchJson } from '@curvefi/prices-api/fetch'
-
-const options = { maxAge: 5 * 1000 * 60, promise: true, preFetch: true } as const
-
-type Asset = { symbol: string }
-type Data = {
-  lendingVaultData: { id: string; controllerAddress: string; assets: { borrowed: Asset; collateral: Asset } }[]
-}
-
-const getAllMarkets = memoizee(
-  async (network: string) => fetchJson<{ data: Data }>(`https://api.curve.fi/api/getLendingVaults/${network}/oneway`),
-  options,
-)
 
 export async function getLendMarketSymbols({ market, network }: MarketUrlParams): Promise<[string, string]> {
-  const {
-    data: { lendingVaultData },
-  } = await getAllMarkets(network as Chain)
+  const marketData = lendServerSideCache.lendingVaultData?.find(
+    (m) => m.blockchainId == network && (m.id === id || m.controllerAddress === id),
+  )
 
-  const id = market.replace('one-way-market', 'oneway') // API ids are different then those generated in curve-lending-js
-  const marketData = lendingVaultData.find((m) => m.id === id || m.controllerAddress === id)
+  const id = market.replace('one-way-market', 'oneway') // API ids are different from those generated in curve-lending-js
   if (!marketData) {
-    const marketKeys = lendingVaultData.map(({ id, controllerAddress }) => ({ id, controllerAddress }))
+    const marketKeys = lendServerSideCache.lendingVaultData
+      ?.filter((m) => m.blockchainId == network)
+      ?.map(({ id, controllerAddress }) => ({ id, controllerAddress }))
     console.warn(`Cannot find market ${market} in ${network}. Markets: ${JSON.stringify(marketKeys, null, 2)}`)
     return ['', market]
   }

--- a/apps/main/src/app/lend/[network]/markets/[market]/market-name.utils.ts
+++ b/apps/main/src/app/lend/[network]/markets/[market]/market-name.utils.ts
@@ -1,4 +1,3 @@
-'use server'
 import { lendServerSideCache } from '@/app/lend/server-side.data'
 import type { MarketUrlParams } from '@/lend/types/lend.types'
 

--- a/apps/main/src/app/lend/server-side.data.ts
+++ b/apps/main/src/app/lend/server-side.data.ts
@@ -1,0 +1,23 @@
+import memoizee from 'memoizee'
+import { fetchJson } from '@curvefi/prices-api/fetch'
+
+type Asset = { symbol: string }
+export type LendingVaultFromApi = {
+  id: string
+  blockchainId: string
+  controllerAddress: string
+  assets: { borrowed: Asset; collateral: Asset }
+}
+type Data = {
+  lendingVaultData?: LendingVaultFromApi[]
+}
+
+export const getAllLendingVaults = memoizee(
+  async () =>
+    fetchJson<{ data: { lendingVaultData: LendingVaultFromApi[] } }>(
+      `https://api.curve.fi/api/getLendingVaults/all`,
+    ).then((r) => r.data.lendingVaultData),
+  { maxAge: 5 * 1000 * 60, promise: true, preFetch: true } as const,
+)
+
+export const lendServerSideCache: Data = {}

--- a/apps/main/src/dex/store/createCacheSlice.ts
+++ b/apps/main/src/dex/store/createCacheSlice.ts
@@ -28,7 +28,7 @@ export type CacheSlice = {
     setTvlVolumeMapper(type: 'tvlMapper' | 'volumeMapper', chainId: ChainId, mapper: ValueMapperCached): void
     setServerPreloadData(
       chainId: ChainId,
-      data: { pools: PoolDataCacheMapper; tvl: ValueMapperCached; volume: ValueMapperCached },
+      data: { pools?: PoolDataCacheMapper; tvl?: ValueMapperCached; volume?: ValueMapperCached },
     ): void
 
     setStateByActiveKey<T>(key: StateKey, activeKey: string, value: T): Promise<void>
@@ -68,9 +68,10 @@ const createCacheSlice = (set: SetState<State>, get: GetState<State>): CacheSlic
     },
 
     setServerPreloadData: (chainId, { tvl, volume, pools }) => {
-      get().setAppStateByActiveKey(sliceKey, 'poolsMapper', chainId.toString(), pools)
-      get().setAppStateByActiveKey(sliceKey, 'tvlMapper', chainId.toString(), tvl)
-      get().setAppStateByActiveKey(sliceKey, 'volumeMapper', chainId.toString(), volume)
+      const setState = get().setAppStateByActiveKey
+      pools && setState(sliceKey, 'poolsMapper', chainId.toString(), pools)
+      tvl && setState(sliceKey, 'tvlMapper', chainId.toString(), tvl)
+      volume && setState(sliceKey, 'volumeMapper', chainId.toString(), volume)
     },
 
     // slice helpers

--- a/apps/main/src/instrumentation.ts
+++ b/apps/main/src/instrumentation.ts
@@ -1,0 +1,40 @@
+import {
+  getLlamaMarketsServerSideData,
+  LlamaMarketsServerSideData,
+} from '@/app/crvusd/[network]/beta-markets/server-side-data'
+import { getAllNetworks, getServerSideCache } from '@/app/dex/[network]/pools.util'
+import type { NetworkConfig } from '@/dex/types/main.types'
+import { DexServerSideCache } from '@/server-side-data'
+
+const timeout = 1000 * 60 // 1 minute
+
+// todo: we could optimize further by setting field by field
+async function refreshDataInBackground(dexNetworks: { [p: number]: NetworkConfig }) {
+  // noinspection InfiniteLoopJS
+  while (true) {
+    const start = Date.now()
+
+    for (const network of Object.values(dexNetworks)) {
+      DexServerSideCache[network.id] = await getServerSideCache(network).catch((e) => {
+        console.error('Failed to fetch server-side cache for network', network.id, e)
+        return {}
+      })
+    }
+
+    LlamaMarketsServerSideData.result = await getLlamaMarketsServerSideData().catch((e) => {
+      console.error('Failed to fetch server-side data for Llama Markets', e)
+      return {}
+    })
+
+    const elapsed = Date.now() - start
+    console.log(`Refreshed server-side data in ${elapsed}ms`)
+    if (elapsed < timeout) {
+      await new Promise((resolve) => setTimeout(resolve, timeout - elapsed))
+    }
+  }
+}
+
+export async function register() {
+  const dexNetworks = await getAllNetworks()
+  refreshDataInBackground(dexNetworks).catch(console.error)
+}

--- a/apps/main/src/server-side-data.ts
+++ b/apps/main/src/server-side-data.ts
@@ -1,0 +1,10 @@
+import type { PoolDataCacheMapper, ValueMapperCached } from '@/dex/types/main.types'
+
+export const DexServerSideCache: Record<
+  string,
+  {
+    pools?: PoolDataCacheMapper
+    tvl?: ValueMapperCached
+    volume?: ValueMapperCached
+  }
+> = {}


### PR DESCRIPTION
- Preload dex, lend and mint data in the background via the [instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation) file
- Do not wait for that in the request cycle - if the data isn't ready, just omit it from the response and let the frontend retrieve it
- Refresh the data every 1 minute