### PR TITLE
fix: withdraw end duration countdown

### DIFF
--- a/apps/main/src/dao/components/Countdown.tsx
+++ b/apps/main/src/dao/components/Countdown.tsx
@@ -1,20 +1,34 @@
 import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-interface VoteCountdownProps {
-  startDate: number | null
+interface CountdownProps {
+  /** startDate adds 7 days to the current date to mimic a DAO proposal voting period */
+  startDate?: number | null
+  /** endDate is the specific date to count down to. Takes precedence over startDate. */
+  endDate?: number | null
   className?: string
 }
 
-const VoteCountdown = ({ startDate, className }: VoteCountdownProps) => {
+const Countdown = ({ startDate, endDate, className }: CountdownProps) => {
   const [timeRemaining, setTimeRemaining] = useState('')
 
   useEffect(() => {
     const updateTimeRemaining = () => {
-      if (!startDate) return
+      let effectiveEndDate: number | null = null
+
+      if (endDate) {
+        effectiveEndDate = endDate
+      } else if (startDate) {
+        effectiveEndDate = startDate + 604800 // 7 days in seconds
+      }
+
+      if (!effectiveEndDate) {
+        setTimeRemaining('')
+        return
+      }
+
       const now = Math.floor(Date.now() / 1000)
-      const endDate = startDate + 604800 // 7 days in seconds
-      const remainingSeconds = endDate - now
+      const remainingSeconds = effectiveEndDate - now
 
       if (remainingSeconds <= 0) {
         setTimeRemaining('Voting has ended')
@@ -34,16 +48,16 @@ const VoteCountdown = ({ startDate, className }: VoteCountdownProps) => {
     return () => {
       clearInterval(timer)
     }
-  }, [startDate])
+  }, [startDate, endDate])
 
   return (
-    <VoteCountdownContainer className={className}>
-      <p>{startDate ? timeRemaining : '-'}</p>
-    </VoteCountdownContainer>
+    <CountdownContainer className={className}>
+      <p>{timeRemaining || '-'}</p>
+    </CountdownContainer>
   )
 }
 
-const VoteCountdownContainer = styled.div`
+const CountdownContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -52,4 +66,4 @@ const VoteCountdownContainer = styled.div`
   font-variant-numeric: tabular-nums;
 `
 
-export default VoteCountdown
+export default Countdown

--- a/apps/main/src/dao/components/PageProposal/ProposalHeader/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/ProposalHeader/index.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
+import Countdown from '@/dao/components/Countdown'
 import MetricsComp, { MetricsColumnData } from '@/dao/components/MetricsComp'
 import SmallLabel from '@/dao/components/SmallLabel'
-import VoteCountdown from '@/dao/components/VoteCountdown'
 import { ProposalData } from '@/dao/entities/proposals-mapper'
 import { t } from '@ui-kit/lib/i18n'
 
@@ -38,7 +38,7 @@ const ProposalHeader = ({ proposal, loading, voteId, proposalType }: ProposalHea
     <TimeRemainingBox
       loading={loading}
       title={t`Time Remaining`}
-      data={<StyledVoteCountdown startDate={proposal?.timestamp ?? null} />}
+      data={<StyledCountdown startDate={proposal?.timestamp ?? null} />}
     />
   </Wrapper>
 )
@@ -145,7 +145,7 @@ const TimeRemainingBox = styled(MetricsComp)`
   }
 `
 
-const StyledVoteCountdown = styled(VoteCountdown)`
+const StyledCountdown = styled(Countdown)`
   margin-top: var(--spacing-1);
 `
 

--- a/apps/main/src/dao/components/PageProposals/Proposal/index.tsx
+++ b/apps/main/src/dao/components/PageProposals/Proposal/index.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
 import styled from 'styled-components'
+import Countdown from '@/dao/components/Countdown'
 import ProposalVoteStatusBox from '@/dao/components/ProposalVoteStatusBox'
 import SmallLabel from '@/dao/components/SmallLabel'
 import { ProposalData } from '@/dao/entities/proposals-mapper'
 import LazyItem from '@ui/LazyItem'
 import { t } from '@ui-kit/lib/i18n'
-import VoteCountdown from '../../VoteCountdown'
 
 type Props = {
   proposalData: ProposalData
@@ -47,7 +47,7 @@ const Proposal = ({ proposalData, handleClick }: Props) => {
             )}
             <ProposalId>#{id}</ProposalId>
             <ProposalType>{type}</ProposalType>
-            <StyledVoteCountdown startDate={timestamp} />
+            <Countdown startDate={timestamp} />
           </ProposalDetailsRow>
           <ProposalMetadata>{truncateMetadata(metadata, 300)}</ProposalMetadata>
         </InformationWrapper>
@@ -165,8 +165,6 @@ const VoteWrapper = styled.div`
   margin: auto 0;
   padding: var(--spacing-3);
 `
-
-const StyledVoteCountdown = styled(VoteCountdown)``
 
 const ExecutedStatus = styled.h4`
   font-size: var(--font-size-1);

--- a/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useAccount } from 'wagmi'
 import AlertFormError from '@/dao/components/AlertFormError'
+import Countdown from '@/dao/components/Countdown'
 import FormActions from '@/dao/components/PageVeCrv/components/FormActions'
 import type { PageVecrv } from '@/dao/components/PageVeCrv/types'
-import VoteCountdown from '@/dao/components/VoteCountdown'
 import { useLockEstimateWithdrawGas } from '@/dao/entities/locker-estimate-withdraw-gas'
 import useEstimateGasConversion from '@/dao/hooks/useEstimateGasConversion'
 import useStore from '@/dao/store/useStore'
@@ -85,7 +85,7 @@ const FormWithdraw = ({ rChainId, vecrvInfo }: PageVecrv) => {
           {!canUnlock && (
             <AlertBox alertType="info">
               {t`Your CRV unlocks in:`}
-              <StyledVoteCountdown startDate={vecrvInfo.lockedAmountAndUnlockTime.unlockTime / 1000} />
+              <StyledCountdown endDate={vecrvInfo.lockedAmountAndUnlockTime.unlockTime / 1000} />
             </AlertBox>
           )}
           {withdrawTxError && withdrawLockedCrvStatus.errorMessage && (
@@ -121,7 +121,7 @@ const RowParagraph = styled.p`
   font-weight: var(--bold);
 `
 
-const StyledVoteCountdown = styled(VoteCountdown)`
+const StyledCountdown = styled(Countdown)`
   margin-left: var(--spacing-2);
 `
 


### PR DESCRIPTION
Changes:
- Renamed VoteCountdown to more generic Countdown
- Added endDate prop to Countdown (startDate adds 7 days to mimic a proposal vote period)