### PR TITLE
chore: bump curvefi/llamalend-api to 1.0.17

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@curvefi/api": "2.66.24",
-    "@curvefi/llamalend-api": "^1.0.16",
+    "@curvefi/llamalend-api": "^1.0.17",
     "@ethersproject/abi": "^5.8.0",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,15 +1570,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:^1.0.16":
-  version: 1.0.16
-  resolution: "@curvefi/llamalend-api@npm:1.0.16"
+"@curvefi/llamalend-api@npm:^1.0.17":
+  version: 1.0.17
+  resolution: "@curvefi/llamalend-api@npm:1.0.17"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.13"
     bignumber.js: "npm:^9.1.2"
     ethers: "npm:^6.13.5"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/96059593126833d9ace01efbfbf5bc5ea7ccf11ef0f4424b69b3dddb1c5992ffd3365121bb03ec22457cbd7803a0c42e33da157e1b3d3b0f403b90d9f413bc9e
+  checksum: 10c0/fd81ca89d51173ca8bbdf03476d03eabe1154fcc99b42d14149a2f3f4f6c804213835d71f5fcf01e012e9710a086c71c3757dd8e7519162d3e40d447f2817776
   languageName: node
   linkType: hard
 
@@ -14737,7 +14737,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:2.66.24"
-    "@curvefi/llamalend-api": "npm:^1.0.16"
+    "@curvefi/llamalend-api": "npm:^1.0.17"
     "@ethersproject/abi": "npm:^5.8.0"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^5.0.1"


### PR DESCRIPTION
Changes:
- Bumped curvefi/llamalend-api to 1.0.17 https://github.com/curvefi/curve-llamalend.js/pull/22