### PR TITLE
fix: crash when prices api is offline

### DIFF
--- a/packages/ui/src/Chart/ChartWrapper.tsx
+++ b/packages/ui/src/Chart/ChartWrapper.tsx
@@ -266,9 +266,7 @@ const ChartWrapper = ({
           <StyledSpinnerWrapper
             minHeight={chartExpanded ? chartHeight.expanded.toString() + 'px' : chartHeight.standard.toString() + 'px'}
           >
-            <ErrorMessage>{`Unable to fetch ${
-              selectedChartIndex !== undefined ? selectChartList?.[selectedChartIndex].label : selectChartList[0].label
-            } data.`}</ErrorMessage>
+            <ErrorMessage>{`Unable to fetch ${selectChartList?.[selectedChartIndex ?? 0]?.label ?? ''} data.`}</ErrorMessage>
             <RefreshButton
               size="small"
               variant="text"


### PR DESCRIPTION
- The pools page is crashing when prices API is offline:
![Screenshot from 2025-06-03 13-15-31](https://github.com/user-attachments/assets/4382ad80-5589-4235-bd38-d582a32d39c8)
![Screenshot from 2025-06-03 13-14-50](https://github.com/user-attachments/assets/b1b2716e-091c-4613-8bc2-7d2b93397bdc)

- After this fix:
![image](https://github.com/user-attachments/assets/b5a50bc7-2b20-4a2b-8b53-0594fa15bf96)
