### PR TITLE
chore: bump prices-api to 1.1.1 and update pool property names in responses

### DIFF
--- a/packages/prices-api/package.json
+++ b/packages/prices-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/prices-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/prices-api/src/lending/parsers.ts
+++ b/packages/prices-api/src/lending/parsers.ts
@@ -12,7 +12,7 @@ export const parseOracle = (x: Responses.GetOracleResponse): Models.Oracle => ({
   chain: x.chain,
   controller: x.controller,
   oracle: x.oracle,
-  pools: x.oracle_pools.map((pool) => ({
+  pools: x.price_source_pools.map((pool) => ({
     address: pool.address,
     borrowedIndex: pool.borrowed_ix,
     borrowedSymbol: pool.borrowed_symbol,

--- a/packages/prices-api/src/lending/responses.ts
+++ b/packages/prices-api/src/lending/responses.ts
@@ -15,7 +15,7 @@ export type GetOracleResponse = {
   chain: Chain
   controller: Address
   oracle: Address
-  oracle_pools: [
+  price_source_pools: [
     {
       address: Address
       borrowed_ix: number


### PR DESCRIPTION
Changes:
- Changed name oracle_pools > price_source_pools to reflect API changes
- Bumped @curvefi/prices-api to 1.1.1