### PR TITLE
fix: dao gauge internal link fallback

### DIFF
--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/index.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/index.tsx
@@ -141,7 +141,7 @@ const GaugeListItem = ({
             >
               {t`VISIT ${gaugeCurveApiData?.isPool ? 'POOL' : 'MARKET'}`}
             </ExternalLinkIconButton>
-            <InternalLinkButton to={`${DAO_ROUTES.PAGE_GAUGES}/${gaugeData.effective_address}`}>
+            <InternalLinkButton to={`${DAO_ROUTES.PAGE_GAUGES}/${gaugeData.effective_address ?? gaugeData.address}`}>
               {t`VISIT GAUGE`}
             </InternalLinkButton>
           </Box>


### PR DESCRIPTION
Changes:
- Added fallback for internal link to gauge page when effective_address is unavailable