### PR TITLE
chore: bump @curvefi/api 2.66.16

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "analyze": "ANALYZE=true next build"
   },
   "dependencies": {
-    "@curvefi/api": "2.66.15",
+    "@curvefi/api": "2.66.16",
     "@curvefi/lending-api": "2.5.8",
     "@curvefi/stablecoin-api": "1.5.19",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,15 +1561,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:2.66.15":
-  version: 2.66.15
-  resolution: "@curvefi/api@npm:2.66.15"
+"@curvefi/api@npm:2.66.16":
+  version: 2.66.16
+  resolution: "@curvefi/api@npm:2.66.16"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.12"
     bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.13.4"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/312f3588fb2c4fc2568061066023befc226dab0aa2163f6de4c0d330ee89f26493eeb237e2c2bc7b272bd484bedb28491a6d9d43b78ea8723699c71cadbc12d5
+  checksum: 10c0/5c116853d9dd381052907494d1dc5b4d69e62281338651b4cdcebe04f30ef9ce48cc19f996e383777cc0c09a48d0e09f6b7de9eb13d2ab5a57a1893cdf84c98d
   languageName: node
   linkType: hard
 
@@ -19009,7 +19009,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:2.66.15"
+    "@curvefi/api": "npm:2.66.16"
     "@curvefi/lending-api": "npm:2.5.8"
     "@curvefi/stablecoin-api": "npm:1.5.19"
     "@hookform/error-message": "npm:^2.0.1"


### PR DESCRIPTION
Fixes mainnet LINK/stLINK-ng pool contract interactions. This is the pool that has its own LP token added as a gauge reward