### PR TITLE
fix: hodgepodge

### DIFF
--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
@@ -1,10 +1,16 @@
 import { useAccount } from 'wagmi'
-import type { SxProps, Theme } from '@mui/material'
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { CONNECT_STAGE, isLoading, useConnection, useWallet } from '@ui-kit/features/connect-wallet'
 import { ConnectedWalletLabel } from './ConnectedWalletLabel'
 import { ConnectWalletButton } from './ConnectWalletButton'
 
-export const ConnectWalletIndicator = ({ sx, onConnect }: { sx?: SxProps<Theme>; onConnect?: () => void }) => {
+export const ConnectWalletIndicator = ({
+  sx,
+  onConnect,
+}: {
+  sx?: SystemStyleObject<Theme>
+  onConnect?: () => void
+}) => {
   const { address } = useAccount()
   const { connect, disconnect } = useWallet()
   const { connectState } = useConnection()

--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
@@ -1,16 +1,10 @@
 import { useAccount } from 'wagmi'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { CONNECT_STAGE, isLoading, useConnection, useWallet } from '@ui-kit/features/connect-wallet'
+import type { SxProps } from '@ui-kit/utils'
 import { ConnectedWalletLabel } from './ConnectedWalletLabel'
 import { ConnectWalletButton } from './ConnectWalletButton'
 
-export const ConnectWalletIndicator = ({
-  sx,
-  onConnect,
-}: {
-  sx?: SystemStyleObject<Theme>
-  onConnect?: () => void
-}) => {
+export const ConnectWalletIndicator = ({ sx, onConnect }: { sx?: SxProps; onConnect?: () => void }) => {
   const { address } = useAccount()
   const { connect, disconnect } = useWallet()
   const { connectState } = useConnection()

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -9,6 +9,7 @@ import IconButton from '@mui/material/IconButton'
 import Link from '@mui/material/Link'
 import Snackbar from '@mui/material/Snackbar'
 import Typography from '@mui/material/Typography'
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
@@ -51,6 +52,7 @@ type ActionInfoProps = {
   size?: ComponentSize
   /** Whether the component is in a loading state. Can be boolean or string (string value is used for skeleton width inference) */
   loading?: boolean | string
+  sx?: SystemStyleObject<Theme>
 }
 
 const labelSize = {
@@ -86,6 +88,7 @@ const ActionInfo = ({
   copy = false,
   copiedTitle,
   loading = false,
+  sx,
 }: ActionInfoProps) => {
   const [isOpen, open, close] = useSwitch(false)
 

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -9,13 +9,12 @@ import IconButton from '@mui/material/IconButton'
 import Link from '@mui/material/Link'
 import Snackbar from '@mui/material/Snackbar'
 import Typography from '@mui/material/Typography'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { TypographyVariantKey } from '@ui-kit/themes/typography'
-import { copyToClipboard } from '@ui-kit/utils'
+import { copyToClipboard, type SxProps } from '@ui-kit/utils'
 import { WithSkeleton } from './WithSkeleton'
 
 const { Spacing, IconSize } = SizesAndSpaces
@@ -52,7 +51,7 @@ type ActionInfoProps = {
   size?: ComponentSize
   /** Whether the component is in a loading state. Can be boolean or string (string value is used for skeleton width inference) */
   loading?: boolean | string
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
 }
 
 const labelSize = {

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -97,7 +97,7 @@ const ActionInfo = ({
   }
 
   return (
-    <Stack direction="row" alignItems="center" gap={Spacing.sm}>
+    <Stack direction="row" alignItems="center" gap={Spacing.sm} sx={sx}>
       <Typography flexGrow={1} variant={labelSize[size]} color={labelColor ?? 'textSecondary'}>
         {label}
       </Typography>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataRow.tsx
@@ -2,10 +2,10 @@ import { useRouter } from 'next/navigation'
 import { type MouseEvent, useCallback, useState } from 'react'
 import TableRow from '@mui/material/TableRow'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { type Row } from '@tanstack/react-table'
 import { type ExpandedPanel, ExpansionRow } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
+import type { SxProps } from '@ui-kit/utils'
 import { CypressHoverClass, hasParentWithClass } from '@ui-kit/utils/dom'
 import { InvertOnHover } from '../InvertOnHover'
 import { ClickableInRowClass, DesktopOnlyHoverClass, type TableItem } from './data-table.utils'
@@ -29,7 +29,7 @@ export const DataRow = <T extends TableItem>({
   expandedPanel,
 }: {
   row: Row<T>
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
   expandedPanel: ExpandedPanel<T>
 }) => {
   const [element, setElement] = useState<HTMLTableRowElement | null>(null) // note: useRef doesn't get updated in cypress

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -4,9 +4,9 @@ import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import type { SxProps } from '@ui-kit/utils'
 import { type TableItem, type TanstackTable } from './data-table.utils'
 import { DataRow } from './DataRow'
 import { EmptyStateRow } from './EmptyStateRow'
@@ -30,7 +30,7 @@ export const DataTable = <T extends TableItem>({
   headerHeight: string
   emptyText: string
   children?: ReactNode // passed to <FilterRow />
-  rowSx?: SystemStyleObject<Theme>
+  rowSx?: SxProps
   minRowHeight?: number
   expandedPanel: ExpandedPanel<T>
 }) => (

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -4,7 +4,7 @@ import Table from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
-import type { SystemStyleObject, Theme } from '@mui/system' // Can't use SxProps for some reason inside an sx *function*
+import type { SystemStyleObject, Theme } from '@mui/system'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { type TableItem, type TanstackTable } from './data-table.utils'

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
@@ -1,5 +1,5 @@
-import type { SxProps, Theme } from '@mui/material'
 import SvgIcon from '@mui/material/SvgIcon'
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 
 /** Allows an icon to be rotated with animations when rotated or getting hidden */
@@ -15,7 +15,7 @@ export const RotatableIcon = ({
   isEnabled?: boolean
   fontSize: number
   icon: typeof SvgIcon
-  sx?: SxProps<Theme>
+  sx?: SystemStyleObject<Theme>
   testId?: string
 }) => (
   <Icon

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
@@ -1,6 +1,6 @@
 import SvgIcon from '@mui/material/SvgIcon'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
+import type { SxProps } from '@ui-kit/utils'
 
 /** Allows an icon to be rotated with animations when rotated or getting hidden */
 export const RotatableIcon = ({
@@ -15,7 +15,7 @@ export const RotatableIcon = ({
   isEnabled?: boolean
   fontSize: number
   icon: typeof SvgIcon
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
   testId?: string
 }) => (
   <Icon

--- a/packages/curve-ui-kit/src/shared/ui/InvertOnHover.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/InvertOnHover.tsx
@@ -1,10 +1,10 @@
 import { cloneElement, type ReactElement } from 'react'
 import type { Theme } from '@mui/material'
-import type { SystemStyleObject } from '@mui/system'
 import { useClassObserver } from '@ui-kit/hooks/useClassObserver'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { InvertTheme } from '@ui-kit/shared/ui/ThemeProvider'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
+import type { SxProps } from '@ui-kit/utils'
 import { classNames, CypressHoverClass, useNativeEventInCypress } from '@ui-kit/utils/dom'
 
 /**
@@ -12,7 +12,7 @@ import { classNames, CypressHoverClass, useNativeEventInCypress } from '@ui-kit/
  * The child component should accept the following props
  */
 type ChildProps = {
-  sx: SystemStyleObject<Theme>
+  sx: SxProps
   onMouseEnter: () => void
   onMouseLeave: () => void
   transition: string

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
@@ -10,18 +10,15 @@ import { TradingSlider } from './TradingSlider'
 const { Spacing, FontSize, FontWeight, Sizing } = SizesAndSpaces
 
 function clampBalance(balance: number | string, maxBalance?: number) {
-  let newBalance = Number(balance)
+  const newBalance = Math.max(0, Number(balance)) // Disallow negative values
 
-  // Disallow negative values.
-  newBalance = Math.max(0, newBalance)
+  if (maxBalance == null) {
+    return newBalance
+  }
 
   // We only clamp the positive side if there's a max balance.
   // This is up to debate and might be removed, it could be considered annoying UX.
-  if (maxBalance != null) {
-    newBalance = Math.min(newBalance, maxBalance)
-  }
-
-  return newBalance
+  return Math.min(newBalance, maxBalance)
 }
 
 type HelperMessageProps = {

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
@@ -79,15 +79,13 @@ const BalanceTextField = ({ balance, maxBalance, isError, onChange }: BalanceTex
         },
       },
     }}
-    onClick={(e) => {
-      /**
-       * Select all content when clicked.
-       * This prevents unintended behavior when users click on the input field.
-       * For example, if the field contains "5000" and a user clicks on the left
-       * to type "4", it would become "45000" instead of the likely intended "4".
-       */
-      ;(e.target as HTMLInputElement).select()
-    }}
+    /**
+     * Select all content when clicked.
+     * This prevents unintended behavior when users click on the input field.
+     * For example, if the field contains "5000" and a user clicks on the left
+     * to type "4", it would become "45000" instead of the likely intended "4".
+     */
+    onFocus={(e) => (e.target as HTMLInputElement).select()}
     onChange={(e) => {
       /**
        * We clamp here and not in the onChange handler passed as property, because

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput.tsx
@@ -32,7 +32,7 @@ const HelperMessage = ({ message, isError }: HelperMessageProps) => (
       backgroundColor: (t) => t.design.Layer[3].Fill,
       paddingBlock: Spacing.sm,
       paddingInlineStart: Spacing.sm,
-      outline: isError ? (t) => `1px solid ${t.design.Layer.Feedback.Error}` : 'none',
+      ...(isError && { outline: (t) => `1px solid ${t.design.Layer.Feedback.Error}` }),
     }}
   >
     {typeof message === 'string' ? (

--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -7,7 +7,7 @@ import CardHeader from '@mui/material/CardHeader'
 import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
-import type { SystemStyleObject, Theme } from '@mui/system'
+import type { SxProps } from '@ui-kit/utils'
 import { SizesAndSpaces } from '../../themes/design/1_sizes_spaces'
 
 export type ModalDialogProps = {
@@ -19,7 +19,7 @@ export type ModalDialogProps = {
   titleAction?: ReactNode
   footer?: ReactNode
   compact?: boolean
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
 }
 
 export const ModalDialog = ({

--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
-import { SxProps, Theme } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardActions from '@mui/material/CardActions'
 import CardContent from '@mui/material/CardContent'
@@ -8,6 +7,7 @@ import CardHeader from '@mui/material/CardHeader'
 import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { SizesAndSpaces } from '../../themes/design/1_sizes_spaces'
 
 export type ModalDialogProps = {
@@ -19,7 +19,7 @@ export type ModalDialogProps = {
   titleAction?: ReactNode
   footer?: ReactNode
   compact?: boolean
-  sx?: SxProps<Theme>
+  sx?: SystemStyleObject<Theme>
 }
 
 export const ModalDialog = ({

--- a/packages/curve-ui-kit/src/shared/ui/TokenIcon.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenIcon.tsx
@@ -1,6 +1,6 @@
 import type { ImgHTMLAttributes } from 'react'
 import Box from '@mui/material/Box'
-import type { SystemStyleObject, Theme } from '@mui/system' // Can't use SxProps for some reason inside an sx *function*
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { getImageBaseUrl } from '@ui/utils/utilsConstants'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { handleBreakpoints } from '@ui-kit/themes/basic-theme'

--- a/packages/curve-ui-kit/src/shared/ui/TokenIcon.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenIcon.tsx
@@ -1,10 +1,10 @@
 import type { ImgHTMLAttributes } from 'react'
 import Box from '@mui/material/Box'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { getImageBaseUrl } from '@ui/utils/utilsConstants'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { handleBreakpoints } from '@ui-kit/themes/basic-theme'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { applySxProps, type SxProps } from '@ui-kit/utils'
 
 const DEFAULT_IMAGE = '/images/default-crypto.png'
 
@@ -16,7 +16,7 @@ export interface TokenIconProps extends ImgHTMLAttributes<HTMLImageElement> {
   tooltip?: string
   address?: string | null
   size?: 'sm' | 'mui-sm' | 'mui-md' | 'xl'
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
 }
 
 export const TokenIcon = ({
@@ -54,7 +54,7 @@ export const TokenIcon = ({
         ...(size === 'mui-sm' && handleBreakpoints({ width: IconSize['sm'], height: IconSize['sm'] })),
         ...(size === 'mui-md' && handleBreakpoints({ width: IconSize['md'], height: IconSize['md'] })),
         ...(size === 'xl' && handleBreakpoints({ width: IconSize['xl'], height: IconSize['xl'] })),
-        ...sx,
+        ...applySxProps(sx, theme),
       })}
     />
   </Tooltip>

--- a/packages/curve-ui-kit/src/utils/index.ts
+++ b/packages/curve-ui-kit/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './web3'
 export * from './network'
 export * from './number'
 export * from './searchText'
+export * from './mui'
 
 export const isCypress = typeof window !== 'undefined' && Boolean((window as { Cypress?: boolean }).Cypress)
 export const isBetaDefault =

--- a/packages/curve-ui-kit/src/utils/mui.ts
+++ b/packages/curve-ui-kit/src/utils/mui.ts
@@ -1,0 +1,12 @@
+import type { Theme } from '@mui/material/styles'
+import type { SystemStyleObject } from '@mui/system'
+
+/** Type definition for MUI sx prop that accepts either a style object or a function returning a style object */
+export type SxProps = SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)
+
+/**
+ * Utility function to resolve sx props by calling theme function if needed and provided
+ * @param sx - The sx prop value (style object, theme function, or undefined)
+ * @param theme - The MUI theme object
+ */
+export const applySxProps = (sx: SxProps | undefined, theme: Theme) => (typeof sx === 'function' ? sx(theme) : sx)

--- a/packages/curve-ui-kit/src/widgets/Header/HeaderLogo.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/HeaderLogo.tsx
@@ -2,9 +2,9 @@ import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
 import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
-import type { SystemStyleObject, Theme } from '@mui/system'
 import { LogoImg } from '@ui/images'
 import type { AppMenuOption } from '@ui-kit/shared/routes'
+import type { SxProps } from '@ui-kit/utils'
 
 const Image = styled('img')({
   width: 30,
@@ -16,7 +16,7 @@ const LogoImageSrc = (LogoImg as unknown as { src: string }).src
 export type HeaderLogoProps = {
   currentMenu: AppMenuOption
   isLite: boolean
-  sx?: SystemStyleObject<Theme>
+  sx?: SxProps
 }
 
 const APP_NAMES = {

--- a/packages/curve-ui-kit/src/widgets/Header/HeaderLogo.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/HeaderLogo.tsx
@@ -1,8 +1,8 @@
 import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
-import type { SxProps, Theme } from '@mui/material/styles'
 import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
+import type { SystemStyleObject, Theme } from '@mui/system'
 import { LogoImg } from '@ui/images'
 import type { AppMenuOption } from '@ui-kit/shared/routes'
 
@@ -16,7 +16,7 @@ const LogoImageSrc = (LogoImg as unknown as { src: string }).src
 export type HeaderLogoProps = {
   currentMenu: AppMenuOption
   isLite: boolean
-  sx?: SxProps<Theme>
+  sx?: SystemStyleObject<Theme>
 }
 
 const APP_NAMES = {


### PR DESCRIPTION
Hodgepodge of a handful of review comments and own small commits that I don't want to clog the soft liquidation PR with. Mainly concerns action infos and the large token input.

The reason why I want to use `SystemStyleObject` for `sx` props consistently instead of `SxProps`, is because `SxProps` doesn't work  with if the object contains a function like `color: t => t.design.Colors[200]`. Functionally this change doesn't change anything, it's just a typescript thing and I don't want to re figure out the solution when SxProps isn't working properly. Rather be consistent.