### PR TITLE
chore: fix floating promises linting errors

### DIFF
--- a/apps/main/src/app/crvusd/client.tsx
+++ b/apps/main/src/app/crvusd/client.tsx
@@ -69,8 +69,8 @@ export const App = ({ children }: { children: ReactNode }) => {
   usePageVisibleInterval(
     () => {
       if (isPageVisible && curve) {
-        fetchAllStoredUsdRates(curve)
-        fetchGasInfo(curve)
+        void fetchAllStoredUsdRates(curve)
+        void fetchGasInfo(curve)
       }
     },
     REFRESH_INTERVAL['5m'],

--- a/apps/main/src/app/dao/client.tsx
+++ b/apps/main/src/app/dao/client.tsx
@@ -82,24 +82,24 @@ export const App = ({ children }: { children: ReactNode }) => {
   // initiate proposals list
   useEffect(() => {
     getProposals()
-    getGauges()
-    getGaugesData()
+    void getGauges()
+    void getGaugesData()
   }, [getGauges, getProposals, getGaugesData])
 
   useEffect(() => {
     if (curve) {
-      fetchAllStoredUsdRates(curve)
+      void fetchAllStoredUsdRates(curve)
     }
   }, [curve, fetchAllStoredUsdRates])
 
   usePageVisibleInterval(
     () => {
       if (curve) {
-        fetchAllStoredUsdRates(curve)
+        void fetchAllStoredUsdRates(curve)
       }
       getProposals()
-      getGauges()
-      getGaugesData()
+      void getGauges()
+      void getGaugesData()
     },
     REFRESH_INTERVAL['5m'],
     isPageVisible,

--- a/apps/main/src/app/dex/client.tsx
+++ b/apps/main/src/app/dex/client.tsx
@@ -48,7 +48,7 @@ export const App = ({ children }: { children: ReactNode }) => {
       const { chainId } = curve
       const poolDatas = Object.values(poolDataMapper)
       await Promise.all([fetchPoolsVolume(chainId, poolDatas), fetchPoolsTvl(curve, poolDatas)])
-      setTokensMapper(chainId, poolDatas)
+      void setTokensMapper(chainId, poolDatas)
     },
     [fetchPoolsTvl, fetchPoolsVolume, poolDataMapper, setTokensMapper],
   )
@@ -62,7 +62,7 @@ export const App = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     // reset the whole app state, as internal links leave the store with old state but curveJS is not loaded
     useStore.setState(useStore.getInitialState())
-    ;(async () => {
+    void (async () => {
       const networks = await fetchNetworks()
 
       useWallet.initialize(theme, networks)
@@ -86,7 +86,7 @@ export const App = ({ children }: { children: ReactNode }) => {
   const refetchPools = useCallback(
     async (curve: CurveApi) => {
       const poolIds = await curvejsApi.network.fetchAllPoolsList(curve, network)
-      fetchPools(curve, poolIds, null)
+      void fetchPools(curve, poolIds, null)
     },
     [fetchPools, network],
   )
@@ -94,12 +94,12 @@ export const App = ({ children }: { children: ReactNode }) => {
   usePageVisibleInterval(
     () => {
       if (curve) {
-        fetchGasInfo(curve)
-        fetchAllStoredUsdRates(curve)
-        fetchPoolsVolumeTvl(curve)
+        void fetchGasInfo(curve)
+        void fetchAllStoredUsdRates(curve)
+        void fetchPoolsVolumeTvl(curve)
 
         if (curve.signerAddress) {
-          fetchAllStoredBalances(curve)
+          void fetchAllStoredBalances(curve)
         }
       }
     },
@@ -110,7 +110,7 @@ export const App = ({ children }: { children: ReactNode }) => {
   usePageVisibleInterval(
     () => {
       if (curve) {
-        refetchPools(curve)
+        void refetchPools(curve)
       }
     },
     REFRESH_INTERVAL['11m'],

--- a/apps/main/src/dao/components/Charts/GaugeWeightHistoryChart/index.tsx
+++ b/apps/main/src/dao/components/Charts/GaugeWeightHistoryChart/index.tsx
@@ -21,7 +21,7 @@ const GaugeWeightHistoryChart = ({ gaugeAddress, minHeight }: GaugeWeightHistory
 
   useEffect(() => {
     if (!gaugeWeightHistoryMapper[gaugeAddress]) {
-      getHistoricGaugeWeights(gaugeAddress)
+      void getHistoricGaugeWeights(gaugeAddress)
     }
   }, [gaugeAddress, gaugeWeightHistoryMapper, getHistoricGaugeWeights])
 
@@ -33,7 +33,7 @@ const GaugeWeightHistoryChart = ({ gaugeAddress, minHeight }: GaugeWeightHistory
             message={t`Error fetching historical gauge weights data`}
             onClick={(e?: MouseEvent) => {
               e?.stopPropagation()
-              getHistoricGaugeWeights(gaugeAddress)
+              void getHistoricGaugeWeights(gaugeAddress)
             }}
           />
         </ErrorWrapper>

--- a/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
@@ -25,7 +25,7 @@ const CrvStats = () => {
 
   useEffect(() => {
     if (provider && veCrvData.totalCrv === 0n && veCrvData.fetchStatus !== 'ERROR') {
-      getVeCrvData(provider)
+      void getVeCrvData(provider)
     }
   }, [veCrvData.totalCrv, veCrvData.fetchStatus, getVeCrvData, provider])
 

--- a/apps/main/src/dao/components/PageAnalytics/DailyLocksChart/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/DailyLocksChart/index.tsx
@@ -17,7 +17,7 @@ const DailyLocks = () => {
 
   useEffect(() => {
     if (veCrvLocks.locks.length === 0 && veCrvLocks.fetchStatus !== 'ERROR') {
-      getVeCrvLocks()
+      void getVeCrvLocks()
     }
   }, [getVeCrvLocks, veCrvLocks.locks.length, veCrvLocks.fetchStatus])
 

--- a/apps/main/src/dao/components/PageAnalytics/VeCrvFeesTable/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/VeCrvFeesTable/index.tsx
@@ -18,7 +18,7 @@ const VeCrcFees = () => {
 
   useEffect(() => {
     if (veCrvFees.fees.length === 0 && !feesError) {
-      getVeCrvFees()
+      void getVeCrvFees()
     }
   }, [getVeCrvFees, veCrvFees, feesError])
 

--- a/apps/main/src/dao/components/PageAnalytics/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/index.tsx
@@ -26,7 +26,7 @@ const Analytics = () => {
 
   useEffect(() => {
     if (veCrvHolders.topHolders.length === 0 && veCrvHolders.fetchStatus !== 'ERROR') {
-      getVeCrvHolders()
+      void getVeCrvHolders()
     }
   }, [getVeCrvHolders, veCrvHolders.topHolders.length, veCrvHolders.fetchStatus])
 

--- a/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeVotesTable/index.tsx
@@ -39,7 +39,7 @@ const GaugeVotesTable = ({ gaugeAddress, tableMinWidth }: GaugeVotesTableProps) 
   // Get user proposal votes
   useEffect(() => {
     if (!gaugeVotesMapper[gaugeAddress] && gaugeVotesLoading && !gaugeVotesError) {
-      getGaugeVotes(gaugeAddress)
+      void getGaugeVotes(gaugeAddress)
     }
   }, [getGaugeVotes, gaugeAddress, gaugeVotesLoading, gaugeVotesError, gaugeVotesMapper])
 

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/SmallScreenCard.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/SmallScreenCard.tsx
@@ -44,7 +44,7 @@ const SmallScreenCard = ({
 
   useEffect(() => {
     if (open && !gaugeWeightHistoryMapper[gaugeData.address]) {
-      getHistoricGaugeWeights(gaugeData.address)
+      void getHistoricGaugeWeights(gaugeData.address)
     }
   }, [gaugeData.address, gaugeWeightHistoryMapper, getHistoricGaugeWeights, open])
 
@@ -111,7 +111,7 @@ const SmallScreenCard = ({
                   message={t`Error fetching historical gauge weights data`}
                   onClick={(e?: MouseEvent) => {
                     e?.stopPropagation()
-                    getHistoricGaugeWeights(gaugeData.address)
+                    void getHistoricGaugeWeights(gaugeData.address)
                   }}
                 />
               </ErrorWrapper>

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/index.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/index.tsx
@@ -58,7 +58,7 @@ const GaugeListItem = ({
 
   useEffect(() => {
     if (open && !gaugeWeightHistoryMapper[gaugeData.address]) {
-      getHistoricGaugeWeights(gaugeData.address)
+      void getHistoricGaugeWeights(gaugeData.address)
     }
   }, [gaugeData.address, gaugeWeightHistoryMapper, getHistoricGaugeWeights, open])
 
@@ -102,7 +102,7 @@ const GaugeListItem = ({
                   message={t`Error fetching historical gauge weights data`}
                   onClick={(e?: MouseEvent) => {
                     e?.stopPropagation()
-                    getHistoricGaugeWeights(gaugeData.address)
+                    void getHistoricGaugeWeights(gaugeData.address)
                   }}
                 />
               </ErrorWrapper>

--- a/apps/main/src/dao/components/PageGauges/GaugeVoting/CurrentVotes.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeVoting/CurrentVotes.tsx
@@ -70,7 +70,7 @@ const CurrentVotes = ({ userAddress }: CurrentVotesProps) => {
   // Get next vote time for all gauges
   useEffect(() => {
     if (userWeightReady) {
-      getAllVoteForGaugeNextTime(userAddress ?? '')
+      void getAllVoteForGaugeNextTime(userAddress ?? '')
     }
   }, [userAddress, userWeightReady, getAllVoteForGaugeNextTime])
 

--- a/apps/main/src/dao/components/PageGauges/GaugeVoting/VoteGaugeField/index.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeVoting/VoteGaugeField/index.tsx
@@ -45,7 +45,7 @@ const VoteGaugeField = ({ powerUsed, userGaugeVoteData, userVeCrv, newVote = fal
 
   const handleCastVote = () => {
     if (!address) return
-    castVote(address, gaugeAddress, power)
+    void castVote(address, gaugeAddress, power)
   }
 
   return (

--- a/apps/main/src/dao/components/PageGauges/GaugeVoting/index.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeVoting/index.tsx
@@ -16,7 +16,7 @@ const GaugeVoting = ({ userAddress }: { userAddress: string | undefined }) => {
 
   useEffect(() => {
     if (userAddress && curve && userGaugeVoteWeightsMapper[userAddress.toLowerCase()] === undefined) {
-      getUserGaugeVoteWeights(userAddress)
+      void getUserGaugeVoteWeights(userAddress)
     }
   }, [getUserGaugeVoteWeights, userAddress, curve, userGaugeVoteWeightsMapper])
 

--- a/apps/main/src/dao/components/PageProposal/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/index.tsx
@@ -73,7 +73,7 @@ const Proposal = ({ routerParams: { proposalId: rProposalId } }: ProposalProps) 
         setSnapshotVeCrv(signer, userAddress, proposal.snapshotBlock, rProposalId)
       }
 
-      getVeCrv()
+      void getVeCrv()
     }
   }, [provider, rProposalId, setSnapshotVeCrv, proposal?.snapshotBlock, snapshotVeCrv, userAddress])
 

--- a/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
@@ -35,7 +35,7 @@ const UserGaugeVotesTable = ({ userAddress, tableMinWidth }: UserGaugeVotesTable
   // Get user locks
   useEffect(() => {
     if (!userGaugeVotesMapper[userAddress] && userGaugeVotesLoading && !userGaugeVotesError) {
-      getUserGaugeVotes(userAddress)
+      void getUserGaugeVotes(userAddress)
     }
   }, [getUserGaugeVotes, userAddress, userGaugeVotesMapper, userGaugeVotesLoading, userGaugeVotesError])
 

--- a/apps/main/src/dao/components/PageUser/UserLocksTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserLocksTable/index.tsx
@@ -41,7 +41,7 @@ const UserLocksTable = ({ userAddress }: UserLocksTableProps) => {
   // Get user locks
   useEffect(() => {
     if (!userLocksMapper[userAddress] && userLocksLoading && !userLocksError) {
-      getUserLocks(userAddress)
+      void getUserLocks(userAddress)
     }
   }, [getUserLocks, userAddress, userLocksMapper, userLocksLoading, userLocksError])
 

--- a/apps/main/src/dao/components/PageUser/UserProposalVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserProposalVotesTable/index.tsx
@@ -37,7 +37,7 @@ const UserProposalVotesTable = ({ userAddress, tableMinWidth }: UserProposalVote
   // Get user proposal votes
   useEffect(() => {
     if (!userProposalVotesMapper[userAddress] && userProposalVotesLoading && !userProposalVotesError) {
-      getUserProposalVotes(userAddress)
+      void getUserProposalVotes(userAddress)
     }
   }, [getUserProposalVotes, userAddress, userProposalVotesLoading, userProposalVotesError, userProposalVotesMapper])
 

--- a/apps/main/src/dao/components/PageUser/index.tsx
+++ b/apps/main/src/dao/components/PageUser/index.tsx
@@ -49,14 +49,14 @@ const UserPage = ({ routerParams: { userAddress: rUserAddress } }: UserPageProps
 
   useEffect(() => {
     if (Object.keys(allHolders).length === 0 && holdersLoading && !holdersError) {
-      getVeCrvHolders()
+      void getVeCrvHolders()
     }
   }, [getVeCrvHolders, allHolders, holdersLoading, holdersError])
 
   // Get user ENS
   useEffect(() => {
     if (!userMapper[userAddress] && provider) {
-      getUserEns(userAddress)
+      void getUserEns(userAddress)
     }
   }, [getUserEns, userAddress, userMapper, provider])
 

--- a/apps/main/src/dao/components/PageVeCrv/Page.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/Page.tsx
@@ -58,7 +58,7 @@ const Page = (params: VeCrvUrlParams) => {
 
   // get initial data
   useEffect(() => {
-    fetchData(curve, isLoadingCurve)
+    void fetchData(curve, isLoadingCurve)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [curve?.chainId, curve?.signerAddress, isLoadingCurve])
 

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
@@ -82,7 +82,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       const fn = networks[rChainId].api.lockCrv.calcUnlockTime
       const calcdUtcDate = fn(curve, rFormType, currUnlockTime, days)
 
-      updateFormValues(
+      void updateFormValues(
         {
           utcDate: toCalendarDate(utcDate),
           utcDateError,
@@ -103,7 +103,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       const fn = networks[rChainId].api.lockCrv.calcUnlockTime
       const calcdUtcDate = fn(curve, rFormType, currUnlockTime, days)
 
-      updateFormValues({ utcDate: toCalendarDate(calcdUtcDate), calcdUtcDate: '', utcDateError: '', days }, false)
+      void updateFormValues({ utcDate: toCalendarDate(calcdUtcDate), calcdUtcDate: '', utcDateError: '', days }, false)
       return calcdUtcDate
     },
     [currUnlockTime, currUnlockUtcTime, rChainId, rFormType, updateFormValues],
@@ -152,7 +152,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   // onMount
   useEffect(() => {
     isSubscribed.current = true
-    updateFormValues({}, true)
+    void updateFormValues({}, true)
 
     return () => {
       isSubscribed.current = false

--- a/apps/main/src/dao/components/PageVeCrv/index.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/index.tsx
@@ -55,7 +55,7 @@ const FormCrvLocker = (pageProps: PageVecrv) => {
 
   // fetch locked crv data
   useEffect(() => {
-    setData()
+    void setData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, signerAddress, isPageVisible])
 

--- a/apps/main/src/dao/hooks/usePageOnMount.ts
+++ b/apps/main/src/dao/hooks/usePageOnMount.ts
@@ -182,13 +182,13 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
     if (connectState.status || connectState.stage) {
       if (isSuccess(connectState)) {
       } else if (isLoading(connectState, CONNECT_STAGE.SWITCH_NETWORK)) {
-        handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
+        void handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_WALLET)) {
-        handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
+        void handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.DISCONNECT_WALLET) && wallet) {
-        handleDisconnectWallet(wallet)
+        void handleDisconnectWallet(wallet)
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_API)) {
-        handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
+        void handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/dao/store/createAppSlice.ts
+++ b/apps/main/src/dao/store/createAppSlice.ts
@@ -94,7 +94,7 @@ const createAppSlice = (set: SetState<State>, get: GetState<State>): AppSlice =>
     }
 
     if (!prevApi || isNetworkSwitched) {
-      get().gas.fetchGasInfo(api)
+      void get().gas.fetchGasInfo(api)
     }
 
     log('Hydrating DAO - Complete')

--- a/apps/main/src/dao/store/createGaugesSlice.ts
+++ b/apps/main/src/dao/store/createGaugesSlice.ts
@@ -141,7 +141,7 @@ const createGaugesSlice = (set: SetState<State>, get: GetState<State>): GaugesSl
         })
 
         get().setAppStateByKey(sliceKey, 'gaugeMapper', newGaugeMapper)
-        get().storeCache.setStateByKey('cacheGaugeMapper', newGaugeMapper)
+        void get().storeCache.setStateByKey('cacheGaugeMapper', newGaugeMapper)
         get().setAppStateByKey(sliceKey, 'gaugesLoading', 'SUCCESS')
       } catch (error) {
         console.error('Error fetching gauges:', error)

--- a/apps/main/src/dao/store/createLockedCrvSlice.ts
+++ b/apps/main/src/dao/store/createLockedCrvSlice.ts
@@ -130,7 +130,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
       const isValidLockDateForm = rFormType === 'adjust_date' ? isValidDays : true
 
       if (isValidCreateForm && isValidLockCrvForm && isValidLockDateForm) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, curve, rFormType, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, curve, rFormType, cFormValues)
       } else {
         get()[sliceKey].setStateByKey('formEstGas', { [activeKey]: DEFAULT_FORM_EST_GAS })
       }
@@ -269,7 +269,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
           })
 
           // re-fetch data
-          get()[sliceKey].fetchVecrvInfo(curve)
+          void get()[sliceKey].fetchVecrvInfo(curve)
           const { wallet } = useWallet.getState()
           if (wallet) {
             get().user.updateUserData(curve, wallet)
@@ -310,7 +310,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
           })
 
           // re-fetch data
-          get()[sliceKey].fetchVecrvInfo(curve)
+          void get()[sliceKey].fetchVecrvInfo(curve)
           const { wallet } = useWallet.getState()
           if (wallet) {
             get().user.updateUserData(curve, wallet)

--- a/apps/main/src/dao/store/createProposalsSlice.ts
+++ b/apps/main/src/dao/store/createProposalsSlice.ts
@@ -168,7 +168,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
         }
 
         get()[sliceKey].setStateByKey('proposalsMapper', proposalsObject)
-        get().storeCache.setStateByKey('cacheProposalsMapper', proposalsObject)
+        void get().storeCache.setStateByKey('cacheProposalsMapper', proposalsObject)
         get()[sliceKey].setStateByKey('proposalsLoadingState', 'SUCCESS')
       } catch (error) {
         console.log(error)

--- a/apps/main/src/dao/store/createUserSlice.ts
+++ b/apps/main/src/dao/store/createUserSlice.ts
@@ -161,7 +161,7 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
         console.error(error)
       }
 
-      getUserProposalVotes(userAddress)
+      void getUserProposalVotes(userAddress)
 
       get()[sliceKey].setStateByKeys({
         userAddress: userAddress.toLowerCase(),
@@ -496,7 +496,7 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
       const gauges = get()[sliceKey].userGaugeVoteWeightsMapper[userAddress?.toLowerCase() ?? '']?.data.gauges
       if (!gauges) return
 
-      Promise.all(gauges.map((gauge) => getVoteForGaugeNextTime(userAddress, gauge.gaugeAddress)))
+      void Promise.all(gauges.map((gauge) => getVoteForGaugeNextTime(userAddress, gauge.gaugeAddress)))
     },
     setUserLocksSortBy: (userAddress: string, sortBy: UserLocksSortBy) => {
       const address = userAddress.toLowerCase()

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -53,7 +53,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
 
   const handleMouseEnter = (foundUsdRate?: string) => {
     if (!foundUsdRate && curve) {
-      fetchUsdRateByToken(curve, tokenAddress)
+      void fetchUsdRateByToken(curve, tokenAddress)
     }
   }
 

--- a/apps/main/src/dex/components/PageCompensation/Page.tsx
+++ b/apps/main/src/dex/components/PageCompensation/Page.tsx
@@ -39,7 +39,7 @@ const Page = () => {
   useEffect(() => {
     if (!pageLoaded) return
     if (provider) {
-      fetchData(provider)
+      void fetchData(provider)
     }
   }, [fetchData, pageLoaded, provider])
 

--- a/apps/main/src/dex/components/PageCompensation/index.tsx
+++ b/apps/main/src/dex/components/PageCompensation/index.tsx
@@ -98,8 +98,8 @@ const FormCompensation = ({
     setVestedTotals({})
 
     if (signerAddress) {
-      getBalances(signerAddress, contracts)
-      getVestContract(signerAddress, contracts)
+      void getBalances(signerAddress, contracts)
+      void getVestContract(signerAddress, contracts)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signerAddress])

--- a/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
@@ -117,7 +117,7 @@ const SelectTokenButton = ({
         }
       }
     }
-    updateUserAddedToken()
+    void updateUserAddedToken()
   }, [basePools, chainId, curve, filterValue, options, updateUserAddedTokens, userAddedTokens])
 
   const selectedToken = useMemo(

--- a/apps/main/src/dex/components/PageCrvLocker/Page.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/Page.tsx
@@ -58,7 +58,7 @@ const Page = (params: CrvLockerUrlParams) => {
 
   // get initial data
   useEffect(() => {
-    fetchData(curve, isLoadingCurve)
+    void fetchData(curve, isLoadingCurve)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [curve?.chainId, curve?.signerAddress, isLoadingCurve])
 

--- a/apps/main/src/dex/components/PageCrvLocker/components/FormLockDate.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/components/FormLockDate.tsx
@@ -81,7 +81,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       const days = utcDate.diff(currUnlockUtcTime, 'd')
       const calcdUtcDate = curvejsApi.lockCrv.calcUnlockTime(curve, rFormType, currUnlockTime, days)
 
-      updateFormValues(
+      void updateFormValues(
         {
           utcDate: toCalendarDate(utcDate),
           utcDateError,
@@ -102,7 +102,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
       const fn = curvejsApi.lockCrv.calcUnlockTime
       const calcdUtcDate = fn(curve, rFormType, currUnlockTime, days)
 
-      updateFormValues({ utcDate: toCalendarDate(calcdUtcDate), calcdUtcDate: '', utcDateError: '', days }, false)
+      void updateFormValues({ utcDate: toCalendarDate(calcdUtcDate), calcdUtcDate: '', utcDateError: '', days }, false)
       return calcdUtcDate
     },
     [currUnlockTime, currUnlockUtcTime, rFormType, updateFormValues],
@@ -151,7 +151,7 @@ const FormLockDate = ({ curve, rChainId, rFormType, vecrvInfo }: PageVecrv) => {
   // onMount
   useEffect(() => {
     isSubscribed.current = true
-    updateFormValues({}, true)
+    void updateFormValues({}, true)
 
     return () => {
       isSubscribed.current = false

--- a/apps/main/src/dex/components/PageCrvLocker/index.tsx
+++ b/apps/main/src/dex/components/PageCrvLocker/index.tsx
@@ -55,7 +55,7 @@ const FormCrvLocker = (pageProps: PageVecrv) => {
 
   // fetch locked crv data
   useEffect(() => {
-    setData()
+    void setData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, signerAddress, isPageVisible])
 

--- a/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
@@ -95,7 +95,7 @@ const FormVecrv = () => {
           type: 'action',
           content: !!formStatus.formTypeCompleted ? t`Withdraw CRV Complete` : t`Withdraw CRV`,
           onClick: () => {
-            if (curve) handleBtnClickWithdraw(activeKey, curve, lockedAmount)
+            if (curve) void handleBtnClickWithdraw(activeKey, curve, lockedAmount)
           },
         },
       }
@@ -155,7 +155,7 @@ const FormVecrv = () => {
               disabled={!curve}
               variant="filled"
               onClick={() => {
-                if (curve) handleBtnClickWithdraw(activeKey, curve, lockedAmount)
+                if (curve) void handleBtnClickWithdraw(activeKey, curve, lockedAmount)
               }}
               size="medium"
             >

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellRewardsTooltip.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellRewardsTooltip.tsx
@@ -18,7 +18,7 @@ const TableCellRewardsTooltip = ({ crv = [], userCrvApy, fetchUserPoolBoost }: P
 
   useEffect(() => {
     isSubscribed.current = true
-    ;(async () => {
+    void (async () => {
       const fetchedBoosted = await fetchUserPoolBoost()
 
       if (isSubscribed.current) {

--- a/apps/main/src/dex/components/PageIntegrations/Page.tsx
+++ b/apps/main/src/dex/components/PageIntegrations/Page.tsx
@@ -19,7 +19,7 @@ const Page = (params: NetworkUrlParams) => {
   const integrationsTags = useStore((state) => state.integrations.integrationsTags)
 
   useEffect(() => {
-    init(rChainId)
+    void init(rChainId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
@@ -68,7 +68,7 @@ const FormDeposit = ({
     ) => {
       setTxInfoBar(null)
       setSlippageConfirmed(false)
-      setFormValues(
+      void setFormValues(
         'DEPOSIT',
         curve,
         poolDataCacheOrApi.pool.id,

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
@@ -72,7 +72,7 @@ const FormDepositStake = ({
     ) => {
       setTxInfoBar(null)
       setSlippageConfirmed(false)
-      setFormValues(
+      void setFormValues(
         'DEPOSIT_STAKE',
         curve,
         poolDataCacheOrApi.pool.id,

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
@@ -47,7 +47,7 @@ const FormStake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
       setTxInfoBar(null)
-      setFormValues('STAKE', curve, poolDataCacheOrApi.pool.id, poolData, updatedFormValues, null, seed.isSeed, '')
+      void setFormValues('STAKE', curve, poolDataCacheOrApi.pool.id, poolData, updatedFormValues, null, seed.isSeed, '')
     },
     [curve, poolData, poolDataCacheOrApi.pool.id, seed.isSeed, setFormValues],
   )

--- a/apps/main/src/dex/components/PagePool/Page.tsx
+++ b/apps/main/src/dex/components/PagePool/Page.tsx
@@ -35,7 +35,7 @@ const Page = (params: PoolUrlParams) => {
     if (!rFormType || !rPoolId || (rPoolId && excludePoolsMapper[rPoolId])) {
       push(reRoutePathname)
     } else if (!!curve && pageLoaded && !isLoadingApi && curve.chainId === +rChainId && haveAllPools && !poolData) {
-      ;(async () => {
+      void (async () => {
         const foundPoolData = await fetchNewPool(curve, rPoolId)
         if (!foundPoolData) {
           push(reRoutePathname)

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
@@ -36,7 +36,7 @@ const PoolStats = ({ curve, routerParams, poolAlert, poolData, poolDataCacheOrAp
   // fetch stats
   useEffect(() => {
     if (curve && poolData) {
-      fetchPoolStats(curve, poolData)
+      void fetchPoolStats(curve, poolData)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, poolId])

--- a/apps/main/src/dex/components/PagePool/Swap/index.tsx
+++ b/apps/main/src/dex/components/PagePool/Swap/index.tsx
@@ -112,7 +112,7 @@ const Swap = ({
       setConfirmedLoss(false)
       setTxInfoBar(null)
 
-      setFormValues(
+      void setFormValues(
         curve,
         poolDataCacheOrApi.pool.id,
         poolData,
@@ -263,7 +263,7 @@ const Swap = ({
   // get user balances
   useEffect(() => {
     if (curve && poolId && haveSigner && (isUndefined(userFromBalance) || isUndefined(userToBalance))) {
-      fetchUserPoolInfo(curve, poolId, true)
+      void fetchUserPoolInfo(curve, poolId, true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, poolId, haveSigner, userFromBalance, userToBalance])
@@ -272,10 +272,10 @@ const Swap = ({
   useEffect(() => {
     if (formValues.fromAddress || formValues.toAddress) {
       if (formValues.fromAddress && isUndefined(fromUsdRate)) {
-        fetchUsdRateByTokens(curve, [formValues.fromAddress])
+        void fetchUsdRateByTokens(curve, [formValues.fromAddress])
       }
       if (formValues.toAddress && isUndefined(toUsdRate)) {
-        fetchUsdRateByTokens(curve, [formValues.toAddress])
+        void fetchUsdRateByTokens(curve, [formValues.toAddress])
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormClaim.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormClaim.tsx
@@ -47,7 +47,7 @@ const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
   const updateFormValues = useCallback(() => {
     setTxInfoBar(null)
     setSlippageConfirmed(false)
-    setFormValues('CLAIM', curve, poolDataCacheOrApi.pool.id, poolData, {}, null, seed.isSeed, '')
+    void setFormValues('CLAIM', curve, poolDataCacheOrApi.pool.id, poolData, {}, null, seed.isSeed, '')
   }, [curve, poolData, poolDataCacheOrApi.pool.id, seed.isSeed, setFormValues])
 
   const handleClaimClick = useCallback(
@@ -107,7 +107,7 @@ const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
               ? getClaimText(formValues, formStatus, 'claimCrvButton', rewardsNeedNudging)
               : t`Claim Rewards`,
           onClick: () => {
-            handleClaimClick(activeKey, curve, poolData, formValues, formStatus, rewardsNeedNudging)
+            void handleClaimClick(activeKey, curve, poolData, formValues, formStatus, rewardsNeedNudging)
           },
         },
       }
@@ -144,7 +144,7 @@ const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
   // fetch claimable
   useEffect(() => {
     if (chainId && poolData && haveSigner) {
-      fetchClaimable(activeKey, chainId, poolData.pool)
+      void fetchClaimable(activeKey, chainId, poolData.pool)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, poolId, signerAddress])
@@ -169,7 +169,7 @@ const FormClaim = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
       cFormStatus.isClaimRewards = isClaimRewards
 
       setStateByKey('formStatus', cFormStatus)
-      handleClaimClick(activeKey, curve, poolData, formValues, cFormStatus, rewardsNeedNudging)
+      void handleClaimClick(activeKey, curve, poolData, formValues, cFormStatus, rewardsNeedNudging)
     }
   }
 

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
@@ -39,7 +39,16 @@ const FormUnstake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
       setTxInfoBar(null)
-      setFormValues('UNSTAKE', curve, poolDataCacheOrApi.pool.id, poolData, updatedFormValues, null, seed.isSeed, '')
+      void setFormValues(
+        'UNSTAKE',
+        curve,
+        poolDataCacheOrApi.pool.id,
+        poolData,
+        updatedFormValues,
+        null,
+        seed.isSeed,
+        '',
+      )
     },
     [curve, poolData, poolDataCacheOrApi.pool.id, seed.isSeed, setFormValues],
   )

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
@@ -74,7 +74,7 @@ const FormWithdraw = ({
     (updatedFormValues: Partial<FormValues>, updatedMaxSlippage: string | null) => {
       setTxInfoBar(null)
       setSlippageConfirmed(false)
-      setFormValues(
+      void setFormValues(
         'WITHDRAW',
         curve,
         poolDataCacheOrApi.pool.id,

--- a/apps/main/src/dex/components/PagePool/components/AlertSeedAmounts.tsx
+++ b/apps/main/src/dex/components/PagePool/components/AlertSeedAmounts.tsx
@@ -34,7 +34,7 @@ const AlertSeedAmounts = ({ seed, poolData }: Props) => {
   }, [])
 
   useEffect(() => {
-    if (!!poolData && loaded && isSeed) getSeedRatio(poolData)
+    if (!!poolData && loaded && isSeed) void getSeedRatio(poolData)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [poolData?.pool?.id, loaded, isSeed])
 

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -131,7 +131,7 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
 
   const fetchData = useCallback(() => {
     if (isPageVisible && curve && poolData) {
-      fetchPoolStats(curve, poolData)
+      void fetchPoolStats(curve, poolData)
     }
   }, [curve, fetchPoolStats, isPageVisible, poolData])
 
@@ -145,7 +145,7 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
       pricesApiPoolsMapper[poolAddress] !== undefined &&
       !snapshotsMapper[poolAddress]
     ) {
-      fetchPricesPoolSnapshots(rChainId, poolAddress)
+      void fetchPricesPoolSnapshots(rChainId, poolAddress)
     }
   }, [curve, fetchPricesPoolSnapshots, poolAddress, pricesApi, pricesApiPoolsMapper, rChainId, snapshotsMapper])
 
@@ -163,7 +163,7 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
   // fetch user pool info
   useEffect(() => {
     if (curve && poolId && !!signerAddress) {
-      fetchUserPoolInfo(curve, poolId)
+      void fetchUserPoolInfo(curve, poolId)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rChainId, poolId, signerAddress])

--- a/apps/main/src/dex/components/PagePoolList/index.tsx
+++ b/apps/main/src/dex/components/PagePoolList/index.tsx
@@ -138,7 +138,7 @@ const PoolList = ({
   usePageVisibleInterval(
     useCallback(() => {
       if (curve && rewardsApyMapper && Object.keys(rewardsApyMapper).length > 0) {
-        fetchPoolsRewardsApy(rChainId, poolDatas)
+        void fetchPoolsRewardsApy(rChainId, poolDatas)
       }
     }, [curve, fetchPoolsRewardsApy, poolDatas, rChainId, rewardsApyMapper]),
     REFRESH_INTERVAL['11m'],

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -125,7 +125,7 @@ const QuickSwap = ({
       setTxInfoBar(null)
       setConfirmedLoss(false)
 
-      setFormValues(
+      void setFormValues(
         pageLoaded && !isLoadingApi ? curve : null,
         updatedFormValues,
         searchedParams,
@@ -236,7 +236,7 @@ const QuickSwap = ({
                   primaryBtnProps: {
                     onClick: () => {
                       if (typeof maxSlippage !== 'undefined' && typeof routesAndOutput !== 'undefined') {
-                        handleBtnClickSwap(
+                        void handleBtnClickSwap(
                           activeKey,
                           curve,
                           formValues,
@@ -256,7 +256,7 @@ const QuickSwap = ({
             : {
                 onClick: () => {
                   if (typeof maxSlippage !== 'undefined' && typeof routesAndOutput !== 'undefined') {
-                    handleBtnClickSwap(
+                    void handleBtnClickSwap(
                       activeKey,
                       curve,
                       formValues,
@@ -331,7 +331,7 @@ const QuickSwap = ({
   useEffect(() => fetchData(), [tokensMapperStr, searchedParams.fromAddress, searchedParams.toAddress])
 
   useEffect(() => {
-    updateTokenList(isReady ? curve : null, tokensMapper)
+    void updateTokenList(isReady ? curve : null, tokensMapper)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady, tokensMapperStr, curve?.signerAddress])
 

--- a/apps/main/src/dex/hooks/usePageOnMount.ts
+++ b/apps/main/src/dex/hooks/usePageOnMount.ts
@@ -51,7 +51,7 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
             updateCurveJs(api)
             updateConnectState('success', '')
 
-            hydrate(api, prevApi, wallet)
+            await hydrate(api, prevApi, wallet)
           } else {
             updateConnectState('', '')
           }

--- a/apps/main/src/dex/hooks/usePageOnMount.ts
+++ b/apps/main/src/dex/hooks/usePageOnMount.ts
@@ -217,13 +217,13 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
     if (connectState.status || connectState.stage) {
       if (isSuccess(connectState)) {
       } else if (isLoading(connectState, CONNECT_STAGE.SWITCH_NETWORK)) {
-        handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
+        void handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_WALLET)) {
-        handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
+        void handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.DISCONNECT_WALLET) && wallet) {
-        handleDisconnectWallet(wallet)
+        void handleDisconnectWallet(wallet)
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_API)) {
-        handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
+        void handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/dex/hooks/usePoolTotalStaked.tsx
+++ b/apps/main/src/dex/hooks/usePoolTotalStaked.tsx
@@ -59,7 +59,7 @@ const usePoolTotalStaked = (poolDataCacheOrApi: PoolDataCacheOrApi) => {
     const shouldCallApi = staked?.timestamp ? dayjs().diff(staked.timestamp, 'seconds') > 30 : true
 
     if (address && rpcUrl && shouldCallApi) {
-      ;(async () => {
+      void (async () => {
         const provider = walletProvider || new JsonRpcProvider(rpcUrl)
         const gaugeContract = isValidAddress(gauge.address)
           ? await getContract('gaugeTotalSupply', gauge.address, provider)
@@ -71,7 +71,7 @@ const usePoolTotalStaked = (poolDataCacheOrApi: PoolDataCacheOrApi) => {
               ? await getContract('poolTotalSupply', address, provider)
               : await getContract('lpTokenTotalSupply', lpToken, provider)
 
-          if (poolContract) getTotalSupply(poolContract, gaugeContract)
+          if (poolContract) void getTotalSupply(poolContract, gaugeContract)
         } else {
           updateTotalStakeValue({ totalStakedPercent: 'N/A', gaugeTotalSupply: 'N/A' })
         }

--- a/apps/main/src/dex/lib/pools.ts
+++ b/apps/main/src/dex/lib/pools.ts
@@ -120,7 +120,7 @@ export async function getPools(
   )
 
   // get gauge info
-  PromisePool.for(Object.values(resp.poolsMapper)).process(async ({ pool }) => {
+  await PromisePool.for(Object.values(resp.poolsMapper)).process(async ({ pool }) => {
     const [gaugeStatusResult, isGaugeKilledResult] = await Promise.allSettled([
       pool.gaugeStatus(),
       pool.isGaugeKilled(),

--- a/apps/main/src/dex/store/createCacheSlice.ts
+++ b/apps/main/src/dex/store/createCacheSlice.ts
@@ -65,7 +65,7 @@ const createCacheSlice = (set: SetState<State>, get: GetState<State>): CacheSlic
         }
       })
 
-      sliceState.setStateByActiveKey(key, chainId.toString(), parsedMapper)
+      void sliceState.setStateByActiveKey(key, chainId.toString(), parsedMapper)
     },
 
     setServerPreloadData: (chainId, { tvl, volume, pools }) => {

--- a/apps/main/src/dex/store/createDashboardSlice.ts
+++ b/apps/main/src/dex/store/createDashboardSlice.ts
@@ -94,12 +94,12 @@ const createDashboardSlice = (set: SetState<State>, get: GetState<State>): Dashb
 
       if (Object.keys(claimableFees).length || Object.keys(vecrvInfo).length) return
 
-      sliceState.fetchVeCrvAndClaimables(activeKey, curve, walletAddress)
+      void sliceState.fetchVeCrvAndClaimables(activeKey, curve, walletAddress)
 
       const { signerAddress } = curve
 
       if (signerAddress && signerAddress.toLowerCase() !== walletAddress) {
-        lockedCrv.fetchVecrvInfo(curve)
+        void lockedCrv.fetchVecrvInfo(curve)
       }
     },
     fetchVeCrvAndClaimables: async (activeKey, curve, walletAddress) => {
@@ -286,7 +286,7 @@ const createDashboardSlice = (set: SetState<State>, get: GetState<State>): Dashb
       }
 
       // get claimableFees, locked crv info
-      if (chainId === 1) sliceState.fetchClaimablesAndLockedDetails(curve)
+      if (chainId === 1) void sliceState.fetchClaimablesAndLockedDetails(curve)
 
       // get dashboard data
       const dashboardDataActiveKey = getDashboardDataActiveKey(chainId, walletAddress)
@@ -366,7 +366,7 @@ const createDashboardSlice = (set: SetState<State>, get: GetState<State>): Dashb
 
       if (key === claimButtonsKey['3CRV']) {
         const storedPoolDataMapper = pools.poolsMapper[chainId]
-        sliceState.fetchDashboardData(curve, walletAddress, storedPoolDataMapper)
+        void sliceState.fetchDashboardData(curve, walletAddress, storedPoolDataMapper)
       }
 
       return resp

--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -181,7 +181,7 @@ const createGlobalSlice = (set: SetState<State>, get: GetState<State>): GlobalSl
     if (!poolIds.length) {
       state.pools.setEmptyPoolListDefault(chainId)
       state.tokens.setEmptyPoolListDefault(chainId)
-      state.pools.fetchBasePools(curveApi)
+      void state.pools.fetchBasePools(curveApi)
       return
     }
 
@@ -192,17 +192,17 @@ const createGlobalSlice = (set: SetState<State>, get: GetState<State>): GlobalSl
     await state.pools.fetchPools(curveApi, poolIds, failedFetching24hOldVprice)
 
     if (!prevCurveApi || isNetworkSwitched) {
-      state.gas.fetchGasInfo(curveApi)
-      state.pools.fetchPricesApiPools(chainId)
-      state.pools.fetchBasePools(curveApi)
+      void state.gas.fetchGasInfo(curveApi)
+      void state.pools.fetchPricesApiPools(chainId)
+      void state.pools.fetchBasePools(curveApi)
 
       // pull all api calls before isLoadingApi if it is not needed for initial load
-      state.usdRates.fetchAllStoredUsdRates(curveApi)
+      void state.usdRates.fetchAllStoredUsdRates(curveApi)
     } else {
     }
 
     if (curveApi.signerAddress) {
-      state.user.fetchUserPoolList(curveApi)
+      void state.user.fetchUserPoolList(curveApi)
     }
 
     log('Hydrating DEX - Complete')

--- a/apps/main/src/dex/store/createLockedCrvSlice.ts
+++ b/apps/main/src/dex/store/createLockedCrvSlice.ts
@@ -129,7 +129,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
       const isValidLockDateForm = rFormType === 'adjust_date' ? isValidDays : true
 
       if (isValidCreateForm && isValidLockCrvForm && isValidLockDateForm) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, curve, rFormType, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, curve, rFormType, cFormValues)
       } else {
         get()[sliceKey].setStateByKey('formEstGas', { [activeKey]: DEFAULT_FORM_EST_GAS })
       }
@@ -268,7 +268,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
           })
 
           // re-fetch data
-          get()[sliceKey].fetchVecrvInfo(curve)
+          void get()[sliceKey].fetchVecrvInfo(curve)
         }
 
         return resp
@@ -303,7 +303,7 @@ const createLockedCrvSlice = (set: SetState<State>, get: GetState<State>): Locke
           })
 
           // re-fetch data
-          get()[sliceKey].fetchVecrvInfo(curve)
+          void get()[sliceKey].fetchVecrvInfo(curve)
         }
 
         return resp

--- a/apps/main/src/dex/store/createPoolDepositSlice.ts
+++ b/apps/main/src/dex/store/createPoolDepositSlice.ts
@@ -273,7 +273,7 @@ const createPoolDepositSlice = (set: SetState<State>, get: GetState<State>): Poo
             ...(get()[sliceKey].formLpTokenExpected[storedActiveKey] ?? DEFAULT_FORM_LP_TOKEN_EXPECTED),
             loading: true,
           })
-          get()[sliceKey].fetchExpected(activeKey, chainId, formType, pool, cFormValues)
+          void get()[sliceKey].fetchExpected(activeKey, chainId, formType, pool, cFormValues)
 
           if (!isSeed) {
             // fetch slippage
@@ -281,7 +281,7 @@ const createPoolDepositSlice = (set: SetState<State>, get: GetState<State>): Poo
               ...(get()[sliceKey].slippage[storedActiveKey] ?? DEFAULT_SLIPPAGE),
               loading: true,
             })
-            get()[sliceKey].fetchSlippage(activeKey, chainId, formType, pool, cFormValues, maxSlippage)
+            void get()[sliceKey].fetchSlippage(activeKey, chainId, formType, pool, cFormValues, maxSlippage)
           }
 
           if (!!signerAddress) {
@@ -300,7 +300,7 @@ const createPoolDepositSlice = (set: SetState<State>, get: GetState<State>): Poo
                 ...(get()[sliceKey].formEstGas[storedActiveKey] ?? DEFAULT_ESTIMATED_GAS),
                 loading: true,
               })
-              get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+              void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
             }
           }
         }
@@ -321,7 +321,7 @@ const createPoolDepositSlice = (set: SetState<State>, get: GetState<State>): Poo
               ...(get()[sliceKey].formEstGas[storedActiveKey] ?? DEFAULT_ESTIMATED_GAS),
               loading: true,
             })
-            get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+            void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
           }
         }
       }

--- a/apps/main/src/dex/store/createPoolListSlice.ts
+++ b/apps/main/src/dex/store/createPoolListSlice.ts
@@ -293,7 +293,7 @@ const createPoolListSlice = (set: SetState<State>, get: GetState<State>): PoolLi
       })
 
       // get rest of pool list data
-      Promise.all([pools.fetchMissingPoolsRewardsApy(rChainId, tablePoolDatas)])
+      void Promise.all([pools.fetchMissingPoolsRewardsApy(rChainId, tablePoolDatas)])
     },
 
     // use local storage data till actual data returns
@@ -385,7 +385,7 @@ const createPoolListSlice = (set: SetState<State>, get: GetState<State>): PoolLi
           return
         }
 
-        sliceState.setSortAndFilterData(
+        void sliceState.setSortAndFilterData(
           rChainId,
           searchParams,
           hideSmallPools,

--- a/apps/main/src/dex/store/createPoolSwapSlice.ts
+++ b/apps/main/src/dex/store/createPoolSwapSlice.ts
@@ -173,7 +173,7 @@ const createPoolSwapSlice = (set: SetState<State>, get: GetState<State>): PoolSw
               ...(get()[sliceKey].formEstGas[storedActiveKey] ?? DEFAULT_EST_GAS),
               loading: true,
             })
-            get()[sliceKey].fetchEstGasApproval(activeKey, curve.chainId, pool, cFormValues, maxSlippage)
+            void get()[sliceKey].fetchEstGasApproval(activeKey, curve.chainId, pool, cFormValues, maxSlippage)
           }
         }
 
@@ -313,7 +313,7 @@ const createPoolSwapSlice = (set: SetState<State>, get: GetState<State>): PoolSw
         activeKey,
         cloneDeep({ ...DEFAULT_EXCHANGE_OUTPUT, loading: true }),
       )
-      get()[sliceKey].fetchExchangeOutput(activeKey, storedActiveKey, curve, pool, cFormValues, maxSlippage)
+      void get()[sliceKey].fetchExchangeOutput(activeKey, storedActiveKey, curve, pool, cFormValues, maxSlippage)
     },
 
     // steps
@@ -372,7 +372,7 @@ const createPoolSwapSlice = (set: SetState<State>, get: GetState<State>): PoolSw
           get()[sliceKey].setStateByKey('formStatus', cFormStatus)
 
           // fetch est gas, approval and exchange
-          get()[sliceKey].fetchEstGasApproval(activeKey, curve.chainId, pool, formValues, maxSlippage)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, curve.chainId, pool, formValues, maxSlippage)
           await get()[sliceKey].fetchExchangeOutput(activeKey, storedActiveKey, curve, pool, formValues, maxSlippage)
         }
 
@@ -425,7 +425,7 @@ const createPoolSwapSlice = (set: SetState<State>, get: GetState<State>): PoolSw
           })
 
           // cache swapped tokens
-          get().storeCache.setStateByActiveKey('routerFormValues', curve.chainId.toString(), {
+          void get().storeCache.setStateByActiveKey('routerFormValues', curve.chainId.toString(), {
             fromAddress,
             fromToken,
             toAddress,

--- a/apps/main/src/dex/store/createPoolWithdrawSlice.ts
+++ b/apps/main/src/dex/store/createPoolWithdrawSlice.ts
@@ -140,7 +140,7 @@ const createPoolWithdrawSlice = (set: SetState<State>, get: GetState<State>): Po
 
       // get gas
       if (!!signerAddress) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
       }
     },
     fetchWithdrawLpToken: async (props) => {
@@ -188,7 +188,7 @@ const createPoolWithdrawSlice = (set: SetState<State>, get: GetState<State>): Po
 
         // get gas
         if (!!signerAddress) {
-          get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
         }
       }
     },
@@ -279,7 +279,7 @@ const createPoolWithdrawSlice = (set: SetState<State>, get: GetState<State>): Po
 
       // get gas
       if (!!signerAddress) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
       }
     },
     fetchClaimable: async (activeKey, chainId, pool) => {
@@ -346,16 +346,16 @@ const createPoolWithdrawSlice = (set: SetState<State>, get: GetState<State>): Po
           maxSlippage,
         }
         if (cFormValues.selected === 'token') {
-          get()[sliceKey].fetchWithdrawToken(props)
+          void get()[sliceKey].fetchWithdrawToken(props)
         } else if (cFormValues.selected === 'lpToken') {
-          get()[sliceKey].fetchWithdrawLpToken(props)
+          void get()[sliceKey].fetchWithdrawLpToken(props)
         } else if (cFormValues.selected === 'imbalance') {
-          get()[sliceKey].fetchWithdrawCustom(props)
+          void get()[sliceKey].fetchWithdrawCustom(props)
         }
       } else if (formType === 'UNSTAKE' && !!signerAddress && +cFormValues.stakedLpToken > 0) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, curve, formType, pool, cFormValues)
       } else if (formType === 'CLAIM') {
-        get()[sliceKey].fetchClaimable(activeKey, chainId, pool)
+        void get()[sliceKey].fetchClaimable(activeKey, chainId, pool)
       }
     },
 

--- a/apps/main/src/dex/store/createPoolsSlice.ts
+++ b/apps/main/src/dex/store/createPoolsSlice.ts
@@ -272,7 +272,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
         )
 
         // update cache
-        storeCache.setStateByActiveKey('poolsMapper', chainId.toString(), poolsMapperCache)
+        void storeCache.setStateByActiveKey('poolsMapper', chainId.toString(), poolsMapperCache)
 
         const partialPoolDatas = poolIds.map((poolId) => poolsMapper[poolId])
 
@@ -289,7 +289,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
         const partialTokens = await tokens.setTokensMapper(chainId, partialPoolDatas)
 
         if (curve.signerAddress) {
-          userBalances.fetchUserBalancesByTokens(curve, partialTokens)
+          void userBalances.fetchUserBalancesByTokens(curve, partialTokens)
         }
 
         return { poolsMapper, poolDatas: partialPoolDatas }
@@ -429,7 +429,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
 
       if (missingRewardsPoolIds.length > 0) {
         log('fetchMissingPoolsRewardsApy', chainId, missingRewardsPoolIds.length)
-        fetchPoolsRewardsApy(chainId, missingRewardsPoolIds)
+        void fetchPoolsRewardsApy(chainId, missingRewardsPoolIds)
       }
 
       // const missingRewardsPoolIds = []
@@ -494,7 +494,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
           state.pools.poolsMapper[chainId][poolData.pool.id] = cPoolData
         }),
       )
-      get().pools.fetchPoolCurrenciesReserves(curve, cPoolData)
+      void get().pools.fetchPoolCurrenciesReserves(curve, cPoolData)
       return { tokens, tokenAddresses }
     },
     updatePool: (chainId, poolId, updatedPoolData) => {

--- a/apps/main/src/dex/store/createQuickSwapSlice.ts
+++ b/apps/main/src/dex/store/createQuickSwapSlice.ts
@@ -346,7 +346,7 @@ const createQuickSwapSlice = (set: SetState<State>, get: GetState<State>): Quick
 
       // api calls
       await sliceState.fetchRoutesAndOutput(curve, searchedParams, maxSlippage)
-      sliceState.fetchEstGasApproval(curve, searchedParams)
+      void sliceState.fetchEstGasApproval(curve, searchedParams)
     },
 
     // select token list
@@ -417,7 +417,7 @@ const createQuickSwapSlice = (set: SetState<State>, get: GetState<State>): Quick
 
           // re-fetch est gas, approval, routes and output
           await sliceState.fetchRoutesAndOutput(curve, searchedParams, globalMaxSlippage)
-          sliceState.fetchEstGasApproval(curve, searchedParams)
+          void sliceState.fetchEstGasApproval(curve, searchedParams)
         }
 
         return resp
@@ -477,10 +477,10 @@ const createQuickSwapSlice = (set: SetState<State>, get: GetState<State>): Quick
           })
 
           // cache swapped tokens
-          state.storeCache.setStateByActiveKey('routerFormValues', chainId.toString(), { fromAddress, toAddress })
+          void state.storeCache.setStateByActiveKey('routerFormValues', chainId.toString(), { fromAddress, toAddress })
 
           // fetch data
-          state.userBalances.fetchUserBalancesByTokens(curve, [fromAddress, toAddress])
+          void state.userBalances.fetchUserBalancesByTokens(curve, [fromAddress, toAddress])
         }
 
         return resp

--- a/apps/main/src/lend/components/ChartOhlcWrapper/PoolActivity.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/PoolActivity.tsx
@@ -23,7 +23,7 @@ const PoolActivity = ({ chainId, poolAddress, coins }: PoolActivityProps) => {
   const minHeight = chartExpanded ? 548 : 330
 
   useEffect(() => {
-    fetchPoolActivity(chainId, poolAddress)
+    void fetchPoolActivity(chainId, poolAddress)
   }, [chainId, fetchPoolActivity, poolAddress])
 
   return (

--- a/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
@@ -263,7 +263,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
 
   const refetchPricesData = useCallback(() => {
     if (market?.addresses.controller) {
-      fetchOraclePoolOhlcData(
+      void fetchOraclePoolOhlcData(
         rChainId,
         market.addresses.controller,
         chartInterval,
@@ -273,7 +273,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
       )
     }
     if (market?.addresses.amm) {
-      fetchLlammaOhlcData(
+      void fetchLlammaOhlcData(
         rChainId,
         rOwmId,
         market.addresses.amm,
@@ -299,7 +299,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
   // initial fetch
   useEffect(() => {
     if (market !== undefined) {
-      fetchLlammaOhlcData(
+      void fetchLlammaOhlcData(
         rChainId,
         rOwmId,
         market.addresses.amm,
@@ -308,7 +308,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
         chartTimeSettings.start,
         chartTimeSettings.end,
       )
-      fetchOraclePoolOhlcData(
+      void fetchOraclePoolOhlcData(
         rChainId,
         market.addresses.controller,
         chartInterval,
@@ -336,7 +336,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
       const startTime = getThreeHundredResultsAgo(timeOption, endTime)
 
       if (market?.addresses.controller && market?.addresses.amm) {
-        fetchMoreData(
+        void fetchMoreData(
           rChainId,
           market?.addresses.controller,
           market?.addresses.amm,

--- a/apps/main/src/lend/components/DetailsMarket/components/MarketParameters.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/MarketParameters.tsx
@@ -54,7 +54,7 @@ const MarketParameters = ({
     ]
 
   useEffect(() => {
-    if (type === 'supply' && owm) fetchVaultPricePerShare(rChainId, owm)
+    if (type === 'supply' && owm) void fetchVaultPricePerShare(rChainId, owm)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [type, owm])
 

--- a/apps/main/src/lend/components/PageIntegrations/Page.tsx
+++ b/apps/main/src/lend/components/PageIntegrations/Page.tsx
@@ -20,7 +20,7 @@ const Page = (params: NetworkUrlParams) => {
   const integrationsTags = useStore((state) => state.integrations.integrationsTags)
 
   useEffect(() => {
-    init(rChainId)
+    void init(rChainId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -79,7 +79,7 @@ const LoanCreate = ({
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>, isFullReset?: boolean, shouldRefetch?: boolean) => {
       setConfirmWarning(DEFAULT_CONFIRM_WARNING)
-      setFormValues(
+      void setFormValues(
         isLoaded ? api : null,
         market,
         isFullReset ? DEFAULT_FORM_VALUES : updatedFormValues,

--- a/apps/main/src/lend/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/Page.tsx
@@ -70,10 +70,10 @@ const Page = (params: MarketUrlParams) => {
 
       // delay fetch rest after form details are fetch first
       setTimeout(() => {
-        fetchAllMarketDetails(api, market, true)
+        void fetchAllMarketDetails(api, market, true)
 
         if (signerAddress) {
-          fetchUserMarketBalances(api, market, true)
+          void fetchUserMarketBalances(api, market, true)
         }
         setInitialLoaded(true)
       }, REFRESH_INTERVAL['3s'])
@@ -85,13 +85,13 @@ const Page = (params: MarketUrlParams) => {
     setLoaded(false)
 
     if (pageLoaded && !isLoadingApi && api && market) {
-      fetchInitial(api, market)
+      void fetchInitial(api, market)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageLoaded, isLoadingApi])
 
   useEffect(() => {
-    if (api && market && isPageVisible && initialLoaded) fetchInitial(api, market)
+    if (api && market && isPageVisible && initialLoaded) void fetchInitial(api, market)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPageVisible])
 

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -79,7 +79,7 @@ const LoanBorrowMore = ({
       shouldRefetch?: boolean,
     ) => {
       setConfirmWarning(DEFAULT_CONFIRM_WARNING)
-      setFormValues(
+      void setFormValues(
         isLoaded ? api : null,
         market,
         isFullReset ? DEFAULT_FORM_VALUES : updatedFormValues,

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -55,7 +55,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>, isFullReset?: boolean) => {
-      setFormValues(isLoaded ? api : null, market, isFullReset ? DEFAULT_FORM_VALUES : updatedFormValues)
+      void setFormValues(isLoaded ? api : null, market, isFullReset ? DEFAULT_FORM_VALUES : updatedFormValues)
     },
     [api, isLoaded, market, setFormValues],
   )

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -60,7 +60,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>, isFullReset?: boolean) => {
       setConfirmWarning(DEFAULT_CONFIRM_WARNING)
-      setFormValues(isLoaded ? api : null, market, updatedFormValues)
+      void setFormValues(isLoaded ? api : null, market, updatedFormValues)
 
       if (isFullReset) setHealthMode(DEFAULT_HEALTH_MODE)
     },

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -83,7 +83,13 @@ const LoanRepay = ({
       shouldRefetch?: boolean,
     ) => {
       setConfirmWarning(DEFAULT_CONFIRM_WARNING)
-      setFormValues(isLoaded ? api : null, market, updatedFormValues, updatedMaxSlippage || maxSlippage, shouldRefetch)
+      void setFormValues(
+        isLoaded ? api : null,
+        market,
+        updatedFormValues,
+        updatedMaxSlippage || maxSlippage,
+        shouldRefetch,
+      )
 
       if (isFullReset) setHealthMode(DEFAULT_HEALTH_MODE)
     },

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -64,7 +64,7 @@ const LoanSelfLiquidation = ({
     setTxInfoBar(null)
 
     if (isLoaded && api && market) {
-      fetchDetails(api, market, maxSlippage)
+      void fetchDetails(api, market, maxSlippage)
     }
   }, [isLoaded, api, market, fetchDetails, maxSlippage])
 
@@ -173,7 +173,7 @@ const LoanSelfLiquidation = ({
 
   // max slippage
   useEffect(() => {
-    if (isLoaded && api && market && maxSlippage) fetchDetails(api, market, maxSlippage)
+    if (isLoaded && api && market && maxSlippage) void fetchDetails(api, market, maxSlippage)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [maxSlippage])
 
@@ -181,7 +181,7 @@ const LoanSelfLiquidation = ({
   useEffect(() => {
     if (isLoaded && api && market && maxSlippage) {
       resetState()
-      fetchDetails(api, market, maxSlippage)
+      void fetchDetails(api, market, maxSlippage)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded])

--- a/apps/main/src/lend/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/Page.tsx
@@ -84,10 +84,10 @@ const Page = (params: MarketUrlParams) => {
 
       // delay fetch rest after form details are fetch first
       setTimeout(() => {
-        fetchAllMarketDetails(api, market, true)
+        void fetchAllMarketDetails(api, market, true)
 
         if (signerAddress && loanExists) {
-          fetchAllUserMarketDetails(api, market, true)
+          void fetchAllUserMarketDetails(api, market, true)
         }
         setInitialLoaded(true)
       }, REFRESH_INTERVAL['3s'])
@@ -99,13 +99,13 @@ const Page = (params: MarketUrlParams) => {
   useEffect(() => {
     setLoaded(false)
     if (pageLoaded && !isLoadingApi && api && market) {
-      fetchInitial(api, market)
+      void fetchInitial(api, market)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageLoaded, isLoadingApi])
 
   useEffect(() => {
-    if (api && market && isPageVisible && initialLoaded) fetchInitial(api, market)
+    if (api && market && isPageVisible && initialLoaded) void fetchInitial(api, market)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPageVisible])
 

--- a/apps/main/src/lend/components/PageMarketList/index.tsx
+++ b/apps/main/src/lend/components/PageMarketList/index.tsx
@@ -65,7 +65,7 @@ const MarketList = (pageProps: PageMarketList) => {
 
   const updateFormValues = useCallback(
     (shouldRefetch?: boolean) => {
-      setFormValues(rChainId, isLoaded ? api : null, marketMapping, shouldRefetch)
+      void setFormValues(rChainId, isLoaded ? api : null, marketMapping, shouldRefetch)
     },
     [setFormValues, rChainId, isLoaded, api, marketMapping],
   )

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -71,14 +71,14 @@ const Page = (params: MarketUrlParams) => {
       setTimeout(async () => {
         const { signerAddress } = api
 
-        fetchAllMarketDetails(api, market, true)
+        void fetchAllMarketDetails(api, market, true)
 
         if (signerAddress) {
           const loanExists = (await fetchUserLoanExists(api, market, true))?.loanExists
           if (loanExists) {
-            fetchAllUserMarketDetails(api, market, true)
+            void fetchAllUserMarketDetails(api, market, true)
           } else {
-            fetchUserMarketBalances(api, market, true)
+            void fetchUserMarketBalances(api, market, true)
           }
         }
         setInitialLoaded(true)
@@ -91,13 +91,13 @@ const Page = (params: MarketUrlParams) => {
     setLoaded(false)
 
     if (!isLoadingApi && api && market) {
-      fetchInitial(api, market)
+      void fetchInitial(api, market)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoadingApi])
 
   useEffect(() => {
-    if (api && market && isPageVisible && initialLoaded) fetchInitial(api, market)
+    if (api && market && isPageVisible && initialLoaded) void fetchInitial(api, market)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPageVisible])
 

--- a/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultClaim/index.tsx
@@ -40,7 +40,7 @@ const VaultClaim = ({ isLoaded, api, market, userActiveKey }: PageContentProps) 
   const haveClaimableRewards = rewards.some((r) => +r.amount > 0)
 
   const updateFormValues = useCallback(() => {
-    setFormValues(userActiveKey, isLoaded ? api : null, market)
+    void setFormValues(userActiveKey, isLoaded ? api : null, market)
   }, [api, isLoaded, market, setFormValues, userActiveKey])
 
   const reset = useCallback(() => {

--- a/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
@@ -50,7 +50,7 @@ const VaultDepositMint = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, 
 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
-      setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
+      void setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
     },
     [api, isLoaded, market, rChainId, rFormType, setFormValues],
   )

--- a/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultStake/index.tsx
@@ -42,7 +42,7 @@ const VaultStake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, userAc
 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
-      setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
+      void setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
     },
     [api, isLoaded, market, rChainId, rFormType, setFormValues],
   )

--- a/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultUnstake/index.tsx
@@ -40,7 +40,7 @@ const VaultUnstake = ({ rChainId, rOwmId, rFormType, isLoaded, api, market, user
 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
-      setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
+      void setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
     },
     [api, isLoaded, market, rChainId, rFormType, setFormValues],
   )

--- a/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultWithdrawRedeem/index.tsx
@@ -60,7 +60,7 @@ const VaultWithdrawRedeem = ({
 
   const updateFormValues = useCallback(
     (updatedFormValues: Partial<FormValues>) => {
-      setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
+      void setFormValues(rChainId, rFormType, isLoaded ? api : null, market, updatedFormValues)
     },
     [api, isLoaded, market, rChainId, rFormType, setFormValues],
   )

--- a/apps/main/src/lend/components/SharedCellData/CellTotalCollateralValue.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellTotalCollateralValue.tsx
@@ -17,7 +17,7 @@ const CellTotalCollateralValue = ({ rChainId, rOwmId }: { rChainId: ChainId; rOw
   const { total = null, tooltipContent = [], error } = totalCollateralValue ?? {}
 
   useEffect(() => {
-    if (market) fetchTotalCollateralValue(rChainId, market)
+    if (market) void fetchTotalCollateralValue(rChainId, market)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rChainId, market])
 

--- a/apps/main/src/lend/components/TokenLabel.tsx
+++ b/apps/main/src/lend/components/TokenLabel.tsx
@@ -50,7 +50,7 @@ const TokenLabel = ({
             size="medium"
             onClick={(evt) => {
               evt.stopPropagation()
-              copyToClipboard(address)
+              void copyToClipboard(address)
             }}
           >
             <Icon name="Copy" size={16} />

--- a/apps/main/src/lend/hooks/useAbiTotalSupply.tsx
+++ b/apps/main/src/lend/hooks/useAbiTotalSupply.tsx
@@ -26,12 +26,12 @@ const useAbiTotalSupply = (rChainId: ChainId, contractAddress: string | undefine
   }, [])
 
   useEffect(() => {
-    if (contract && isValidAddress) getTotalSupply(contract)
+    if (contract && isValidAddress) void getTotalSupply(contract)
   }, [contract, isValidAddress, getTotalSupply])
 
   usePageVisibleInterval(
     () => {
-      if (contract && isValidAddress) getTotalSupply(contract)
+      if (contract && isValidAddress) void getTotalSupply(contract)
     },
     REFRESH_INTERVAL['1m'],
     isPageVisible,

--- a/apps/main/src/lend/hooks/useContract.ts
+++ b/apps/main/src/lend/hooks/useContract.ts
@@ -41,7 +41,7 @@ const useAbiGaugeTotalSupply = (
         : walletProvider || new JsonRpcProvider(networks[rChainId].rpcUrl)
 
       if (jsonModuleName && contractAddress && provider) {
-        ;(async () => setContract(await getContract(jsonModuleName, contractAddress, provider)))()
+        void (async () => setContract(await getContract(jsonModuleName, contractAddress, provider)))()
       }
     }
   }, [contractAddress, getContract, walletProvider, jsonModuleName, rChainId, signerRequired])

--- a/apps/main/src/lend/hooks/usePageOnMount.ts
+++ b/apps/main/src/lend/hooks/usePageOnMount.ts
@@ -196,13 +196,13 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
     if (connectState.status || connectState.stage) {
       if (isSuccess(connectState)) {
       } else if (isLoading(connectState, CONNECT_STAGE.SWITCH_NETWORK)) {
-        handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
+        void handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_WALLET)) {
-        handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
+        void handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.DISCONNECT_WALLET) && wallet) {
-        handleDisconnectWallet(wallet)
+        void handleDisconnectWallet(wallet)
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_API)) {
-        handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
+        void handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/lend/hooks/useVaultShares.ts
+++ b/apps/main/src/lend/hooks/useVaultShares.ts
@@ -33,7 +33,7 @@ function useVaultShares(rChainId: ChainId, rOwmId: string, vaultShares: string |
   }, [pricePerShareResp, usdRate, symbol, vaultShares])
 
   useEffect(() => {
-    if (market && +vaultShares > 0) fetchVaultPricePerShare(rChainId, market)
+    if (market && +vaultShares > 0) void fetchVaultPricePerShare(rChainId, market)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [market?.id, vaultShares])
 

--- a/apps/main/src/lend/store/createLoanBorrowMoreSlice.ts
+++ b/apps/main/src/lend/store/createLoanBorrowMoreSlice.ts
@@ -233,7 +233,7 @@ const createLoanBorrowMore = (_: SetState<State>, get: GetState<State>): LoanBor
       // api calls
       await sliceState.fetchMaxRecv(activeKey.activeKeyMax, api, market, isLeverage)
       await sliceState.fetchDetailInfo(activeKey.activeKey, api, market, maxSlippage, isLeverage)
-      sliceState.fetchEstGasApproval(activeKey.activeKey, api, market, maxSlippage, isLeverage)
+      void sliceState.fetchEstGasApproval(activeKey.activeKey, api, market, maxSlippage, isLeverage)
     },
 
     // steps
@@ -266,7 +266,7 @@ const createLoanBorrowMore = (_: SetState<State>, get: GetState<State>): LoanBor
           isApprovedCompleted: !error,
           stepError: error,
         })
-        if (!error) sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage, isLeverage)
+        if (!error) void sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage, isLeverage)
         return { ...resp, error }
       }
     },
@@ -312,15 +312,15 @@ const createLoanBorrowMore = (_: SetState<State>, get: GetState<State>): LoanBor
         } else {
           // api calls
           const loanExists = (await user.fetchUserLoanExists(api, market, true))?.loanExists
-          if (loanExists) user.fetchAll(api, market, true)
-          markets.fetchAll(api, market, true)
+          if (loanExists) void user.fetchAll(api, market, true)
+          void markets.fetchAll(api, market, true)
 
           // update formStatus
           sliceState.setStateByKeys({
             ...DEFAULT_STATE,
             formStatus: { ...DEFAULT_FORM_STATUS, isApproved: true, isComplete: true },
           })
-          sliceState.setFormValues(api, market, DEFAULT_FORM_VALUES, maxSlippage, isLeverage)
+          void sliceState.setFormValues(api, market, DEFAULT_FORM_VALUES, maxSlippage, isLeverage)
           return { ...resp, error }
         }
       }

--- a/apps/main/src/lend/store/createLoanCollateralAddSlice.ts
+++ b/apps/main/src/lend/store/createLoanCollateralAddSlice.ts
@@ -118,8 +118,8 @@ const createLoanCollateralAdd = (_: SetState<State>, get: GetState<State>): Loan
       }
 
       // api calls
-      sliceState.fetchDetailInfo(activeKey, api, market)
-      sliceState.fetchEstGasApproval(activeKey, api, market)
+      void sliceState.fetchDetailInfo(activeKey, api, market)
+      void sliceState.fetchEstGasApproval(activeKey, api, market)
     },
 
     // step
@@ -145,7 +145,7 @@ const createLoanCollateralAdd = (_: SetState<State>, get: GetState<State>): Loan
           isApproved: !error,
           isInProgress: !error,
         })
-        if (!error) sliceState.fetchEstGasApproval(activeKey, api, market)
+        if (!error) void sliceState.fetchEstGasApproval(activeKey, api, market)
         return { ...resp, error }
       }
     },
@@ -179,8 +179,8 @@ const createLoanCollateralAdd = (_: SetState<State>, get: GetState<State>): Loan
         } else {
           // api calls
           const loanExists = (await user.fetchUserLoanExists(api, market, true))?.loanExists
-          if (loanExists) user.fetchAll(api, market, true)
-          markets.fetchAll(api, market, true)
+          if (loanExists) void user.fetchAll(api, market, true)
+          void markets.fetchAll(api, market, true)
 
           // update formStatus
           sliceState.setStateByKeys({

--- a/apps/main/src/lend/store/createLoanCollateralRemoveSlice.ts
+++ b/apps/main/src/lend/store/createLoanCollateralRemoveSlice.ts
@@ -131,8 +131,8 @@ const createLoanCollateralRemove = (_: SetState<State>, get: GetState<State>): L
 
       // api calls
       await sliceState.fetchMaxRemovable(api, market)
-      sliceState.fetchDetailInfo(activeKey, api, market)
-      sliceState.fetchEstGas(activeKey, api, market)
+      void sliceState.fetchDetailInfo(activeKey, api, market)
+      void sliceState.fetchEstGas(activeKey, api, market)
     },
 
     // steps
@@ -166,15 +166,15 @@ const createLoanCollateralRemove = (_: SetState<State>, get: GetState<State>): L
         } else {
           // api calls
           const loanExists = (await user.fetchUserLoanExists(api, market, true))?.loanExists
-          if (loanExists) user.fetchAll(api, market, true)
-          markets.fetchAll(api, market, true)
+          if (loanExists) void user.fetchAll(api, market, true)
+          void void markets.fetchAll(api, market, true)
 
           // update formStatus
           sliceState.setStateByKeys({
             ...DEFAULT_STATE,
             formStatus: { ...DEFAULT_FORM_STATUS, isComplete: true },
           })
-          sliceState.setFormValues(api, market, DEFAULT_FORM_VALUES)
+          void sliceState.setFormValues(api, market, DEFAULT_FORM_VALUES)
           return { ...resp, error }
         }
       }

--- a/apps/main/src/lend/store/createLoanCreateSlice.ts
+++ b/apps/main/src/lend/store/createLoanCreateSlice.ts
@@ -248,11 +248,11 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>): LoanCreat
       }
 
       // api calls
-      if (isLeverage) sliceState.fetchMaxLeverage(market)
+      if (isLeverage) void sliceState.fetchMaxLeverage(market)
       await sliceState.fetchMaxRecv(activeKeys.activeKeyMax, api, market, isLeverage)
       await sliceState.fetchDetailInfo(activeKeys.activeKey, api, market, maxSlippage, isLeverage)
-      sliceState.fetchEstGasApproval(activeKeys.activeKey, api, market, maxSlippage, isLeverage)
-      sliceState.fetchLiqRanges(activeKeys.activeKeyLiqRange, api, market, isLeverage)
+      void sliceState.fetchEstGasApproval(activeKeys.activeKey, api, market, maxSlippage, isLeverage)
+      void sliceState.fetchLiqRanges(activeKeys.activeKeyLiqRange, api, market, isLeverage)
     },
 
     // steps
@@ -286,7 +286,7 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>): LoanCreat
           isApprovedCompleted: !error,
           stepError: error,
         })
-        if (!error) sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage, isLeverage)
+        if (!error) void sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage, isLeverage)
         return { ...resp, error }
       }
     },
@@ -330,7 +330,7 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>): LoanCreat
           if (loanExits) {
             // api calls
             await user.fetchAll(api, market, true)
-            markets.fetchAll(api, market, true)
+            void markets.fetchAll(api, market, true)
             markets.setStateByKey('marketDetailsView', 'user')
 
             // update formStatus

--- a/apps/main/src/lend/store/createLoanRepaySlice.ts
+++ b/apps/main/src/lend/store/createLoanRepaySlice.ts
@@ -190,7 +190,7 @@ const createLoanRepaySlice = (set: SetState<State>, get: GetState<State>): LoanR
 
       // api calls
       await sliceState.fetchDetailInfo(activeKey, api, market, maxSlippage, userState)
-      sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage)
+      void sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage)
     },
 
     // steps
@@ -226,7 +226,7 @@ const createLoanRepaySlice = (set: SetState<State>, get: GetState<State>): LoanR
           isApprovedCompleted: !error,
           stepError: error,
         })
-        if (!error) sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage)
+        if (!error) void sliceState.fetchEstGasApproval(activeKey, api, market, maxSlippage)
         return { ...resp, error }
       }
     },
@@ -274,13 +274,13 @@ const createLoanRepaySlice = (set: SetState<State>, get: GetState<State>): LoanR
           return { ...resp, error, loanExists }
         } else {
           if (loanExists) {
-            user.fetchAll(api, market, true)
+            void user.fetchAll(api, market, true)
           } else {
-            user.fetchUserMarketBalances(api, market, true)
+            void user.fetchUserMarketBalances(api, market, true)
             const userActiveKey = getUserActiveKey(api, market)
             user.setStateByActiveKey('loansDetailsMapper', userActiveKey, undefined)
           }
-          markets.fetchAll(api, market, true)
+          void markets.fetchAll(api, market, true)
 
           // update formStatus
           sliceState.setStateByKeys({

--- a/apps/main/src/lend/store/createLoanSelfLiquidationSlice.ts
+++ b/apps/main/src/lend/store/createLoanSelfLiquidationSlice.ts
@@ -103,7 +103,7 @@ const createLoanSelfLiquidationSlice = (set: SetState<State>, get: GetState<Stat
       sliceState.setStateByKey('formStatus', { ...get()[sliceKey].formStatus, loading: false })
 
       // api call
-      sliceState.fetchEstGasApproval(api, market, maxSlippage)
+      void sliceState.fetchEstGasApproval(api, market, maxSlippage)
     },
     fetchEstGasApproval: async (api, market, maxSlippage) => {
       const { gas } = get()
@@ -149,7 +149,7 @@ const createLoanSelfLiquidationSlice = (set: SetState<State>, get: GetState<Stat
           isInProgress: !error,
           stepError: error,
         })
-        if (!error) sliceState.fetchEstGasApproval(api, market, maxSlippage)
+        if (!error) void sliceState.fetchEstGasApproval(api, market, maxSlippage)
         return { ...resp, error }
       }
     },
@@ -184,8 +184,8 @@ const createLoanSelfLiquidationSlice = (set: SetState<State>, get: GetState<Stat
           return { ...resp, error, loanExists }
         } else {
           // api calls
-          if (loanExists) user.fetchAll(api, market, true)
-          markets.fetchAll(api, market, true)
+          if (loanExists) void user.fetchAll(api, market, true)
+          void markets.fetchAll(api, market, true)
 
           // update state
           sliceState.setStateByKey('formStatus', { ...DEFAULT_FORM_STATUS, isApproved: true, isComplete: true })

--- a/apps/main/src/lend/store/createVaultClaimSlice.ts
+++ b/apps/main/src/lend/store/createVaultClaimSlice.ts
@@ -66,7 +66,7 @@ const createVaultClaim = (set: SetState<State>, get: GetState<State>): VaultClai
 
       // api calls
       if (signerAddress) {
-        get()[sliceKey].fetchClaimable(userActiveKey, api, market)
+        void get()[sliceKey].fetchClaimable(userActiveKey, api, market)
       }
     },
 
@@ -87,9 +87,9 @@ const createVaultClaim = (set: SetState<State>, get: GetState<State>): VaultClai
 
       if (resp.userActiveKey === userActiveKey) {
         // re-fetch api
-        get()[sliceKey].fetchClaimable(resp.userActiveKey, api, market)
-        get().user.fetchUserMarketBalances(api, market, true)
-        get().markets.fetchAll(api, market, true)
+        void get()[sliceKey].fetchClaimable(resp.userActiveKey, api, market)
+        void get().user.fetchUserMarketBalances(api, market, true)
+        void get().markets.fetchAll(api, market, true)
 
         // update state
         const partialFormStatus: Partial<FormStatus> = {

--- a/apps/main/src/lend/store/createVaultDepositMintSlice.ts
+++ b/apps/main/src/lend/store/createVaultDepositMintSlice.ts
@@ -125,11 +125,11 @@ const createVaultMint = (set: SetState<State>, get: GetState<State>): VaultDepos
       }
 
       // api calls
-      get()[sliceKey].fetchDetails(activeKey, formType, market)
+      void get()[sliceKey].fetchDetails(activeKey, formType, market)
 
       if (signerAddress) {
         await get()[sliceKey].fetchMax(rChainId, formType, market)
-        get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
       }
     },
 
@@ -155,7 +155,7 @@ const createVaultMint = (set: SetState<State>, get: GetState<State>): VaultDepos
           isInProgress: true,
         }
         get()[sliceKey].setStateByKey('formStatus', merge(cloneDeep(FORM_STATUS), partialFormStatus))
-        if (!resp.error) get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
+        if (!resp.error) void get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
         return resp
       }
     },
@@ -175,8 +175,8 @@ const createVaultMint = (set: SetState<State>, get: GetState<State>): VaultDepos
 
       if (resp.activeKey === get()[sliceKey].activeKey) {
         // re-fetch api
-        get().user.fetchUserMarketBalances(api, market, true)
-        get().markets.fetchAll(api, market, true)
+        void get().user.fetchUserMarketBalances(api, market, true)
+        void get().markets.fetchAll(api, market, true)
 
         // update state
         const partialFormStatus: Partial<FormStatus> = {

--- a/apps/main/src/lend/store/createVaultStakeSlice.ts
+++ b/apps/main/src/lend/store/createVaultStakeSlice.ts
@@ -94,7 +94,7 @@ const createVaultStake = (set: SetState<State>, get: GetState<State>): VaultStak
 
       // api calls
       if (signerAddress) {
-        get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
       }
     },
 
@@ -119,7 +119,7 @@ const createVaultStake = (set: SetState<State>, get: GetState<State>): VaultStak
           isInProgress: true,
         }
         get()[sliceKey].setStateByKey('formStatus', merge(cloneDeep(FORM_STATUS), partialFormStatus))
-        if (!resp.error) get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
+        if (!resp.error) void get()[sliceKey].fetchEstGasApproval(activeKey, formType, api, market)
         return resp
       }
     },
@@ -138,8 +138,8 @@ const createVaultStake = (set: SetState<State>, get: GetState<State>): VaultStak
 
       if (resp.activeKey === get()[sliceKey].activeKey) {
         // re-fetch api
-        get().user.fetchUserMarketBalances(api, market, true)
-        get().markets.fetchAll(api, market, true)
+        void get().user.fetchUserMarketBalances(api, market, true)
+        void get().markets.fetchAll(api, market, true)
 
         // update state
         const partialFormStatus: Partial<FormStatus> = {

--- a/apps/main/src/lend/store/createVaultUnstakeSlice.ts
+++ b/apps/main/src/lend/store/createVaultUnstakeSlice.ts
@@ -92,7 +92,7 @@ const createVaultUnstake = (set: SetState<State>, get: GetState<State>): VaultUn
 
       // api calls
       if (signerAddress) {
-        get()[sliceKey].fetchEstGas(activeKey, formType, api, market)
+        void get()[sliceKey].fetchEstGas(activeKey, formType, api, market)
       }
     },
 
@@ -112,8 +112,8 @@ const createVaultUnstake = (set: SetState<State>, get: GetState<State>): VaultUn
 
       if (resp.activeKey === get()[sliceKey].activeKey) {
         // re-fetch api
-        get().user.fetchUserMarketBalances(api, market, true)
-        get().markets.fetchAll(api, market, true)
+        void get().user.fetchUserMarketBalances(api, market, true)
+        void get().markets.fetchAll(api, market, true)
 
         // update state
         const partialFormStatus: Partial<FormStatus> = {

--- a/apps/main/src/lend/store/createVaultWithdrawRedeemSlice.ts
+++ b/apps/main/src/lend/store/createVaultWithdrawRedeemSlice.ts
@@ -123,8 +123,8 @@ const createVaultWithdrawRedeem = (set: SetState<State>, get: GetState<State>): 
 
       // api calls
       await get()[sliceKey].fetchMax(api, formType, market)
-      get()[sliceKey].fetchDetails(activeKey, formType, api, market)
-      get()[sliceKey].fetchEstGas(activeKey, formType, api, market)
+      void get()[sliceKey].fetchDetails(activeKey, formType, api, market)
+      void get()[sliceKey].fetchEstGas(activeKey, formType, api, market)
     },
 
     // steps
@@ -150,8 +150,8 @@ const createVaultWithdrawRedeem = (set: SetState<State>, get: GetState<State>): 
 
       if (resp.activeKey === get()[sliceKey].activeKey) {
         // api calls
-        get().user.fetchUserMarketBalances(api, market, true)
-        get()[sliceKey].fetchMax(api, formType, market)
+        void get().user.fetchUserMarketBalances(api, market, true)
+        void get()[sliceKey].fetchMax(api, formType, market)
 
         // update state
         const partialFormStatus: Partial<FormStatus> = { error: resp.error, isComplete: !resp.error }

--- a/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/DeployButton.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/DeployButton.tsx
@@ -47,21 +47,21 @@ const DeployButton = ({ className }: DeployButtonProps) => {
   const handleClick = useCallback(async () => {
     if (stakingModule === 'deposit') {
       if (isInputAmountApproved) {
-        deposit(inputAmount)
+        void deposit(inputAmount)
       }
       if (!isInputAmountApproved) {
         const approved = await depositApprove(inputAmount)
         if (approved) {
-          deposit(inputAmount)
+          void deposit(inputAmount)
         }
       }
     }
 
     if (stakingModule === 'withdraw') {
       if (inputAmount === userBalance.scrvUSD) {
-        redeem(inputAmount)
+        void redeem(inputAmount)
       } else {
-        redeem(inputAmount)
+        void redeem(inputAmount)
       }
     }
   }, [stakingModule, isInputAmountApproved, deposit, inputAmount, depositApprove, redeem, userBalance])

--- a/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/index.tsx
@@ -61,13 +61,13 @@ const DepositWithdraw = ({ className }: DepositWithdrawProps) => {
       if (lending && curve && inputAmount !== '0') {
         if (stakingModule === 'deposit') {
           if (isDepositApprovalReady) {
-            estimateGasDeposit(inputAmount)
+            void estimateGasDeposit(inputAmount)
           } else {
-            estimateGasDepositApprove(inputAmount)
+            void estimateGasDepositApprove(inputAmount)
           }
           previewAction('deposit', inputAmount)
         } else {
-          estimateGasWithdraw(inputAmount)
+          void estimateGasWithdraw(inputAmount)
           previewAction('withdraw', inputAmount)
         }
       }

--- a/apps/main/src/loan/components/PageCrvUsdStaking/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/index.tsx
@@ -60,19 +60,19 @@ const CrvUsdStaking = ({ params }: { params: NetworkUrlParams }) => {
     const fetchData = async () => {
       if (!lendApi || !signerAddress) return
       // ensure user balances are up to date on load
-      refetchUserScrvUsdBalance()
+      void refetchUserScrvUsdBalance()
       fetchExchangeRate()
       fetchCrvUsdSupplies()
     }
 
-    fetchData()
+    void fetchData()
   }, [lendApi, signerAddress, fetchExchangeRate, fetchCrvUsdSupplies, refetchUserScrvUsdBalance])
 
   useEffect(() => {
     if (!lendApi || !chainId || !signerAddress || inputAmount === '0') return
 
     if (stakingModule === 'deposit') {
-      checkApproval.depositApprove(inputAmount)
+      void checkApproval.depositApprove(inputAmount)
     }
   }, [checkApproval, lendApi, chainId, signerAddress, inputAmount, stakingModule])
 

--- a/apps/main/src/loan/components/PageIntegrations/Page.tsx
+++ b/apps/main/src/loan/components/PageIntegrations/Page.tsx
@@ -18,7 +18,7 @@ const Page = (params: NetworkUrlParams) => {
   const integrationsTags = useStore((state) => state.integrations.integrationsTags)
 
   useEffect(() => {
-    init(rChainId)
+    void init(rChainId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -78,7 +78,7 @@ const LoanCreate = ({
   const updateFormValues = useCallback(
     (updatedFormValues: FormValues) => {
       if (curve && llamma) {
-        setFormValues(curve, isLeverage, llamma, updatedFormValues, maxSlippage)
+        void setFormValues(curve, isLeverage, llamma, updatedFormValues, maxSlippage)
       }
     },
     [curve, isLeverage, llamma, maxSlippage, setFormValues],

--- a/apps/main/src/loan/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/Page.tsx
@@ -81,10 +81,10 @@ const Page = (params: CollateralUrlParams) => {
       })
 
       const updatedFormValues = { ...formValues, n: formValues.n || llamma.defaultBands }
-      setFormValues(curve, isLeverage, llamma, updatedFormValues, maxSlippage)
+      void setFormValues(curve, isLeverage, llamma, updatedFormValues, maxSlippage)
 
       if (curve.signerAddress) {
-        fetchUserLoanWalletBalances(curve, llamma)
+        void fetchUserLoanWalletBalances(curve, llamma)
       }
     },
     [fetchUserLoanWalletBalances, formValues, maxSlippage, setFormValues, setStateByKeys],
@@ -99,7 +99,7 @@ const Page = (params: CollateralUrlParams) => {
       } else {
         resetUserDetailsState(llamma)
         fetchInitial(curve, isLeverage, llamma)
-        fetchLoanDetails(curve, llamma)
+        void fetchLoanDetails(curve, llamma)
         setLoaded(true)
       }
     }
@@ -125,7 +125,7 @@ const Page = (params: CollateralUrlParams) => {
   // max slippage updated
   useEffect(() => {
     if (loaded && !!curve) {
-      setFormValues(curve, isLeverage, llamma, formValues, maxSlippage)
+      void setFormValues(curve, isLeverage, llamma, formValues, maxSlippage)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [maxSlippage])
@@ -133,7 +133,7 @@ const Page = (params: CollateralUrlParams) => {
   usePageVisibleInterval(
     () => {
       if (isPageVisible && curve && llamma) {
-        fetchLoanDetails(curve, llamma)
+        void fetchLoanDetails(curve, llamma)
       }
     },
     REFRESH_INTERVAL['1m'],

--- a/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
@@ -64,7 +64,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
 
   const updateFormValues = (updatedFormValues: FormValues) => {
     if (chainId && llamma) {
-      setFormValues(chainId, llamma, updatedFormValues, maxRemovable)
+      void setFormValues(chainId, llamma, updatedFormValues, maxRemovable)
     }
   }
 

--- a/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
@@ -65,7 +65,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
   const updateFormValues = useCallback(
     (updatedFormValues: FormValues) => {
       if (chainId && llamma) {
-        setFormValues(chainId, llamma, updatedFormValues)
+        void setFormValues(chainId, llamma, updatedFormValues)
       }
     },
     [chainId, llamma, setFormValues],

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -67,7 +67,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
 
   const updateFormValues = (updatedFormValues: FormValues) => {
     if (chainId && llamma) {
-      setFormValues(chainId, llamma, updatedFormValues)
+      void setFormValues(chainId, llamma, updatedFormValues)
     }
   }
 

--- a/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
@@ -88,7 +88,7 @@ const LoanDeleverage = ({
         setHealthMode(DEFAULT_HEALTH_MODE)
       }
 
-      setFormValues(
+      void setFormValues(
         llammaId,
         curve,
         llamma,

--- a/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
@@ -72,7 +72,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
   const updateFormValues = useCallback(
     (updatedFormValues: FormValues) => {
       if (chainId && llamma) {
-        setFormValues(chainId, llamma, updatedFormValues)
+        void setFormValues(chainId, llamma, updatedFormValues)
       }
     },
     [chainId, llamma, setFormValues],
@@ -224,7 +224,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
   // init
   useEffect(() => {
     if (isReady && chainId && llamma) {
-      init(chainId, llamma)
+      void init(chainId, llamma)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady, chainId, llamma])

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -58,7 +58,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
 
       if (chainId && llamma && (isErrorReset || isFullReset)) {
         setStateByKey('formStatus', { ...DEFAULT_FORM_STATUS, isApproved: formStatus.isApproved })
-        fetchTokensToLiquidate(rChainId, llamma, llammaId, maxSlippage, userWalletBalances)
+        void fetchTokensToLiquidate(rChainId, llamma, llammaId, maxSlippage, userWalletBalances)
       }
     },
     [
@@ -169,7 +169,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
   // init
   useEffect(() => {
     if (chainId && llamma && llammaId && typeof userWalletBalances?.stablecoin !== 'undefined') {
-      fetchTokensToLiquidate(chainId, llamma, llammaId, maxSlippage, userWalletBalances)
+      void fetchTokensToLiquidate(chainId, llamma, llammaId, maxSlippage, userWalletBalances)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [curve?.signerAddress, chainId, llamma, llammaId, maxSlippage, userWalletBalances?.stablecoin])

--- a/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanSwap/index.tsx
@@ -64,7 +64,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
   const updateFormValues = useCallback(
     (updatedFormValues: FormValues) => {
       if (chainId && llamma) {
-        setFormValues(chainId, llamma, updatedFormValues, maxSlippage)
+        void setFormValues(chainId, llamma, updatedFormValues, maxSlippage)
       }
     },
     [chainId, llamma, maxSlippage, setFormValues],
@@ -101,7 +101,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
       updatedFormValues.item1 = formValues.item2 ?? detailInfo.amount
       updatedFormValues.item2Key = formValues.item1Key
 
-      fetchMaxSwappable(chainId, llamma, updatedFormValues)
+      void fetchMaxSwappable(chainId, llamma, updatedFormValues)
       updateFormValues(updatedFormValues)
     }
   }
@@ -204,7 +204,7 @@ const Swap = ({ curve, llamma, llammaId, rChainId }: Props) => {
   // init
   useMemo(() => {
     if (chainId && llamma) {
-      init(chainId, llamma)
+      void init(chainId, llamma)
     }
   }, [chainId, init, llamma])
 

--- a/apps/main/src/loan/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/Page.tsx
@@ -82,7 +82,7 @@ const Page = (params: CollateralUrlParams) => {
       if (!rChainId || !rCollateralId || !rFormType) {
         push(getCollateralListPathname(params))
       } else if (curve.signerAddress && llamma) {
-        ;(async () => {
+        void (async () => {
           const fetchedLoanDetails = await fetchLoanDetails(curve, llamma)
           if (!fetchedLoanDetails.loanExists.loanExists) {
             resetUserDetailsState(llamma)
@@ -116,8 +116,8 @@ const Page = (params: CollateralUrlParams) => {
   usePageVisibleInterval(
     () => {
       if (isPageVisible && curve && !!curve.signerAddress && llamma && loanExists) {
-        fetchLoanDetails(curve, llamma)
-        fetchUserLoanDetails(curve, llamma)
+        void fetchLoanDetails(curve, llamma)
+        void fetchUserLoanDetails(curve, llamma)
       }
     },
     REFRESH_INTERVAL['1m'],

--- a/apps/main/src/loan/components/PageMarketList/index.tsx
+++ b/apps/main/src/loan/components/PageMarketList/index.tsx
@@ -48,7 +48,7 @@ const CollateralList = (pageProps: PageCollateralList) => {
 
   const updateFormValues = useCallback(
     (shouldRefetch?: boolean) => {
-      setFormValues(rChainId, pageLoaded ? curve : null, shouldRefetch)
+      void setFormValues(rChainId, pageLoaded ? curve : null, shouldRefetch)
     },
     [setFormValues, rChainId, pageLoaded, curve],
   )
@@ -67,7 +67,7 @@ const CollateralList = (pageProps: PageCollateralList) => {
           const loanExists = loanExistsMapper[collateralId]?.loanExists
           if (loanExists) {
             loansExists = true
-            fetchUserLoanPartialDetails(curve, collateralData.llamma)
+            void fetchUserLoanPartialDetails(curve, collateralData.llamma)
           }
         }
       })
@@ -92,7 +92,7 @@ const CollateralList = (pageProps: PageCollateralList) => {
     () => {
       //  re-fetch data
       if (curve && collateralDatas) {
-        fetchLoansDetails(curve, collateralDatas)
+        void fetchLoansDetails(curve, collateralDatas)
       }
     },
     REFRESH_INTERVAL['5m'],

--- a/apps/main/src/loan/components/PagePegKeepers/index.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/index.tsx
@@ -17,7 +17,7 @@ const PagePegKeepers = ({ rChainId, provider }: { rChainId: ChainId; provider: P
 
   useEffect(() => {
     if (provider) {
-      fetchDetails(provider)
+      void fetchDetails(provider)
       setLoaded(true)
     }
   }, [fetchDetails, provider])
@@ -27,7 +27,7 @@ const PagePegKeepers = ({ rChainId, provider }: { rChainId: ChainId; provider: P
       if (!loaded) return
 
       resetState()
-      if (provider) fetchDetails(provider)
+      if (provider) void fetchDetails(provider)
     },
     REFRESH_INTERVAL['5m'],
     isPageVisible,

--- a/apps/main/src/loan/hooks/usePageOnMount.ts
+++ b/apps/main/src/loan/hooks/usePageOnMount.ts
@@ -232,14 +232,14 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
     if (connectState.status || connectState.stage) {
       if (isSuccess(connectState)) {
       } else if (isLoading(connectState, CONNECT_STAGE.SWITCH_NETWORK)) {
-        handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
+        void handleNetworkSwitch(getOptions(CONNECT_STAGE.SWITCH_NETWORK, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_WALLET)) {
-        handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
+        void handleConnectWallet(getOptions(CONNECT_STAGE.CONNECT_WALLET, connectState.options))
       } else if (isLoading(connectState, CONNECT_STAGE.DISCONNECT_WALLET) && wallet) {
-        handleDisconnectWallet(wallet)
+        void handleDisconnectWallet(wallet)
       } else if (isLoading(connectState, CONNECT_STAGE.CONNECT_API)) {
-        handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
-        handleConnectLendApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
+        void handleConnectCurveApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
+        void handleConnectLendApi(getOptions(CONNECT_STAGE.CONNECT_API, connectState.options))
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/loan/hooks/usePageOnMount.ts
+++ b/apps/main/src/loan/hooks/usePageOnMount.ts
@@ -80,7 +80,7 @@ function usePageOnMount(chainIdNotRequired?: boolean) {
             updateLending(api)
             updateConnectState('success', '')
 
-            hydrate(api, prevApi, wallet)
+            await hydrate(api, prevApi, wallet)
           } else {
             updateConnectState('', '')
           }

--- a/apps/main/src/loan/store/createAppSlice.ts
+++ b/apps/main/src/loan/store/createAppSlice.ts
@@ -90,7 +90,7 @@ const createAppSlice = (set: SetState<State>, get: GetState<State>): AppSlice =>
       await loans.fetchLoansDetails(curveApi, collateralDatas)
 
       if (!prevCurveApi || isNetworkSwitched) {
-        usdRates.fetchAllStoredUsdRates(curveApi)
+        void usdRates.fetchAllStoredUsdRates(curveApi)
       }
     }
 

--- a/apps/main/src/loan/store/createCollateralListSlice.ts
+++ b/apps/main/src/loan/store/createCollateralListSlice.ts
@@ -161,7 +161,7 @@ const createCollateralListSlice = (set: SetState<State>, get: GetState<State>): 
       })
 
       if (activeKey === `${rChainId}-${TITLE.totalBorrowed}-desc`) {
-        storeCache.setStateByActiveKey('collateralList', activeKey, newResult)
+        void storeCache.setStateByActiveKey('collateralList', activeKey, newResult)
       }
 
       if (!initialLoaded) sliceState.setStateByKey('initialLoaded', true)

--- a/apps/main/src/loan/store/createCollateralsSlice.ts
+++ b/apps/main/src/loan/store/createCollateralsSlice.ts
@@ -65,10 +65,10 @@ const createCollateralsSlice = (set: SetState<State>, get: GetState<State>) => (
       get()[sliceKey].setStateByActiveKey('collateralDatasMapper', chainId.toString(), collateralDatasMapper)
 
       // fetch collaterals USD rates
-      get().usdRates.fetchUsdRateByTokens(curve, collateralAddresses)
+      void get().usdRates.fetchUsdRateByTokens(curve, collateralAddresses)
 
       // add to cache
-      get().storeCache.setStateByActiveKey('collateralDatasMapper', chainId.toString(), collateralDatasCacheMapper)
+      void get().storeCache.setStateByActiveKey('collateralDatasMapper', chainId.toString(), collateralDatasCacheMapper)
 
       return { collateralDatas, collateralDatasMapper }
     },

--- a/apps/main/src/loan/store/createLoanCollateralDecreaseSlice.ts
+++ b/apps/main/src/loan/store/createLoanCollateralDecreaseSlice.ts
@@ -75,7 +75,7 @@ const createLoanCollateralDecrease = (set: SetState<State>, get: GetState<State>
     ...DEFAULT_STATE,
 
     init: (chainId: ChainId, llamma: Llamma) => {
-      get()[sliceKey].fetchMaxRemovable(chainId, llamma)
+      void get()[sliceKey].fetchMaxRemovable(chainId, llamma)
     },
     fetchEstGas: async (activeKey: string, chainId: ChainId, llamma: Llamma, formValues: FormValues) => {
       const { collateral } = formValues
@@ -139,8 +139,8 @@ const createLoanCollateralDecrease = (set: SetState<State>, get: GetState<State>
 
       // fetch detail, approval, est gas, set loading
       if (haveCollateral) {
-        get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
-        get()[sliceKey].fetchEstGas(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchEstGas(activeKey, chainId, llamma, cFormValues)
       } else {
         get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
         get()[sliceKey].setStateByActiveKey('formEstGas', activeKey, DEFAULT_FORM_EST_GAS)
@@ -162,7 +162,7 @@ const createLoanCollateralDecrease = (set: SetState<State>, get: GetState<State>
       const chainId = curve.chainId
       const removeCollateralFn = networks[chainId].api.collateralDecrease.removeCollateral
       const resp = await removeCollateralFn(activeKey, provider, llamma, formValues.collateral)
-      get()[sliceKey].fetchMaxRemovable(chainId, llamma)
+      void get()[sliceKey].fetchMaxRemovable(chainId, llamma)
       const { loanExists } = await get().loans.fetchLoanDetails(curve, llamma)
       if (!loanExists.loanExists) {
         get().loans.resetUserDetailsState(llamma)

--- a/apps/main/src/loan/store/createLoanCollateralIncreaseSlice.ts
+++ b/apps/main/src/loan/store/createLoanCollateralIncreaseSlice.ts
@@ -130,8 +130,8 @@ const createLoanCollateralIncrease = (set: SetState<State>, get: GetState<State>
 
       // fetch detail, approval, est gas, set loading
       if (haveCollateral) {
-        get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
       } else {
         get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
         get()[sliceKey].setStateByActiveKey('formEstGas', activeKey, DEFAULT_FORM_EST_GAS)
@@ -163,7 +163,7 @@ const createLoanCollateralIncrease = (set: SetState<State>, get: GetState<State>
         })
 
         if (!resp.error) {
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
         }
         return resp
       }

--- a/apps/main/src/loan/store/createLoanCreateSlice.ts
+++ b/apps/main/src/loan/store/createLoanCreateSlice.ts
@@ -305,7 +305,7 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>) => ({
           storedFormValues.debt !== formValues.debt ||
           !get()[sliceKey].liqRangesMapper[activeKeyLiqRange]
         ) {
-          get()[sliceKey].fetchLiqRanges(activeKeyLiqRange, chainId, isLeverage, llamma, clonedFormValues)
+          void get()[sliceKey].fetchLiqRanges(activeKeyLiqRange, chainId, isLeverage, llamma, clonedFormValues)
         }
 
         // fetch approval and estimate gas, detail
@@ -319,7 +319,7 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>) => ({
           }
 
           // fetch detail info
-          get()[sliceKey].fetchDetailInfo(
+          void get()[sliceKey].fetchDetailInfo(
             activeKey,
             chainId,
             isLeverage,
@@ -330,7 +330,14 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>) => ({
           )
 
           if (signerAddress && !collateralError) {
-            get()[sliceKey].fetchEstGasApproval(activeKey, chainId, isLeverage, llamma, clonedFormValues, maxSlippage)
+            void get()[sliceKey].fetchEstGasApproval(
+              activeKey,
+              chainId,
+              isLeverage,
+              llamma,
+              clonedFormValues,
+              maxSlippage,
+            )
           }
         } else {
           if (isLeverage) {
@@ -386,7 +393,7 @@ const createLoanCreate = (set: SetState<State>, get: GetState<State>) => ({
           error: resp.error,
         })
 
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, isLeverage, llamma, formValues, maxSlippage)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, isLeverage, llamma, formValues, maxSlippage)
 
         return resp
       }

--- a/apps/main/src/loan/store/createLoanDecreaseSlice.ts
+++ b/apps/main/src/loan/store/createLoanDecreaseSlice.ts
@@ -116,7 +116,7 @@ const createLoanDecrease = (set: SetState<State>, get: GetState<State>) => ({
         get()[sliceKey].setStateByActiveKey('formEstGas', activeKey, loadingFormEstGas)
         get()[sliceKey].setStateByKeys({ activeKey, formValues: cloneDeep(cFormValues) })
 
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
       } else {
         // validate debt
         const haveDebt = +debt > 0
@@ -153,11 +153,11 @@ const createLoanDecrease = (set: SetState<State>, get: GetState<State>) => ({
           clonedFormStatus.warning = isMaxPayable ? 'warning-is-payoff-amount' : ''
           get()[sliceKey].setStateByKey('formStatus', clonedFormStatus)
 
-          isMaxPayable
+          void (isMaxPayable
             ? get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
-            : get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
+            : get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues))
 
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
         } else if (!haveDebt || cFormValues.debtError) {
           get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
           get()[sliceKey].setStateByActiveKey('formEstGas', activeKey, DEFAULT_FORM_EST_GAS)
@@ -190,7 +190,7 @@ const createLoanDecrease = (set: SetState<State>, get: GetState<State>) => ({
           formProcessing: !resp.error,
           error: resp.error,
         })
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
 
         return resp
       }

--- a/apps/main/src/loan/store/createLoanDeleverageSlice.ts
+++ b/apps/main/src/loan/store/createLoanDeleverageSlice.ts
@@ -124,7 +124,7 @@ const createLoanDeleverageSlice = (set: SetState<State>, get: GetState<State>): 
           const clonedStoredFormEstGas = cloneDeep(storedFormEstGas)
           clonedStoredFormEstGas.loading = true
           get()[sliceKey].setStateByKey('formEstGas', { [activeKey]: clonedStoredFormEstGas })
-          get()[sliceKey].fetchEstGas(activeKey, chainId, llamma, cFormValues, maxSlippage)
+          void get()[sliceKey].fetchEstGas(activeKey, chainId, llamma, cFormValues, maxSlippage)
         }
       }
     },

--- a/apps/main/src/loan/store/createLoanIncreaseSlice.ts
+++ b/apps/main/src/loan/store/createLoanIncreaseSlice.ts
@@ -82,7 +82,7 @@ const createLoanIncrease = (set: SetState<State>, get: GetState<State>) => ({
     ...DEFAULT_STATE,
 
     init: async (chainId: ChainId, llamma: Llamma) => {
-      get()[sliceKey].fetchMaxRecv(chainId, llamma, DEFAULT_FORM_VALUES)
+      void get()[sliceKey].fetchMaxRecv(chainId, llamma, DEFAULT_FORM_VALUES)
     },
     fetchEstGasApproval: async (activeKey: string, chainId: ChainId, llamma: Llamma, formValues: FormValues) => {
       const { collateral, debt } = formValues
@@ -159,10 +159,10 @@ const createLoanIncrease = (set: SetState<State>, get: GetState<State>) => ({
 
       // fetch detail, approval, est gas, set loading
       if (haveDebt || haveCollateral) {
-        get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
+        void get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues)
 
         if (!cFormValues.debtError && !cFormValues.collateralError && !cFormValues.debtError) {
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues)
         }
       } else if (!haveDebt || !haveCollateral) {
         get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
@@ -197,7 +197,7 @@ const createLoanIncrease = (set: SetState<State>, get: GetState<State>) => ({
           formProcessing: !resp.error,
           error: resp.error,
         })
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues)
 
         return resp
       }
@@ -218,7 +218,7 @@ const createLoanIncrease = (set: SetState<State>, get: GetState<State>) => ({
 
       // re-fetch max
       const resp = await borrowMoreFn(activeKey, provider, llamma, collateral, debt)
-      get()[sliceKey].fetchMaxRecv(chainId, llamma, formValues)
+      void get()[sliceKey].fetchMaxRecv(chainId, llamma, formValues)
 
       // re-fetch loan info
       const { loanExists } = await get().loans.fetchLoanDetails(curve, llamma)

--- a/apps/main/src/loan/store/createLoanLiquidate.ts
+++ b/apps/main/src/loan/store/createLoanLiquidate.ts
@@ -96,7 +96,7 @@ const createLoanLiquidate = (set: SetState<State>, get: GetState<State>) => ({
 
       get()[sliceKey].setStateByKey('formStatus', clonedFormStatus)
       if (canSelfLiquidate) {
-        get()[sliceKey].fetchEstGasApproval(chainId, llamma, maxSlippage, clonedFormStatus)
+        void get()[sliceKey].fetchEstGasApproval(chainId, llamma, maxSlippage, clonedFormStatus)
       }
     },
 
@@ -121,7 +121,7 @@ const createLoanLiquidate = (set: SetState<State>, get: GetState<State>) => ({
         error: resp.error,
       }
       get()[sliceKey].setStateByKey('formStatus', updatedFormStatus)
-      get()[sliceKey].fetchEstGasApproval(chainId, llamma, maxSlippage, updatedFormStatus)
+      void get()[sliceKey].fetchEstGasApproval(chainId, llamma, maxSlippage, updatedFormStatus)
       return resp
     },
     fetchStepLiquidate: async (curve: Curve, llamma: Llamma, liquidationAmt: string, maxSlippage: string) => {

--- a/apps/main/src/loan/store/createLoanSwap.ts
+++ b/apps/main/src/loan/store/createLoanSwap.ts
@@ -110,7 +110,7 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
     init: async (chainId: ChainId, llamma: Llamma) => {
       const activeKey = getSwapActiveKey(llamma, DEFAULT_FORM_VALUES)
       get()[sliceKey].setStateByKey('activeKey', activeKey)
-      get()[sliceKey].fetchMaxSwappable(chainId, llamma, DEFAULT_FORM_VALUES)
+      void get()[sliceKey].fetchMaxSwappable(chainId, llamma, DEFAULT_FORM_VALUES)
     },
     fetchEstGasApproval: async (
       activeKey: string,
@@ -158,10 +158,10 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
 
         // fetch est gas
         if (!item1Error) {
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, resp.amount, maxSlippage)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, resp.amount, maxSlippage)
         } else {
           get()[sliceKey].setStateByKey('formValues', { ...get()[sliceKey].formValues, item1Error })
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, resp.amount, maxSlippage)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, resp.amount, maxSlippage)
         }
       }
     },
@@ -219,9 +219,9 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
       // fetch approval, estimated gas and detail info
       if (haveItem1 || haveItem2) {
         if (haveItem1) {
-          get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues, item1, maxSlippage)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, cFormValues, item1, maxSlippage)
         }
-        get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues, maxSlippage)
+        void get()[sliceKey].fetchDetailInfo(activeKey, chainId, llamma, cFormValues, maxSlippage)
       } else if (!haveItem1) {
         get()[sliceKey].setStateByActiveKey('detailInfo', activeKey, DEFAULT_DETAIL_INFO)
         get()[sliceKey].setStateByActiveKey('formEstGas', activeKey, DEFAULT_FORM_EST_GAS)
@@ -258,7 +258,7 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
           error: resp.error,
         })
 
-        get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, formValues.item1, maxSlippage)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, llamma, formValues, formValues.item1, maxSlippage)
 
         return resp
       }
@@ -284,7 +284,7 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
       const resp = await swapFn(activeKey, provider, llamma, formValues, maxSlippage)
       if (activeKey === get()[sliceKey].activeKey) {
         // re-fetch loan info
-        get().loans.fetchLoanDetails(curve, llamma)
+        void get().loans.fetchLoanDetails(curve, llamma)
 
         // reset form
         const updatedFormValues = {
@@ -294,7 +294,7 @@ const createLoanSwap = (set: SetState<State>, get: GetState<State>) => ({
         }
 
         // re-fetch max
-        get()[sliceKey].fetchMaxSwappable(chainId, llamma, updatedFormValues)
+        void get()[sliceKey].fetchMaxSwappable(chainId, llamma, updatedFormValues)
 
         get()[sliceKey].setStateByKeys({
           activeKey: getSwapActiveKey(llamma, updatedFormValues),

--- a/apps/main/src/loan/store/createLoansSlice.ts
+++ b/apps/main/src/loan/store/createLoansSlice.ts
@@ -101,10 +101,10 @@ const createLoansSlice = (set: SetState<State>, get: GetState<State>) => ({
       get()[sliceKey].setStateByActiveKey('existsMapper', collateralId, loanExists)
 
       if (curve.signerAddress) {
-        get()[sliceKey].fetchUserLoanWalletBalances(curve, llamma)
+        void get()[sliceKey].fetchUserLoanWalletBalances(curve, llamma)
 
         if (loanExists.loanExists) {
-          get()[sliceKey].fetchUserLoanDetails(curve, llamma)
+          void get()[sliceKey].fetchUserLoanDetails(curve, llamma)
         }
       }
 

--- a/apps/main/src/loan/store/createPegKeepersSlice.ts
+++ b/apps/main/src/loan/store/createPegKeepersSlice.ts
@@ -125,7 +125,7 @@ const createPegKeepersSlice = (set: SetState<State>, get: GetState<State>): PegK
         sliceState.setStateByKey('formStatus', { [pegKeeperAddress]: { ...DEFAULT_FORM_STATUS, isComplete: true } })
 
         // re-fetch data
-        sliceState.fetchEstCallerProfit(provider, pegKeeperAddress)
+        void sliceState.fetchEstCallerProfit(provider, pegKeeperAddress)
 
         return { hash, error: '' }
       } catch (error) {

--- a/apps/main/src/loan/store/createScrvUsdSlice.ts
+++ b/apps/main/src/loan/store/createScrvUsdSlice.ts
@@ -244,7 +244,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
             errorMessage: '',
           })
           dismissNotificationHandler()
-          get()[sliceKey].checkApproval.depositApprove(amount)
+          void get()[sliceKey].checkApproval.depositApprove(amount)
 
           const successNotificationMessage = t`Succesfully approved ${amount} crvUSD!`
           notify(successNotificationMessage, 'success', 15000)

--- a/apps/main/src/loan/store/createUsdRatesSlice.ts
+++ b/apps/main/src/loan/store/createUsdRatesSlice.ts
@@ -70,7 +70,7 @@ const createUsdRatesSlice = (set: SetState<State>, get: GetState<State>) => ({
     },
     fetchAllStoredUsdRates: async (curve: Curve) => {
       const tokenAddresses = Object.keys(get().usdRates.tokens)
-      get()[sliceKey].fetchUsdRateByTokens(curve, tokenAddresses)
+      void get()[sliceKey].fetchUsdRateByTokens(curve, tokenAddresses)
     },
 
     // slice helpers


### PR DESCRIPTION
This PR mostly purposefully `voids` promises that are already not being awaited. This includes promises in `useEffect`, `useCallback` and the various slices. Not awaiting was already the default behavior and seems to be intended. You shouldn't await in `useEffect` and `useCallback`, and in the slices it seems data is being fetched haphazardly that doesn't have to be blocking. Only awaits added are to the `hydrate` function on init, and `async function getPools` in `apps\main\src\dex\lib\pools.ts`.