### PR TITLE
styling: alert boxes should have a 2px border width

### DIFF
--- a/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
+++ b/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
@@ -26,6 +26,7 @@ export const defineMuiAlert = (
   styleOverrides: {
     root: handleBreakpoints({
       ...bodyXsRegular,
+      borderWidth: '2px',
       paddingInlineStart: Spacing.md,
       paddingInlineEnd: Spacing.sm,
       paddingBlockStart: Spacing.sm,

--- a/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
+++ b/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
@@ -7,7 +7,7 @@ import { handleBreakpoints } from '@ui-kit/themes/basic-theme'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { DesignSystem } from '../design'
 
-const { Spacing, IconSize } = SizesAndSpaces
+const { Spacing, IconSize, OutlineWidth } = SizesAndSpaces
 
 const titleAndIconSelector = '.MuiAlertTitle-root, .MuiAlert-icon'
 
@@ -26,7 +26,7 @@ export const defineMuiAlert = (
   styleOverrides: {
     root: handleBreakpoints({
       ...bodyXsRegular,
-      borderWidth: '2px',
+      borderWidth: OutlineWidth,
       paddingInlineStart: Spacing.md,
       paddingInlineEnd: Spacing.sm,
       paddingBlockStart: Spacing.sm,


### PR DESCRIPTION
I noticed alerts weren't thicc enough. Turns out the borders are the default MUI 1px wide, when they should be 2px according to Figma.

![image](https://github.com/user-attachments/assets/7ce9fb27-b484-4319-8821-d0e955c4e847)