### PR TITLE
Fix crvUSD domain typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # curve-frontend
 
-Curve-frontend is a NextJs user-interface application designed to connect to Curve's deployment of smart contracts. This UI application is designed for both the [crvUSD](https://crvusd-curve.fi) and [Curve](https://curve.fi) dapps, and utilizes [curve-js](https://github.com/curvefi/curve-js) and [curve-stablecoin-api](https://github.com/curvefi/curve-stablecoin-js) to communicate with the blockchain.
+Curve-frontend is a NextJs user-interface application designed to connect to Curve's deployment of smart contracts. This UI application is designed for both the [crvUSD](https://crvusd.curve.fi) and [Curve](https://curve.fi) dapps, and utilizes [curve-js](https://github.com/curvefi/curve-js) and [curve-stablecoin-api](https://github.com/curvefi/curve-stablecoin-js) to communicate with the blockchain.
 
 ## Prerequisites
 


### PR DESCRIPTION
- Domain is `crvusd.curve.fi` not `crvusd-curve.fi`