### PR TITLE
chore: forbid console.log

### DIFF
--- a/apps/main/src/app/api/dex/[network]/route.ts
+++ b/apps/main/src/app/api/dex/[network]/route.ts
@@ -58,7 +58,7 @@ async function refreshDex() {
   for (const network of Object.values(dexNetworks)) {
     const networkStart = Date.now()
     DexServerSideCache[network.id] = await getServerSideCache(network)
-    console.log(`Refreshed DEX ${network.id} in ${Date.now() - networkStart}ms`)
+    console.info(`Refreshed DEX ${network.id} in ${Date.now() - networkStart}ms`)
   }
 }
 

--- a/apps/main/src/app/api/dex/[network]/route.ts
+++ b/apps/main/src/app/api/dex/[network]/route.ts
@@ -25,7 +25,8 @@ const getVolumeCache = async (network: NetworkConfig, pools: PoolDataMapper) => 
     try {
       return [pool.id, { value: await pool.stats.volume() }]
     } catch (e) {
-      const logMethod = pool.id === 'crveth' ? 'log' : 'warn' // this pool is always throwing an error
+      const logMethod = pool.id === 'crveth' ? 'info' : 'warn' // this pool is always throwing an error
+      // eslint-disable-next-line no-console -- false positive
       console[logMethod](e)
       return [pool.id, null]
     }

--- a/apps/main/src/background.ts
+++ b/apps/main/src/background.ts
@@ -20,7 +20,7 @@ export async function refreshDataInBackground(name: string, callback: () => Prom
     })
     const end = new Date()
     const elapsed = end.getTime() - start
-    console.log(`${end.toISOString()} Refreshed ${name} in ${elapsed}ms`)
+    console.info(`${end.toISOString()} Refreshed ${name} in ${elapsed}ms`)
     if (elapsed < RefreshTimeoutMs) {
       await new Promise((resolve) => setTimeout(resolve, RefreshTimeoutMs - elapsed))
     }

--- a/apps/main/src/dao/components/PageVeCrv/Page.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/Page.tsx
@@ -17,7 +17,6 @@ import { t } from '@ui-kit/lib/i18n'
 import { useApiStore } from '@ui-kit/shared/useApiStore'
 
 const Page = (params: VeCrvUrlParams) => {
-  console.log(params)
   const [rFormType] = params.formType
   const { push } = useRouter()
   const { routerParams, curve } = usePageOnMount()

--- a/apps/main/src/dao/store/createAnalyticsSlice.ts
+++ b/apps/main/src/dao/store/createAnalyticsSlice.ts
@@ -122,7 +122,7 @@ const createAnalyticsSlice = (set: SetState<State>, get: GetState<State>): Analy
           fetchStatus: 'SUCCESS',
         })
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('veCrvFees', {
           fees: [],
           veCrvTotalFees: 0,
@@ -144,7 +144,7 @@ const createAnalyticsSlice = (set: SetState<State>, get: GetState<State>): Analy
           fetchStatus: 'SUCCESS',
         })
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('veCrvLocks', {
           locks: [],
           fetchStatus: 'ERROR',
@@ -193,7 +193,7 @@ const createAnalyticsSlice = (set: SetState<State>, get: GetState<State>): Analy
           fetchStatus: 'SUCCESS',
         })
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('veCrvHolders', {
           topHolders: [],
           allHolders: {},
@@ -278,7 +278,7 @@ const createAnalyticsSlice = (set: SetState<State>, get: GetState<State>): Analy
           fetchStatus: 'SUCCESS',
         })
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('veCrvData', {
           totalVeCrv: 0,
           totalLockedCrv: 0,

--- a/apps/main/src/dao/store/createGaugesSlice.ts
+++ b/apps/main/src/dao/store/createGaugesSlice.ts
@@ -262,7 +262,7 @@ const createGaugesSlice = (set: SetState<State>, get: GetState<State>): GaugesSl
             state[sliceKey].gaugeWeightHistoryMapper[gaugeAddress].loadingState = 'ERROR'
           }),
         )
-        console.log(error)
+        console.warn(error)
       }
     },
 

--- a/apps/main/src/dao/store/createProposalsSlice.ts
+++ b/apps/main/src/dao/store/createProposalsSlice.ts
@@ -171,7 +171,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
         get().storeCache.setStateByKey('cacheProposalsMapper', proposalsObject)
         get()[sliceKey].setStateByKey('proposalsLoadingState', 'SUCCESS')
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('proposalsLoadingState', 'ERROR')
       }
     },
@@ -188,7 +188,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
 
         // the api returns a detail object if the proposal is not found
         if ('detail' in data) {
-          console.log(data.detail)
+          console.info('cannot find proposal', data.detail)
           return
         }
 
@@ -218,7 +218,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
           }),
         )
       } catch (error) {
-        console.log(error)
+        console.warn(error)
         get()[sliceKey].setStateByKey('proposalLoadingState', 'ERROR')
       }
     },
@@ -241,7 +241,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
 
         // the api returns a detail object if the proposal is not found
         if ('detail' in data) {
-          console.log(data.detail)
+          console.info('cannot find proposal', data.detail)
           return
         }
 
@@ -359,7 +359,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
       try {
         await fetchGasInfo(curve)
       } catch (error) {
-        console.log(error)
+        console.warn(error)
       }
 
       try {
@@ -427,7 +427,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
           },
         })
 
-        console.log(error)
+        console.warn(error)
       }
     },
     executeProposal: async (voteId: number, voteType: ProposalType) => {
@@ -455,7 +455,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
       try {
         await fetchGasInfo(curve)
       } catch (error) {
-        console.log(error)
+        console.warn(error)
       }
 
       try {
@@ -522,7 +522,7 @@ const createProposalsSlice = (set: SetState<State>, get: GetState<State>): Propo
           },
         })
 
-        console.log(error)
+        console.warn(error)
       }
     },
     setStateByKey: (key, value) => {

--- a/apps/main/src/dao/store/createUserSlice.ts
+++ b/apps/main/src/dao/store/createUserSlice.ts
@@ -297,7 +297,7 @@ const createUserSlice = (set: SetState<State>, get: GetState<State>): UserSlice 
           }),
         )
       } catch (error) {
-        console.log(error)
+        console.warn(error)
 
         set(
           produce((state) => {

--- a/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
@@ -112,7 +112,7 @@ const SelectTokenButton = ({
 
           updateUserAddedTokens(filterValueLowerCase, token[0].symbol, false, isBasePool)
         } catch (error) {
-          console.log(error)
+          console.warn(error)
           setError(error)
         }
       }

--- a/apps/main/src/dex/store/createCreatePoolSlice.ts
+++ b/apps/main/src/dex/store/createCreatePoolSlice.ts
@@ -576,7 +576,6 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
           }),
         )
       }
-      console.log(get().createPool.initialPrice)
     },
     refreshInitialPrice: async (curve: CurveApi) => {
       const tokenAPriceRaw = await get().usdRates.fetchUsdRateByToken(
@@ -779,7 +778,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
       try {
         await fetchGasInfo(curve)
       } catch (error) {
-        console.log(error)
+        console.warn(error)
       }
 
       set(
@@ -865,7 +864,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
                 state.createPool.transactionState.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
           // ----- TWOCRYPTO -----
         } else {
@@ -1043,7 +1042,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
                 state.createPool.transactionState.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         // ----- STABLE PLAIN POOL -----
@@ -1132,7 +1131,7 @@ const createCreatePoolSlice = (set: SetState<State>, get: GetState<State>) => ({
                 state.createPool.transactionState.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
       }

--- a/apps/main/src/dex/store/createDeployGaugeSlice.ts
+++ b/apps/main/src/dex/store/createDeployGaugeSlice.ts
@@ -234,7 +234,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mainnet.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
 
@@ -271,7 +271,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mainnet.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
 
@@ -308,7 +308,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mainnet.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
 
@@ -345,7 +345,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mainnet.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'STABLEOLD') {
@@ -381,7 +381,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mainnet.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
       }
@@ -429,7 +429,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.sidechain.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'TWOCRYPTO') {
@@ -467,7 +467,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.sidechain.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'TWOCRYPTONG') {
@@ -505,7 +505,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.sidechain.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'THREECRYPTO') {
@@ -543,7 +543,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.sidechain.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'STABLEOLD') {
@@ -581,7 +581,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.sidechain.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
       }
@@ -630,7 +630,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mirror.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'TWOCRYPTO') {
@@ -669,7 +669,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mirror.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'TWOCRYPTONG') {
@@ -708,7 +708,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mirror.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'THREECRYPTO') {
@@ -747,7 +747,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mirror.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
         if (gaugeType === 'STABLEOLD') {
@@ -783,7 +783,7 @@ const createDeployGaugeSlice = (set: SetState<State>, get: GetState<State>) => (
                 state.deployGauge.deploymentStatus.mirror.errorMessage = error.message
               }),
             )
-            console.log(error)
+            console.warn(error)
           }
         }
       }

--- a/apps/main/src/dex/store/createPoolsSlice.ts
+++ b/apps/main/src/dex/store/createPoolsSlice.ts
@@ -524,7 +524,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
             }),
           )
         } catch (error) {
-          console.log(error)
+          console.warn(error)
         }
       }
     },
@@ -555,7 +555,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
             }),
           )
         } catch (error) {
-          console.log(error)
+          console.warn(error)
         }
       }
     },
@@ -621,7 +621,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
               state.pools.pricesApiState.chartStatus = 'ERROR'
             }),
           )
-          console.log(error)
+          console.warn(error)
         }
       } else {
         try {
@@ -664,7 +664,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
               state.pools.pricesApiState.chartStatus = 'ERROR'
             }),
           )
-          console.log(error)
+          console.warn(error)
         }
       }
     },
@@ -716,7 +716,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
             )
           }
         } catch (error) {
-          console.log(error)
+          console.warn(error)
         }
       } else {
         try {
@@ -756,7 +756,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
               state.pools.pricesApiState.chartStatus = 'ERROR'
             }),
           )
-          console.log(error)
+          console.warn(error)
         }
       }
     },
@@ -836,7 +836,7 @@ const createPoolsSlice = (set: SetState<State>, get: GetState<State>): PoolsSlic
             state.pools.pricesApiState.activityStatus = 'ERROR'
           }),
         )
-        console.log(error)
+        console.warn(error)
       }
     },
     setChartTimeOption: (timeOption: TimeOptions) => {

--- a/apps/main/src/lend/utils/helpers.ts
+++ b/apps/main/src/lend/utils/helpers.ts
@@ -16,7 +16,7 @@ export function isHighSlippage(slippage: number, maxSlippage: string) {
 
 export function log(fnName: string, ...args: unknown[]) {
   if (isDevelopment) {
-    console.log(`curve-frontend -> ${fnName}:`, ...args)
+    console.info(`curve-frontend -> ${fnName}:`, ...args)
   }
 }
 

--- a/apps/main/src/loan/lib/apiCrvusd.ts
+++ b/apps/main/src/loan/lib/apiCrvusd.ts
@@ -1168,7 +1168,7 @@ const loanDeleverage = {
 
       return { activeKey, resp }
     } catch (error) {
-      console.log(error)
+      console.warn(error)
       resp.error = getErrorMessage(error, 'error-deleverage-api')
       return { activeKey, resp }
     }

--- a/apps/main/src/loan/store/createScrvUsdSlice.ts
+++ b/apps/main/src/loan/store/createScrvUsdSlice.ts
@@ -257,7 +257,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
             transaction: null,
             errorMessage: error.message,
           })
-          console.log(error)
+          console.warn(error)
           return false
         }
       },
@@ -317,7 +317,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
             transaction: null,
             errorMessage: error.message,
           })
-          console.log(error)
+          console.warn(error)
         }
       },
       withdraw: async (amount: string) => {
@@ -376,7 +376,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
             transaction: null,
             errorMessage: error.message,
           })
-          console.log(error)
+          console.warn(error)
         }
       },
       redeem: async (amount: string) => {
@@ -400,7 +400,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
         })
 
         try {
-          console.log('redeem', amount)
+          console.info('redeem', amount)
 
           const transactionHash = await lendApi.st_crvUSD.redeem(amount)
 
@@ -437,7 +437,7 @@ const createScrvUsdSlice = (set: SetState<State>, get: GetState<State>) => ({
             transaction: null,
             errorMessage: error.message,
           })
-          console.log(error)
+          console.warn(error)
         }
       },
     },

--- a/apps/main/src/loan/utils/helpers.ts
+++ b/apps/main/src/loan/utils/helpers.ts
@@ -18,7 +18,7 @@ export function isHighSlippage(slippage: number, maxSlippage: string) {
 
 export function log(fnName: string, ...args: unknown[]) {
   if (isDevelopment) {
-    console.log(`curve-frontend -> ${fnName}:`, ...args)
+    console.info(`curve-frontend -> ${fnName}:`, ...args)
   }
 }
 

--- a/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
@@ -187,7 +187,7 @@ const meta: Meta<typeof TokenSelector> = {
     error: '',
     disabledTokens: defaultDisabledTokens,
     disableSorting: false,
-    onToken: (token) => console.log('Selected token:', token),
+    onToken: (token) => console.info('Selected token:', token),
   },
   argTypes: {
     tokens: {
@@ -314,7 +314,7 @@ export const WithCustomOptions: Story = {
     customOptions: (
       <Stack gap={Spacing.xs}>
         <Typography variant="headingXsBold">Custom Options</Typography>
-        <Button variant="outlined" fullWidth onClick={() => console.log('Custom option clicked')}>
+        <Button variant="outlined" fullWidth onClick={() => console.info('Custom option clicked')}>
           Add Custom Token
         </Button>
       </Stack>

--- a/packages/curve-ui-kit/src/features/slippage-settings/SlippageSettings.stories.tsx
+++ b/packages/curve-ui-kit/src/features/slippage-settings/SlippageSettings.stories.tsx
@@ -14,7 +14,7 @@ const SlippageSettingsComponent = ({
   // Mock the setMaxSlippage function
   const handleSave = (newSlippage: string) => {
     setMaxSlippage(newSlippage)
-    console.log('Max slippage updated:', newSlippage)
+    console.info('Max slippage updated:', newSlippage)
   }
 
   return <SlippageSettings {...props} maxSlippage={maxSlippage} onSave={handleSave} />

--- a/packages/curve-ui-kit/src/lib/logging.ts
+++ b/packages/curve-ui-kit/src/lib/logging.ts
@@ -87,11 +87,8 @@ export function log(key: LogKey, status?: LogStatus | unknown, ...args: unknown[
       case LogStatus.WARNING:
       case LogStatus.MUTATION:
         return console.warn
-      case LogStatus.INFO:
-      case LogStatus.QUERY:
-        return console.info
       default:
-        return console.log
+        return console.info
     }
   }
   if (isCypress || typeof window === 'undefined') {

--- a/packages/curve-ui-kit/src/shared/HashRouterRedirect.tsx
+++ b/packages/curve-ui-kit/src/shared/HashRouterRedirect.tsx
@@ -28,7 +28,7 @@ export function HashRouterRedirect({ app, redirects }: { app?: AppName; redirect
   const { replace } = useRouter()
   useEffect(() => {
     const newUrl = getRedirectUrl(window.location, app, redirects)
-    console.log(`Redirecting from ${window.location.href} to ${newUrl}`)
+    console.info(`Redirecting from ${window.location.href} to ${newUrl}`)
     replace(newUrl)
   }, [app, replace, redirects])
   return <Skeleton />

--- a/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
@@ -28,7 +28,7 @@ export function CopyIconButton({
           size="extraSmall"
           {...iconProps}
           onClick={() => {
-            console.log(`Copying to clipboard: ${copyText}`)
+            console.info(`Copying to clipboard: ${copyText}`)
             return navigator.clipboard
               ? navigator.clipboard
                   .writeText(copyText)

--- a/packages/curve-ui-kit/src/shared/ui/stories/Banner.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Banner.stories.tsx
@@ -73,7 +73,7 @@ export const WithButton: Story = {
     severity: 'alert',
     children: 'This is an error message with an action button',
     buttonText: 'Dismiss',
-    onClick: () => console.log('Button clicked'),
+    onClick: () => console.info('Button clicked'),
   },
 }
 

--- a/packages/curve-ui-kit/src/shared/ui/stories/SearchField.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/SearchField.stories.tsx
@@ -32,20 +32,20 @@ type Story = StoryObj<typeof SearchField>
 
 export const Default: Story = {
   args: {
-    onSearch: (value: string) => console.log('Search:', value),
+    onSearch: (value: string) => console.info('Search:', value),
   },
 }
 
 export const WithCustomPlaceholder: Story = {
   args: {
-    onSearch: (value: string) => console.log('Search:', value),
+    onSearch: (value: string) => console.info('Search:', value),
     placeholder: 'Search networks',
   },
 }
 
 export const Small: Story = {
   args: {
-    onSearch: (value: string) => console.log('Search:', value),
+    onSearch: (value: string) => console.info('Search:', value),
     size: 'small',
   },
 }
@@ -70,7 +70,7 @@ export const WithInputRef = () => {
 
 export const CustomStyled: Story = {
   args: {
-    onSearch: (value: string) => console.log('Search:', value),
+    onSearch: (value: string) => console.info('Search:', value),
     sx: {
       width: '300px',
       backgroundColor: '#f5f5f5',

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -27,7 +27,12 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-floating-promises': 'warn',
-
+    "no-console": [
+      "error", // use console.log only for debugging
+      {
+        "allow": ["warn", "error", "info", "trace", "assert"]
+      }
+    ],
     'import/order': [
       'warn',
       {

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -68,5 +68,5 @@ module.exports = {
       presets: [require.resolve('next/babel')],
     },
   },
-  ignorePatterns: ['**/curve-ui-kit/.storybook/**/*', '**/*/*.js'],
+  ignorePatterns: ['**/curve-ui-kit/.storybook/**/*', '**/*/*.js', '**/dist/**/*.*'],
 }

--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -13,7 +13,7 @@ const IGNORE_ERROR_PATTERNS = [
 
 Cypress.on('uncaught:exception', (err) => {
   const ignore = IGNORE_ERROR_PATTERNS.find((p) => p.test(err.message))
-  console.log('Uncaught exception', ignore ? `ignored: ${ignore.source}` : err.message)
+  console.info('Uncaught exception', ignore ? `ignored: ${ignore.source}` : err.message)
   if (ignore) {
     return false // this will prevent the test from failing
   }

--- a/tests/killHardhatNodes.js
+++ b/tests/killHardhatNodes.js
@@ -13,7 +13,7 @@ const killNode = (chainId) => {
         reject(`Error killing Chain ID '${chainId}' node at port ${port}: ${stderr}`)
         return
       }
-      console.log(`Killed Chain ID '${chainId}' node at port ${port}`)
+      console.info(`Killed Chain ID '${chainId}' node at port ${port}`)
       resolve(stdout)
     })
   })
@@ -25,7 +25,7 @@ const main = async () => {
 
   try {
     await Promise.all(idsToKill.map(killNode))
-    console.log('Selected nodes killed successfully.')
+    console.info('Selected nodes killed successfully.')
   } catch (error) {
     console.error(error)
   }

--- a/tests/runHardhatNodes.js
+++ b/tests/runHardhatNodes.js
@@ -18,12 +18,12 @@ const startNode = (network) =>
 
     const isPortInUse = await checkPort(port)
     if (isPortInUse) {
-      console.log(`Network '${network.alias}' node is already running at http://${HOST_NAME}:${port}`)
+      console.info(`Network '${network.alias}' node is already running at http://${HOST_NAME}:${port}`)
       resolve(null)
       return
     }
 
-    console.log(`Starting network '${network.alias}' node at http://${HOST_NAME}:${port}`)
+    console.info(`Starting network '${network.alias}' node at http://${HOST_NAME}:${port}`)
     const command = `npx hardhat node --config ./hardhat.config.js --port ${port} --hostname ${HOST_NAME}`
     const nodeProcess = spawn('sh', ['-c', command], { env })
     nodeProcess.on('close', (code) => {
@@ -44,7 +44,7 @@ const startNode = (network) =>
           nodeProcess.kill()
           reject(`Network '${network.alias}' node not responding at http://${HOST_NAME}:${port}. Error: ${err}`)
         } else {
-          console.log(`Network '${network.alias}' node started at http://${HOST_NAME}:${port}`)
+          console.info(`Network '${network.alias}' node started at http://${HOST_NAME}:${port}`)
           resolve(nodeProcess)
         }
       },
@@ -71,7 +71,7 @@ const main = async () => {
 
   try {
     await Promise.all(validNetworkIds.map((networkId) => startNode(networks[networkId])))
-    console.log('Selected network nodes started successfully.')
+    console.info('Selected network nodes started successfully.')
   } catch (error) {
     console.error(error)
     process.exit(1)


### PR DESCRIPTION
- Forbid `console.log` so we can use it during debugging only
- Update existing `console.log` calls
  - Errors are now warns
  - Debugging statements are removed 
  - The rest is changed to `console.info`