### PR TITLE
chore: bump curvefi/api to 2.67.2

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "analyze": "ANALYZE=true next build"
   },
   "dependencies": {
-    "@curvefi/api": "^2.67.1",
+    "@curvefi/api": "^2.67.2",
     "@curvefi/llamalend-api": "^1.0.21",
     "@ethersproject/abi": "^5.8.0",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,15 +1709,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:^2.67.1":
-  version: 2.67.1
-  resolution: "@curvefi/api@npm:2.67.1"
+"@curvefi/api@npm:^2.67.2":
+  version: 2.67.2
+  resolution: "@curvefi/api@npm:2.67.2"
   dependencies:
     "@curvefi/ethcall": "npm:^6.0.14"
     bignumber.js: "npm:^9.3.0"
     ethers: "npm:^6.14.1"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/f09069183b71566ff975d68f882b5c43ba34f850e63784f3aeb0495c935e9a954f9a5684ba7e5820f4230e383159a7589015e69e1f397a550275022822ddd6f2
+  checksum: 10c0/512485f80cfca919a4f0943c32a54a46d1ab92bd7f130c001ca1d567c6b74fc4528a8ac689ab0b49892a0aa73d0d1d6dbb626eb85e815fc4e6b58ed96c088b9d
   languageName: node
   linkType: hard
 
@@ -14999,7 +14999,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "main@workspace:apps/main"
   dependencies:
-    "@curvefi/api": "npm:^2.67.1"
+    "@curvefi/api": "npm:^2.67.2"
     "@curvefi/llamalend-api": "npm:^1.0.21"
     "@ethersproject/abi": "npm:^5.8.0"
     "@hookform/error-message": "npm:^2.0.1"


### PR DESCRIPTION
Changes:
- Bumped curvefi/api to 2.67.2 https://github.com/curvefi/curve-js/pull/479