### PR TITLE
chore: bump lending-api to 2.5.9

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@curvefi/api": "2.66.16",
-    "@curvefi/lending-api": "2.5.8",
+    "@curvefi/lending-api": "2.5.9",
     "@curvefi/stablecoin-api": "1.5.19",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1597,16 +1597,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/lending-api@npm:2.5.8":
-  version: 2.5.8
-  resolution: "@curvefi/lending-api@npm:2.5.8"
+"@curvefi/lending-api@npm:2.5.9":
+  version: 2.5.9
+  resolution: "@curvefi/lending-api@npm:2.5.9"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.13"
     axios: "npm:^0.21.1"
     bignumber.js: "npm:^9.0.1"
     ethers: "npm:^6.10.0"
     memoizee: "npm:^0.4.15"
-  checksum: 10c0/069c8ff4f000b1c58dd22b6fe21e291ec19b092456ceaa7a16da07f946a9886c5ccc9bb246c36ad1224db9619f586c667fbbd95d3284ac7c8353fddc926ca689
+  checksum: 10c0/25be33be6a5320200b94cd3f3b8b9b4178ff08cd508073a4fadba4b7d987a1580fe9062b3a83f083c478317087bd81dc5c67f3a6933cb9fecd89cb2701eedbd2
   languageName: node
   linkType: hard
 
@@ -19010,7 +19010,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:2.66.16"
-    "@curvefi/lending-api": "npm:2.5.8"
+    "@curvefi/lending-api": "npm:2.5.9"
     "@curvefi/stablecoin-api": "npm:1.5.19"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^5.0.1"


### PR DESCRIPTION
Changes:
- bumped curvefi/lending-api to 2.5.9 https://github.com/curvefi/curve-lending-js/pull/59/files