### PR TITLE
chore: e2e retry

### DIFF
--- a/tests/cypress/e2e/loan/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/loan/llamalend-markets.cy.ts
@@ -90,7 +90,8 @@ describe(`LlamaLend Markets`, () => {
     }
   })
 
-  it('should show charts', () => {
+  // todo: retry cause this fails in large screens with small data set (laziness not triggered, everything is shown)
+  it('should show charts', RETRY_IN_CI, () => {
     withFilterChips(() => {
       cy.get(`[data-testid="chip-lend"]`).click()
       cy.get(`[data-testid="pool-type-mint"]`).should('not.exist')


### PR DESCRIPTION
- add a retry to this test, cause this fails in large screens with small data set
- sometimes the whole data is already rendered, so the lazy loading check fails
- in the future, we need to make sure there are enough data rows or the screen is small enough