### PR TITLE
fix: disable deleverage when in soft liquidation

### DIFF
--- a/apps/main/src/loan/components/PageLoanManage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/index.tsx
@@ -15,6 +15,7 @@ import type {
   PageLoanManageProps,
 } from '@/loan/components/PageLoanManage/types'
 import { hasDeleverage } from '@/loan/components/PageLoanManage/utils'
+import { useUserLoanStatus } from '@/loan/hooks/useUserLoanDetails'
 import useStore from '@/loan/store/useStore'
 import { getLoanCreatePathname, getLoanManagePathname } from '@/loan/utils/utilsRouter'
 import { AppFormContent, AppFormContentWrapper, AppFormHeader } from '@ui/AppForm'
@@ -29,6 +30,7 @@ const LoanManage = ({ curve, isReady, llamma, llammaId, params, rChainId, rColla
 
   const loanExists = useStore((state) => state.loans.existsMapper[llammaId]?.loanExists)
   const resetUserDetailsState = useStore((state) => state.loans.resetUserDetailsState)
+  const isSoftLiquidation = useUserLoanStatus(llammaId) === 'soft_liquidation'
 
   const [selectedTabIdx, setSelectedTabIdx] = useState(0)
   const [tabPositions, setTabPositions] = useState<{ left: number; width: number; top: number }[]>([])
@@ -40,7 +42,7 @@ const LoanManage = ({ curve, isReady, llamma, llammaId, params, rChainId, rColla
     // { label: t`Swap`, key: MANAGE_LOAN_FORM_TYPE.swap }, // hide swap (aka liquidation) from UI for now
   ].filter((f) => {
     if (f.key === 'deleverage') {
-      return hasDeleverage(llamma)
+      return hasDeleverage(llamma) && !isSoftLiquidation
     } else {
       return true
     }


### PR DESCRIPTION
I couldn't find a user in soft liq, so how I tested it instead:

Use mich's address which has a had liquidation in the wsteth crvusd market, then locally change:
```const isSoftLiquidation = useUserLoanStatus(llammaId) === 'soft_liquidation'```
into
```const isSoftLiquidation = useUserLoanStatus(llammaId) === 'hard_liquidation'```

Do not merge yet: I'm awaiting a reply on my question whether deleverage should also be disabled when hard liquidated

EDIT: Turns out a **full** deleverage should still be possible while in SL, while a **partial** deleverage is not. In that case, hiding the tab would not be a good idea as we'd take away functionality.