### PR TITLE
fix: wait for reconnect to initialize curveJS

### DIFF
--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/utils/wallet-helpers.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/utils/wallet-helpers.ts
@@ -25,5 +25,5 @@ const timeout = (message: string, timeoutMs: number) =>
 export const withTimeout = <T>(
   connectPromise: Promise<T>,
   message = t`Timeout connecting wallet`,
-  timeoutMs = REFRESH_INTERVAL['3s'],
+  timeoutMs = REFRESH_INTERVAL['15s'],
 ): Promise<T> => Promise.race([connectPromise, timeout(message, timeoutMs)])


### PR DESCRIPTION
- while onboard is connecting to the wallet, we shouldn't call curveJS `init` as that generates unnecessary computing and rendering
- does not fix the same issue with wagmi, that's handled already in #873 