### PR TITLE
styling: add inline button style and fix link variant specificity

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Balance.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Balance.tsx
@@ -25,11 +25,11 @@ type MaxButtonProps = {
 /** Reusable Max button component with consistent styling */
 const MaxButton = ({ children, underline, onClick }: MaxButtonProps) => (
   <Button
+    variant="inline"
     color="ghost"
     size="extraSmall"
     onClick={onClick}
     sx={{
-      minWidth: 'unset',
       /**
        * Remove any properties that cause the total height component to change
        * depending on the value of the 'max' property of BalanceText.
@@ -37,7 +37,6 @@ const MaxButton = ({ children, underline, onClick }: MaxButtonProps) => (
        * white space and thus breathing room. However in this case we want the
        * link to be embedded into the typography and be as compact as possible.
        */
-      '&': { height: 'auto', padding: 0, border: 0, lineHeight: 0 },
       ...(underline && {
         '&:hover .balance': {
           textDecoration: 'underline',

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.d.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.d.ts
@@ -22,5 +22,6 @@ declare module '@mui/material/Button' {
     contained: true
     outlined: true
     link: true
+    inline: true
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -72,10 +72,24 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
           {
             props: { variant: 'link' },
             style: {
-              textTransform: 'none',
-              padding: 0,
-              // !important is required as the sizes defined below with `buttonSize` have a higher specificity.
-              height: `${Sizing[400]} !important`,
+              '&.MuiButton-root': {
+                textTransform: 'none',
+                padding: 0,
+                height: Sizing[400],
+              },
+            },
+          },
+          {
+            props: { variant: 'inline' },
+            style: {
+              '&.MuiButton-root': {
+                textTransform: 'none',
+                padding: 0,
+                border: 0,
+                lineHeight: 1,
+                height: `auto`,
+                minWidth: 'unset',
+              },
             },
           },
         ],

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -89,6 +89,8 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
                 lineHeight: 1,
                 height: `auto`,
                 minWidth: 'unset',
+                textAlign: 'start',
+                justifyContent: 'start',
               },
             },
           },

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -72,7 +72,7 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
           {
             props: { variant: 'link' },
             style: {
-              '&.MuiButton-root': {
+              '&.MuiButton-link': {
                 textTransform: 'none',
                 padding: 0,
                 height: Sizing[400],
@@ -82,7 +82,7 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
           {
             props: { variant: 'inline' },
             style: {
-              '&.MuiButton-root': {
+              '&.MuiButton-inline': {
                 textTransform: 'none',
                 padding: 0,
                 border: 0,

--- a/packages/curve-ui-kit/src/themes/stories/Button.stories.ts
+++ b/packages/curve-ui-kit/src/themes/stories/Button.stories.ts
@@ -82,6 +82,14 @@ export const Link: Story = {
   },
 }
 
+export const Inline: Story = {
+  args: {
+    variant: 'inline',
+    color: 'ghost',
+    children: 'Inline',
+  },
+}
+
 export const Success: Story = {
   args: {
     color: 'success',


### PR DESCRIPTION
Think I've been able to get rid of the `!important` by using `&.MuiButton-link` and `&.MuiButton-inline` instead.

I've decided to introduce the `inline` variant and keep it separate from the [existing mui](https://mui.com/material-ui/react-button/#text-button) `text` variant. The `text` variant is when you still want some of that spacing and padding, `inline` is for when you truly want a text 'button' inside a paragraph/typography.

Besides the `Balance` component, another use case (which is why I've decided to create the variant) is for the link inside the alert in pic below
![image](https://github.com/user-attachments/assets/607c6c5d-b76d-4aa3-b69b-48be4c464fe7)
