### PR TITLE
feat: add warning banner for domain change

### DIFF
--- a/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
+++ b/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
@@ -36,6 +36,7 @@ const useLocalStorage = <Type, Default = Type>(key: string, initialValue?: Defau
 /* -- Export specific hooks so that we can keep an overview of all the local storage keys used in the app -- */
 export const useShowTestNets = () => useLocalStorage<boolean>('showTestnets', false)
 export const useBetaFlag = () => useLocalStorage<boolean>('beta', isBetaDefault)
+export const useNewDomainNotificationSeen = () => useLocalStorage<boolean>('isNewDomainNotificationSeen', false)
 export const useFilterExpanded = (tableTitle: string) =>
   useLocalStorage<boolean>(`filter-expanded-${kebabCase(tableTitle)}`)
 

--- a/packages/curve-ui-kit/src/shared/ui/Banner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Banner.tsx
@@ -1,9 +1,14 @@
 import type { ReactNode } from 'react'
+import CloseIcon from '@mui/icons-material/Close'
 import { type SxProps, type Theme } from '@mui/material'
 import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
+import IconButton from '@mui/material/IconButton'
+import LinkMui from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import Typography, { type TypographyProps } from '@mui/material/Typography'
+import { t } from '@ui-kit/lib/i18n'
+import { ArrowTopRightIcon } from '@ui-kit/shared/icons/ArrowTopRightIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { InvertTheme } from './ThemeProvider'
 
@@ -47,12 +52,14 @@ export const Banner = ({
   buttonText,
   children,
   severity = 'default',
+  learnMoreUrl,
   color,
 }: {
   onClick?: () => void
   buttonText?: string
   children: ReactNode
   severity?: BannerSeverity
+  learnMoreUrl?: string
   color?: TypographyProps['color']
 }) => (
   <Card
@@ -78,16 +85,31 @@ export const Banner = ({
           {children}
         </Typography>
       </InvertTheme>
-      {buttonText && (
-        <Button
-          color="ghost"
-          onClick={onClick}
-          size="extraSmall"
-          sx={{ ...(color?.startsWith('#') && { color: `${color} !important` }) }}
-        >
-          {buttonText}
-        </Button>
-      )}
+      <Stack direction="row" alignItems="center" justifyContent="start" height="100%">
+        {learnMoreUrl && (
+          <Button
+            component={LinkMui}
+            href={learnMoreUrl}
+            target="_blank"
+            color="ghost"
+            variant="link"
+            endIcon={<ArrowTopRightIcon />}
+            size="extraSmall"
+          >
+            {t`Learn more`}
+          </Button>
+        )}
+        {onClick &&
+          (buttonText ? (
+            <Button color="ghost" onClick={onClick} size="extraSmall">
+              {buttonText}
+            </Button>
+          ) : (
+            <IconButton onClick={onClick} size="extraSmall">
+              <CloseIcon />
+            </IconButton>
+          ))}
+      </Stack>
     </Stack>
   </Card>
 )

--- a/packages/curve-ui-kit/src/shared/ui/Banner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Banner.tsx
@@ -10,7 +10,7 @@ import Typography, { type TypographyProps } from '@mui/material/Typography'
 import { t } from '@ui-kit/lib/i18n'
 import { ArrowTopRightIcon } from '@ui-kit/shared/icons/ArrowTopRightIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { InvertTheme } from './ThemeProvider'
+import { ChangeTheme, InvertTheme } from './ThemeProvider'
 
 type BannerSeverity = 'default' | 'highlight' | 'warning' | 'alert'
 
@@ -86,29 +86,32 @@ export const Banner = ({
         </Typography>
       </InvertTheme>
       <Stack direction="row" alignItems="center" justifyContent="start" height="100%">
-        {learnMoreUrl && (
-          <Button
-            component={LinkMui}
-            href={learnMoreUrl}
-            target="_blank"
-            color="ghost"
-            variant="link"
-            endIcon={<ArrowTopRightIcon />}
-            size="extraSmall"
-          >
-            {t`Learn more`}
-          </Button>
-        )}
-        {onClick &&
-          (buttonText ? (
-            <Button color="ghost" onClick={onClick} size="extraSmall">
-              {buttonText}
+        {/* fixme: currently using light theme on dark theme */}
+        <ChangeTheme to={color === '#000' && 'light'}>
+          {learnMoreUrl && (
+            <Button
+              component={LinkMui}
+              href={learnMoreUrl}
+              target="_blank"
+              color="ghost"
+              variant="link"
+              endIcon={<ArrowTopRightIcon />}
+              size="extraSmall"
+            >
+              {t`Learn more`}
             </Button>
-          ) : (
-            <IconButton onClick={onClick} size="extraSmall">
-              <CloseIcon />
-            </IconButton>
-          ))}
+          )}
+          {onClick &&
+            (buttonText ? (
+              <Button color="ghost" onClick={onClick} size="extraSmall">
+                {buttonText}
+              </Button>
+            ) : (
+              <IconButton onClick={onClick} size="extraSmall">
+                <CloseIcon />
+              </IconButton>
+            ))}
+        </ChangeTheme>
       </Stack>
     </Stack>
   </Card>

--- a/packages/curve-ui-kit/src/shared/ui/Banner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Banner.tsx
@@ -79,7 +79,12 @@ export const Banner = ({
         </Typography>
       </InvertTheme>
       {buttonText && (
-        <Button color="ghost" onClick={onClick} size="extraSmall">
+        <Button
+          color="ghost"
+          onClick={onClick}
+          size="extraSmall"
+          sx={{ ...(color?.startsWith('#') && { color: `${color} !important` }) }}
+        >
           {buttonText}
         </Button>
       )}

--- a/packages/curve-ui-kit/src/shared/ui/Banner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Banner.tsx
@@ -47,11 +47,13 @@ export const Banner = ({
   buttonText,
   children,
   severity = 'default',
+  color,
 }: {
   onClick?: () => void
   buttonText?: string
   children: ReactNode
   severity?: BannerSeverity
+  color?: TypographyProps['color']
 }) => (
   <Card
     sx={{
@@ -72,7 +74,7 @@ export const Banner = ({
       justifyContent="space-between"
     >
       <InvertTheme inverted={TitleInverted[severity]}>
-        <Typography color={TitleColor[severity]} variant="headingXsBold">
+        <Typography color={color ?? TitleColor[severity]} variant="headingXsBold">
           {children}
         </Typography>
       </InvertTheme>

--- a/packages/curve-ui-kit/src/shared/ui/DomainChangedBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DomainChangedBanner.tsx
@@ -1,0 +1,36 @@
+import { Stack, Typography } from '@mui/material'
+import AlertTitle from '@mui/material/AlertTitle'
+import Link from '@mui/material/Link'
+import { t } from '@ui-kit/lib/i18n'
+import { ExclamationTriangleIcon } from '@ui-kit/shared/icons/ExclamationTriangleIcon'
+import { Banner } from '@ui-kit/shared/ui/Banner'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing } = SizesAndSpaces
+
+export const DomainChangedBanner = ({ onDismiss, color }: { onDismiss: () => void; color: string }) => (
+  <Banner
+    severity="warning"
+    onClick={onDismiss}
+    color={color}
+    learnMoreUrl="https://x.com/CurveFinance/status/1922210827362349546"
+  >
+    <Stack direction="row" alignItems="end" gap={Spacing.xxs}>
+      <ExclamationTriangleIcon />
+      <AlertTitle>{t`Domain Change`}</AlertTitle>
+    </Stack>
+    <Typography variant="bodySRegular" sx={{ textTransform: 'none' }}>
+      {t`Curve Finance has moved to a new domain`}
+      {': '}
+      <Link href="https://curve.finance" target="_blank" color={color}>
+        {t`curve.finance`}
+      </Link>
+      {'. '}
+      {t`Always make sure you are on the right domain.`} {t`Read the announcement `}
+      <Link href="https://x.com/CurveFinance/status/1922210827362349546" target="_blank" color={color}>
+        {t`tweet`}
+      </Link>
+      .
+    </Typography>
+  </Banner>
+)

--- a/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
@@ -1,17 +1,14 @@
 import { forwardRef, Ref } from 'react'
 import { useAccount, useChainId, useSwitchChain } from 'wagmi'
-import { Stack, Typography } from '@mui/material'
-import AlertTitle from '@mui/material/AlertTitle'
 import Box from '@mui/material/Box'
-import Link from '@mui/material/Link'
 import { useTheme } from '@mui/material/styles'
 import { CONNECT_STAGE, isFailure, useConnection } from '@ui-kit/features/connect-wallet'
 import type { WagmiChainId } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
 import { useBetaFlag, useNewDomainNotificationSeen } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
-import { ExclamationTriangleIcon } from '@ui-kit/shared/icons/ExclamationTriangleIcon'
 import { LlamaIcon } from '@ui-kit/shared/icons/LlamaIcon'
 import { Banner } from '@ui-kit/shared/ui/Banner'
+import { DomainChangedBanner } from '@ui-kit/shared/ui/DomainChangedBanner'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { isCypress } from '@ui-kit/utils'
 
@@ -21,7 +18,7 @@ export type GlobalBannerProps = {
   ref: Ref<HTMLDivElement>
 }
 
-const { IconSize, Spacing } = SizesAndSpaces
+const { IconSize } = SizesAndSpaces
 
 // Update `NEXT_PUBLIC_MAINTENANCE_MESSAGE` environment variable value to display a global message in app.
 const maintenanceMessage = process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE
@@ -78,30 +75,7 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
             </Banner>
           )}
           {showDomainChangeMessage && (
-            <Banner
-              severity="warning"
-              buttonText={t`Dismiss`}
-              onClick={() => setIsNewDomainNotificationSeen(true)}
-              color={warnColor}
-            >
-              <Stack direction="row" alignItems="end" gap={Spacing.xxs}>
-                <ExclamationTriangleIcon />
-                <AlertTitle>{t`Domain Change`}</AlertTitle>
-              </Stack>
-              <Typography variant="bodySRegular" sx={{ textTransform: 'none' }}>
-                {t`Curve Finance has moved to a new domain`}
-                {': '}
-                <Link href="https://curve.finance" target="_blank" color={warnColor}>
-                  {t`curve.finance`}
-                </Link>
-                {'. '}
-                {t`Always make sure you are on the right domain.`} {t`Read the announcement `}
-                <Link href="https://x.com/CurveFinance/status/1922210827362349546" target="_blank" color={warnColor}>
-                  {t`tweet`}
-                </Link>
-                .
-              </Typography>
-            </Banner>
+            <DomainChangedBanner onDismiss={() => setIsNewDomainNotificationSeen(true)} color={warnColor} />
           )}
         </Box>
       )

--- a/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
@@ -1,11 +1,14 @@
 import { forwardRef, Ref } from 'react'
-import { useChainId, useSwitchChain } from 'wagmi'
-import { useAccount } from 'wagmi'
+import { useAccount, useChainId, useSwitchChain } from 'wagmi'
+import { Stack, Typography } from '@mui/material'
+import AlertTitle from '@mui/material/AlertTitle'
 import Box from '@mui/material/Box'
+import Link from '@mui/material/Link'
 import { CONNECT_STAGE, isFailure, useConnection } from '@ui-kit/features/connect-wallet'
 import type { WagmiChainId } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
 import { useBetaFlag } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
+import { ExclamationTriangleIcon } from '@ui-kit/shared/icons/ExclamationTriangleIcon'
 import { LlamaIcon } from '@ui-kit/shared/icons/LlamaIcon'
 import { Banner } from '@ui-kit/shared/ui/Banner'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -17,7 +20,7 @@ export type GlobalBannerProps = {
   ref: Ref<HTMLDivElement>
 }
 
-const { IconSize } = SizesAndSpaces
+const { IconSize, Spacing } = SizesAndSpaces
 
 // Update `NEXT_PUBLIC_MAINTENANCE_MESSAGE` environment variable value to display a global message in app.
 const maintenanceMessage = process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE
@@ -31,12 +34,17 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
     const { switchChain } = useSwitchChain()
     const { connectState } = useConnection()
     const showConnectApiErrorMessage = isFailure(connectState, CONNECT_STAGE.CONNECT_API)
+    const showDomainChangeMessage = new Date() < new Date('2025-06-01') // TODO: remove code line after this date
     const walletChainId = useChainId()
     const showSwitchNetworkMessage =
       (isConnected && walletChainId != chainId) || isFailure(connectState, CONNECT_STAGE.SWITCH_NETWORK)
 
     return (
-      (showSwitchNetworkMessage || showConnectApiErrorMessage || maintenanceMessage || showBetaBanner) && (
+      (showSwitchNetworkMessage ||
+        showConnectApiErrorMessage ||
+        maintenanceMessage ||
+        showBetaBanner ||
+        showDomainChangeMessage) && (
         <Box ref={ref}>
           {showBetaBanner && (
             <Banner onClick={() => setIsBeta(false)} buttonText={t`Disable Beta Mode`}>
@@ -57,6 +65,29 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
           {showConnectApiErrorMessage && (
             <Banner severity="alert">
               {t`There is an issue connecting to the API. You can try switching your RPC or, if you are connected to a wallet, please switch to a different one.`}
+            </Banner>
+          )}
+          {showDomainChangeMessage && (
+            <Banner severity="warning">
+              <Stack direction="row" alignItems="end" gap={Spacing.xxs}>
+                <ExclamationTriangleIcon />
+                <AlertTitle>{t`Domain Change`}</AlertTitle>
+              </Stack>
+              <Typography color="textSecondary" variant="bodyMRegular" sx={{ textTransform: 'none' }}>
+                {t`Curve Finance has moved to a new domain: `}
+                <Link href="https://curve.finance" target="_blank" color="textSecondary">
+                  {t`curve.finance`}
+                </Link>
+                {t`. Always make sure you are on the right domain. `}
+                {t`Read the announcement `}
+                <Link
+                  href="https://x.com/CurveFinance/status/1922210827362349546"
+                  target="_blank"
+                  color="textSecondary"
+                >
+                  {t`tweet.`}
+                </Link>
+              </Typography>
             </Banner>
           )}
         </Box>

--- a/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
@@ -7,7 +7,7 @@ import Link from '@mui/material/Link'
 import { useTheme } from '@mui/material/styles'
 import { CONNECT_STAGE, isFailure, useConnection } from '@ui-kit/features/connect-wallet'
 import type { WagmiChainId } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
-import { useBetaFlag } from '@ui-kit/hooks/useLocalStorage'
+import { useBetaFlag, useNewDomainNotificationSeen } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { ExclamationTriangleIcon } from '@ui-kit/shared/icons/ExclamationTriangleIcon'
 import { LlamaIcon } from '@ui-kit/shared/icons/LlamaIcon'
@@ -31,11 +31,13 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
     const [isBeta, setIsBeta] = useBetaFlag()
     const showBetaBanner = isBeta && !isCypress
 
+    const [isNewDomainNotificationSeen, setIsNewDomainNotificationSeen] = useNewDomainNotificationSeen()
+    const showDomainChangeMessage = !isNewDomainNotificationSeen && new Date() < new Date('2025-06-01') // TODO: delete after this date
+
     const { isConnected } = useAccount()
     const { switchChain } = useSwitchChain()
     const { connectState } = useConnection()
     const showConnectApiErrorMessage = isFailure(connectState, CONNECT_STAGE.CONNECT_API)
-    const showDomainChangeMessage = new Date() < new Date('2025-06-01') // TODO: remove code line after this date
     const walletChainId = useChainId()
     const showSwitchNetworkMessage =
       (isConnected && walletChainId != chainId) || isFailure(connectState, CONNECT_STAGE.SWITCH_NETWORK)
@@ -76,12 +78,17 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
             </Banner>
           )}
           {showDomainChangeMessage && (
-            <Banner severity="warning">
+            <Banner
+              severity="warning"
+              buttonText={t`Dismiss`}
+              onClick={() => setIsNewDomainNotificationSeen(true)}
+              color={warnColor}
+            >
               <Stack direction="row" alignItems="end" gap={Spacing.xxs}>
                 <ExclamationTriangleIcon />
-                <AlertTitle color={warnColor}>{t`Domain Change`}</AlertTitle>
+                <AlertTitle>{t`Domain Change`}</AlertTitle>
               </Stack>
-              <Typography color={warnColor} variant="bodySRegular" sx={{ textTransform: 'none' }}>
+              <Typography variant="bodySRegular" sx={{ textTransform: 'none' }}>
                 {t`Curve Finance has moved to a new domain`}
                 {': '}
                 <Link href="https://curve.finance" target="_blank" color={warnColor}>

--- a/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
@@ -73,20 +73,22 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
                 <ExclamationTriangleIcon />
                 <AlertTitle>{t`Domain Change`}</AlertTitle>
               </Stack>
-              <Typography color="textSecondary" variant="bodyMRegular" sx={{ textTransform: 'none' }}>
-                {t`Curve Finance has moved to a new domain: `}
+              <Typography color="textSecondary" variant="bodySRegular" sx={{ textTransform: 'none' }}>
+                {t`Curve Finance has moved to a new domain`}
+                {': '}
                 <Link href="https://curve.finance" target="_blank" color="textSecondary">
                   {t`curve.finance`}
                 </Link>
-                {t`. Always make sure you are on the right domain. `}
-                {t`Read the announcement `}
+                {'. '}
+                {t`Always make sure you are on the right domain.`} {t`Read the announcement `}
                 <Link
                   href="https://x.com/CurveFinance/status/1922210827362349546"
                   target="_blank"
                   color="textSecondary"
                 >
-                  {t`tweet.`}
+                  {t`tweet`}
                 </Link>
+                .
               </Typography>
             </Banner>
           )}

--- a/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/GlobalBanner.tsx
@@ -4,6 +4,7 @@ import { Stack, Typography } from '@mui/material'
 import AlertTitle from '@mui/material/AlertTitle'
 import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
+import { useTheme } from '@mui/material/styles'
 import { CONNECT_STAGE, isFailure, useConnection } from '@ui-kit/features/connect-wallet'
 import type { WagmiChainId } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
 import { useBetaFlag } from '@ui-kit/hooks/useLocalStorage'
@@ -39,6 +40,8 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
     const showSwitchNetworkMessage =
       (isConnected && walletChainId != chainId) || isFailure(connectState, CONNECT_STAGE.SWITCH_NETWORK)
 
+    const warnColor = useTheme().palette.mode === 'dark' ? '#000' : 'textSecondary' // todo: fix this in the design system of the alert component
+
     return (
       (showSwitchNetworkMessage ||
         showConnectApiErrorMessage ||
@@ -51,10 +54,15 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
               <LlamaIcon sx={{ width: IconSize.sm, height: IconSize.sm }} /> {t`BETA MODE ENABLED`}
             </Banner>
           )}
-          {maintenanceMessage && <Banner severity="warning">{maintenanceMessage}</Banner>}
+          {maintenanceMessage && (
+            <Banner severity="warning" color={warnColor}>
+              {maintenanceMessage}
+            </Banner>
+          )}
           {showSwitchNetworkMessage && (
             <Banner
               severity="warning"
+              color={warnColor}
               buttonText={t`Change network`}
               onClick={() => switchChain({ chainId: chainId as WagmiChainId })}
             >
@@ -71,21 +79,17 @@ export const GlobalBanner = forwardRef<HTMLDivElement, Omit<GlobalBannerProps, '
             <Banner severity="warning">
               <Stack direction="row" alignItems="end" gap={Spacing.xxs}>
                 <ExclamationTriangleIcon />
-                <AlertTitle>{t`Domain Change`}</AlertTitle>
+                <AlertTitle color={warnColor}>{t`Domain Change`}</AlertTitle>
               </Stack>
-              <Typography color="textSecondary" variant="bodySRegular" sx={{ textTransform: 'none' }}>
+              <Typography color={warnColor} variant="bodySRegular" sx={{ textTransform: 'none' }}>
                 {t`Curve Finance has moved to a new domain`}
                 {': '}
-                <Link href="https://curve.finance" target="_blank" color="textSecondary">
+                <Link href="https://curve.finance" target="_blank" color={warnColor}>
                   {t`curve.finance`}
                 </Link>
                 {'. '}
                 {t`Always make sure you are on the right domain.`} {t`Read the announcement `}
-                <Link
-                  href="https://x.com/CurveFinance/status/1922210827362349546"
-                  target="_blank"
-                  color="textSecondary"
-                >
+                <Link href="https://x.com/CurveFinance/status/1922210827362349546" target="_blank" color={warnColor}>
                   {t`tweet`}
                 </Link>
                 .

--- a/packages/curve-ui-kit/src/shared/ui/ThemeProvider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ThemeProvider.tsx
@@ -28,3 +28,9 @@ export const InvertTheme = ({
   const theme = createTheme(themeName, inverted)
   return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
 }
+
+export const ChangeTheme = ({ children, to }: { children: ReactNode; to: keyof typeof themes | false }) => {
+  if (!to) return children
+  const theme = createTheme(to)
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>
+}

--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -18,8 +18,14 @@ const expectedFooterXMargin = { mobile: 32, tablet: 48, desktop: 48 }
 const expectedFooterMinWidth = 288
 const expectedFooterMaxWidth = 1536
 
-// disable header height tests until the domain banner is hidden
-const domainBannerDisplayed = describe('Header', () => {
+function hideDomainBanner(win: Cypress.AUTWindow) {
+  // avoid the domain banner, this may be deleted after the date below
+  if (new Date() < new Date('2025-06-01')) {
+    win.localStorage.setItem('isNewDomainNotificationSeen', 'true')
+  }
+}
+
+describe('Header', () => {
   let viewport: readonly [number, number]
 
   describe('Desktop', () => {
@@ -33,10 +39,7 @@ const domainBannerDisplayed = describe('Header', () => {
       cy.visit(`/${appPath}/`, {
         onBeforeLoad: (win) => {
           isDarkMode = checkIsDarkMode(win)
-          // avoid the domain banner, this may be deleted after the date below
-          if (new Date() < new Date('2025-06-01')) {
-            win.localStorage.setItem('isNewDomainNotificationSeen', 'true')
-          }
+          hideDomainBanner(win)
         },
       })
       waitIsLoaded(appPath)
@@ -101,7 +104,9 @@ const domainBannerDisplayed = describe('Header', () => {
       viewport = oneMobileOrTabletViewport()
       cy.viewport(...viewport)
       appPath = oneAppPath()
-      cy.visit(`/${appPath}`)
+      cy.visit(`/${appPath}`, {
+        onBeforeLoad: hideDomainBanner,
+      })
       waitIsLoaded(appPath)
     })
 

--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -19,9 +19,7 @@ const expectedFooterMinWidth = 288
 const expectedFooterMaxWidth = 1536
 
 // disable header height tests until the domain banner is hidden
-const domainBannerDisplayed = new Date() < new Date('2025-06-01')
-
-describe('Header', () => {
+const domainBannerDisplayed = describe('Header', () => {
   let viewport: readonly [number, number]
 
   describe('Desktop', () => {
@@ -33,29 +31,34 @@ describe('Header', () => {
       cy.viewport(...viewport)
       appPath = oneAppPath()
       cy.visit(`/${appPath}/`, {
-        onBeforeLoad: (win) => (isDarkMode = checkIsDarkMode(win)),
+        onBeforeLoad: (win) => {
+          isDarkMode = checkIsDarkMode(win)
+          // avoid the domain banner, this may be deleted after the date below
+          if (new Date() < new Date('2025-06-01')) {
+            win.localStorage.setItem('isNewDomainNotificationSeen', 'true')
+          }
+        },
       })
       waitIsLoaded(appPath)
     })
 
-    if (!domainBannerDisplayed)
-      it('should have the right size', () => {
-        cy.get("[data-testid='main-nav']").invoke('outerHeight').should('equal', expectedMainNavHeight)
-        cy.get("[data-testid='subnav']").invoke('outerHeight').should('equal', expectedSubNavHeight)
-        cy.get(`header`)
-          .invoke('outerHeight')
-          .should('equal', expectedSubNavHeight + expectedMainNavHeight)
-        cy.get(`header`)
-          .invoke('outerWidth')
-          .should('equal', viewport[0] - SCROLL_WIDTH)
-        cy.get("[data-testid='navigation-connect-wallet']").invoke('outerHeight').should('equal', expectedConnectHeight)
+    it('should have the right size', () => {
+      cy.get("[data-testid='main-nav']").invoke('outerHeight').should('equal', expectedMainNavHeight)
+      cy.get("[data-testid='subnav']").invoke('outerHeight').should('equal', expectedSubNavHeight)
+      cy.get(`header`)
+        .invoke('outerHeight')
+        .should('equal', expectedSubNavHeight + expectedMainNavHeight)
+      cy.get(`header`)
+        .invoke('outerWidth')
+        .should('equal', viewport[0] - SCROLL_WIDTH)
+      cy.get("[data-testid='navigation-connect-wallet']").invoke('outerHeight').should('equal', expectedConnectHeight)
 
-        const expectedFooterWidth = Math.min(
-          expectedFooterMaxWidth,
-          viewport[0] - expectedFooterXMargin.desktop - SCROLL_WIDTH,
-        )
-        cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth)
-      })
+      const expectedFooterWidth = Math.min(
+        expectedFooterMaxWidth,
+        viewport[0] - expectedFooterXMargin.desktop - SCROLL_WIDTH,
+      )
+      cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth)
+    })
 
     it('should switch themes', () => {
       cy.get(`[data-testid='navigation-connect-wallet']`).then(($nav) => {
@@ -102,26 +105,23 @@ describe('Header', () => {
       waitIsLoaded(appPath)
     })
 
-    if (!domainBannerDisplayed)
-      it(`should have the right size`, () => {
-        const breakpoint = viewport[0] < TABLET_BREAKPOINT ? 'mobile' : 'tablet'
-        const expectedFooterWidth = Math.max(
-          expectedFooterMinWidth,
-          viewport[0] - SCROLL_WIDTH - expectedFooterXMargin[breakpoint],
-        )
-        cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height')
-        cy.get(`header`)
-          .invoke('outerWidth')
-          .should('equal', viewport[0] - SCROLL_WIDTH, 'Header width')
-        cy.get("[data-testid='footer-content']")
-          .invoke('outerWidth')
-          .should('equal', expectedFooterWidth, 'Footer width')
-        cy.get(`[data-testid='menu-toggle']`).click()
-        cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height changed')
-        cy.get("[data-testid='navigation-connect-wallet']")
-          .invoke('outerHeight')
-          .should('equal', expectedConnectHeight, 'Connect height')
-      })
+    it(`should have the right size`, () => {
+      const breakpoint = viewport[0] < TABLET_BREAKPOINT ? 'mobile' : 'tablet'
+      const expectedFooterWidth = Math.max(
+        expectedFooterMinWidth,
+        viewport[0] - SCROLL_WIDTH - expectedFooterXMargin[breakpoint],
+      )
+      cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height')
+      cy.get(`header`)
+        .invoke('outerWidth')
+        .should('equal', viewport[0] - SCROLL_WIDTH, 'Header width')
+      cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth, 'Footer width')
+      cy.get(`[data-testid='menu-toggle']`).click()
+      cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height changed')
+      cy.get("[data-testid='navigation-connect-wallet']")
+        .invoke('outerHeight')
+        .should('equal', expectedConnectHeight, 'Connect height')
+    })
 
     it('should open the menu and navigate', () => {
       cy.get(`[data-testid='mobile-drawer']`).should('not.exist')

--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -18,6 +18,9 @@ const expectedFooterXMargin = { mobile: 32, tablet: 48, desktop: 48 }
 const expectedFooterMinWidth = 288
 const expectedFooterMaxWidth = 1536
 
+// disable header height tests until the domain banner is hidden
+const domainBannerDisplayed = new Date() < new Date('2025-06-01')
+
 describe('Header', () => {
   let viewport: readonly [number, number]
 
@@ -35,23 +38,24 @@ describe('Header', () => {
       waitIsLoaded(appPath)
     })
 
-    it('should have the right size', () => {
-      cy.get("[data-testid='main-nav']").invoke('outerHeight').should('equal', expectedMainNavHeight)
-      cy.get("[data-testid='subnav']").invoke('outerHeight').should('equal', expectedSubNavHeight)
-      cy.get(`header`)
-        .invoke('outerHeight')
-        .should('equal', expectedSubNavHeight + expectedMainNavHeight)
-      cy.get(`header`)
-        .invoke('outerWidth')
-        .should('equal', viewport[0] - SCROLL_WIDTH)
-      cy.get("[data-testid='navigation-connect-wallet']").invoke('outerHeight').should('equal', expectedConnectHeight)
+    if (!domainBannerDisplayed)
+      it('should have the right size', () => {
+        cy.get("[data-testid='main-nav']").invoke('outerHeight').should('equal', expectedMainNavHeight)
+        cy.get("[data-testid='subnav']").invoke('outerHeight').should('equal', expectedSubNavHeight)
+        cy.get(`header`)
+          .invoke('outerHeight')
+          .should('equal', expectedSubNavHeight + expectedMainNavHeight)
+        cy.get(`header`)
+          .invoke('outerWidth')
+          .should('equal', viewport[0] - SCROLL_WIDTH)
+        cy.get("[data-testid='navigation-connect-wallet']").invoke('outerHeight').should('equal', expectedConnectHeight)
 
-      const expectedFooterWidth = Math.min(
-        expectedFooterMaxWidth,
-        viewport[0] - expectedFooterXMargin.desktop - SCROLL_WIDTH,
-      )
-      cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth)
-    })
+        const expectedFooterWidth = Math.min(
+          expectedFooterMaxWidth,
+          viewport[0] - expectedFooterXMargin.desktop - SCROLL_WIDTH,
+        )
+        cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth)
+      })
 
     it('should switch themes', () => {
       cy.get(`[data-testid='navigation-connect-wallet']`).then(($nav) => {
@@ -98,23 +102,26 @@ describe('Header', () => {
       waitIsLoaded(appPath)
     })
 
-    it(`should have the right size`, () => {
-      const breakpoint = viewport[0] < TABLET_BREAKPOINT ? 'mobile' : 'tablet'
-      const expectedFooterWidth = Math.max(
-        expectedFooterMinWidth,
-        viewport[0] - SCROLL_WIDTH - expectedFooterXMargin[breakpoint],
-      )
-      cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height')
-      cy.get(`header`)
-        .invoke('outerWidth')
-        .should('equal', viewport[0] - SCROLL_WIDTH, 'Header width')
-      cy.get("[data-testid='footer-content']").invoke('outerWidth').should('equal', expectedFooterWidth, 'Footer width')
-      cy.get(`[data-testid='menu-toggle']`).click()
-      cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height changed')
-      cy.get("[data-testid='navigation-connect-wallet']")
-        .invoke('outerHeight')
-        .should('equal', expectedConnectHeight, 'Connect height')
-    })
+    if (!domainBannerDisplayed)
+      it(`should have the right size`, () => {
+        const breakpoint = viewport[0] < TABLET_BREAKPOINT ? 'mobile' : 'tablet'
+        const expectedFooterWidth = Math.max(
+          expectedFooterMinWidth,
+          viewport[0] - SCROLL_WIDTH - expectedFooterXMargin[breakpoint],
+        )
+        cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height')
+        cy.get(`header`)
+          .invoke('outerWidth')
+          .should('equal', viewport[0] - SCROLL_WIDTH, 'Header width')
+        cy.get("[data-testid='footer-content']")
+          .invoke('outerWidth')
+          .should('equal', expectedFooterWidth, 'Footer width')
+        cy.get(`[data-testid='menu-toggle']`).click()
+        cy.get(`header`).invoke('outerHeight').should('equal', expectedMobileNavHeight, 'Header height changed')
+        cy.get("[data-testid='navigation-connect-wallet']")
+          .invoke('outerHeight')
+          .should('equal', expectedConnectHeight, 'Connect height')
+      })
 
     it('should open the menu and navigate', () => {
       cy.get(`[data-testid='mobile-drawer']`).should('not.exist')


### PR DESCRIPTION
This pull request updates the `GlobalBanner` component in the `curve-ui-kit` package to include a new warning message about a domain change.

- Added a new `showDomainChangeMessage` condition to display a warning banner if the current date is before June 1, 2025. 
- This banner informs users about the domain change to `curve.finance` and includes links to the announcement and tweet.