### PR TITLE
feat: limit percentage to 2 decimals (llamalend)

### DIFF
--- a/apps/main/src/loan/components/PageLlamaMarkets/cells/RateCell.tsx
+++ b/apps/main/src/loan/components/PageLlamaMarkets/cells/RateCell.tsx
@@ -45,7 +45,7 @@ export const RateCell = ({ market, type }: { market: LlamaMarket; type: RateType
     >
       <Stack gap={Spacing.xs} ref={ref}>
         <Typography variant="tableCellMBold" color="textPrimary">
-          {rate && formatPercentFixed(rate)}
+          {rate != null && formatPercentFixed(rate)}
         </Typography>
 
         {rate != null && poolRewards.length > 0 && (


### PR DESCRIPTION
In the llamalend table percentage values show up to 3 decimals or 4 if below 0. Reducing them to 2 decimals reduces cognitive load. 