### PR TITLE
feat: allow ohlc endpoints to recieve only oracle price data

### DIFF
--- a/apps/main/src/dex/components/PagePool/PoolDetails/ChartOhlcWrapper/PoolActivity.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/ChartOhlcWrapper/PoolActivity.tsx
@@ -26,11 +26,11 @@ const PoolActivity = ({
   chartCombinations: PricesApiCoin[][]
 }) => {
   const activityHidden = useStore((state) => state.pools.pricesApiState.activityHidden)
-  const {
-    pricesApiState: { activityStatus, tradeEventsData, liquidityEventsData },
-    setActivityHidden,
-    fetchPricesApiActivity,
-  } = useStore((state) => state.pools)
+  const activityStatus = useStore((state) => state.pools.pricesApiState.activityStatus)
+  const tradeEventsData = useStore((state) => state.pools.pricesApiState.tradeEventsData)
+  const liquidityEventsData = useStore((state) => state.pools.pricesApiState.liquidityEventsData)
+  const setActivityHidden = useStore((state) => state.pools.setActivityHidden)
+  const fetchPricesApiActivity = useStore((state) => state.pools.fetchPricesApiActivity)
 
   const [eventOption, setEventOption] = useState<'TRADE' | 'LP'>('TRADE')
 

--- a/apps/main/src/dex/components/PagePool/PoolDetails/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/ChartOhlcWrapper/index.tsx
@@ -15,24 +15,19 @@ import { t } from '@ui-kit/lib/i18n'
 
 const PoolInfoData = ({ rChainId, pricesApiPoolData }: { rChainId: ChainId; pricesApiPoolData: PricesApiPool }) => {
   const theme = useUserProfileStore((state) => state.theme)
-
-  const {
-    pricesApiState: {
-      chartOhlcData,
-      chartStatus,
-      timeOption,
-      chartExpanded,
-      activityHidden,
-      tradesTokens,
-      refetchingCapped,
-      lastFetchEndTime,
-    },
-    setChartTimeOption,
-    setChartExpanded,
-    fetchPricesApiCharts,
-    fetchPricesApiActivity,
-    fetchMorePricesApiCharts,
-  } = useStore((state) => state.pools)
+  const chartOhlcData = useStore((state) => state.pools.pricesApiState.chartOhlcData)
+  const chartStatus = useStore((state) => state.pools.pricesApiState.chartStatus)
+  const timeOption = useStore((state) => state.pools.pricesApiState.timeOption)
+  const chartExpanded = useStore((state) => state.pools.pricesApiState.chartExpanded)
+  const activityHidden = useStore((state) => state.pools.pricesApiState.activityHidden)
+  const tradesTokens = useStore((state) => state.pools.pricesApiState.tradesTokens)
+  const refetchingCapped = useStore((state) => state.pools.pricesApiState.refetchingCapped)
+  const lastFetchEndTime = useStore((state) => state.pools.pricesApiState.lastFetchEndTime)
+  const setChartTimeOption = useStore((state) => state.pools.setChartTimeOption)
+  const setChartExpanded = useStore((state) => state.pools.setChartExpanded)
+  const fetchPricesApiCharts = useStore((state) => state.pools.fetchPricesApiCharts)
+  const fetchPricesApiActivity = useStore((state) => state.pools.fetchPricesApiActivity)
+  const fetchMorePricesApiCharts = useStore((state) => state.pools.fetchMorePricesApiCharts)
   const isMdUp = useStore((state) => state.isMdUp)
 
   const [poolInfo, setPoolInfo] = useState<'chart' | 'poolActivity'>('chart')

--- a/apps/main/src/lend/components/ChartOhlcWrapper/PoolActivity.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/PoolActivity.tsx
@@ -10,15 +10,13 @@ import { t } from '@ui-kit/lib/i18n'
 import { PoolActivityProps } from './types'
 
 const PoolActivity = ({ chainId, poolAddress, coins }: PoolActivityProps) => {
-  const {
-    activityFetchStatus,
-    lendTradesData,
-    lendControllerData,
-    setActivityHidden,
-    fetchPoolActivity,
-    chartExpanded,
-    activityHidden,
-  } = useStore((state) => state.ohlcCharts)
+  const activityFetchStatus = useStore((state) => state.ohlcCharts.activityFetchStatus)
+  const lendTradesData = useStore((state) => state.ohlcCharts.lendTradesData)
+  const lendControllerData = useStore((state) => state.ohlcCharts.lendControllerData)
+  const setActivityHidden = useStore((state) => state.ohlcCharts.setActivityHidden)
+  const fetchPoolActivity = useStore((state) => state.ohlcCharts.fetchPoolActivity)
+  const chartExpanded = useStore((state) => state.ohlcCharts.chartExpanded)
+  const activityHidden = useStore((state) => state.ohlcCharts.activityHidden)
 
   const [eventOption, setEventOption] = useState<'TRADE' | 'LP'>('TRADE')
 

--- a/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
@@ -24,7 +24,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
   const activeKey = useStore((state) => state.loanCreate.activeKey)
   const formValues = useStore((state) => state.loanCreate.formValues)
   const activeKeyLiqRange = useStore((state) => state.loanCreate.activeKeyLiqRange)
-  const loanCreateDetailInfo = useStore((state) => state.loanCreate.detailInfoLeverage[activeKey])
+  const loanCreateLeverageDetailInfo = useStore((state) => state.loanCreate.detailInfoLeverage[activeKey])
   const userPrices = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details?.prices ?? null)
   const liqRangesMapper = useStore((state) => state.loanCreate.liqRangesMapper[activeKeyLiqRange])
   const borrowMorePrices = useStore((state) => state.loanBorrowMore.detailInfo[borrowMoreActiveKey]?.prices ?? null)
@@ -92,7 +92,10 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
         price2: [],
       }
 
-      for (const data of currentChart.data) {
+      // if a pool only has oracle price data, use that
+      const chartArray = currentChart.data.length !== 0 ? currentChart.data : currentChart.oraclePriceData
+
+      for (const data of chartArray) {
         range.price1 = [
           ...range.price1,
           {
@@ -110,7 +113,6 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
       }
       return range
     }
-
     // create loan prices
     if (formValues.n && liqRangesMapper && currentChart.data) {
       if (liqRangesMapper[formValues.n].prices.length !== 0) {
@@ -118,7 +120,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
         // flip order to match other data
         liqRanges.new = formatRange([currentPrices[1], currentPrices[0]])
       } else {
-        const currentPrices = loanCreateDetailInfo?.prices
+        const currentPrices = loanCreateLeverageDetailInfo?.prices
 
         if (currentPrices) {
           liqRanges.new = formatRange([currentPrices[0], currentPrices[1]])
@@ -156,13 +158,14 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
     formValues.n,
     liqRangesMapper,
     currentChart.data,
+    currentChart.oraclePriceData,
     userPrices,
     borrowMorePrices,
     repayLoanPrices,
     addCollateralPrices,
     removeCollateralPrices,
     repayLeveragePrices,
-    loanCreateDetailInfo,
+    loanCreateLeverageDetailInfo?.prices,
   ])
 
   const coins: LendingMarketTokens = useMemo(

--- a/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
@@ -21,7 +21,9 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
   const loanRepayActiveKey = useStore((state) => state.loanRepay.activeKey)
   const loanCollateralAddActiveKey = useStore((state) => state.loanCollateralAdd.activeKey)
   const loanCollateralRemoveActiveKey = useStore((state) => state.loanCollateralRemove.activeKey)
-  const { activeKey, formValues, activeKeyLiqRange } = useStore((state) => state.loanCreate)
+  const activeKey = useStore((state) => state.loanCreate.activeKey)
+  const formValues = useStore((state) => state.loanCreate.formValues)
+  const activeKeyLiqRange = useStore((state) => state.loanCreate.activeKeyLiqRange)
   const loanCreateDetailInfo = useStore((state) => state.loanCreate.detailInfoLeverage[activeKey])
   const userPrices = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details?.prices ?? null)
   const liqRangesMapper = useStore((state) => state.loanCreate.liqRangesMapper[activeKeyLiqRange])
@@ -35,30 +37,27 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
   const removeCollateralPrices = useStore(
     (state) => state.loanCollateralRemove.detailInfo[loanCollateralRemoveActiveKey]?.prices ?? null,
   )
-
   const theme = useUserProfileStore((state) => state.theme)
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-
   const isMdUp = useStore((state) => state.layout.isMdUp)
-  const {
-    chartLlammaOhlc,
-    chartOraclePoolOhlc,
-    timeOption,
-    setChartTimeOption,
-    fetchLlammaOhlcData,
-    fetchOraclePoolOhlcData,
-    fetchMoreData,
-    activityHidden,
-    chartExpanded,
-    setChartExpanded,
-    toggleLiqRangeCurrentVisible,
-    toggleLiqRangeNewVisible,
-    toggleOraclePriceVisible,
-    liqRangeCurrentVisible,
-    liqRangeNewVisible,
-    oraclePriceVisible,
-  } = useStore((state) => state.ohlcCharts)
+  const chartLlammaOhlc = useStore((state) => state.ohlcCharts.chartLlammaOhlc)
+  const chartOraclePoolOhlc = useStore((state) => state.ohlcCharts.chartOraclePoolOhlc)
+  const timeOption = useStore((state) => state.ohlcCharts.timeOption)
+  const setChartTimeOption = useStore((state) => state.ohlcCharts.setChartTimeOption)
+  const fetchLlammaOhlcData = useStore((state) => state.ohlcCharts.fetchLlammaOhlcData)
+  const fetchOraclePoolOhlcData = useStore((state) => state.ohlcCharts.fetchOraclePoolOhlcData)
+  const fetchMoreData = useStore((state) => state.ohlcCharts.fetchMoreData)
+  const activityHidden = useStore((state) => state.ohlcCharts.activityHidden)
+  const chartExpanded = useStore((state) => state.ohlcCharts.chartExpanded)
+  const setChartExpanded = useStore((state) => state.ohlcCharts.setChartExpanded)
+  const toggleLiqRangeCurrentVisible = useStore((state) => state.ohlcCharts.toggleLiqRangeCurrentVisible)
+  const toggleLiqRangeNewVisible = useStore((state) => state.ohlcCharts.toggleLiqRangeNewVisible)
+  const toggleOraclePriceVisible = useStore((state) => state.ohlcCharts.toggleOraclePriceVisible)
+  const liqRangeCurrentVisible = useStore((state) => state.ohlcCharts.liqRangeCurrentVisible)
+  const liqRangeNewVisible = useStore((state) => state.ohlcCharts.liqRangeNewVisible)
+  const oraclePriceVisible = useStore((state) => state.ohlcCharts.oraclePriceVisible)
   const priceInfo = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId]?.prices ?? null)
+
   const { oraclePrice } = priceInfo ?? {}
   const [poolInfo, setPoolInfo] = useState<'chart' | 'poolActivity'>('chart')
   const [selectedChartIndex, setChartSelectedIndex] = useState(0)

--- a/apps/main/src/lend/store/createOhlcChartSlice.ts
+++ b/apps/main/src/lend/store/createOhlcChartSlice.ts
@@ -300,7 +300,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             }
           }),
         )
-        console.error(error)
       }
     },
     fetchMoreLlammaOhlcData: async (
@@ -379,7 +378,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc.fetchStatus = 'ERROR'
           }),
         )
-        console.error(error)
         return {
           ohlcData: [],
           volumeData: [],
@@ -495,7 +493,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             }
           }),
         )
-        console.error(error)
       }
     },
     fetchMoreOraclePoolOhlcData: async (
@@ -570,7 +567,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartOraclePoolOhlc.fetchStatus = 'ERROR'
           }),
         )
-        console.error(error)
         return {
           ohlcData: [],
           oracleData: [],
@@ -727,7 +723,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].activityFetchStatus = 'ERROR'
           }),
         )
-        console.error(error)
       }
     },
     setActivityHidden: (bool?: boolean) => {

--- a/apps/main/src/lend/store/createOhlcChartSlice.ts
+++ b/apps/main/src/lend/store/createOhlcChartSlice.ts
@@ -233,29 +233,37 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         for (const item of ohlc) {
           const time = item.time.getLocalTimestamp()
 
-          volumeArray.push({
-            time,
-            value: item.volume,
-            color: item.open < item.close ? '#26a69982' : '#ef53507e',
-          })
+          if (item.volume && item.open && item.close) {
+            volumeArray.push({
+              time,
+              value: item.volume,
+              color: item.open < item.close ? '#26a69982' : '#ef53507e',
+            })
+          }
 
-          baselinePriceArray.push({
-            time,
-            base_price: item.basePrice,
-          })
+          if (item.basePrice) {
+            baselinePriceArray.push({
+              time,
+              base_price: item.basePrice,
+            })
+          }
 
-          oraclePriceArray.push({
-            time,
-            value: item.oraclePrice,
-          })
+          if (item.oraclePrice) {
+            oraclePriceArray.push({
+              time,
+              value: item.oraclePrice,
+            })
+          }
 
-          ohlcDataArray.push({
-            time,
-            open: item.open,
-            close: item.close,
-            high: item.high,
-            low: item.low,
-          })
+          if (item.open && item.close && item.high && item.low) {
+            ohlcDataArray.push({
+              time,
+              open: item.open,
+              close: item.close,
+              high: item.high,
+              low: item.low,
+            })
+          }
         }
 
         const arrLength = oraclePriceArray.length - 1
@@ -292,7 +300,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             }
           }),
         )
-        console.log(error)
+        console.error(error)
       }
     },
     fetchMoreLlammaOhlcData: async (
@@ -324,29 +332,37 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         for (const item of ohlc) {
           const time = item.time.getLocalTimestamp()
 
-          volumeArray.push({
-            time,
-            value: item.volume,
-            color: item.open < item.close ? '#26a69982' : '#ef53507e',
-          })
+          if (item.volume && item.open && item.close) {
+            volumeArray.push({
+              time,
+              value: item.volume,
+              color: item.open < item.close ? '#26a69982' : '#ef53507e',
+            })
+          }
 
-          baselinePriceArray.push({
-            time,
-            base_price: item.basePrice,
-          })
+          if (item.basePrice) {
+            baselinePriceArray.push({
+              time,
+              base_price: item.basePrice,
+            })
+          }
 
-          oraclePriceArray.push({
-            time,
-            value: item.oraclePrice,
-          })
+          if (item.oraclePrice) {
+            oraclePriceArray.push({
+              time,
+              value: item.oraclePrice,
+            })
+          }
 
-          ohlcDataArray.push({
-            time,
-            open: item.open,
-            close: item.close,
-            high: item.high,
-            low: item.low,
-          })
+          if (item.open && item.close && item.high && item.low) {
+            ohlcDataArray.push({
+              time,
+              open: item.open,
+              close: item.close,
+              high: item.high,
+              low: item.low,
+            })
+          }
         }
 
         return {
@@ -363,7 +379,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartLlammaOhlc.fetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
+        console.error(error)
         return {
           ohlcData: [],
           volumeData: [],
@@ -479,7 +495,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             }
           }),
         )
-        console.log(error)
+        console.error(error)
       }
     },
     fetchMoreOraclePoolOhlcData: async (
@@ -554,7 +570,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartOraclePoolOhlc.fetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
+        console.error(error)
         return {
           ohlcData: [],
           oracleData: [],
@@ -711,7 +727,7 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].activityFetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
+        console.error(error)
       }
     },
     setActivityHidden: (bool?: boolean) => {

--- a/apps/main/src/loan/components/ChartOhlcWrapper/PoolActivity.tsx
+++ b/apps/main/src/loan/components/ChartOhlcWrapper/PoolActivity.tsx
@@ -17,15 +17,13 @@ interface Props {
 }
 
 const PoolActivity = ({ chainId, poolAddress, coins }: Props) => {
-  const {
-    activityFetchStatus,
-    llammaTradesData,
-    llammaControllerData,
-    setActivityHidden,
-    fetchPoolActivity,
-    chartExpanded,
-    activityHidden,
-  } = useStore((state) => state.ohlcCharts)
+  const activityFetchStatus = useStore((state) => state.ohlcCharts.activityFetchStatus)
+  const llammaTradesData = useStore((state) => state.ohlcCharts.llammaTradesData)
+  const llammaControllerData = useStore((state) => state.ohlcCharts.llammaControllerData)
+  const setActivityHidden = useStore((state) => state.ohlcCharts.setActivityHidden)
+  const fetchPoolActivity = useStore((state) => state.ohlcCharts.fetchPoolActivity)
+  const chartExpanded = useStore((state) => state.ohlcCharts.chartExpanded)
+  const activityHidden = useStore((state) => state.ohlcCharts.activityHidden)
 
   const [eventOption, setEventOption] = useState<'TRADE' | 'LP'>('TRADE')
 

--- a/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
@@ -19,7 +19,8 @@ const ChartOhlcWrapper = ({ rChainId, llamma, llammaId }: ChartOhlcWrapperProps)
   const deleverageActiveKey = useStore((state) => state.loanDeleverage.activeKey)
   const collateralIncreaseActiveKey = useStore((state) => state.loanCollateralIncrease.activeKey)
   const collateralDecreaseActiveKey = useStore((state) => state.loanCollateralDecrease.activeKey)
-  const { formValues, activeKeyLiqRange } = useStore((state) => state.loanCreate)
+  const formValues = useStore((state) => state.loanCreate.formValues)
+  const activeKeyLiqRange = useStore((state) => state.loanCreate.activeKeyLiqRange)
   const userPrices = useStore((state) => state.loans.userDetailsMapper[llammaId]?.userPrices ?? null)
   const liqRangesMapper = useStore((state) => state.loanCreate.liqRangesMapper[activeKeyLiqRange])
   const increaseLoanPrices = useStore((state) => state.loanIncrease.detailInfo[increaseActiveKey]?.prices ?? null)
@@ -31,33 +32,30 @@ const ChartOhlcWrapper = ({ rChainId, llamma, llammaId }: ChartOhlcWrapperProps)
   const decreaseCollateralPrices = useStore(
     (state) => state.loanCollateralDecrease.detailInfo[collateralDecreaseActiveKey]?.prices ?? null,
   )
-
   const theme = useUserProfileStore((state) => state.theme)
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
-
   const isMdUp = useStore((state) => state.layout.isMdUp)
-  const {
-    chartFetchStatus,
-    timeOption,
-    refetchingCapped,
-    lastFetchEndTime,
-    chartOhlcData,
-    volumeData,
-    oraclePriceData,
-    setChartTimeOption,
-    fetchOhlcData,
-    fetchMoreOhlcData,
-    activityHidden,
-    chartExpanded,
-    setChartExpanded,
-    toggleLiqRangeCurrentVisible,
-    toggleLiqRangeNewVisible,
-    toggleOraclePriceVisible,
-    liqRangeCurrentVisible,
-    liqRangeNewVisible,
-    oraclePriceVisible,
-  } = useStore((state) => state.ohlcCharts)
+  const chartFetchStatus = useStore((state) => state.ohlcCharts.chartFetchStatus)
+  const timeOption = useStore((state) => state.ohlcCharts.timeOption)
+  const refetchingCapped = useStore((state) => state.ohlcCharts.refetchingCapped)
+  const lastFetchEndTime = useStore((state) => state.ohlcCharts.lastFetchEndTime)
+  const chartOhlcData = useStore((state) => state.ohlcCharts.chartOhlcData)
+  const volumeData = useStore((state) => state.ohlcCharts.volumeData)
+  const oraclePriceData = useStore((state) => state.ohlcCharts.oraclePriceData)
+  const setChartTimeOption = useStore((state) => state.ohlcCharts.setChartTimeOption)
+  const fetchOhlcData = useStore((state) => state.ohlcCharts.fetchOhlcData)
+  const fetchMoreOhlcData = useStore((state) => state.ohlcCharts.fetchMoreOhlcData)
+  const activityHidden = useStore((state) => state.ohlcCharts.activityHidden)
+  const chartExpanded = useStore((state) => state.ohlcCharts.chartExpanded)
+  const setChartExpanded = useStore((state) => state.ohlcCharts.setChartExpanded)
+  const toggleLiqRangeCurrentVisible = useStore((state) => state.ohlcCharts.toggleLiqRangeCurrentVisible)
+  const toggleLiqRangeNewVisible = useStore((state) => state.ohlcCharts.toggleLiqRangeNewVisible)
+  const toggleOraclePriceVisible = useStore((state) => state.ohlcCharts.toggleOraclePriceVisible)
+  const liqRangeCurrentVisible = useStore((state) => state.ohlcCharts.liqRangeCurrentVisible)
+  const liqRangeNewVisible = useStore((state) => state.ohlcCharts.liqRangeNewVisible)
+  const oraclePriceVisible = useStore((state) => state.ohlcCharts.oraclePriceVisible)
   const priceInfo = useStore((state) => state.loans.detailsMapper[llammaId]?.priceInfo ?? null)
+
   const { oraclePrice } = priceInfo ?? {}
   const [poolInfo, setPoolInfo] = useState<'chart' | 'poolActivity'>('chart')
 

--- a/apps/main/src/loan/store/createOhlcChartSlice.ts
+++ b/apps/main/src/loan/store/createOhlcChartSlice.ts
@@ -186,7 +186,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartFetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
       }
     },
     fetchMoreOhlcData: async (
@@ -264,7 +263,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].chartFetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
       }
     },
     fetchPoolActivity: async (chainId: ChainId, poolAddress: string) => {
@@ -317,7 +315,6 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
             state[sliceKey].activityFetchStatus = 'ERROR'
           }),
         )
-        console.log(error)
       }
     },
     setActivityHidden: (bool?: boolean) => {

--- a/apps/main/src/loan/store/createOhlcChartSlice.ts
+++ b/apps/main/src/loan/store/createOhlcChartSlice.ts
@@ -132,41 +132,34 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         for (const item of ohlc) {
           const time = item.time.getLocalTimestamp()
 
-          volumeArray = [
-            ...volumeArray,
-            {
+          if (item.volume && item.open && item.close) {
+            volumeArray.push({
               time,
               value: item.volume,
               color: item.open < item.close ? '#26a69982' : '#ef53507e',
-            },
-          ]
-
-          baselinePriceArray = [
-            ...baselinePriceArray,
-            {
+            })
+          }
+          if (item.basePrice) {
+            baselinePriceArray.push({
               time,
               base_price: item.basePrice,
-            },
-          ]
-
-          oraclePriceArray = [
-            ...oraclePriceArray,
-            {
+            })
+          }
+          if (item.oraclePrice) {
+            oraclePriceArray.push({
               time,
               value: item.oraclePrice,
-            },
-          ]
-
-          ohlcDataArray = [
-            ...ohlcDataArray,
-            {
+            })
+          }
+          if (item.open && item.close && item.high && item.low) {
+            ohlcDataArray.push({
               time,
               open: item.open,
               close: item.close,
               high: item.high,
               low: item.low,
-            },
-          ]
+            })
+          }
         }
         const arrLength = oraclePriceArray.length - 1
         const loanPriceInfo = get().loans.detailsMapper[llammaId]?.priceInfo
@@ -225,41 +218,34 @@ const createOhlcChart = (set: SetState<State>, get: GetState<State>) => ({
         for (const item of ohlc) {
           const time = item.time.getLocalTimestamp()
 
-          volumeArray = [
-            ...volumeArray,
-            {
+          if (item.volume && item.open && item.close) {
+            volumeArray.push({
               time,
               value: item.volume,
               color: item.open < item.close ? '#26a69982' : '#ef53507e',
-            },
-          ]
-
-          baselinePriceArray = [
-            ...baselinePriceArray,
-            {
+            })
+          }
+          if (item.basePrice) {
+            baselinePriceArray.push({
               time,
               base_price: item.basePrice,
-            },
-          ]
-
-          oraclePriceArray = [
-            ...oraclePriceArray,
-            {
+            })
+          }
+          if (item.oraclePrice) {
+            oraclePriceArray.push({
               time,
               value: item.oraclePrice,
-            },
-          ]
-
-          ohlcDataArray = [
-            ...ohlcDataArray,
-            {
+            })
+          }
+          if (item.open && item.close && item.high && item.low) {
+            ohlcDataArray.push({
               time,
               open: item.open,
               close: item.close,
               high: item.high,
               low: item.low,
-            },
-          ]
+            })
+          }
         }
 
         set(

--- a/packages/prices-api/package.json
+++ b/packages/prices-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/prices-api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/prices-api/src/llamma/models.ts
+++ b/packages/prices-api/src/llamma/models.ts
@@ -44,11 +44,11 @@ export type LlammaTrade = {
 
 export type LlammaOHLC = {
   time: Date
-  open: number
-  close: number
-  high: number
-  low: number
-  basePrice: number
-  oraclePrice: number
-  volume: number
+  open: number | null
+  close: number | null
+  high: number | null
+  low: number | null
+  basePrice: number | null
+  oraclePrice: number | null
+  volume: number | null
 }

--- a/packages/prices-api/src/llamma/parsers.ts
+++ b/packages/prices-api/src/llamma/parsers.ts
@@ -46,11 +46,11 @@ export const parseTrades = (x: Responses.GetLlammaTradesResponse['data'][number]
 
 export const parseOHLC = (x: Responses.GetLlammaOHLCResponse['data'][number]): Models.LlammaOHLC => ({
   time: toDate(x.time),
-  open: x.open,
-  close: x.close,
-  high: x.high,
-  low: x.low,
-  basePrice: x.base_price,
-  oraclePrice: x.oracle_price,
-  volume: x.volume,
+  open: x.open ?? null,
+  close: x.close ?? null,
+  high: x.high ?? null,
+  low: x.low ?? null,
+  basePrice: x.base_price ?? null,
+  oraclePrice: x.oracle_price ?? null,
+  volume: x.volume ?? null,
 })

--- a/packages/prices-api/src/llamma/responses.ts
+++ b/packages/prices-api/src/llamma/responses.ts
@@ -47,12 +47,12 @@ export type GetLlammaTradesResponse = {
 export type GetLlammaOHLCResponse = {
   data: {
     time: number
-    open: number
-    close: number
-    high: number
-    low: number
-    base_price: number
-    oracle_price: number
-    volume: number
+    open: number | null
+    close: number | null
+    high: number | null
+    low: number | null
+    base_price: number | null
+    oracle_price: number | null
+    volume: number | null
   }[]
 }


### PR DESCRIPTION
This was originally pushed in #775 but was reverted due to an error when a user tried repaying an sDOLA position.

I've tested locally to borrow, borrow with leverage, repay, borrow more, self liquidate using mock data in the sDOLA market without experiencing any issues so it seems to work ok.

Additional changes to #775:
- Map liquidation range charts lengths with oraclePriceData if ohlc data points are unavailable.