### PR TITLE
feat: increase max width of ChipPoolName

### DIFF
--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -109,12 +109,14 @@ const ChipPoolAddress = styled.span`
 const ChipPoolName = styled(TextEllipsis)`
   font-size: var(--font-size-4);
 
+  max-width: 13.125rem; // 200px
+
   @media (min-width: ${breakpoints.sm}rem) {
     font-size: 1.25rem; // 20px
-    max-width: 13.75rem; // 220px
+    max-width: 16.25rem; // 260px
   }
   @media (min-width: ${breakpoints.lg}rem) {
-    max-width: 13.125rem; // 210px
+    max-width: 16.25rem; // 260px
   }
 `
 


### PR DESCRIPTION
The pool name width is too small, which causes issues with displaying pools like CrossCurve. This PR is made to fix that.

Before:

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e0400179-4e41-4c75-9ec3-fa649ed1eee0" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/dbef2f5a-3d8c-47ab-abb4-c747b4b42022" width="300"/></td>
  </tr>
  <tr>
    <td align="center"><i>Desktop</i></td>
    <td align="center"><i>Mobile</i></td>
  </tr>
</table>

After:

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/41f20caa-7bf5-4293-834d-4c402007cc78" width="300"/></td>
    <td><img src="https://github.com/user-attachments/assets/e8f6ea34-6868-4dc7-9224-5fae52ee6bc7" width="300"/></td>
  </tr>
  <tr>
    <td align="center"><i>Desktop</i></td>
    <td align="center"><i>Mobile</i></td>
  </tr>
</table>
