### PR TITLE
fix: incorrect token icon url when no blockchain is given

### DIFF
--- a/packages/ui/src/utils/utilsConstants.ts
+++ b/packages/ui/src/utils/utilsConstants.ts
@@ -10,7 +10,7 @@ export const NOT_FOUND_IMAGE_URL = `${CURVE_ASSETS_URL}/branding/four-oh-llama.j
 export const MAX_USD_VALUE = 100_000_000_000_000 // $ 100T 🤑
 
 export const getImageBaseUrl = (blockchainId: string) =>
-  `${CURVE_ASSETS_URL}/images/assets${blockchainId == 'ethereum' ? '' : `-${blockchainId}`}/`
+  `${CURVE_ASSETS_URL}/images/assets${!blockchainId || blockchainId == 'ethereum' ? '' : `-${blockchainId}`}/`
 
 export const getBlockchainIconUrl = (blockchainId: string) => `${CURVE_ASSETS_URL}/chains/${blockchainId}.png`
 


### PR DESCRIPTION
By default, if no chain is given it should use the 'main' one, which is ethereum.
However, it would incorrect add a `-` to the URL because the empty string isn't `ethereum`. Oopsie!
You can test it in the TokenIcon storybook, an empty chain should resolve to an icon and not to the error token icon.

![image](https://github.com/user-attachments/assets/59f53aca-77ff-453a-9b6e-533c2bf01ad3)
