### PR TITLE
chore: update setup node action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: yarn


### PR DESCRIPTION
This should solve issues with the cache service (error 422) in the lint action

See https://github.com/actions/setup-node/issues/1275#issuecomment-2808800966