### PR TITLE
styling: accordion ghost title is no longer forced uppercase

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Accordion.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Accordion.tsx
@@ -109,6 +109,8 @@ export const Accordion = ({
               color="textSecondary"
               sx={{
                 textAlign: 'start',
+                // Specifcally unset to override the variant's uppercase styling; we want full control here
+                textTransform: ghost ? 'unset' : 'uppercase',
               }}
             >
               {title}

--- a/packages/curve-ui-kit/src/shared/ui/stories/Accordion.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Accordion.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof Accordion> = {
     },
   },
   args: {
-    title: 'Accordion Title',
+    title: 'Accordion title',
     ghost: false,
     size: 'small',
     defaultExpanded: false,


### PR DESCRIPTION
The title in ghost variants of accordions shouldn't be forced uppercase. Because the typography variants force it to be, it specifically gets set to `unset` so that we are in full control again over its capitalization.
![image](https://github.com/user-attachments/assets/2f5b7542-d884-46d8-9e39-dd51aadc1ae5)
