### PR TITLE
styling: increase wallet icon size in balance component

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Balance.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Balance.tsx
@@ -90,7 +90,7 @@ export type Props = {
 
 export const Balance = ({ symbol, max, balance, notionalValue, hideIcon, onMax }: Props) => (
   <Stack direction="row" gap={Spacing.xs} alignItems="center">
-    {!hideIcon && <AccountBalanceWalletOutlinedIcon sx={{ width: IconSize.xs, height: IconSize.xs }} />}
+    {!hideIcon && <AccountBalanceWalletOutlinedIcon sx={{ width: IconSize.sm, height: IconSize.sm }} />}
 
     {max === 'balance' && balance != null ? (
       <MaxButton underline={true} onClick={() => onMax?.(balance)}>


### PR DESCRIPTION
Concerns the icon in pic attached. By default it's too small so it's now sized according to the Figma

![image](https://github.com/user-attachments/assets/0ec56b16-364c-4fe3-8a4e-590828680bf3)
