### PR TITLE
feat: borderless slider

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TradingSlider.tsx
@@ -3,7 +3,7 @@ import Slider from '@mui/material/Slider'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { SLIDER_BACKGROUND_VAR } from '@ui-kit/themes/components/slider'
+import { CLASS_BORDERLESS, SLIDER_BACKGROUND_VAR } from '@ui-kit/themes/components/slider'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { Spacing, FontSize, FontWeight, Sizing } = SizesAndSpaces
@@ -38,7 +38,7 @@ export const TradingSlider = ({
     }}
   >
     <Slider
-      className="borderless"
+      className={CLASS_BORDERLESS}
       size="medium"
       value={percentage}
       onChange={(_event, newValue) => onPercentageChange?.(Array.isArray(newValue) ? newValue[0] : newValue)}

--- a/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
+++ b/packages/curve-ui-kit/src/themes/components/slider/mui-slider.ts
@@ -7,6 +7,7 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 const { Sizing } = SizesAndSpaces
 
 const THUMB_WIDTH = 20 // 20px is a default MUI value, not responsive to reduce headaches
+export const CLASS_BORDERLESS = 'borderless'
 
 /**
  * CSS custom property name for customizing the slider background color.
@@ -103,7 +104,7 @@ export const defineMuiSlider = (design: DesignSystem): Components['MuiSlider'] =
       position: 'relative',
       ...rightExtension(design),
       ...leftExtension(design),
-      '&.borderless::after': {
+      [`&.${CLASS_BORDERLESS}::after`]: {
         border: 0,
       },
     },

--- a/packages/curve-ui-kit/src/themes/stories/Slider.stories.tsx
+++ b/packages/curve-ui-kit/src/themes/stories/Slider.stories.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box'
 import Slider from '@mui/material/Slider'
 import type { Meta, StoryObj } from '@storybook/react'
 import { fn } from '@storybook/test'
+import { CLASS_BORDERLESS } from '../components/slider'
 
 const SliderComponent = (props: React.ComponentProps<typeof Slider>) => {
   const [value, setValue] = useState<number | number[]>(props.defaultValue as number | number[])
@@ -129,7 +130,7 @@ export const RangeSlider: Story = {
 
 export const Borderless: Story = {
   args: {
-    className: 'borderless',
+    className: CLASS_BORDERLESS,
   },
   parameters: {
     docs: {


### PR DESCRIPTION
MUI sliders don't accept custom props or variants so I'm kinda stuck adding support for a non-typed "borderless" class name. Not the way I like it but I've exhausted all options I can think of.

![image](https://github.com/user-attachments/assets/3bb711b9-1dfa-46c8-bf15-9a21257409fb)