### PR TITLE
fix: use document hasFocus

### DIFF
--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/ConnectionContext.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/ConnectionContext.tsx
@@ -120,7 +120,7 @@ export const ConnectionProvider = <
         }
 
         const walletChainId = getWalletChainId(wallet)
-        if (walletChainId && walletChainId !== chainId && !document.hidden) {
+        if (walletChainId && walletChainId !== chainId && document.hasFocus()) {
           setConnectState({ status: LOADING, stage: SWITCH_NETWORK })
           if (!(await setChain({ chainId: ethers.toQuantity(chainId) }))) {
             if (signal.aborted) return


### PR DESCRIPTION
- `document.hidden` can be still true for multiple tabs when there are multiple windows
- by using `document.hasFocus()` we guarantee there is only one tab active at the same time