### PR TITLE
chore: dependabot groups and interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,9 @@ updates:
       - /packages/external-rewards/
       - /tests/
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+      time: "08:00"
+      timezone: "Europe/Zurich"
     ignore:
       - dependency-name: immer
         update-types: ["version-update:semver-major"]
@@ -21,3 +23,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: zustand
         update-types: ["version-update:semver-major"]
+    groups:
+      # Group all minor updates in a single PR
+      minor-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -64,7 +64,7 @@
     "@svgr/webpack": "^8.1.0",
     "@types/lodash": "^4.17.16",
     "@types/memoizee": "^0.4.12",
-    "@types/node": "22.13.13",
+    "@types/node": "22.13.14",
     "@types/react": "*",
     "@types/react-dom": "*",
     "@types/validator": "^13.12.2",

--- a/packages/curve-ui-kit/package.json
+++ b/packages/curve-ui-kit/package.json
@@ -59,7 +59,7 @@
     "@storybook/addon-a11y": "^8.6.9",
     "@storybook/addon-docs": "^8.6.9",
     "@storybook/addon-essentials": "^8.6.9",
-    "@storybook/addon-interactions": "^8.6.9",
+    "@storybook/addon-interactions": "^8.6.11",
     "@storybook/addon-themes": "^8.6.9",
     "@storybook/blocks": "^8.6.11",
     "@storybook/nextjs": "^8.6.9",

--- a/packages/curve-ui-kit/package.json
+++ b/packages/curve-ui-kit/package.json
@@ -64,7 +64,7 @@
     "@storybook/blocks": "^8.6.11",
     "@storybook/nextjs": "^8.6.9",
     "@storybook/react": "^8.6.9",
-    "@storybook/test": "^8.6.9",
+    "@storybook/test": "^8.6.11",
     "@types/react": "*",
     "@types/react-dom": "*",
     "eslint": "*",

--- a/packages/curve-ui-kit/package.json
+++ b/packages/curve-ui-kit/package.json
@@ -61,7 +61,7 @@
     "@storybook/addon-essentials": "^8.6.9",
     "@storybook/addon-interactions": "^8.6.9",
     "@storybook/addon-themes": "^8.6.9",
-    "@storybook/blocks": "^8.6.9",
+    "@storybook/blocks": "^8.6.11",
     "@storybook/nextjs": "^8.6.9",
     "@storybook/react": "^8.6.9",
     "@storybook/test": "^8.6.9",

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -12,7 +12,7 @@
     "eslint-config-next": "^15.2.4",
     "eslint-config-prettier": "^10.1.1",
     "eslint-config-turbo": "^2.4.4",
-    "eslint-import-resolver-typescript": "^4.2.3",
+    "eslint-import-resolver-typescript": "^4.2.5",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-react": "7.37.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8626,6 +8626,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/instrumenter@npm:8.6.11":
+  version: 8.6.11
+  resolution: "@storybook/instrumenter@npm:8.6.11"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@vitest/utils": "npm:^2.1.1"
+  peerDependencies:
+    storybook: ^8.6.11
+  checksum: 10c0/a5a9fb3f8837b6ec609213e898e37b88b6f6faff7068b4a7dadba0a48f7348f1ee8942726119afda4748dcc7407003ad4bf79ebc22e03c5e238c23422d382ce1
+  languageName: node
+  linkType: hard
+
 "@storybook/instrumenter@npm:8.6.9":
   version: 8.6.9
   resolution: "@storybook/instrumenter@npm:8.6.9"
@@ -8796,7 +8808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/test@npm:8.6.9, @storybook/test@npm:^8.6.9":
+"@storybook/test@npm:8.6.9":
   version: 8.6.9
   resolution: "@storybook/test@npm:8.6.9"
   dependencies:
@@ -8810,6 +8822,23 @@ __metadata:
   peerDependencies:
     storybook: ^8.6.9
   checksum: 10c0/f271329f690ce92a1cc5fe775be88caf3875b49dacdafac48c38ad8f3471dba4da843ed168b590e2cdbf4695b65bbc55f1d345a9f0a942e89429cf28cb2bc8c6
+  languageName: node
+  linkType: hard
+
+"@storybook/test@npm:^8.6.11":
+  version: 8.6.11
+  resolution: "@storybook/test@npm:8.6.11"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/instrumenter": "npm:8.6.11"
+    "@testing-library/dom": "npm:10.4.0"
+    "@testing-library/jest-dom": "npm:6.5.0"
+    "@testing-library/user-event": "npm:14.5.2"
+    "@vitest/expect": "npm:2.0.5"
+    "@vitest/spy": "npm:2.0.5"
+  peerDependencies:
+    storybook: ^8.6.11
+  checksum: 10c0/4c29f52c26b49a979c490688248c8c49625198abffb6c8b7f2fc07a85d9c07c9120646980bab06226c89d0c56c27d73484c0cae0556550b39b17981eab08637c
   languageName: node
   linkType: hard
 
@@ -13698,7 +13727,7 @@ __metadata:
     "@storybook/blocks": "npm:^8.6.11"
     "@storybook/nextjs": "npm:^8.6.9"
     "@storybook/react": "npm:^8.6.9"
-    "@storybook/test": "npm:^8.6.9"
+    "@storybook/test": "npm:^8.6.11"
     "@tanstack/query-sync-storage-persister": "npm:5.69.0"
     "@tanstack/react-query": "npm:5.69.0"
     "@tanstack/react-query-devtools": "npm:5.69.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8808,7 +8808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/test@npm:8.6.11":
+"@storybook/test@npm:8.6.11, @storybook/test@npm:^8.6.11":
   version: 8.6.11
   resolution: "@storybook/test@npm:8.6.11"
   dependencies:
@@ -8839,23 +8839,6 @@ __metadata:
   peerDependencies:
     storybook: ^8.6.9
   checksum: 10c0/f271329f690ce92a1cc5fe775be88caf3875b49dacdafac48c38ad8f3471dba4da843ed168b590e2cdbf4695b65bbc55f1d345a9f0a942e89429cf28cb2bc8c6
-  languageName: node
-  linkType: hard
-
-"@storybook/test@npm:^8.6.11":
-  version: 8.6.11
-  resolution: "@storybook/test@npm:8.6.11"
-  dependencies:
-    "@storybook/global": "npm:^5.0.0"
-    "@storybook/instrumenter": "npm:8.6.11"
-    "@testing-library/dom": "npm:10.4.0"
-    "@testing-library/jest-dom": "npm:6.5.0"
-    "@testing-library/user-event": "npm:14.5.2"
-    "@vitest/expect": "npm:2.0.5"
-    "@vitest/spy": "npm:2.0.5"
-  peerDependencies:
-    storybook: ^8.6.11
-  checksum: 10c0/4c29f52c26b49a979c490688248c8c49625198abffb6c8b7f2fc07a85d9c07c9120646980bab06226c89d0c56c27d73484c0cae0556550b39b17981eab08637c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8409,18 +8409,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-interactions@npm:^8.6.9":
-  version: 8.6.9
-  resolution: "@storybook/addon-interactions@npm:8.6.9"
+"@storybook/addon-interactions@npm:^8.6.11":
+  version: 8.6.11
+  resolution: "@storybook/addon-interactions@npm:8.6.11"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/instrumenter": "npm:8.6.9"
-    "@storybook/test": "npm:8.6.9"
+    "@storybook/instrumenter": "npm:8.6.11"
+    "@storybook/test": "npm:8.6.11"
     polished: "npm:^4.2.2"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
-    storybook: ^8.6.9
-  checksum: 10c0/148dd8746eecdb970e51d72a3831b369b8550dfaf7773afdb33367aee06de4875bffe0653e59b79352150270183e810bcae8f6167861f3ad5cc66c1082e4b311
+    storybook: ^8.6.11
+  checksum: 10c0/d14489cf3664a240a95bebb9634dac556ae07ed4c95504512ebb8633617e677dced71a8f896567adc4a70effd46aed5bac83596a1f90109504c29a94342ba21a
   languageName: node
   linkType: hard
 
@@ -8805,6 +8805,23 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/85a46802eadf8e9570033c861f21f6c09c6f2afb2294a17cb90401fc574711679c1baaec0fe75d55a1c00fc31d5f8e8f921ea388c79dea4541aa0c8dcc60eadb
+  languageName: node
+  linkType: hard
+
+"@storybook/test@npm:8.6.11":
+  version: 8.6.11
+  resolution: "@storybook/test@npm:8.6.11"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/instrumenter": "npm:8.6.11"
+    "@testing-library/dom": "npm:10.4.0"
+    "@testing-library/jest-dom": "npm:6.5.0"
+    "@testing-library/user-event": "npm:14.5.2"
+    "@vitest/expect": "npm:2.0.5"
+    "@vitest/spy": "npm:2.0.5"
+  peerDependencies:
+    storybook: ^8.6.11
+  checksum: 10c0/4c29f52c26b49a979c490688248c8c49625198abffb6c8b7f2fc07a85d9c07c9120646980bab06226c89d0c56c27d73484c0cae0556550b39b17981eab08637c
   languageName: node
   linkType: hard
 
@@ -13731,7 +13748,7 @@ __metadata:
     "@storybook/addon-a11y": "npm:^8.6.9"
     "@storybook/addon-docs": "npm:^8.6.9"
     "@storybook/addon-essentials": "npm:^8.6.9"
-    "@storybook/addon-interactions": "npm:^8.6.9"
+    "@storybook/addon-interactions": "npm:^8.6.11"
     "@storybook/addon-themes": "npm:^8.6.9"
     "@storybook/blocks": "npm:^8.6.11"
     "@storybook/nextjs": "npm:^8.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10171,109 +10171,109 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-darwin-arm64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.3.1"
+"@unrs/resolver-binding-darwin-arm64@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-darwin-arm64@npm:1.3.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-darwin-x64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.3.1"
+"@unrs/resolver-binding-darwin-x64@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-darwin-x64@npm:1.3.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-freebsd-x64@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.3.1"
+"@unrs/resolver-binding-freebsd-x64@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-freebsd-x64@npm:1.3.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.3.1"
+"@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-arm-gnueabihf@npm:1.3.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.3.1"
+"@unrs/resolver-binding-linux-arm-musleabihf@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-arm-musleabihf@npm:1.3.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm64-gnu@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.3.1"
+"@unrs/resolver-binding-linux-arm64-gnu@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-arm64-gnu@npm:1.3.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-arm64-musl@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.3.1"
+"@unrs/resolver-binding-linux-arm64-musl@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-arm64-musl@npm:1.3.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.3.1"
+"@unrs/resolver-binding-linux-ppc64-gnu@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-ppc64-gnu@npm:1.3.2"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-s390x-gnu@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.3.1"
+"@unrs/resolver-binding-linux-s390x-gnu@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-s390x-gnu@npm:1.3.2"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-x64-gnu@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.3.1"
+"@unrs/resolver-binding-linux-x64-gnu@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-x64-gnu@npm:1.3.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-linux-x64-musl@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.3.1"
+"@unrs/resolver-binding-linux-x64-musl@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-linux-x64-musl@npm:1.3.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-wasm32-wasi@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.3.1"
+"@unrs/resolver-binding-wasm32-wasi@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-wasm32-wasi@npm:1.3.2"
   dependencies:
     "@napi-rs/wasm-runtime": "npm:^0.2.7"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-arm64-msvc@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.3.1"
+"@unrs/resolver-binding-win32-arm64-msvc@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-win32-arm64-msvc@npm:1.3.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-ia32-msvc@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.3.1"
+"@unrs/resolver-binding-win32-ia32-msvc@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-win32-ia32-msvc@npm:1.3.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@unrs/resolver-binding-win32-x64-msvc@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.3.1"
+"@unrs/resolver-binding-win32-x64-msvc@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.3.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -15128,7 +15128,7 @@ __metadata:
     eslint-config-next: "npm:^15.2.4"
     eslint-config-prettier: "npm:^10.1.1"
     eslint-config-turbo: "npm:^2.4.4"
-    eslint-import-resolver-typescript: "npm:^4.2.3"
+    eslint-import-resolver-typescript: "npm:^4.2.5"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-no-only-tests: "npm:^3.3.0"
     eslint-plugin-react: "npm:7.37.4"
@@ -15221,16 +15221,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^4.2.3":
-  version: 4.2.4
-  resolution: "eslint-import-resolver-typescript@npm:4.2.4"
+"eslint-import-resolver-typescript@npm:^4.2.5":
+  version: 4.2.5
+  resolution: "eslint-import-resolver-typescript@npm:4.2.5"
   dependencies:
     debug: "npm:^4.4.0"
     get-tsconfig: "npm:^4.10.0"
     is-bun-module: "npm:^2.0.0"
     stable-hash: "npm:^0.0.5"
     tinyglobby: "npm:^0.2.12"
-    unrs-resolver: "npm:^1.3.1"
+    unrs-resolver: "npm:^1.3.2"
   peerDependencies:
     eslint: "*"
     eslint-plugin-import: "*"
@@ -15240,7 +15240,7 @@ __metadata:
       optional: true
     eslint-plugin-import-x:
       optional: true
-  checksum: 10c0/1c5a9cc86f632c1e6e36bd601774e08ad2c04ac8d74b4569bf2748fa74e6049be05ac99418df7c98023939fa72707b12cfae0d94ce5bae90a09e77353a79a25d
+  checksum: 10c0/9134c4dd6e8b3cf1356d6bff68939153c81255c0ac7f694e829c3c7f5e785936591cfe43209d866c8a3b379d3a8dcd203651ec49bd99361fcb54dc0c2b9ce8fc
   languageName: node
   linkType: hard
 
@@ -23587,25 +23587,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unrs-resolver@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "unrs-resolver@npm:1.3.1"
+"unrs-resolver@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "unrs-resolver@npm:1.3.2"
   dependencies:
-    "@unrs/resolver-binding-darwin-arm64": "npm:1.3.1"
-    "@unrs/resolver-binding-darwin-x64": "npm:1.3.1"
-    "@unrs/resolver-binding-freebsd-x64": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.3.1"
-    "@unrs/resolver-binding-linux-x64-musl": "npm:1.3.1"
-    "@unrs/resolver-binding-wasm32-wasi": "npm:1.3.1"
-    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.3.1"
-    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.3.1"
-    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.3.1"
+    "@unrs/resolver-binding-darwin-arm64": "npm:1.3.2"
+    "@unrs/resolver-binding-darwin-x64": "npm:1.3.2"
+    "@unrs/resolver-binding-freebsd-x64": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-arm64-gnu": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-arm64-musl": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-s390x-gnu": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-x64-gnu": "npm:1.3.2"
+    "@unrs/resolver-binding-linux-x64-musl": "npm:1.3.2"
+    "@unrs/resolver-binding-wasm32-wasi": "npm:1.3.2"
+    "@unrs/resolver-binding-win32-arm64-msvc": "npm:1.3.2"
+    "@unrs/resolver-binding-win32-ia32-msvc": "npm:1.3.2"
+    "@unrs/resolver-binding-win32-x64-msvc": "npm:1.3.2"
   dependenciesMeta:
     "@unrs/resolver-binding-darwin-arm64":
       optional: true
@@ -23637,7 +23637,7 @@ __metadata:
       optional: true
     "@unrs/resolver-binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/6b305a04007c1462f31601d667ef141c1fda9417819f8cf240ef9f8921b5e1fce7bb6857a265959dd1b4c38533705323162b7ab4b92736c8904e2044a198d587
+  checksum: 10c0/f9b6d18193bcaae7ef9e284a74c85d4cb3d8c833851f1b23254a947297e672826223d82798dbff818455fefeda02084340aca904300fd5060468c2f243767cc1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9789,12 +9789,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:22.13.13, @types/node@npm:>=13.7.0, @types/node@npm:^22.12.0":
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^22.12.0":
   version: 22.13.13
   resolution: "@types/node@npm:22.13.13"
   dependencies:
     undici-types: "npm:~6.20.0"
   checksum: 10c0/daf792ba5dcff1316abf4b33680f94b792f8d54d6ae495efc8929531e0ba1284a248d29aab117d2259f9280284d986ad5799b193b0516e2b926d713aab835f7d
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:22.13.14":
+  version: 22.13.14
+  resolution: "@types/node@npm:22.13.14"
+  dependencies:
+    undici-types: "npm:~6.20.0"
+  checksum: 10c0/fa2ab5b8277bfbcc86c42e46a3ea9871b0d559894cc9d955685d17178c9499f0b1bf03d1d1ea8d92ef2dda818988f4035acb8abf9dc15423a998fa56173ab804
   languageName: node
   linkType: hard
 
@@ -18705,7 +18714,7 @@ __metadata:
     "@svgr/webpack": "npm:^8.1.0"
     "@types/lodash": "npm:^4.17.16"
     "@types/memoizee": "npm:^0.4.12"
-    "@types/node": "npm:22.13.13"
+    "@types/node": "npm:22.13.14"
     "@types/react": "npm:*"
     "@types/react-dom": "npm:*"
     "@types/validator": "npm:^13.12.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,7 +8479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/blocks@npm:8.6.9, @storybook/blocks@npm:^8.6.9":
+"@storybook/blocks@npm:8.6.9":
   version: 8.6.9
   resolution: "@storybook/blocks@npm:8.6.9"
   dependencies:
@@ -8495,6 +8495,25 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10c0/87b7094aba92f766bf6c30a1cb908f37c3ae178cd7630a8cc607ee0c701816ad42e5d9141fdbb727b523f9a834e36929995c9d65e62e6f8661936e0df51be087
+  languageName: node
+  linkType: hard
+
+"@storybook/blocks@npm:^8.6.11":
+  version: 8.6.11
+  resolution: "@storybook/blocks@npm:8.6.11"
+  dependencies:
+    "@storybook/icons": "npm:^1.2.12"
+    ts-dedent: "npm:^2.0.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    storybook: ^8.6.11
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/3bed2a65fa9bf0550cd074e0fa1936daa0a4b9509296f945b5ba485713f00db6faead36e73d7e246a41c29c847ec292a89bbd58e7c34675e0f36412682a7979a
   languageName: node
   linkType: hard
 
@@ -13676,7 +13695,7 @@ __metadata:
     "@storybook/addon-essentials": "npm:^8.6.9"
     "@storybook/addon-interactions": "npm:^8.6.9"
     "@storybook/addon-themes": "npm:^8.6.9"
-    "@storybook/blocks": "npm:^8.6.9"
+    "@storybook/blocks": "npm:^8.6.11"
     "@storybook/nextjs": "npm:^8.6.9"
     "@storybook/react": "npm:^8.6.9"
     "@storybook/test": "npm:^8.6.9"


### PR DESCRIPTION
- group all minor updates in a single PR so it may be tested and merged at once.
- run updates once a month. Security-wise there needs to be a balance between updating too fast and too slow
- bundle dependabot updates
  -  #800
  -  #799
  -  #798
  -  #797
  -  #796
  -  #795