### PR TITLE
feat: hide columns without position

### DIFF
--- a/apps/main/src/loan/components/PageLlamaMarkets/LendingMarketsTable.tsx
+++ b/apps/main/src/loan/components/PageLlamaMarkets/LendingMarketsTable.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from 'react'
-import { useAccount } from 'wagmi'
 import { DEFAULT_SORT, LLAMA_MARKET_COLUMNS } from '@/loan/components/PageLlamaMarkets/columns'
 import { LlamaMarketColumnId } from '@/loan/components/PageLlamaMarkets/columns.enum'
 import {
@@ -36,10 +35,9 @@ const { Spacing, MaxWidth, Sizing } = SizesAndSpaces
  * The visibility on mobile is based on the sort field.
  * On larger devices, it uses the visibility settings that may be customized by the user.
  */
-const useVisibility = (sortField: LlamaMarketColumnId) => {
-  const { isConnected } = useAccount()
+const useVisibility = (sortField: LlamaMarketColumnId, hasPositions: boolean | undefined) => {
   const isMobile = useMediaQuery((t) => t.breakpoints.down('tablet'))
-  const groups = useMemo(() => createLlamaMarketsColumnOptions(isConnected), [isConnected])
+  const groups = useMemo(() => createLlamaMarketsColumnOptions(hasPositions), [hasPositions])
   const visibilitySettings = useVisibilitySettings(groups)
   const columnVisibility = useMemo(() => createLlamaMarketsMobileColumns(sortField), [sortField])
   return { ...visibilitySettings, ...(isMobile && { columnVisibility }) }
@@ -65,7 +63,7 @@ export const LendingMarketsTable = ({
   ])
   const [sorting, onSortingChange] = useSortFromQueryString(DEFAULT_SORT)
   const sortField = (sorting.length ? sorting : DEFAULT_SORT)[0].id as LlamaMarketColumnId
-  const { columnSettings, columnVisibility, toggleVisibility } = useVisibility(sortField)
+  const { columnSettings, columnVisibility, toggleVisibility } = useVisibility(sortField, result?.hasPositions)
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const table = useReactTable({
     columns: LLAMA_MARKET_COLUMNS,

--- a/apps/main/src/loan/components/PageLlamaMarkets/hooks/useLlamaMarketsColumnVisibility.tsx
+++ b/apps/main/src/loan/components/PageLlamaMarkets/hooks/useLlamaMarketsColumnVisibility.tsx
@@ -13,50 +13,53 @@ export const createLlamaMarketsMobileColumns = (sortBy: LlamaMarketColumnId) =>
 /**
  * Create a map of column visibility for the Llama markets table that can be customized by the user.
  * This is not used on mobile devices (see `createLlamaMarketsMobileColumns` above).
- * @param isConnected Whether there is a wallet connected.
+ * @param hasPositions Whether the user is connected and has positions. Undefined during loading.
  */
-export const createLlamaMarketsColumnOptions = (isConnected: boolean) => [
-  {
-    label: t`Markets`,
-    options: [
-      {
-        label: t`Available Liquidity`,
-        columns: [LlamaMarketColumnId.LiquidityUsd],
-        active: true,
-        enabled: true,
-      },
-      {
-        label: t`Utilization`,
-        columns: [LlamaMarketColumnId.UtilizationPercent],
-        active: true,
-        enabled: true,
-      },
-    ],
-  },
-  {
-    label: t`Borrow`,
-    options: [
-      { columns: [LlamaMarketColumnId.BorrowRate], active: true, enabled: true },
-      { label: t`Chart`, columns: [LlamaMarketColumnId.BorrowChart], active: true, enabled: true },
-      {
-        label: t`Borrow Details`,
-        columns: [LlamaMarketColumnId.UserHealth, LlamaMarketColumnId.UserBorrowed],
-        active: true,
-        enabled: isConnected,
-      },
-    ],
-  },
-  {
-    label: t`Lend`,
-    options: [
-      { columns: [LlamaMarketColumnId.LendRate], active: true, enabled: true },
-      { label: t`Chart`, columns: [LlamaMarketColumnId.LendChart], active: false, enabled: true },
-      {
-        label: t`Lend Details`,
-        columns: [LlamaMarketColumnId.UserEarnings, LlamaMarketColumnId.UserDeposited],
-        active: true,
-        enabled: isConnected,
-      },
-    ],
-  },
-]
+export const createLlamaMarketsColumnOptions = (hasPositions: boolean | undefined) =>
+  hasPositions == null
+    ? []
+    : [
+        {
+          label: t`Markets`,
+          options: [
+            {
+              label: t`Available Liquidity`,
+              columns: [LlamaMarketColumnId.LiquidityUsd],
+              active: true,
+              enabled: true,
+            },
+            {
+              label: t`Utilization`,
+              columns: [LlamaMarketColumnId.UtilizationPercent],
+              active: true,
+              enabled: true,
+            },
+          ],
+        },
+        {
+          label: t`Borrow`,
+          options: [
+            { columns: [LlamaMarketColumnId.BorrowRate], active: true, enabled: true },
+            { label: t`Chart`, columns: [LlamaMarketColumnId.BorrowChart], active: true, enabled: true },
+            {
+              label: t`Borrow Details`,
+              columns: [LlamaMarketColumnId.UserHealth, LlamaMarketColumnId.UserBorrowed],
+              active: true,
+              enabled: hasPositions,
+            },
+          ],
+        },
+        {
+          label: t`Lend`,
+          options: [
+            { columns: [LlamaMarketColumnId.LendRate], active: true, enabled: true },
+            { label: t`Chart`, columns: [LlamaMarketColumnId.LendChart], active: false, enabled: true },
+            {
+              label: t`Lend Details`,
+              columns: [LlamaMarketColumnId.UserEarnings, LlamaMarketColumnId.UserDeposited],
+              active: true,
+              enabled: hasPositions,
+            },
+          ],
+        },
+      ]


### PR DESCRIPTION
This pull request refactors the logic for determining column visibility in the Llama Markets table to use a new `hasPositions` parameter instead of relying on the `isConnected` state from the `useAccount` hook. This change improves clarity and ensures the visibility logic is tied to the user's actual positions rather than just their connection status.