### PR TITLE
fix: stop resetting swap

### DIFF
--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -323,11 +323,6 @@ const QuickSwap = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [curve?.chainId])
 
-  // full reset
-  useEffect(() => {
-    if (isReady) updateFormValues({})
-  }, [isReady, updateFormValues])
-
   // updateForm
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => fetchData(), [tokensMapperStr, searchedParams.fromAddress, searchedParams.toAddress])


### PR DESCRIPTION
- remove an old effect that didn't use to get triggered
- this effect caused the page to restart routing endlessly in some situations