### PR TITLE
feat: add trading slider widget

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -92,7 +92,7 @@ export const TradingSlider = ({
           ),
         },
       }}
-      sx={{ minWidth: '4.5rem' }} // just enough for comma value with 2 digits like 99,99%
+      sx={{ minWidth: '7ch' }} // just enough for comma value with 2 digits like 99,99%
     />
   </Stack>
 )

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -63,7 +63,7 @@ export const TradingSlider = ({ percentage, onPercentageChange, onPercentageComm
         },
         input: {
           sx: {
-            color: (t) => t.design.Text.TextColors.Tertiary,
+            color: (t) => t.design.Text.TextColors.Primary,
             backgroundColor: (t) => t.design.Inputs.Base.Default.Fill,
             fontFamily: (t) => t.typography.bodySBold.fontFamily,
             fontSize: FontSize.sm,

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -4,6 +4,7 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { SLIDER_BACKGROUND_VAR } from '@ui-kit/themes/components/slider'
 
 const { Spacing, FontSize, FontWeight, Sizing } = SizesAndSpaces
 
@@ -46,7 +47,7 @@ export const TradingSlider = ({
       min={0}
       max={100}
       step={step}
-      sx={{ '--slider-background': (t) => t.design.Color.Primary[200] }}
+      sx={{ [SLIDER_BACKGROUND_VAR]: (t) => t.design.Color.Primary[200] }}
     />
 
     <TextField

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -1,0 +1,90 @@
+import Slider from '@mui/material/Slider'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing, FontSize, FontWeight, Sizing } = SizesAndSpaces
+
+type Props = {
+  /** Current percentage value (0-100) */
+  percentage: number
+  /** Callback when percentage changes on the slider */
+  onPercentageChange?: (percentage: number) => void
+  /** Callback when percentage changes by rleasing the slider or entering a number */
+  onPercentageCommitted?: (percentage: number) => void
+  /** Step increment for the slider and input */
+  step?: number
+}
+
+export const TradingSlider = ({ percentage, onPercentageChange, onPercentageCommitted, step = 1 }: Props) => (
+  <Stack
+    direction="row"
+    alignItems="center"
+    gap={Spacing.md}
+    sx={{
+      flexGrow: 1,
+      marginInlineStart: Spacing.md,
+    }}
+  >
+    <Slider
+      size="medium"
+      value={percentage}
+      onChange={(_event, newValue) => onPercentageChange?.(Array.isArray(newValue) ? newValue[0] : newValue)}
+      onChangeCommitted={(_event, newValue) =>
+        onPercentageCommitted?.(Array.isArray(newValue) ? newValue[0] : newValue)
+      }
+      min={0}
+      max={100}
+      step={step}
+      sx={{ '--slider-background': (t) => t.design.Color.Primary[200] }}
+    />
+
+    <TextField
+      type="number"
+      placeholder="0"
+      size="small"
+      variant="standard"
+      value={percentage}
+      onChange={(event) => {
+        const numValue = Number(event.target.value)
+        const clampedValue = Math.min(Math.max(numValue, 0), 100)
+        event.target.value = String(clampedValue) // remove leading zeros
+
+        if (!isNaN(numValue) && percentage !== clampedValue) {
+          onPercentageCommitted?.(clampedValue)
+        }
+      }}
+      slotProps={{
+        htmlInput: {
+          min: 0,
+          max: 100,
+          step,
+        },
+        input: {
+          sx: {
+            color: (t) => t.design.Text.TextColors.Tertiary,
+            backgroundColor: (t) => t.design.Inputs.Base.Default.Fill,
+            fontFamily: (t) => t.typography.bodySBold.fontFamily,
+            fontSize: FontSize.sm,
+            fontWeight: FontWeight.Bold,
+            height: Sizing.sm,
+            '& input::-webkit-outer-spin-button, & input::-webkit-inner-spin-button': {
+              display: 'none',
+            },
+            '& input': {
+              padding: 0,
+              marginInline: Spacing.sm,
+            },
+          },
+          endAdornment: (
+            <Typography variant="bodySBold" color="textTertiary">
+              %
+            </Typography>
+          ),
+        },
+      }}
+      sx={{ minWidth: '4.5rem' }} // just enough for comma value with 2 digits like 99,99%
+    />
+  </Stack>
+)

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -1,3 +1,4 @@
+import type { Property } from 'csstype'
 import Slider from '@mui/material/Slider'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
@@ -15,9 +16,17 @@ type Props = {
   onPercentageCommitted?: (percentage: number) => void
   /** Step increment for the slider and input */
   step?: number
+  /** Text alignment for the input field */
+  textAlign?: Property.TextAlign
 }
 
-export const TradingSlider = ({ percentage, onPercentageChange, onPercentageCommitted, step = 1 }: Props) => (
+export const TradingSlider = ({
+  percentage,
+  onPercentageChange,
+  onPercentageCommitted,
+  step = 1,
+  textAlign = 'left',
+}: Props) => (
   <Stack
     direction="row"
     alignItems="center"
@@ -75,6 +84,7 @@ export const TradingSlider = ({ percentage, onPercentageChange, onPercentageComm
             '& input': {
               padding: 0,
               marginInline: Spacing.sm,
+              textAlign,
             },
           },
           endAdornment: (

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -72,8 +72,6 @@ export const TradingSlider = ({
         },
         input: {
           sx: {
-            color: (t) => t.design.Text.TextColors.Primary,
-            backgroundColor: (t) => t.design.Inputs.Base.Default.Fill,
             fontFamily: (t) => t.typography.bodySBold.fontFamily,
             fontSize: FontSize.sm,
             fontWeight: FontWeight.Bold,

--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -58,9 +58,9 @@ export const TradingSlider = ({
       onChange={(event) => {
         const numValue = Number(event.target.value)
         const clampedValue = Math.min(Math.max(numValue, 0), 100)
-        event.target.value = String(clampedValue) // remove leading zeros
 
         if (!isNaN(numValue) && percentage !== clampedValue) {
+          event.target.value = String(clampedValue) // remove leading zeros
           onPercentageCommitted?.(clampedValue)
         }
       }}

--- a/packages/curve-ui-kit/src/shared/ui/stories/TradingSlider.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/TradingSlider.stories.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import Box from '@mui/material/Box'
+import type { Meta, StoryObj } from '@storybook/react'
+import { TradingSlider } from '../TradingSlider'
+
+const TradingSliderComponent = (props: React.ComponentProps<typeof TradingSlider>) => {
+  const [percentage, setPercentage] = useState<number>(props.percentage || 50)
+
+  return (
+    <Box sx={{ width: '400px' }}>
+      <TradingSlider
+        {...props}
+        percentage={percentage}
+        onPercentageChange={(newPercentage) => {
+          setPercentage(newPercentage)
+          props.onPercentageChange?.(newPercentage)
+        }}
+        onPercentageCommitted={(newPercentage) => {
+          setPercentage(newPercentage)
+          props.onPercentageCommitted?.(newPercentage)
+        }}
+      />
+    </Box>
+  )
+}
+
+const meta: Meta<typeof TradingSlider> = {
+  title: 'UI Kit/Widgets/TradingSlider',
+  component: TradingSliderComponent,
+  argTypes: {
+    percentage: {
+      control: 'number',
+      description: 'The current percentage value (0-100)',
+    },
+    step: {
+      control: 'number',
+      description: 'Step increment for the slider and input',
+    },
+    onPercentageChange: {
+      description: 'Callback when percentage changes on the slider',
+    },
+    onPercentageCommitted: {
+      description: 'Callback when percentage changes by releasing the slider or entering a number',
+    },
+  },
+  args: {
+    percentage: 50,
+    step: 1,
+    onPercentageChange: (x) => console.info('Percentage changing:', x),
+    onPercentageCommitted: (x) => console.info('Percentage committed:', x),
+  },
+}
+
+type Story = StoryObj<typeof TradingSlider>
+
+export const Default: Story = {}
+
+export default meta

--- a/packages/curve-ui-kit/src/shared/ui/stories/TradingSlider.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/TradingSlider.stories.tsx
@@ -36,6 +36,11 @@ const meta: Meta<typeof TradingSlider> = {
       control: 'number',
       description: 'Step increment for the slider and input',
     },
+    textAlign: {
+      control: 'select',
+      options: ['left', 'center', 'right'],
+      description: 'Text alignment for the input field',
+    },
     onPercentageChange: {
       description: 'Callback when percentage changes on the slider',
     },
@@ -46,6 +51,7 @@ const meta: Meta<typeof TradingSlider> = {
   args: {
     percentage: 50,
     step: 1,
+    textAlign: 'left',
     onPercentageChange: (x) => console.info('Percentage changing:', x),
     onPercentageCommitted: (x) => console.info('Percentage committed:', x),
   },

--- a/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
+++ b/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
@@ -44,6 +44,8 @@ const borderPseudoElement = (design: DesignSystem) => ({
     left: -THUMB_WIDTH / 2,
     border: `1px solid ${design.Color.Neutral[500]}`,
     zIndex: -1,
+    // used by TradingSlider to set the background color. I can't add TSX props so this is the only way.
+    backgroundColor: 'var(--slider-background)',
   },
 })
 

--- a/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
+++ b/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
@@ -8,6 +8,13 @@ const { Sizing } = SizesAndSpaces
 
 const THUMB_WIDTH = 20 // 20px is a default MUI value, not responsive to reduce headaches
 
+/**
+ * CSS custom property name for customizing the slider background color.
+ * Used by components like TradingSlider to set a background color.
+ * This approach is necessary because we can't add TSX props directly.
+ */
+export const SLIDER_BACKGROUND_VAR = '--slider-background'
+
 type Size = 'small' | 'medium'
 const heights: Record<Size, Responsive> = {
   small: Sizing.xs,
@@ -44,8 +51,7 @@ const borderPseudoElement = (design: DesignSystem) => ({
     left: -THUMB_WIDTH / 2,
     border: `1px solid ${design.Color.Neutral[500]}`,
     zIndex: -1,
-    // used by TradingSlider to set the background color. I can't add TSX props so this is the only way.
-    backgroundColor: 'var(--slider-background)',
+    backgroundColor: `var(${SLIDER_BACKGROUND_VAR})`,
   },
 })
 


### PR DESCRIPTION
Special variant of the MUI slider primitive that adds a percentage input field and changes the background color of the slider. Will be part of the Large Input widget.

Note: did not add the vertical markers for 25%, 50% and 75%. Too much hassle atm and of very low importance.

![image](https://github.com/user-attachments/assets/80237c60-195d-4f45-9378-24b8a8f40c45)
