### PR TITLE
fix: update slippage settings modal to reset form values on reopen

### DIFF
--- a/packages/curve-ui-kit/src/features/slippage-settings/ui/SlippageSettingsModal.tsx
+++ b/packages/curve-ui-kit/src/features/slippage-settings/ui/SlippageSettingsModal.tsx
@@ -128,9 +128,12 @@ export const SlippageSettingsModal = ({ isOpen, maxSlippage, onSave, onClose }: 
    */
   const [lastError, setLastError] = useState<Error | undefined>(undefined)
 
+  // Update form values when slippage changes or modal is closed without saving and re-opened
   useEffect(() => {
-    setFormValues(initFormValues(maxSlippage))
-  }, [maxSlippage])
+    if (isOpen) {
+      setFormValues(initFormValues(maxSlippage))
+    }
+  }, [isOpen, maxSlippage])
 
   useEffect(() => {
     if (error) {

--- a/packages/curve-ui-kit/src/features/slippage-settings/ui/SlippageSettingsModal.tsx
+++ b/packages/curve-ui-kit/src/features/slippage-settings/ui/SlippageSettingsModal.tsx
@@ -128,12 +128,9 @@ export const SlippageSettingsModal = ({ isOpen, maxSlippage, onSave, onClose }: 
    */
   const [lastError, setLastError] = useState<Error | undefined>(undefined)
 
-  // Update form values when slippage changes or modal is closed without saving and re-opened
   useEffect(() => {
-    if (isOpen) {
-      setFormValues(initFormValues(maxSlippage))
-    }
-  }, [isOpen, maxSlippage])
+    setFormValues(initFormValues(maxSlippage))
+  }, [maxSlippage])
 
   useEffect(() => {
     if (error) {
@@ -196,6 +193,7 @@ export const SlippageSettingsModal = ({ isOpen, maxSlippage, onSave, onClose }: 
     <ModalDialog
       open={isOpen}
       onClose={onClose}
+      onTransitionExited={() => setFormValues(initFormValues(maxSlippage))}
       title={t`Slippage Settings`}
       footer={footer}
       // Compact modal

--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -15,7 +15,7 @@ export type ModalDialogProps = {
   title: string
   open: boolean
   onClose: () => void
-  onTransitionExited: () => void
+  onTransitionExited?: () => void
   titleAction?: ReactNode
   footer?: ReactNode
   sx?: SxProps<Theme>

--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -15,13 +15,23 @@ export type ModalDialogProps = {
   title: string
   open: boolean
   onClose: () => void
+  onTransitionExited: () => void
   titleAction?: ReactNode
   footer?: ReactNode
   sx?: SxProps<Theme>
 }
 
-export const ModalDialog = ({ children, open, onClose, title, titleAction, footer, sx }: ModalDialogProps) => (
-  <Dialog open={open} onClose={onClose} sx={sx} disableRestoreFocus>
+export const ModalDialog = ({
+  children,
+  open,
+  onClose,
+  onTransitionExited,
+  title,
+  titleAction,
+  footer,
+  sx,
+}: ModalDialogProps) => (
+  <Dialog open={open} onClose={onClose} onTransitionExited={onTransitionExited} sx={sx} disableRestoreFocus>
     <Card
       sx={{
         ...SizesAndSpaces.ModalHeight.sm,


### PR DESCRIPTION
When you open the slippage settings modal, change it but discard and then re-open, the form values don't reset and it will show the discarded values even though you did not click 'Save'. This edge case was handled in the old modal but must've slipped my mind when re-implementing. It's only a cosmetic issue.