### PR TITLE
fix: chain selector jumps

### DIFF
--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSelectorModal.tsx
@@ -36,7 +36,7 @@ export const TokenSelectorModal = ({ isOpen, showManageList, compact, onClose, .
       title={isManageListOpen ? t`Manage Token List` : t`Select Token`}
       titleAction={
         isManageListOpen && (
-          <IconButton onClick={closeManageList}>
+          <IconButton onClick={closeManageList} size="extraSmall">
             <ArrowBackIcon />
           </IconButton>
         )

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
@@ -80,7 +80,7 @@ export const ChainSwitcher = <TChainId extends number>({
           title={isSettingsOpen ? t`Select Network Settings` : t`Select Network`}
           titleAction={
             isSettingsOpen && (
-              <IconButton onClick={closeSettings}>
+              <IconButton onClick={closeSettings} size="extraSmall">
                 <ArrowBackIcon />
               </IconButton>
             )


### PR DESCRIPTION
Default IconButton sizing is a bit bigger than we use in the card headers, where we use `size="extraSmall"`

![image](https://github.com/user-attachments/assets/a7bad1d9-b4ab-4cc1-a1ea-123d9c8e9201)

![image](https://github.com/user-attachments/assets/c726c5c4-687d-4167-bc18-e6403c658fe1)