### PR TITLE
refactor: remove dependency of an available basepool list for pool page advanced tab

### DIFF
--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -24,11 +24,13 @@ type PoolParametersProps = {
 const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) => {
   const poolAddress = poolData.pool.address
   const snapshotsMapper = useStore((state) => state.pools.snapshotsMapper)
+  const isBasePoolsLoading = useStore((state) => state.pools.basePoolsLoading)
   const basePools = useStore((state) => state.pools.basePools)
   const pricesApiPoolDataMapper = useStore((state) => state.pools.pricesApiPoolDataMapper)
   const network = useStore((state) => state.networks.networks[rChainId])
   const snapshotData = snapshotsMapper[poolAddress]
   const pricesData = pricesApiPoolDataMapper[poolAddress]
+  const basePoolList = isBasePoolsLoading ? [] : basePools[rChainId]
 
   const convert1e8 = (number: number) => formatNumber(number / 10 ** 8, { showAllFractionDigits: true })
   const convert1e10 = (number: number) => formatNumber(number / 10 ** 10, { showAllFractionDigits: true })
@@ -89,7 +91,7 @@ const PoolParameters = ({ pricesApi, poolData, rChainId }: PoolParametersProps) 
             <PoolParameterValue>
               {returnPoolType(pricesData.pool_type, pricesData.coins.length)}
               {pricesData.metapool && `, ${t`Metapool`}`}
-              {basePools[rChainId].some((pool) => pool.pool === poolAddress) && `, ${t`Basepool`}`}
+              {basePoolList.some((pool) => pool.pool === poolAddress) && `, ${t`Basepool`}`}
             </PoolParameterValue>
           </PoolParameter>
           {pricesData.base_pool && (

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -353,10 +353,9 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
                 />
               </StatsWrapper>
             )}
-            {selectedTab === 'advanced' &&
-              poolData &&
-              snapshotsMapper[poolData.pool.address] !== undefined &&
-              !basePoolsLoading && <PoolParameters pricesApi={pricesApi} poolData={poolData} rChainId={rChainId} />}
+            {selectedTab === 'advanced' && poolData && snapshotsMapper[poolData.pool.address] !== undefined && (
+              <PoolParameters pricesApi={pricesApi} poolData={poolData} rChainId={rChainId} />
+            )}
           </AppPageInfoContentWrapper>
         </AppPageInfoWrapper>
       </Wrapper>


### PR DESCRIPTION
The basepool list is fetched on chain, requiring access to an RPC. In the Advanced tab it is only used to verify if a token is a basepool or not. In this PR this dependency is removed and the basepool token validation will only happen when a wallet is connected, allowing a user not yet connected to browse pool parameters freely.

Changes:
- Removed dependency of a fully loaded list of basepool in order to show the advanced tab (for pool parameters) on pool pages