### PR TITLE
fix: make sure action info labels start on the left side

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo.tsx
@@ -98,7 +98,7 @@ const ActionInfo = ({
 
   return (
     <Stack direction="row" alignItems="center" gap={Spacing.sm} sx={sx}>
-      <Typography flexGrow={1} variant={labelSize[size]} color={labelColor ?? 'textSecondary'}>
+      <Typography flexGrow={1} variant={labelSize[size]} color={labelColor ?? 'textSecondary'} textAlign="start">
         {label}
       </Typography>
 


### PR DESCRIPTION
Currently the label is centered horizontally if you apply flex grow 1 to the action info. Primarily an issue when used as an accordion title.