### PR TITLE
chore: set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# configuration options: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - /
+      - /apps/main/
+      - /packages/curve-ui-kit/
+      - /packages/tsconfig/
+      - /packages/prices-api/
+      - /packages/eslint-config-custom/
+      - /packages/ui/
+      - /packages/external-rewards/
+      - /tests/
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: immer
+        update-types: ["version-update:semver-major"]
+      - dependency-name: lightweight-charts
+        update-types: ["version-update:semver-major"]
+      - dependency-name: zustand
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Set up Dependabot for the repository by adding a new configuration file.
- Added a Dependabot configuration file
- Configured a weekly update schedule
- Specified packages to ignore for semver major updates.