### PR TITLE
fix: memoize wagmi configuration

### DIFF
--- a/apps/main/src/app/dex/client.tsx
+++ b/apps/main/src/app/dex/client.tsx
@@ -60,7 +60,10 @@ export const App = ({ children }: { children: ReactNode }) => {
       window.addEventListener('resize', () => handleResizeListener())
       window.addEventListener('scroll', () => delay(() => updateShowScrollButton(window.scrollY), 200))
     })()
-    return () => setAppLoaded(false)
+    return () => {
+      setAppLoaded(false)
+      updateGlobalStoreByKey('loaded', false)
+    }
   }, [fetchNetworks, handleResizeListener, updateGlobalStoreByKey, updateShowScrollButton])
 
   const onChainUnavailable = useCallback(

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/ConnectionContext.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/ConnectionContext.tsx
@@ -62,7 +62,7 @@ const ConnectionContext = createContext<ConnectionContextValue<unknown>>({
 const compareSignerAddress = <TChainId extends any>(
   wallet: Wallet | null,
   lib: { chainId: TChainId; signerAddress?: string } | null,
-) => wallet?.account.address?.toLowerCase() == lib?.signerAddress?.toLowerCase()
+) => wallet?.account.address?.toLowerCase() == (lib?.signerAddress?.toLowerCase() || null)
 
 /** Module-level variables to track initialization state across multiple calls */
 let mutexPromise: Promise<unknown> | null = null

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/wagmi-config.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/wagmi-config.ts
@@ -1,4 +1,5 @@
 import uniq from 'lodash/uniq'
+import memoize from 'memoizee'
 import type { Chain } from 'viem'
 import { defineChain } from 'viem/utils'
 import type { BaseConfig } from '@ui/utils'
@@ -20,65 +21,69 @@ const DECIMALS: Record<number, number> = {
 
 /**
  * Creates a Wagmi configuration based on the provided network configurations.
+ * We use memoize here because useMemo may be called multiple times, breaking the wagmi auto-reconnect.
  * @param networks - A record mapping chain IDs to their respective network configurations.
  * @return A Wagmi configuration object that includes chains, connectors, and transports.
  */
-export const createWagmiConfig = <ChainId extends number, NetworkConfig extends BaseConfig>(
-  networks: Record<ChainId, NetworkConfig>,
-) => {
-  const chains = Object.fromEntries(wagmiChains.map((chain) => [chain.id, chain]))
-  const networkEntries = Object.entries(networks).map(([id, config]) => [+id, config]) as [ChainId, NetworkConfig][]
-  return createConfig({
-    chains: networkEntries.map(([id, config]): Chain => {
-      // use the backend data to configure new chains, but use wagmi contract addresses and useful properties/RPCs
-      const wagmiChain = chains[id] as Chain | undefined
-      return defineChain({
-        id,
-        testnet: config.isTestnet,
-        nativeCurrency: { name: config.symbol, symbol: config.symbol, decimals: DECIMALS[id] ?? 18 },
-        ...wagmiChain,
-        name: config.name,
-        rpcUrls: {
-          default: { http: uniq([config.rpcUrl, ...(wagmiChain?.rpcUrls.default.http ?? [])]) },
-        },
-        ...(config.explorerUrl && {
-          blockExplorers: {
-            default: { name: new URL(config.explorerUrl).host, url: config.explorerUrl },
+export const createWagmiConfig = memoize(
+  <ChainId extends number, NetworkConfig extends BaseConfig>(networks: Record<ChainId, NetworkConfig>) => {
+    const chains = Object.fromEntries(wagmiChains.map((chain) => [chain.id, chain]))
+    const networkEntries = Object.entries(networks).map(([id, config]) => [+id, config]) as [ChainId, NetworkConfig][]
+    return createConfig({
+      chains: networkEntries.map(([id, config]): Chain => {
+        // use the backend data to configure new chains, but use wagmi contract addresses and useful properties/RPCs
+        const wagmiChain = chains[id] as Chain | undefined
+        return defineChain({
+          id,
+          testnet: config.isTestnet,
+          nativeCurrency: { name: config.symbol, symbol: config.symbol, decimals: DECIMALS[id] ?? 18 },
+          ...wagmiChain,
+          name: config.name,
+          rpcUrls: {
+            default: { http: uniq([config.rpcUrl, ...(wagmiChain?.rpcUrls.default.http ?? [])]) },
           },
-        }),
-      })
-    }) as [Chain, ...Chain[]],
-    connectors: Object.values(connectors),
-    transports: Object.fromEntries(
-      networkEntries.map(([id]) => [
-        id,
-        /**
-         * Transport configuration for Wagmi:
-         * 1. unstable_connector(injected) - Uses the user's injected wallet for transactions
-         *
-         *    According to Wagmi docs, it is highly recommended to use unstable_connector
-         *    inside a fallback transport because connector requests may fail due to:
-         *    - Chain ID mismatches
-         *    - Limited RPC method support
-         *    - Rate-limiting of wallet provider
-         *
-         * 2. http transport - Used as fallback when connector transport fails
-         *    - Configured with batch size of 3 to comply with DRPC free tier limits
-         *    - Prevents error code 29 from exceeding batch limits
-         *
-         * Note: WalletConnect ignores this http endpoint and uses chain.rpcUrls.default.http[0]
-         * regardless of the configuration here.
-         */
-        fallback([unstable_connector(injected), http(undefined, { batch: { batchSize: 3 } })]),
-      ]),
-    ) as Record<ChainId, Transport>,
-    /**
-     * Disabled to prevent auto-reconnect on disconnecting an injected wallet.
-     * Solves the same issue as discussed on https://github.com/wevm/wagmi/discussions/3537.
-     * We don't use wallet specific injected connectors anyway and prefer to use the single global one.
-     */
-    multiInjectedProviderDiscovery: false,
-  })
-}
+          ...(config.explorerUrl && {
+            blockExplorers: {
+              default: { name: new URL(config.explorerUrl).host, url: config.explorerUrl },
+            },
+          }),
+        })
+      }) as [Chain, ...Chain[]],
+      connectors: Object.values(connectors),
+      transports: Object.fromEntries(
+        networkEntries.map(([id]) => [
+          id,
+          /**
+           * Transport configuration for Wagmi:
+           * 1. unstable_connector(injected) - Uses the user's injected wallet for transactions
+           *
+           *    According to Wagmi docs, it is highly recommended to use unstable_connector
+           *    inside a fallback transport because connector requests may fail due to:
+           *    - Chain ID mismatches
+           *    - Limited RPC method support
+           *    - Rate-limiting of wallet provider
+           *
+           * 2. http transport - Used as fallback when connector transport fails
+           *    - Configured with batch size of 3 to comply with DRPC free tier limits
+           *    - Prevents error code 29 from exceeding batch limits
+           *
+           * Note: WalletConnect ignores this http endpoint and uses chain.rpcUrls.default.http[0]
+           * regardless of the configuration here.
+           */
+          fallback([unstable_connector(injected), http(undefined, { batch: { batchSize: 3 } })]),
+        ]),
+      ) as Record<ChainId, Transport>,
+      /**
+       * Disabled to prevent auto-reconnect on disconnecting an injected wallet.
+       * Solves the same issue as discussed on https://github.com/wevm/wagmi/discussions/3537.
+       * We don't use wallet specific injected connectors anyway and prefer to use the single global one.
+       */
+      multiInjectedProviderDiscovery: false,
+    })
+  },
+  {
+    length: 1,
+  },
+)
 
 export type WagmiChainId = ReturnType<typeof createWagmiConfig>['chains'][number]['id']

--- a/packages/curve-ui-kit/src/utils/useTraceProps.ts
+++ b/packages/curve-ui-kit/src/utils/useTraceProps.ts
@@ -19,8 +19,8 @@ export function useTraceProps<T extends Record<string, unknown>>(name: string, p
     propsRef.current = props
   }, [props, name])
   useEffect(() => {
-    console.info(`useTraceProps ${name} ${new Date().toISOString()}: Mounted`, propsRef.current)
-    return () => console.warn(`useTraceProps ${name} ${new Date().toISOString()}: Unmounted`, propsRef.current)
+    console.info(`useTraceProps ${name} ${new Date().toISOString()}: Mounted`, { ...propsRef.current })
+    return () => console.warn(`useTraceProps ${name} ${new Date().toISOString()}: Unmounted`, { ...propsRef.current })
   }, [name])
 }
 


### PR DESCRIPTION
- use memoize here because useMemo may be called multiple times, breaking the wagmi auto-reconnect.
- stop re-hydrating too often due to signer address `'' != null`
- enumerate all props in `useTraceProps`