### PR TITLE
fix: AppPageFormContainer margin breakpoints

### DIFF
--- a/packages/ui/src/AppPage/styles.ts
+++ b/packages/ui/src/AppPage/styles.ts
@@ -27,7 +27,7 @@ export const AppPageFormContainer = styled.div<{ isAdvanceMode: boolean }>`
     margin-left: 1rem;
     margin-right: 1rem;
   }
-  @media (min-width: ${breakpoints.sm}rem) {
+  @media (min-width: 650px) {
     margin-left: 3rem;
     margin-right: 3rem;
   }


### PR DESCRIPTION
3rem margin was set for market and pool pages via AppPageFormContainer on screens between 426px and 961px causing very suboptimal uses of smaller screens.

Changes:
- Change the 3rem margin breakpoint to 650px from 426px.

Before:
https://github.com/user-attachments/assets/eea8fbcd-4de6-41d5-b536-9e3eb9123300

After:
https://github.com/user-attachments/assets/93f9c844-9fe9-4fed-8dfe-ab0a86b9cfab
