### PR TITLE
refactor: loan user details hooks

### DIFF
--- a/apps/main/src/lend/components/ChartLiquidationRange/index.tsx
+++ b/apps/main/src/lend/components/ChartLiquidationRange/index.tsx
@@ -12,14 +12,14 @@ import {
 } from 'recharts'
 import styled from 'styled-components'
 import ChartTooltip, { TipContent, TipIcon, TipTitle } from '@/lend/components/ChartTooltip'
-import { HeathColorKey } from '@/lend/types/lend.types'
+import { HealthColorKey } from '@/lend/types/lend.types'
 import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import type { ThemeKey } from '@ui-kit/themes/basic-theme'
 
 interface Props {
   data: { name: string; curr: number[]; new: number[]; oraclePrice: string; oraclePriceBand: number | null }[]
-  healthColorKey: HeathColorKey | undefined
+  healthColorKey: HealthColorKey | undefined
   height?: number
   isDetailView?: boolean // component not inside the form
   isManage: boolean

--- a/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import PoolActivity from '@/lend/components/ChartOhlcWrapper/PoolActivity'
 import { useOneWayMarket } from '@/lend/entities/chain'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import useStore from '@/lend/store/useStore'
 import AlertBox from '@ui/AlertBox'
 import Box from '@ui/Box'
@@ -25,7 +26,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId }: ChartOhlcWrapperP
   const formValues = useStore((state) => state.loanCreate.formValues)
   const activeKeyLiqRange = useStore((state) => state.loanCreate.activeKeyLiqRange)
   const loanCreateLeverageDetailInfo = useStore((state) => state.loanCreate.detailInfoLeverage[activeKey])
-  const userPrices = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details?.prices ?? null)
+  const userPrices = useUserLoanDetails(userActiveKey)?.prices ?? null
   const liqRangesMapper = useStore((state) => state.loanCreate.liqRangesMapper[activeKeyLiqRange])
   const borrowMorePrices = useStore((state) => state.loanBorrowMore.detailInfo[borrowMoreActiveKey]?.prices ?? null)
   const repayActiveKey = useStore((state) => state.loanRepay.activeKey)

--- a/apps/main/src/lend/components/DetailInfoHealth.tsx
+++ b/apps/main/src/lend/components/DetailInfoHealth.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
 import { useOneWayMarket } from '@/lend/entities/chain'
 import { helpers } from '@/lend/lib/apiLending'
 import useStore from '@/lend/store/useStore'
-import { OneWayMarketTemplate, PageContentProps, HeathColorKey, HealthMode } from '@/lend/types/lend.types'
+import { OneWayMarketTemplate, PageContentProps, HealthColorKey, HealthMode } from '@/lend/types/lend.types'
 import Box from '@ui/Box'
 import DetailInfo from '@ui/DetailInfo'
 import Icon from '@ui/Icon'
@@ -155,7 +155,7 @@ const DetailInfoHealth = ({
   )
 }
 
-const HealthPercent = styled.span<{ colorKey: HeathColorKey }>`
+const HealthPercent = styled.span<{ colorKey: HealthColorKey }>`
   color: ${({ colorKey }) => `var(--health_mode_${colorKey}_darkBg--color)`};
 `
 

--- a/apps/main/src/lend/components/DetailInfoHealth.tsx
+++ b/apps/main/src/lend/components/DetailInfoHealth.tsx
@@ -12,6 +12,7 @@ import Icon from '@ui/Icon'
 import IconTooltip from '@ui/Tooltip/TooltipIcon'
 import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { useUserLoanDetails } from '../hooks/useUserLoanDetails'
 
 type FormType = 'create-loan' | 'collateral-decrease' | ''
 
@@ -45,11 +46,16 @@ const DetailInfoHealth = ({
 }) => {
   const market = useOneWayMarket(rChainId, rOwmId).data
   const oraclePriceBand = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId]?.prices?.oraclePriceBand)
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const {
+    healthFull: healthFullCurrent,
+    healthNotFull: healthNotFullCurrent,
+    bands: bandsCurrent,
+    status,
+  } = useUserLoanDetails(userActiveKey)
 
   const [currentHealthMode, setCurrentHealthMode] = useState(DEFAULT_HEALTH_MODE)
 
-  const currentHealthModeColorKey = userLoanDetails?.status?.colorKey
+  const currentHealthModeColorKey = status?.colorKey
   const newHealthModeColorKey = healthMode?.colorKey
 
   // new health mode
@@ -86,23 +92,31 @@ const DetailInfoHealth = ({
 
   // current health mode
   useEffect(() => {
-    if (typeof oraclePriceBand === 'number' && userLoanDetails) {
-      const { healthFull, healthNotFull, bands } = userLoanDetails
+    if (typeof oraclePriceBand === 'number' && bandsCurrent && healthFullCurrent && healthNotFullCurrent) {
       setCurrentHealthMode(
         getHealthMode(
           market,
           oraclePriceBand,
           amount,
-          bands,
+          bandsCurrent,
           formType,
-          healthFull,
-          healthNotFull,
+          healthFullCurrent,
+          healthNotFullCurrent,
           '',
           newHealthModeColorKey,
         ),
       )
     }
-  }, [oraclePriceBand, amount, formType, newHealthModeColorKey, market, userLoanDetails])
+  }, [
+    oraclePriceBand,
+    amount,
+    formType,
+    newHealthModeColorKey,
+    market,
+    bandsCurrent,
+    healthFullCurrent,
+    healthNotFullCurrent,
+  ])
 
   const healthPercent = useMemo(() => {
     if (healthMode.percent) {

--- a/apps/main/src/lend/components/DetailInfoLiqRange.tsx
+++ b/apps/main/src/lend/components/DetailInfoLiqRange.tsx
@@ -11,6 +11,7 @@ import { Chip } from '@ui/Typography'
 import { formatNumber } from '@ui/utils'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { t } from '@ui-kit/lib/i18n'
+import { useUserLoanDetails } from '../hooks/useUserLoanDetails'
 
 const DetailInfoLiqRange = ({
   rChainId,
@@ -43,13 +44,12 @@ const DetailInfoLiqRange = ({
   userActiveKey: string
   handleLiqRangesEdit?: () => void
 }) => {
-  const userDetailsResp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
+  const { prices: currPrices, bands: currBands } = useUserLoanDetails(userActiveKey)
   const loanPricesResp = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId])
 
   const theme = useUserProfileStore((state) => state.theme)
 
   const { prices: loanPrices } = loanPricesResp ?? {}
-  const { prices: currPrices, bands: currBands } = userDetailsResp?.details ?? {}
 
   const { parsedNewBands, parsedNewPrices } = useMemo(
     () =>

--- a/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoan.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoan.tsx
@@ -16,6 +16,7 @@ import CellLoanState from '@/lend/components/SharedCellData/CellLoanState'
 import CellLoss from '@/lend/components/SharedCellData/CellLoss'
 import CellUserMain from '@/lend/components/SharedCellData/CellUserMain'
 import { TITLE } from '@/lend/constants'
+import { useUserLoanStatus } from '@/lend/hooks/useUserLoanDetails'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
 import { PageContentProps, TitleKey } from '@/lend/types/lend.types'
@@ -29,19 +30,16 @@ const DetailsUserLoan = (pageProps: PageContentProps) => {
   const { rChainId, rOwmId, api, market, titleMapper, userActiveKey } = pageProps
 
   const loanExistsResp = useStore((state) => state.user.loansExistsMapper[userActiveKey])
-  const userLoanDetailsResp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
   const chartExpanded = useStore((state) => state.ohlcCharts.chartExpanded)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
+  const isSoftLiquidation = useUserLoanStatus(userActiveKey) === 'soft_liquidation'
 
-  // TODO: handle error
-  const { details: userLoanDetails } = userLoanDetailsResp ?? {}
   const { signerAddress } = api ?? {}
 
   const pricesApiAvailable = networks[rChainId]?.pricesData
   const showConnectWallet = typeof signerAddress !== 'undefined' && !signerAddress
   const foundLoan = typeof loanExistsResp !== 'undefined' && loanExistsResp.loanExists
-  const isSoftLiquidation = userLoanDetails?.status?.colorKey === 'soft_liquidation'
 
   const cellProps = {
     rChainId,

--- a/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanAlertSoftLiquidation.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanAlertSoftLiquidation.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { PageContentProps } from '@/lend/types/lend.types'
 import AlertBox from '@ui/AlertBox'
 import Box from '@ui/Box'
@@ -9,14 +9,11 @@ import { t } from '@ui-kit/lib/i18n'
 
 const DetailsUserLoanAlertSoftLiquidation = ({ market, userActiveKey }: PageContentProps) => {
   const { borrowed_token, collateral_token } = market ?? {}
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  // TODO handle error
-  const { details } = userLoanDetails ?? {}
+  const { state } = useUserLoanDetails(userActiveKey)
 
   const softLiquidationAmountText = useMemo(() => {
     let text = ''
-    const { collateral = '0', borrowed = '0' } = details?.state ?? {}
+    const { collateral = '0', borrowed = '0' } = state ?? {}
 
     text += +collateral > 0 ? `${formatNumber(collateral)} ${collateral_token?.symbol}` : ''
 
@@ -30,7 +27,7 @@ const DetailsUserLoanAlertSoftLiquidation = ({ market, userActiveKey }: PageCont
     }
 
     return text
-  }, [borrowed_token?.symbol, collateral_token?.symbol, details?.state])
+  }, [borrowed_token?.symbol, collateral_token?.symbol, state])
 
   return (
     <AlertBox alertType="warning">

--- a/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanChartBandBalances.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanChartBandBalances.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import ChartBandBalances from '@/lend/components/ChartBandBalances'
 import type { BrushStartEndIndex } from '@/lend/components/ChartBandBalances/types'
 import { DEFAULT_BAND_CHART_DATA } from '@/lend/components/DetailsUser/utils'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import useStore from '@/lend/store/useStore'
 import { PageContentProps } from '@/lend/types/lend.types'
@@ -17,14 +18,13 @@ const DetailsUserLoanChartBandBalances = ({
   const loansPrices = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId])
   const loansStatsBands = useStore((state) => state.markets.statsBandsMapper[rChainId]?.[rOwmId])
   const userActiveKey = helpers.getUserActiveKey(api, market!)
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
 
   const [brushIndex, setBrushIndex] = useState<BrushStartEndIndex>({
     startIndex: undefined,
     endIndex: undefined,
   })
 
-  const { bandsBalances } = userLoanDetails?.details ?? {}
+  const { bandsBalances } = useUserLoanDetails(userActiveKey)
   const { liquidationBand } = loansStatsBands?.bands ?? {}
   const { oraclePrice, oraclePriceBand } = loansPrices?.prices ?? {}
 

--- a/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanChartLiquidationRange.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanChartLiquidationRange.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import ChartLiquidationRange from '@/lend/components/ChartLiquidationRange'
 import { SubTitle } from '@/lend/components/DetailsMarket/styles'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import useStore from '@/lend/store/useStore'
 import { PageContentProps } from '@/lend/types/lend.types'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
@@ -8,11 +9,10 @@ import { t } from '@ui-kit/lib/i18n'
 
 const DetailsUserLoanChartLiquidationRange = ({ rChainId, rOwmId, userActiveKey }: PageContentProps) => {
   const loanDetailsPrices = useStore((state) => state.markets.pricesMapper[rChainId]?.[rOwmId]?.prices)
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
 
   const theme = useUserProfileStore((state) => state.theme)
 
-  const { prices: currPrices, status } = userLoanDetails ?? {}
+  const { prices: currPrices, status } = useUserLoanDetails(userActiveKey)
 
   // default to empty data to show chart
   const liqRangeData = useMemo(

--- a/apps/main/src/lend/components/DetailsUser/components/UserInfoLeverage.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/UserInfoLeverage.tsx
@@ -1,9 +1,7 @@
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 
 export const UserInfoLeverage = ({ userActiveKey }: { userActiveKey: string }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
 
   if (error) return '?'
 

--- a/apps/main/src/lend/components/DetailsUser/components/UserInfoPnl.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/UserInfoPnl.tsx
@@ -1,14 +1,12 @@
 import styled from 'styled-components'
 import Chip from 'ui/src/Typography/Chip'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import Box from '@ui/Box'
 import { formatNumber, FORMAT_OPTIONS } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 
 export const UserInfoPnl = ({ userActiveKey }: { userActiveKey: string }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
 
   if (error) return '?'
 

--- a/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/LoanFormCreate/index.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/
 import { FieldsWrapper } from '@/lend/components/SharedFormStyles/FieldsWrapper'
 import { NOFITY_MESSAGE } from '@/lend/constants'
 import useMarketAlert from '@/lend/hooks/useMarketAlert'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
@@ -54,7 +55,7 @@ const LoanCreate = ({
   const isPageVisible = useStore((state) => state.isPageVisible)
   const loanExistsResp = useStore((state) => state.user.loansExistsMapper[userActiveKey])
   const maxRecv = useStore((state) => state.loanCreate.maxRecv[activeKeyMax])
-  const userDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
   const refetchMaxRecv = useStore((state) => state.loanCreate.refetchMaxRecv)
   const fetchStepApprove = useStore((state) => state.loanCreate.fetchStepApprove)
@@ -149,7 +150,7 @@ const LoanCreate = ({
               market={market}
               receive={expectedCollateral?.totalCollateral ?? userCollateral}
               formValueStateDebt={debt}
-              userState={userDetails?.state}
+              userState={userState}
               userWallet={userBalances}
               type="create"
             />
@@ -233,7 +234,7 @@ const LoanCreate = ({
 
       return stepsKey.map((k) => stepsObj[k])
     },
-    [expectedCollateral?.totalCollateral, fetchStepApprove, handleClickCreate, userBalances, userDetails?.state],
+    [expectedCollateral?.totalCollateral, fetchStepApprove, handleClickCreate, userBalances, userState],
   )
 
   // onMount
@@ -298,7 +299,7 @@ const LoanCreate = ({
     market?.id,
     signerAddress,
     userBalances,
-    userDetails?.state,
+    userState,
   ])
 
   // signerAddress, maxSlippage state change

--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -15,6 +15,7 @@ import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
 import { FieldsWrapper } from '@/lend/components/SharedFormStyles/FieldsWrapper'
 import { NOFITY_MESSAGE } from '@/lend/constants'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
@@ -53,7 +54,7 @@ const LoanBorrowMore = ({
   const loanExists = useStore((state) => state.user.loansExistsMapper[userActiveKey]?.loanExists)
   const maxRecv = useStore((state) => state.loanBorrowMore.maxRecv[activeKeyMax])
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const fetchStepApprove = useStore((state) => state.loanBorrowMore.fetchStepApprove)
   const fetchStepIncrease = useStore((state) => state.loanBorrowMore.fetchStepIncrease)
   const refetchMaxRecv = useStore((state) => state.loanBorrowMore.refetchMaxRecv)
@@ -163,7 +164,7 @@ const LoanBorrowMore = ({
               market={market}
               receive={expectedCollateral?.totalCollateral ?? userCollateral}
               formValueStateDebt={debt}
-              userState={userLoanDetails?.state}
+              userState={userState}
               userWallet={userBalances}
               type="change"
             />
@@ -245,7 +246,7 @@ const LoanBorrowMore = ({
       }
       return stepsKey.map((k) => stepsObj[k])
     },
-    [expectedCollateral?.totalCollateral, userLoanDetails?.state, userBalances, fetchStepApprove, handleBtnClickBorrow],
+    [expectedCollateral?.totalCollateral, userState, userBalances, fetchStepApprove, handleBtnClickBorrow],
   )
 
   // onMount
@@ -314,7 +315,7 @@ const LoanBorrowMore = ({
     activeKey,
     confirmedWarning,
     expectedCollateral?.totalCollateral,
-    userLoanDetails?.state,
+    userState,
     userBalances,
     detailInfoLeverage?.expectedCollateral,
     detailInfoLeverage?.isHighPriceImpact,

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralAdd/index.tsx
@@ -12,6 +12,7 @@ import { StyledDetailInfoWrapper } from '@/lend/components/PageLoanManage/styles
 import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
 import { NOFITY_MESSAGE } from '@/lend/constants'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import { DEFAULT_FORM_VALUES } from '@/lend/store/createLoanCollateralAddSlice'
@@ -38,7 +39,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
   const formValues = useStore((state) => state.loanCollateralAdd.formValues)
   const loanExists = useStore((state) => state.user.loansExistsMapper[userActiveKey]?.loanExists)
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
-  const userDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const fetchStepApprove = useStore((state) => state.loanCollateralAdd.fetchStepApprove)
   const fetchStepIncrease = useStore((state) => state.loanCollateralAdd.fetchStepIncrease)
   const setFormValues = useStore((state) => state.loanCollateralAdd.setFormValues)
@@ -101,7 +102,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
               pendingMessage={notifyMessage}
               market={market}
               receive={formValues.collateral}
-              userState={userDetails?.state}
+              userState={userState}
               userWallet={userBalances}
               type="change"
             />
@@ -144,7 +145,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
 
       return stepsKey.map((k) => stepsObj[k])
     },
-    [fetchStepApprove, handleBtnClickAdd, userBalances, userDetails?.state],
+    [fetchStepApprove, handleBtnClickAdd, userBalances, userState],
   )
 
   // onMount
@@ -171,7 +172,7 @@ const LoanCollateralAdd = ({ rChainId, rOwmId, api, isLoaded, market, userActive
       setSteps(updatedSteps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, activeKey, formEstGas?.loading, formStatus, formValues, userBalances, userDetails?.state])
+  }, [isLoaded, activeKey, formEstGas?.loading, formStatus, formValues, userBalances, userState])
 
   const activeStep = signerAddress ? getActiveStep(steps) : null
   const disabled = !!formStatus.step

--- a/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanCollateralRemove/index.tsx
@@ -13,6 +13,7 @@ import { StyledDetailInfoWrapper } from '@/lend/components/PageLoanManage/styles
 import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
 import { NOFITY_MESSAGE } from '@/lend/constants'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import { DEFAULT_FORM_VALUES } from '@/lend/store/createLoanCollateralRemoveSlice'
@@ -40,7 +41,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
   const maxRemovable = useStore((state) => state.loanCollateralRemove.maxRemovable)
   const loanExists = useStore((state) => state.user.loansExistsMapper[userActiveKey]?.loanExists)
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
-  const userDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const fetchStepDecrease = useStore((state) => state.loanCollateralRemove.fetchStepDecrease)
   const setFormValues = useStore((state) => state.loanCollateralRemove.setFormValues)
   const resetState = useStore((state) => state.loanCollateralRemove.resetState)
@@ -114,7 +115,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
               pendingMessage={notifyMessage}
               market={market}
               receive={`-${formValues.collateral}`}
-              userState={userDetails?.state}
+              userState={userState}
               userWallet={userBalances}
               type="change"
             />
@@ -164,7 +165,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
 
       return stepsKey.map((k) => stepsObj[k])
     },
-    [handleBtnClickRemove, userBalances, userDetails?.state],
+    [handleBtnClickRemove, userBalances, userState],
   )
 
   // onMount
@@ -210,7 +211,7 @@ const LoanCollateralRemove = ({ rChainId, rOwmId, isLoaded, api, market, userAct
     formStatus,
     formValues,
     userBalances,
-    userDetails?.state,
+    userState,
   ])
 
   const activeStep = signerAddress ? getActiveStep(steps) : null

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -14,6 +14,7 @@ import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
 import { FieldsWrapper } from '@/lend/components/SharedFormStyles/FieldsWrapper'
 import { NOFITY_MESSAGE } from '@/lend/constants'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
@@ -53,7 +54,7 @@ const LoanRepay = ({
   const formValues = useStore((state) => state.loanRepay.formValues)
   const isPageVisible = useStore((state) => state.isPageVisible)
   const loanExists = useStore((state) => state.user.loansExistsMapper[userActiveKey]?.loanExists)
-  const userLoanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
   const fetchStepApprove = useStore((state) => state.loanRepay.fetchStepApprove)
   const fetchStepRepay = useStore((state) => state.loanRepay.fetchStepRepay)
@@ -69,7 +70,6 @@ const LoanRepay = ({
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)
 
   const { signerAddress } = api ?? {}
-  const { state } = userLoanDetails || {}
   const { borrowed_token, collateral_token } = market ?? {}
   const { decimals: borrowedTokenDecimals } = borrowed_token ?? {}
   const { expectedBorrowed } = detailInfoLeverage ?? {}
@@ -171,7 +171,7 @@ const LoanRepay = ({
               receive={expectedBorrowed?.totalBorrowed}
               formValueStateCollateral={stateCollateral}
               formValueUserBorrowed={userBorrowed}
-              userState={state}
+              userState={userState}
               userWallet={userBalances}
               market={market}
               type={detailInfoLeverage?.repayIsFull || isFullRepay ? 'full' : 'partial'}
@@ -254,7 +254,7 @@ const LoanRepay = ({
       expectedBorrowed?.totalBorrowed,
       fetchStepApprove,
       handleBtnClickPay,
-      state,
+      userState,
       userBalances,
     ],
   )
@@ -330,7 +330,7 @@ const LoanRepay = ({
     formStatus,
     formValues,
     maxSlippage,
-    state,
+    userState,
     userBalances,
   ])
 
@@ -340,8 +340,8 @@ const LoanRepay = ({
   const isFullRepay = formValues.isFullRepay || (detailInfoLeverage?.repayIsFull ?? false)
 
   const disableCheckbox = useMemo(() => {
-    if (state && userBalances && borrowedTokenDecimals) {
-      const { borrowed: stateBorrowed, debt: stateDebt } = state
+    if (userState && userBalances && borrowedTokenDecimals) {
+      const { borrowed: stateBorrowed, debt: stateDebt } = userState
       const { borrowed: userBorrowed } = userBalances
 
       const isPayableWithStateBorrowed = isGreaterThanOrEqualTo(stateBorrowed, stateDebt, borrowedTokenDecimals)
@@ -353,7 +353,7 @@ const LoanRepay = ({
     }
 
     return true
-  }, [borrowedTokenDecimals, disable, expectedBorrowed, signerAddress, state, userBalances])
+  }, [borrowedTokenDecimals, disable, expectedBorrowed, signerAddress, userState, userBalances])
 
   return (
     <>
@@ -366,15 +366,15 @@ const LoanRepay = ({
                 inpTopLabel={t`Repay from collateral:`}
                 inpError={formValues.stateCollateralError}
                 inpDisabled={disable}
-                inpLabelLoading={loanExists && !!signerAddress && typeof state?.collateral === 'undefined'}
-                inpLabelDescription={formatNumber(state?.collateral, { defaultValue: '-' })}
+                inpLabelLoading={loanExists && !!signerAddress && typeof userState?.collateral === 'undefined'}
+                inpLabelDescription={formatNumber(userState?.collateral, { defaultValue: '-' })}
                 inpValue={formValues.stateCollateral}
                 tokenAddress={collateral_token?.address}
                 tokenSymbol={collateral_token?.symbol}
-                tokenBalance={formatNumber(state?.collateral, { defaultValue: '-' })}
+                tokenBalance={formatNumber(userState?.collateral, { defaultValue: '-' })}
                 handleInpChange={(stateCollateral) => updateFormValues({ stateCollateral, isFullRepay: false })}
                 handleMaxClick={() =>
-                  updateFormValues({ stateCollateral: state?.collateral ?? '', isFullRepay: false })
+                  updateFormValues({ stateCollateral: userState?.collateral ?? '', isFullRepay: false })
                 }
               />
 
@@ -401,22 +401,22 @@ const LoanRepay = ({
           <InpToken
             id="userBorrowed"
             inpError={formValues.userBorrowedError}
-            inpDisabled={disable || (!hasLeverage && !state)}
+            inpDisabled={disable || (!hasLeverage && !userState)}
             inpLabelLoading={!!signerAddress && typeof userBalances?.borrowed === 'undefined'}
             inpLabelDescription={formatNumber(userBalances?.borrowed, { defaultValue: '-' })}
             inpValue={formValues.userBorrowed}
             tokenAddress={borrowed_token?.address}
             tokenSymbol={borrowed_token?.symbol}
             tokenBalance={userBalances?.borrowed}
-            debt={state?.debt ?? '0'}
+            debt={userState?.debt ?? '0'}
             handleInpChange={(userBorrowed) => {
               if (expectedBorrowed) {
                 updateFormValues({ userBorrowed, isFullRepay: false })
                 return
               }
 
-              if (!expectedBorrowed && state && borrowedTokenDecimals) {
-                const { borrowed: stateBorrowed, debt: stateDebt } = state
+              if (!expectedBorrowed && userState && borrowedTokenDecimals) {
+                const { borrowed: stateBorrowed, debt: stateDebt } = userState
                 const totalRepay = sum([stateBorrowed, userBorrowed], borrowedTokenDecimals)
                 const isFullRepay = isGreaterThanOrEqualTo(totalRepay, stateDebt, borrowedTokenDecimals)
                 updateFormValues({ userBorrowed, isFullRepay })
@@ -436,7 +436,7 @@ const LoanRepay = ({
                 return
               }
 
-              if (api && market && userBalances && state?.debt && borrowedTokenDecimals) {
+              if (api && market && userBalances && userState?.debt && borrowedTokenDecimals) {
                 const { userLoanDetailsResp } = await fetchAllUserDetails(api, market, true)
                 const { borrowed: stateBorrowed = '0', debt: stateDebt = '0' } =
                   userLoanDetailsResp?.details?.state ?? {}
@@ -457,7 +457,7 @@ const LoanRepay = ({
           />
         </FieldsWrapper>
         <StyledInpChip size="xs">
-          {t`Debt balance`} {formatNumber(state?.debt, { defaultValue: '-' })} {borrowed_token?.symbol}
+          {t`Debt balance`} {formatNumber(userState?.debt, { defaultValue: '-' })} {borrowed_token?.symbol}
         </StyledInpChip>
       </Box>
 

--- a/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanSelfLiquidation/index.tsx
@@ -11,6 +11,7 @@ import LoanFormConnect from '@/lend/components/LoanFormConnect'
 import type { FormStatus, StepKey } from '@/lend/components/PageLoanManage/LoanSelfLiquidation/types'
 import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { NOFITY_MESSAGE } from '@/lend/constants'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
 import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
@@ -50,7 +51,7 @@ const LoanSelfLiquidation = ({
   const futureRates = useStore((state) => state.loanSelfLiquidation.futureRates)
   const liquidationAmt = useStore((state) => state.loanSelfLiquidation.liquidationAmt)
   const loanExists = useStore((state) => state.user.loansExistsMapper[userActiveKey]?.loanExists)
-  const userDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey]?.details)
+  const { state: userState } = useUserLoanDetails(userActiveKey)
   const userBalances = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
   const fetchDetails = useStore((state) => state.loanSelfLiquidation.fetchDetails)
   const fetchStepApprove = useStore((state) => state.loanSelfLiquidation.fetchStepApprove)
@@ -63,7 +64,6 @@ const LoanSelfLiquidation = ({
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)
 
   const { signerAddress } = api ?? {}
-  const { state } = userDetails ?? {}
 
   const reset = useCallback(() => {
     setTxInfoBar(null)
@@ -193,12 +193,12 @@ const LoanSelfLiquidation = ({
 
   // steps
   useEffect(() => {
-    if (isLoaded && api && market && state) {
-      const updatedSteps = getSteps(api, market, formEstGas, formStatus, liquidationAmt, maxSlippage, steps, state)
+    if (isLoaded && api && market && userState) {
+      const updatedSteps = getSteps(api, market, formEstGas, formStatus, liquidationAmt, maxSlippage, steps, userState)
       setSteps(updatedSteps)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoaded, formEstGas?.loading, liquidationAmt, formStatus, maxSlippage, userBalances, state])
+  }, [isLoaded, formEstGas?.loading, liquidationAmt, formStatus, maxSlippage, userBalances, userState])
 
   const activeStep = signerAddress ? getActiveStep(steps) : null
 

--- a/apps/main/src/lend/components/SharedCellData/CellHealthStatus.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellHealthStatus.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { HealthColorKey } from '@/lend/types/lend.types'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 
@@ -8,13 +8,11 @@ const HealthColorText = styled.span<{ colorKey?: HealthColorKey }>`
 `
 
 const CellHealthStatus = ({ userActiveKey, type }: { userActiveKey: string; type: 'status' | 'percent' }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
 
   return (
     <>
-      {typeof resp === 'undefined' ? (
+      {Object.keys(details).length === 0 ? (
         '-'
       ) : error ? (
         '?'

--- a/apps/main/src/lend/components/SharedCellData/CellHealthStatus.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellHealthStatus.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
 import useStore from '@/lend/store/useStore'
-import { HeathColorKey } from '@/lend/types/lend.types'
+import { HealthColorKey } from '@/lend/types/lend.types'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 
-const HealthColorText = styled.span<{ colorKey?: HeathColorKey }>`
+const HealthColorText = styled.span<{ colorKey?: HealthColorKey }>`
   color: ${({ colorKey }) => `var(--health_mode_${colorKey}--color)`};
 `
 

--- a/apps/main/src/lend/components/SharedCellData/CellLiquidationRange.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellLiquidationRange.tsx
@@ -1,12 +1,10 @@
 import isUndefined from 'lodash/isUndefined'
 import { useMemo } from 'react'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 
 const CellHealthStatus = ({ userActiveKey, type }: { userActiveKey: string; type: 'range' | 'band' | 'bandPct' }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
 
   const liqPriceRange = useMemo(() => {
     const [price1, price2] = details?.prices ?? []
@@ -23,7 +21,7 @@ const CellHealthStatus = ({ userActiveKey, type }: { userActiveKey: string; type
     <>
       {error ? (
         '?'
-      ) : !liqPriceRange || !details ? (
+      ) : !liqPriceRange || Object.keys(details).length === 0 ? (
         '-'
       ) : type === 'range' ? (
         <strong>{`${liqPriceRange.price2} to ${liqPriceRange.price1}`}</strong>

--- a/apps/main/src/lend/components/SharedCellData/CellLlammaBalances.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellLlammaBalances.tsx
@@ -1,22 +1,20 @@
 import styled from 'styled-components'
 import InpChipUsdRate from '@/lend/components/InpChipUsdRate'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { OneWayMarketTemplate } from '@/lend/types/lend.types'
 import Box from '@ui/Box'
 import TextCaption from '@ui/TextCaption'
 import { formatNumber } from '@ui/utils'
 
 const CellLlammaBalances = ({ userActiveKey, market }: { userActiveKey: string; market: OneWayMarketTemplate }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
   const { borrowed_token, collateral_token } = market ?? {}
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
 
   return (
     <>
       {error ? (
         '?'
-      ) : !details ? (
+      ) : Object.keys(details).length === 0 ? (
         '-'
       ) : (
         <Box flex gridGap={3}>

--- a/apps/main/src/lend/components/SharedCellData/CellLoanState.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellLoanState.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import styled from 'styled-components'
 import Chip from 'ui/src/Typography/Chip'
 import InpChipUsdRate from '@/lend/components/InpChipUsdRate'
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { OneWayMarketTemplate } from '@/lend/types/lend.types'
 import Box from '@ui/Box'
 import TextCaption from '@ui/TextCaption'
@@ -10,10 +10,8 @@ import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 
 const CellLoanState = ({ userActiveKey, market }: { userActiveKey: string; market: OneWayMarketTemplate }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
   const { address } = market?.collateral_token ?? {}
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
   const { current_collateral_estimation, deposited_collateral } = details?.loss ?? {}
 
   const diff = useMemo(() => {

--- a/apps/main/src/lend/components/SharedCellData/CellLoss.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellLoss.tsx
@@ -1,19 +1,17 @@
-import useStore from '@/lend/store/useStore'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 
 const SMALL_NUMBER = 0.0001
 
 const CellLoss = ({ userActiveKey, type }: { userActiveKey: string; type: 'amount' | 'percent' }) => {
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
-
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
   const { loss, loss_pct } = details?.loss ?? {}
 
   return (
     <>
       {error ? (
         '?'
-      ) : !details ? (
+      ) : Object.keys(details).length === 0 ? (
         '-'
       ) : type === 'amount' ? (
         <>{loss === undefined ? '?' : Number(loss) <= SMALL_NUMBER || Number(loss) === 0 ? 0 : formatNumber(loss)}</>

--- a/apps/main/src/lend/components/SharedCellData/CellUserMain.tsx
+++ b/apps/main/src/lend/components/SharedCellData/CellUserMain.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import InpChipUsdRate from '@/lend/components/InpChipUsdRate'
+import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import useVaultShares from '@/lend/hooks/useVaultShares'
 import useStore from '@/lend/store/useStore'
 import { ChainId, OneWayMarketTemplate } from '@/lend/types/lend.types'
@@ -23,10 +24,9 @@ const CellUserMain = ({
 }) => {
   const { borrowed_token } = market ?? {}
   const userBalancesResp = useStore((state) => state.user.marketsBalancesMapper[userActiveKey])
-  const resp = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
 
   const { vaultShares = '0', gauge = '0', error: userBalancesError } = userBalancesResp ?? {}
-  const { details, error } = resp ?? {}
+  const { error, ...details } = useUserLoanDetails(userActiveKey)
   const totalVaultShares = +vaultShares + +gauge
   const { borrowedAmount, borrowedAmountUsd } = useVaultShares(rChainId, rOwmId, totalVaultShares)
 

--- a/apps/main/src/lend/hooks/useUserLoanDetails.ts
+++ b/apps/main/src/lend/hooks/useUserLoanDetails.ts
@@ -1,0 +1,28 @@
+import useStore from '@/lend/store/useStore'
+import type { HealthColorKey, UserLoanDetails } from '@/lend/types/lend.types'
+
+type Details = UserLoanDetails['details'] & { error: string }
+
+/**
+ * Retrieves user loan details for a specific user active key.
+ * @param userActiveKey - The unique identifier for the user's active loan
+ * @returns User loan details object with error property merged for easier destructuring
+ */
+export function useUserLoanDetails(userActiveKey: string): Details {
+  const loanDetails = useStore((state) => state.user.loansDetailsMapper[userActiveKey])
+
+  return !loanDetails || loanDetails.details == null
+    ? ({} as Details)
+    : { ...loanDetails.details, error: loanDetails.error }
+}
+
+/**
+ * Gets the health status color key for a user's loan.
+ * @param userActiveKey - The unique identifier for the user's active loan
+ * @returns Health color key indicating loan status, or empty string if no status available
+ */
+export function useUserLoanStatus(userActiveKey: string): HealthColorKey {
+  const userDetails = useUserLoanDetails(userActiveKey)
+
+  return userDetails?.status?.colorKey ?? ''
+}

--- a/apps/main/src/lend/lib/apiLending.ts
+++ b/apps/main/src/lend/lib/apiLending.ts
@@ -16,7 +16,7 @@ import {
   ExpectedBorrowed,
   ExpectedCollateral,
   FutureRates,
-  HeathColorKey,
+  HealthColorKey,
   LiqRangeResp,
   MarketMaxLeverage,
   MarketPrices,
@@ -2002,7 +2002,7 @@ export default apiLending
  * But user is at risk of liquidation if not full < 0
  */
 function _getLiquidationStatus(healthNotFull: string, userIsCloseToLiquidation: boolean, userStateStablecoin: string) {
-  const userStatus: { label: string; colorKey: HeathColorKey; tooltip: string } = {
+  const userStatus: { label: string; colorKey: HealthColorKey; tooltip: string } = {
     label: 'Healthy',
     colorKey: 'healthy',
     tooltip: '',

--- a/apps/main/src/lend/types/lend.types.ts
+++ b/apps/main/src/lend/types/lend.types.ts
@@ -95,10 +95,10 @@ export type PageContentProps = {
   market: OneWayMarketTemplate | undefined
   titleMapper: TitleMapper
 }
-export type HeathColorKey = 'healthy' | 'close_to_liquidation' | 'soft_liquidation' | 'hard_liquidation' | ''
+export type HealthColorKey = 'healthy' | 'close_to_liquidation' | 'soft_liquidation' | 'hard_liquidation' | ''
 export type HealthMode = {
   percent: string
-  colorKey: HeathColorKey
+  colorKey: HealthColorKey
   icon: ReactNode
   message: string | null
   warningTitle: string
@@ -235,7 +235,7 @@ export type UserLoanDetails = {
     prices: string[]
     range: number | null
     state: { collateral: string; borrowed: string; debt: string; N: string }
-    status: { label: string; colorKey: HeathColorKey; tooltip: string }
+    status: { label: string; colorKey: HealthColorKey; tooltip: string }
     leverage: string
     pnl: Record<string, string>
   } | null

--- a/apps/main/src/loan/components/ChartLiquidationRange/index.tsx
+++ b/apps/main/src/loan/components/ChartLiquidationRange/index.tsx
@@ -12,13 +12,13 @@ import {
 } from 'recharts'
 import styled from 'styled-components'
 import ChartTooltip, { TipContent, TipIcon, TipTitle } from '@/loan/components/ChartTooltip'
-import { HeathColorKey, Theme } from '@/loan/types/loan.types'
+import { HealthColorKey, Theme } from '@/loan/types/loan.types'
 import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 
 interface Props {
   data: { name: string; curr: number[]; new: number[]; oraclePrice: string; oraclePriceBand: number | null }[]
-  healthColorKey: HeathColorKey | undefined
+  healthColorKey: HealthColorKey | undefined
   isDetailView?: boolean // component not inside the form
   isManage: boolean
   theme: Theme

--- a/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import PoolActivity from '@/loan/components/ChartOhlcWrapper/PoolActivity'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import AlertBox from '@ui/AlertBox'
 import Box from '@ui/Box'
@@ -24,7 +25,7 @@ const ChartOhlcWrapper = ({ rChainId, llamma, llammaId }: ChartOhlcWrapperProps)
   const collateralDecreaseActiveKey = useStore((state) => state.loanCollateralDecrease.activeKey)
   const formValues = useStore((state) => state.loanCreate.formValues)
   const activeKeyLiqRange = useStore((state) => state.loanCreate.activeKeyLiqRange)
-  const userPrices = useStore((state) => state.loans.userDetailsMapper[llammaId]?.userPrices ?? null)
+  const userPrices = useUserLoanDetails(llammaId)?.userPrices ?? null
   const liqRangesMapper = useStore((state) => state.loanCreate.liqRangesMapper[activeKeyLiqRange])
   const increaseLoanPrices = useStore((state) => state.loanIncrease.detailInfo[increaseActiveKey]?.prices ?? null)
   const decreaseLoanPrices = useStore((state) => state.loanDecrease.detailInfo[decreaseActiveKey]?.prices ?? null)

--- a/apps/main/src/loan/components/DetailInfoHealth.tsx
+++ b/apps/main/src/loan/components/DetailInfoHealth.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { DEFAULT_HEALTH_MODE } from '@/loan/components/PageLoanManage/utils'
-import { HealthMode, HeathColorKey, LoanDetails, UserLoanDetails } from '@/loan/types/loan.types'
+import { HealthMode, HealthColorKey, LoanDetails, UserLoanDetails } from '@/loan/types/loan.types'
 import { getIsUserCloseToLiquidation } from '@/loan/utils/utilsCurvejs'
 import { parseHealthPercent } from '@/loan/utils/utilsLoan'
 import Box from '@ui/Box'
@@ -151,7 +151,7 @@ const DetailInfoHealth = ({
   )
 }
 
-const HealthPercent = styled.span<{ colorKey: HeathColorKey }>`
+const HealthPercent = styled.span<{ colorKey: HealthColorKey }>`
   color: ${({ colorKey }) => `var(--health_mode_${colorKey}_darkBg--color)`};
 `
 

--- a/apps/main/src/loan/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import { Llamma } from '@/loan/types/loan.types'
 import { getTokenName } from '@/loan/utils/utilsLoan'
 import AlertBox from '@ui/AlertBox'
@@ -9,9 +9,7 @@ import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 
 const AlertSoftLiquidation = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma | null }) => {
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
-
-  const { collateral = '0', stablecoin = '0' } = userLoanDetails?.userState ?? {}
+  const { collateral = '0', stablecoin = '0' } = useUserLoanDetails(llammaId)?.userState ?? {}
 
   const softLiquidationAmountText = useMemo(() => {
     let text = ''

--- a/apps/main/src/loan/components/LoanInfoUser/components/ChartUserBands.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/ChartUserBands.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import ChartBandBalances from '@/loan/components/ChartBandBalances'
 import type { BrushStartEndIndex } from '@/loan/components/ChartBandBalances/types'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { Llamma } from '@/loan/types/loan.types'
 import { t } from '@ui-kit/lib/i18n'
@@ -21,14 +22,13 @@ const DEFAULT_BAND_CHART_DATA = {
 
 const ChartUserBands = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma | null }) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const { userBandsBalances, userLiquidationBand } = useUserLoanDetails(llammaId)
 
   const [brushIndex, setBrushIndex] = useState<BrushStartEndIndex>({
     startIndex: undefined,
     endIndex: undefined,
   })
 
-  const { userBandsBalances } = userLoanDetails ?? {}
   const { oraclePrice, oraclePriceBand } = loanDetails?.priceInfo ?? {}
 
   const chartBandBalancesData = useMemo(() => {
@@ -74,7 +74,7 @@ const ChartUserBands = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma
       llamma={llamma}
       oraclePrice={oraclePrice}
       oraclePriceBand={oraclePriceBand}
-      showLiquidationIndicator={!!userLoanDetails?.userLiquidationBand}
+      showLiquidationIndicator={!!userLiquidationBand}
       title={t`Bands`}
       setBrushIndex={setBrushIndex}
     />

--- a/apps/main/src/loan/components/LoanInfoUser/components/ChartUserLiquidationRange.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/ChartUserLiquidationRange.tsx
@@ -1,16 +1,15 @@
 import { useMemo } from 'react'
 import ChartLiquidationRange from '@/loan/components/ChartLiquidationRange'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { HealthMode } from '@/loan/types/loan.types'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 
 const ChartUserLiquidationRange = ({ healthMode, llammaId }: { healthMode: HealthMode; llammaId: string }) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const { userPrices: currPrices } = useUserLoanDetails(llammaId)
 
   const theme = useUserProfileStore((state) => state.theme)
-
-  const { userPrices: currPrices } = userLoanDetails ?? {}
 
   // default to empty data to show chart
   const liqRangeData = useMemo(

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoDebt.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoDebt.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import InpChipUsdRate from '@/loan/components/InpChipUsdRate'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import ListInfoItem from '@ui/ListInfo'
 import { formatNumber } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
@@ -14,9 +14,7 @@ const UserInfoDebt = ({
   stablecoin: string | undefined
   stablecoinAddress: string | undefined
 }) => {
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
-
-  const { userState } = userLoanDetails ?? {}
+  const { userState } = useUserLoanDetails(llammaId)
 
   return (
     <ListInfoItem title={t`Debt`} titleDescription={`(${stablecoin})`} mainValue={formatNumber(userState?.debt)}>

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLiquidationRange.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLiquidationRange.tsx
@@ -1,6 +1,6 @@
 import isUndefined from 'lodash/isUndefined'
 import { useMemo } from 'react'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import { formatNumber } from '@ui/utils'
 
 const UserInfoLiquidationRange = ({
@@ -10,9 +10,7 @@ const UserInfoLiquidationRange = ({
   llammaId: string
   type: 'liquidationRange' | 'liquidationBandRange'
 }) => {
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
-
-  const { userPrices, userBands } = userLoanDetails ?? {}
+  const { userPrices, userBands } = useUserLoanDetails(llammaId)
 
   const liqPriceRange = useMemo(() => {
     const [price1, price2] = userPrices ?? []

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
@@ -1,12 +1,12 @@
 import InpChipUsdRate from '@/loan/components/InpChipUsdRate'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import { Llamma } from '@/loan/types/loan.types'
 import Box from '@ui/Box'
 import ListInfoItem from '@ui/ListInfo'
 import { formatNumber } from '@ui/utils'
 
 const UserInfoLlammaBalances = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma | null }) => {
-  const userState = useStore((state) => state.loans.userDetailsMapper[llammaId]?.userState)
+  const { userState } = useUserLoanDetails(llammaId)
 
   const {
     coins: [stablecoin, collateral],

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLoss.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLoss.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import InpChipUsdRate from '@/loan/components/InpChipUsdRate'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import { Llamma } from '@/loan/types/loan.types'
 import Box from '@ui/Box'
 import TextCaption from '@ui/TextCaption'
@@ -20,8 +20,7 @@ const UserInfoLoss = ({
   llamma: Llamma | null
   type: 'lossCollateral' | 'lossAmount' | 'lossPercent'
 }) => {
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
-
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const { current_collateral_estimation, deposited_collateral, loss, loss_pct } = userLoanDetails?.userLoss ?? {}
 
   const [_, collateralAddress] = llamma?.coinAddresses ?? []

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfos.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfos.tsx
@@ -7,7 +7,7 @@ import UserInfoLlammaBalances from '@/loan/components/LoanInfoUser/components/Us
 import UserInfoLoss from '@/loan/components/LoanInfoUser/components/UserInfoLoss'
 import { HealthColorText } from '@/loan/components/LoanInfoUser/styles'
 import { TITLE } from '@/loan/constants'
-import useStore from '@/loan/store/useStore'
+import { useUserLoanDetails, useUserLoanStatus } from '@/loan/hooks/useUserLoanDetails'
 import { Llamma, HealthMode, TitleKey, TitleMapper } from '@/loan/types/loan.types'
 import ListInfoItem, { ListInfoItems, ListInfoItemsWrapper } from '@ui/ListInfo'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
@@ -26,8 +26,8 @@ const UserInfos = ({
   healthMode: HealthMode
   titleMapper: TitleMapper
 }) => {
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
-
+  const { userBandsPct, userStatus } = useUserLoanDetails(llammaId)
+  const colorKey = useUserLoanStatus(llammaId)
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
 
   const {
@@ -35,14 +35,13 @@ const UserInfos = ({
     coinAddresses: [stablecoinAddress],
   } = llamma ?? { coins: [], coinAddresses: [] }
 
-  const { userBandsPct, userStatus } = userLoanDetails ?? {}
   const props = { llammaId, llamma }
 
   // prettier-ignore
   const contents: { titleKey: TitleKey; content: ReactNode; show?: boolean }[][] = [
     [
-      { titleKey: TITLE.healthStatus, content: <HealthColorText colorKey={userStatus?.colorKey}>{userStatus?.label ?? '-'}</HealthColorText> },
-      { titleKey: TITLE.healthPercent, content: <HealthColorText colorKey={userStatus?.colorKey}>{healthMode?.percent ? formatNumber(healthMode?.percent, FORMAT_OPTIONS.PERCENT) : '-'}</HealthColorText> },
+      { titleKey: TITLE.healthStatus, content: <HealthColorText colorKey={colorKey}>{userStatus?.label ?? '-'}</HealthColorText> },
+      { titleKey: TITLE.healthPercent, content: <HealthColorText colorKey={colorKey}>{healthMode?.percent ? formatNumber(healthMode?.percent, FORMAT_OPTIONS.PERCENT) : '-'}</HealthColorText> },
     ],
     [
       { titleKey: TITLE.liquidationRange, content: <UserInfoLiquidationRange {...props} type='liquidationRange' /> },

--- a/apps/main/src/loan/components/LoanInfoUser/index.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/index.tsx
@@ -9,6 +9,7 @@ import ChartUserLiquidationRange from '@/loan/components/LoanInfoUser/components
 import UserInfos from '@/loan/components/LoanInfoUser/components/UserInfos'
 import type { PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import { DEFAULT_HEALTH_MODE } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails, useUserLoanStatus } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { ChainId } from '@/loan/types/loan.types'
 import Box from '@ui/Box'
@@ -22,14 +23,13 @@ interface Props extends Pick<PageLoanManageProps, 'llamma' | 'llammaId' | 'title
 
 const LoanInfoUser = ({ llamma, llammaId, rChainId, titleMapper }: Props) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const { userBands, healthFull, healthNotFull } = useUserLoanDetails(llammaId)
   const { chartExpanded } = useStore((state) => state.ohlcCharts)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
+  const isSoftLiquidation = useUserLoanStatus(llammaId) === 'soft_liquidation'
 
-  const { userBands, healthFull, healthNotFull, userStatus } = userLoanDetails ?? {}
   const { oraclePriceBand } = loanDetails ?? {}
-  const isSoftLiquidation = userStatus?.colorKey === 'soft_liquidation'
 
   const [healthMode, setHealthMode] = useState(DEFAULT_HEALTH_MODE)
 

--- a/apps/main/src/loan/components/LoanInfoUser/styles.ts
+++ b/apps/main/src/loan/components/LoanInfoUser/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
-import { HeathColorKey } from '@/loan/types/loan.types'
+import { HealthColorKey } from '@/loan/types/loan.types'
 
-export const HealthColorText = styled.span<{ colorKey?: HeathColorKey }>`
+export const HealthColorText = styled.span<{ colorKey?: HealthColorKey }>`
   color: ${({ colorKey }) => `var(--health_mode_${colorKey}--color)`};
 `

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoLeverage.tsx
@@ -8,6 +8,7 @@ import DetailInfoSlippageTolerance from '@/loan/components/DetailInfoSlippageTol
 import DetailInfoTradeRoutes from '@/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoTradeRoutes'
 import type { FormDetailInfo, FormDetailInfoSharedProps } from '@/loan/components/PageLoanCreate/types'
 import { DEFAULT_DETAIL_INFO_LEVERAGE } from '@/loan/components/PageLoanCreate/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { getTokenName } from '@/loan/utils/utilsLoan'
 import DetailInfo from '@ui/DetailInfo'
@@ -41,7 +42,7 @@ const DetailInfoLeverage = ({
   const isEditLiqRange = useStore((state) => state.loanCreate.isEditLiqRange)
   const liqRanges = useStore((state) => state.loanCreate.liqRanges[activeKeyLiqRange])
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
 
   const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 

--- a/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoNonLeverage.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/LoanFormCreate/components/DetailInfoNonLeverage.tsx
@@ -5,6 +5,7 @@ import DetailInfoLiqRange from '@/loan/components/DetailInfoLiqRange'
 import DetailInfoN from '@/loan/components/DetailInfoN'
 import type { FormDetailInfo, FormDetailInfoSharedProps } from '@/loan/components/PageLoanCreate/types'
 import { DEFAULT_DETAIL_INFO } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { LiquidationRangeSlider } from '@ui-kit/shared/ui/LiquidationRangeSlider'
 
@@ -33,7 +34,7 @@ const DetailInfoNonLeverage = ({
   const isEditLiqRange = useStore((state) => state.loanCreate.isEditLiqRange)
   const liqRanges = useStore((state) => state.loanCreate.liqRanges[activeKeyLiqRange])
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
 
   return (
     <div>

--- a/apps/main/src/loan/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/Page.tsx
@@ -46,7 +46,11 @@ const Page = (params: CollateralUrlParams) => {
   const { connect: connectWallet, provider } = useWallet()
   const [loaded, setLoaded] = useState(false)
 
-  const collateralData = useStore((state) => state.collaterals.collateralDatasMapper[rChainId]?.[rCollateralId])
+  const { llamma, displayName } = useStore(
+    (state) => state.collaterals.collateralDatasMapper[rChainId]?.[rCollateralId],
+  )
+  const llammaId = llamma?.id ?? ''
+
   const formValues = useStore((state) => state.loanCreate.formValues)
   const loanExists = useStore((state) => state.loans.existsMapper[rCollateralId]?.loanExists)
   const isMdUp = useStore((state) => state.layout.isMdUp)
@@ -62,8 +66,6 @@ const Page = (params: CollateralUrlParams) => {
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
   const maxSlippage = useUserProfileStore((state) => state.maxSlippage.crypto)
 
-  const llamma = collateralData?.llamma
-  const llammaId = llamma?.id ?? ''
   const isReady = !!llamma
   const isValidRouterParams = !!rChainId && !!rCollateralId
   const isLeverage = rFormType === 'leverage'
@@ -150,7 +152,7 @@ const Page = (params: CollateralUrlParams) => {
 
   const TitleComp = () => (
     <AppPageFormTitleWrapper>
-      <Title>{collateralData?.displayName || getTokenName(llamma).collateral}</Title>
+      <Title>{displayName || getTokenName(llamma).collateral}</Title>
     </AppPageFormTitleWrapper>
   )
 

--- a/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralDecrease/index.tsx
@@ -11,6 +11,7 @@ import type { FormStatus, FormValues, StepKey } from '@/loan/components/PageLoan
 import { StyledDetailInfoWrapper, StyledInpChip } from '@/loan/components/PageLoanManage/styles'
 import type { FormEstGas, PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import { DEFAULT_DETAIL_INFO, DEFAULT_FORM_EST_GAS, DEFAULT_HEALTH_MODE } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import { DEFAULT_FORM_STATUS } from '@/loan/store/createLoanCollateralDecreaseSlice'
 import useStore from '@/loan/store/useStore'
@@ -41,7 +42,7 @@ const CollateralDecrease = ({ curve, llamma, llammaId, rChainId }: Props) => {
   const formValues = useStore((state) => state.loanCollateralDecrease.formValues)
   const maxRemovable = useStore((state) => state.loanCollateralDecrease.maxRemovable)
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalances = useStore(
     (state) => state.loans.userWalletBalancesMapper[llammaId] ?? DEFAULT_WALLET_BALANCES,
   )

--- a/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/CollateralIncrease/index.tsx
@@ -12,6 +12,7 @@ import type { FormStatus, FormValues, StepKey } from '@/loan/components/PageLoan
 import { StyledDetailInfoWrapper, StyledInpChip } from '@/loan/components/PageLoanManage/styles'
 import type { FormEstGas, PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import { DEFAULT_DETAIL_INFO, DEFAULT_FORM_EST_GAS, DEFAULT_HEALTH_MODE } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import { DEFAULT_FORM_STATUS } from '@/loan/store/createLoanCollateralIncreaseSlice'
 import useStore from '@/loan/store/useStore'
@@ -41,7 +42,7 @@ const CollateralIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
   const formStatus = useStore((state) => state.loanCollateralIncrease.formStatus)
   const formValues = useStore((state) => state.loanCollateralIncrease.formValues)
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalancesLoading = useStore((state) => state.loans.userWalletBalancesLoading)
   const userWalletBalances = useStore(
     (state) => state.loans.userWalletBalancesMapper[llammaId] ?? DEFAULT_WALLET_BALANCES,

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -12,6 +12,7 @@ import type { FormStatus, FormValues, StepKey } from '@/loan/components/PageLoan
 import { StyledDetailInfoWrapper, StyledInpChip } from '@/loan/components/PageLoanManage/styles'
 import type { FormEstGas, PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import { DEFAULT_DETAIL_INFO, DEFAULT_FORM_EST_GAS, DEFAULT_HEALTH_MODE } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import { DEFAULT_FORM_STATUS } from '@/loan/store/createLoanDecreaseSlice'
 import useStore from '@/loan/store/useStore'
@@ -44,7 +45,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
   const formStatus = useStore((state) => state.loanDecrease.formStatus)
   const formValues = useStore((state) => state.loanDecrease.formValues)
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalances = useStore(
     (state) => state.loans.userWalletBalancesMapper[llammaId] ?? DEFAULT_WALLET_BALANCES,
   )

--- a/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_HEALTH_MODE,
   hasDeleverage,
 } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import useStore from '@/loan/store/useStore'
 import { LlamaApi, Llamma } from '@/loan/types/loan.types'
@@ -62,7 +63,7 @@ const LoanDeleverage = ({
   const formValues = useStore((state) => state.loanDeleverage.formValues)
   const isPageVisible = useStore((state) => state.isPageVisible)
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalancesLoading = useStore((state) => state.loans.userWalletBalancesLoading)
   const fetchStepRepay = useStore((state) => state.loanDeleverage.fetchStepRepay)
   const setFormValues = useStore((state) => state.loanDeleverage.setFormValues)

--- a/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanIncrease/index.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_HEALTH_MODE,
   DEFAULT_USER_WALLET_BALANCES,
 } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import { DEFAULT_FORM_STATUS, getMaxRecvActiveKey } from '@/loan/store/createLoanIncreaseSlice'
 import useStore from '@/loan/store/useStore'
@@ -47,7 +48,7 @@ const LoanIncrease = ({ curve, isReady, llamma, llammaId }: Props) => {
   const maxRecvActiveKey = llamma ? getMaxRecvActiveKey(llamma, formValues.collateral) : ''
   const maxRecv = useStore((state) => state.loanIncrease.maxRecv[maxRecvActiveKey])
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalancesLoading = useStore((state) => state.loans.userWalletBalancesLoading)
   const userWalletBalances = useStore(
     (state) => state.loans.userWalletBalancesMapper[llammaId] ?? DEFAULT_USER_WALLET_BALANCES,

--- a/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanLiquidate/index.tsx
@@ -8,6 +8,7 @@ import LoanFormConnect from '@/loan/components/LoanFormConnect'
 import type { FormStatus, StepKey } from '@/loan/components/PageLoanManage/LoanLiquidate/types'
 import type { FormEstGas, PageLoanManageProps } from '@/loan/components/PageLoanManage/types'
 import { DEFAULT_FORM_EST_GAS } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import networks from '@/loan/networks'
 import { DEFAULT_FORM_STATUS, haveEnoughCrvusdForLiquidation } from '@/loan/store/createLoanLiquidate'
 import useStore from '@/loan/store/useStore'
@@ -36,7 +37,7 @@ const LoanLiquidate = ({ curve, llamma, llammaId, params, rChainId }: Props) => 
   const formEstGas = useStore((state) => state.loanLiquidate.formEstGas ?? DEFAULT_FORM_EST_GAS)
   const formStatus = useStore((state) => state.loanLiquidate.formStatus)
   const liquidationAmt = useStore((state) => state.loanLiquidate.liquidationAmt)
-  const userLoanDetails = useStore((state) => state.loans.userDetailsMapper[llammaId])
+  const userLoanDetails = useUserLoanDetails(llammaId)
   const userWalletBalances = useStore((state) => state.loans.userWalletBalancesMapper[llammaId])
 
   const fetchTokensToLiquidate = useStore((state) => state.loanLiquidate.fetchTokensToLiquidate)

--- a/apps/main/src/loan/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/Page.tsx
@@ -46,7 +46,11 @@ const Page = (params: CollateralUrlParams) => {
   const titleMapper = useTitleMapper()
   const rChainId = useChainId(params)
 
-  const collateralData = useStore((state) => state.collaterals.collateralDatasMapper[rChainId]?.[rCollateralId])
+  const { llamma, displayName } = useStore(
+    (state) => state.collaterals.collateralDatasMapper[rChainId]?.[rCollateralId],
+  )
+  const llammaId = llamma?.id || ''
+
   const isMdUp = useStore((state) => state.layout.isMdUp)
   const isPageVisible = useStore((state) => state.isPageVisible)
   const navHeight = useStore((state) => state.layout.navHeight)
@@ -62,8 +66,6 @@ const Page = (params: CollateralUrlParams) => {
   const [selectedTab, setSelectedTab] = useState<DetailInfoTypes>('user')
   const [loaded, setLoaded] = useState(false)
 
-  const llamma = collateralData?.llamma
-  const llammaId = llamma?.id || ''
   const isValidRouterParams = !!rChainId && !!rCollateralId && !!rFormType
   const isReady = !!curve?.signerAddress && !!llamma
 
@@ -133,7 +135,7 @@ const Page = (params: CollateralUrlParams) => {
 
   const TitleComp = () => (
     <AppPageFormTitleWrapper>
-      <Title>{collateralData?.displayName || getTokenName(llamma).collateral}</Title>
+      <Title>{displayName || getTokenName(llamma).collateral}</Title>
     </AppPageFormTitleWrapper>
   )
 

--- a/apps/main/src/loan/hooks/useUserLoanDetails.ts
+++ b/apps/main/src/loan/hooks/useUserLoanDetails.ts
@@ -1,0 +1,22 @@
+import useStore from '@/loan/store/useStore'
+import type { HealthColorKey } from '@/loan/types/loan.types'
+
+/**
+ * Retrieves user loan details for a specific llamma market
+ * @param llammaId - The llamma market identifier
+ * @returns User loan details object or empty object if not found
+ */
+export function useUserLoanDetails(llammaId: string) {
+  return useStore((state) => state.loans.userDetailsMapper[llammaId]) ?? {}
+}
+
+/**
+ * Gets the health status color key for a user's loan
+ * @param llammaId - The llamma market identifier
+ * @returns Health color key indicating loan status, or empty string if no status available
+ */
+export function useUserLoanStatus(llammaId: string): HealthColorKey {
+  const loanDetails = useUserLoanDetails(llammaId)
+
+  return loanDetails?.userStatus?.colorKey ?? ''
+}

--- a/apps/main/src/loan/types/loan.types.ts
+++ b/apps/main/src/loan/types/loan.types.ts
@@ -60,10 +60,10 @@ export type CollateralDataCache = {
 }
 export type CollateralDataCacheMapper = { [collateralId: string]: CollateralDataCache }
 export type CollateralDataCacheOrApi = CollateralDataCache | CollateralData
-export type HeathColorKey = 'healthy' | 'close_to_liquidation' | 'soft_liquidation' | 'hard_liquidation' | ''
+export type HealthColorKey = 'healthy' | 'close_to_liquidation' | 'soft_liquidation' | 'hard_liquidation' | ''
 export type HealthMode = {
   percent: string
-  colorKey: HeathColorKey
+  colorKey: HealthColorKey
   icon: ReactNode
   message: string | null
   warningTitle: string
@@ -128,7 +128,7 @@ export type UserLoanDetails = {
   userIsCloseToLiquidation: boolean
   userLiquidationBand: number | null
   userLoss: { deposited_collateral: string; current_collateral_estimation: string; loss: string; loss_pct: string }
-  userStatus: { label: string; colorKey: HeathColorKey; tooltip: string }
+  userStatus: { label: string; colorKey: HealthColorKey; tooltip: string }
 }
 export type UserWalletBalances = {
   stablecoin: string

--- a/apps/main/src/loan/utils/utilsCurvejs.ts
+++ b/apps/main/src/loan/utils/utilsCurvejs.ts
@@ -2,7 +2,7 @@ import type { Eip1193Provider } from 'ethers'
 import cloneDeep from 'lodash/cloneDeep'
 import sortBy from 'lodash/sortBy'
 import networks from '@/loan/networks'
-import { BandBalance, ChainId, type LlamaApi, HeathColorKey, Llamma, UserLoanDetails } from '@/loan/types/loan.types'
+import { BandBalance, ChainId, type LlamaApi, HealthColorKey, Llamma, UserLoanDetails } from '@/loan/types/loan.types'
 import PromisePool from '@supercharge/promise-pool'
 import { BN } from '@ui/utils'
 
@@ -39,7 +39,7 @@ export function getLiquidationStatus(
   userIsCloseToLiquidation: boolean,
   userStateStablecoin: string,
 ) {
-  const userStatus: { label: string; colorKey: HeathColorKey; tooltip: string } = {
+  const userStatus: { label: string; colorKey: HealthColorKey; tooltip: string } = {
     label: 'Healthy',
     colorKey: 'healthy',
     tooltip: '',


### PR DESCRIPTION
There's a discrepancy on how user loan details (and the loan status which I need later on) are loaded. Therefore, I introduced similar hooks for both lend & loan apps that aim to streamline and make fetching user loan details more simple. No more direct store usage, but just use a hook to fetch user loan data instead without caring about the backend.