### PR TITLE
feat: add balance widget

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Balance.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Balance.tsx
@@ -1,0 +1,93 @@
+import AccountBalanceWalletOutlinedIcon from '@mui/icons-material/AccountBalanceWalletOutlined'
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing, IconSize } = SizesAndSpaces
+
+const formatNumber = (value: number): string =>
+  value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
+/**
+ * Props for the Balance component
+ */
+type Props = {
+  /** The token symbol to display */
+  symbol: string
+  /** Controls how the max value is displayed:
+   * - 'balance': Shows the balance as a clickable link
+   * - 'button': Shows a separate 'Max' button
+   * - 'off': No max functionality is shown
+   */
+  max: 'balance' | 'button' | 'off'
+  /** The token balance amount (optional, in case of loading) */
+  balance?: number
+  /** The USD value of the balance (optional) */
+  notionalValue?: number
+  /** Whether to hide the wallet icon */
+  hideIcon?: boolean
+  /** Callback function when max button/balance is clicked */
+  onMax?: (maxValue: number) => void
+}
+
+export const Balance = ({ symbol, max, balance, notionalValue, hideIcon, onMax }: Props) => {
+  const balanceText = (
+    <>
+      <Typography variant="highlightS" color={balance !== undefined ? 'textPrimary' : 'textTertiary'}>
+        {balance ? formatNumber(balance) : '?'}
+      </Typography>
+
+      <Typography variant="highlightS" color="textPrimary">
+        {symbol}
+      </Typography>
+    </>
+  )
+
+  return (
+    <Stack direction="row" gap={Spacing.xs} alignItems="center">
+      {!hideIcon && <AccountBalanceWalletOutlinedIcon sx={{ width: IconSize.xs, height: IconSize.xs }} />}
+
+      {max === 'balance' && balance !== undefined ? (
+        <Button
+          color="ghost"
+          variant="link"
+          size="extraSmall"
+          onClick={() => onMax?.(balance)}
+          sx={{
+            '&:hover': {
+              textDecoration: 'underline',
+            },
+          }}
+        >
+          {balanceText}
+        </Button>
+      ) : (
+        balanceText
+      )}
+
+      {notionalValue && (
+        <Typography variant="bodySRegular" color="textTertiary">
+          ${formatNumber(notionalValue)}
+        </Typography>
+      )}
+
+      {max === 'button' && balance !== undefined && (
+        <Button
+          color="ghost"
+          variant="link"
+          size="extraSmall"
+          onClick={() => onMax?.(balance)}
+          sx={{
+            minWidth: 'unset',
+          }}
+        >
+          Max
+        </Button>
+      )}
+    </Stack>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/stories/Balance.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Balance.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Balance } from '../Balance'
+
+const meta: Meta<typeof Balance> = {
+  title: 'UI Kit/Widgets/Balance',
+  component: Balance,
+  argTypes: {
+    symbol: {
+      control: 'text',
+      description: 'The token symbol',
+    },
+    balance: {
+      control: 'number',
+      description: 'The token balance',
+    },
+    notionalValue: {
+      control: 'number',
+      description: 'The USD value of the balance',
+    },
+    max: {
+      control: 'select',
+      options: ['balance', 'button', 'off'],
+      description: 'The max button mode',
+    },
+    hideIcon: {
+      control: 'boolean',
+      description: 'Whether to hide the wallet icon',
+    },
+    onMax: {
+      action: 'onMax',
+      description: 'Callback when max button is clicked',
+    },
+  },
+  args: {
+    symbol: 'ETH',
+    balance: 1.234,
+    max: 'off',
+    hideIcon: false,
+    onMax: (maxValue: number) => {
+      // eslint-disable-next-line no-console
+      console.log('Max value:', maxValue)
+    },
+  },
+}
+
+type Story = StoryObj<typeof Balance>
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        component: 'Balance',
+        story: 'Simple balance widget showing a token balance',
+      },
+    },
+  },
+}
+
+export const WithNotionalValue: Story = {
+  args: {
+    notionalValue: 2345.67,
+  },
+}
+
+export const WithMaxButton: Story = {
+  args: {
+    max: 'button',
+  },
+}
+
+export const WithMaxBalance: Story = {
+  args: {
+    max: 'balance',
+  },
+}
+
+export const NoIcon: Story = {
+  args: {
+    hideIcon: true,
+  },
+}
+
+export const FullFeatured: Story = {
+  args: {
+    balance: 42.69,
+    notionalValue: 69420.42,
+    max: 'button',
+  },
+}
+
+export const FullFeaturedWithMaxBalance: Story = {
+  args: {
+    balance: 42.69,
+    notionalValue: 69420.42,
+    max: 'balance',
+  },
+}
+
+export const NoBalance: Story = {
+  args: {
+    balance: undefined,
+  },
+}
+
+export default meta


### PR DESCRIPTION
Adds a smol little 'balance' widget. We're going to use it in a few places, most notable user inputs. In short, you use it to show the balance of a specific token (symbol). The balance itself is optional as there's a chance we're waiting for the reply of an async (contract) call.

The 'max' button comes in three varieties:
1. 'off': There is no clickable button anywhere, it's read-only
2. 'balance': You can click the balance (if it's available)
3. 'button': There's a blue 'max' button all the way to the right

![image](https://github.com/user-attachments/assets/a29b875d-a36a-416d-ab42-b49f0961218a)
![image](https://github.com/user-attachments/assets/63ceece9-abc0-4212-a40b-c162f704fd59)
![image](https://github.com/user-attachments/assets/79ad35e4-4f33-4b55-bd31-3d9ac4721acb)
