### PR TITLE
fix: eliminate lastOraclePrice update race condition to ensure accurate oracle data in charts

### DIFF
--- a/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
@@ -191,7 +191,7 @@ const ChartOhlcWrapper = ({ rChainId, llamma, llammaId }: ChartOhlcWrapperProps)
     fetchOhlcData(rChainId, llammaId, address, chartInterval, timeUnit, chartTimeSettings.start, chartTimeSettings.end)
   }
 
-  // set snapshot data and subscribe to new data
+  // fetch ohlc data
   useEffect(() => {
     if (llamma !== undefined) {
       fetchOhlcData(

--- a/packages/ui/src/Chart/CandleChart.tsx
+++ b/packages/ui/src/Chart/CandleChart.tsx
@@ -480,6 +480,19 @@ const CandleChart = ({
         })
       }
     }
+
+    // update latest oracle price from more recent data source to ensure most recent data is displayed
+    if (
+      latestOraclePrice &&
+      oraclePriceSeriesRef.current &&
+      oraclePriceData &&
+      oraclePriceData[oraclePriceData.length - 1].value !== +latestOraclePrice
+    ) {
+      oraclePriceSeriesRef.current.update({
+        time: oraclePriceData[oraclePriceData.length - 1].time,
+        value: +latestOraclePrice,
+      })
+    }
   }, [
     colors.backgroundColor,
     colors.rangeColorA25Old,
@@ -487,22 +500,13 @@ const CandleChart = ({
     fetchMoreChartData,
     fetchingMore,
     lastTimescale,
+    latestOraclePrice,
     liquidationRange,
     ohlcData,
     oraclePriceData,
     refetchingCapped,
     volumeData,
   ])
-
-  // update the latest data point to ensure the oracle price is current in case there hasn't been recent events in the pool
-  useEffect(() => {
-    if (latestOraclePrice && oraclePriceSeriesRef.current && oraclePriceData) {
-      oraclePriceSeriesRef.current.update({
-        time: oraclePriceData[oraclePriceData.length - 1].time,
-        value: +latestOraclePrice,
-      })
-    }
-  }, [latestOraclePrice, oraclePriceData])
 
   useEffect(() => {
     wrapperRef.current = new ResizeObserver((entries) => {


### PR DESCRIPTION
Changes:
- Eliminate race condition where lastOraclePrice chart update() call might be overwritten by setData() by ensuring update() is ran after setData()