### PR TITLE
styling: use tertiary color for action info prev val and arrow

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -99,7 +99,7 @@ const ActionInfo = ({
 
       {prevValue && (
         <Stack direction="row" alignItems="center">
-          <Typography variant={prevValueSize[size]} color={prevValueColor ?? 'textSecondary'}>
+          <Typography variant={prevValueSize[size]} color={prevValueColor ?? 'textTertiary'}>
             {prevValue}
           </Typography>
 
@@ -107,7 +107,7 @@ const ActionInfo = ({
             sx={{
               width: IconSize.sm,
               height: IconSize.sm,
-              color: (t) => t.palette.text.primary,
+              color: (t) => t.palette.text.tertiary,
             }}
           />
         </Stack>


### PR DESCRIPTION
Adjust color to match new figma colors for previous value and its arrow
![image](https://github.com/user-attachments/assets/77a9edf2-a13a-44e3-b809-15f5d8ac06b5)
