### PR TITLE
feat: multiple metric notionals

### DIFF
--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/StatsStack.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/StatsStack.tsx
@@ -32,8 +32,8 @@ const StatsStack = () => {
         <Metric
           label="Total crvUSD Staked"
           value={yieldData?.[yieldData.length - 1]?.supply}
+          valueOptions={{ unit: CRVUSD_OPTION }}
           loading={yieldIsFetching}
-          unit={CRVUSD_OPTION}
           copyText={t`Copied total crvUSD staked`}
         />
       </Grid>
@@ -41,9 +41,8 @@ const StatsStack = () => {
         <Metric
           label="Current APY"
           value={statisticsData?.aprProjected}
+          valueOptions={{ unit: 'percentage', decimals: 2 }}
           loading={statisticsIsFetching}
-          decimals={2}
-          unit="percentage"
           copyText={t`Copied current APY`}
         />
       </Grid>
@@ -51,8 +50,8 @@ const StatsStack = () => {
         <Metric
           label="Total Revenue Distributed"
           value={revenueData?.totalDistributed ? weiToEther(Number(revenueData.totalDistributed)) : undefined}
+          valueOptions={{ unit: CRVUSD_OPTION }}
           loading={revenueIsFetching}
-          unit={CRVUSD_OPTION}
           copyText={t`Copied total revenue distributed`}
         />
       </Grid>
@@ -60,8 +59,8 @@ const StatsStack = () => {
         <Metric
           label="Weekly Accumulated Revenue"
           value={revenueData?.epochs[revenueData.epochs.length - 1].weeklyRevenue}
+          valueOptions={{ unit: CRVUSD_OPTION }}
           loading={revenueIsFetching}
-          unit={CRVUSD_OPTION}
           copyText={t`Copied weekly accumulated revenue`}
         />
       </Grid>

--- a/apps/main/src/loan/components/PageCrvUsdStaking/StatsBanner/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/StatsBanner/index.tsx
@@ -38,24 +38,24 @@ const StatsBanner = () => {
       <Stack direction="row" gap={Sizing[200]} justifyContent="space-between" flexWrap="wrap">
         <Metric
           label={t`30 Days Projection`}
-          unit="dollar"
           value={scrvUsdApy ? oneMonthProjectionYield(scrvUsdApy, exampleBalance) : undefined}
+          valueOptions={{ unit: 'dollar' }}
           loading={isStatisticsLoading}
           tooltip={t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}
           copyText={t`Copied 30 days projection`}
         />
         <Metric
           label={t`1 Year Projection`}
-          unit="dollar"
           value={scrvUsdApy ? oneYearProjectionYield(scrvUsdApy, exampleBalance) : undefined}
+          valueOptions={{ unit: 'dollar' }}
           loading={isStatisticsLoading}
           tooltip={t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}
           copyText={t`Copied 1 year projection`}
         />
         <Metric
           label={t`Estimated APY`}
-          unit="percentage"
           value={scrvUsdApy}
+          valueOptions={{ unit: 'percentage' }}
           loading={isStatisticsLoading}
           tooltip={t`Annual percentage yield (APY) refers to how much interest is distributed on savings and takes compounded interest into account. 
 This value is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}

--- a/apps/main/src/loan/components/PageCrvUsdStaking/UserPosition/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/UserPosition/index.tsx
@@ -62,16 +62,16 @@ const UserPosition = ({ chartExpanded = false }: { chartExpanded?: boolean }) =>
               size="large"
               label={t`Your crvUSD Staked`}
               value={userScrvUsdBalanceInCrvUsd}
+              valueOptions={{ unit: CRVUSD_OPTIONS }}
               loading={userBalanceLoading || usdRateLoading || exchangeRateLoading}
-              unit={CRVUSD_OPTIONS}
             />
           </Grid>
           <Grid flexGrow={1}>
             <Metric
               size="large"
               label={t`Your share of the vault`}
-              unit="percentage"
               value={userShareOfTotalScrvUsdSupply}
+              valueOptions={{ unit: 'percentage' }}
               loading={isStatisticsLoading}
             />
           </Grid>
@@ -81,8 +81,8 @@ const UserPosition = ({ chartExpanded = false }: { chartExpanded?: boolean }) =>
             <Metric
               size="small"
               label={t`30 Days Projection`}
-              unit="dollar"
               value={scrvUsdApy && oneMonthProjectionYield(scrvUsdApy, userScrvUsdBalance)}
+              valueOptions={{ unit: 'dollar' }}
               loading={isStatisticsLoading || userBalanceLoading}
               tooltip={t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}
             />
@@ -91,8 +91,8 @@ const UserPosition = ({ chartExpanded = false }: { chartExpanded?: boolean }) =>
             <Metric
               size="small"
               label={t`1 Year Projection`}
-              unit="dollar"
               value={scrvUsdApy && oneYearProjectionYield(scrvUsdApy, userScrvUsdBalance)}
+              valueOptions={{ unit: 'dollar' }}
               loading={isStatisticsLoading || userBalanceLoading}
               tooltip={t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}
             />
@@ -101,8 +101,8 @@ const UserPosition = ({ chartExpanded = false }: { chartExpanded?: boolean }) =>
             <Metric
               size="small"
               label={t`scrvUSD Staking Rate`}
-              unit="percentage"
               value={scrvUsdApy}
+              valueOptions={{ unit: 'percentage' }}
               loading={isStatisticsLoading}
               tooltip={t`Annual percentage yield (APY) refers to how much interest is distributed on savings and takes compounded interest into account. 
 This value is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`}

--- a/apps/main/src/loan/components/PageLlamaMarkets/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/loan/components/PageLlamaMarkets/LlamaMarketExpandedPanel.tsx
@@ -57,24 +57,23 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
           ></CardHeader>
         </Grid>
         <Grid size={6}>
-          <Metric label={t`Borrow Rate`} value={rates.borrow} unit="percentage" />
+          <Metric label={t`Borrow Rate`} value={rates.borrow} valueOptions={{ unit: 'percentage' }} />
         </Grid>
         {leverage > 0 && (
           <Grid size={6}>
-            <Metric label={t`Leverage 🔥`} value={leverage} unit="multiplier" />
+            <Metric label={t`Leverage 🔥`} value={leverage} valueOptions={{ unit: 'multiplier' }} />
           </Grid>
         )}
         <Grid size={6}>
           <Metric
             label={t`Utilization`}
             value={utilizationPercent}
-            unit="percentage"
+            valueOptions={{ unit: 'percentage', decimals: 2 }}
             testId="metric-utilizationPercent"
-            decimals={2}
           />
         </Grid>
         <Grid size={6}>
-          <Metric label={t`Available Liquidity`} value={liquidityUsd} unit="dollar" />
+          <Metric label={t`Available Liquidity`} value={liquidityUsd} valueOptions={{ unit: 'dollar' }} />
         </Grid>
         <Grid size={12} data-testid="llama-market-graph">
           <Stack direction="column" alignItems="center">
@@ -93,7 +92,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
           </Grid>
           {earnings?.earnings != null && (
             <Grid size={6}>
-              <Metric label={t`Earnings`} value={earnings.earnings.earnings} unit="dollar" />
+              <Metric label={t`Earnings`} value={earnings.earnings.earnings} valueOptions={{ unit: 'dollar' }} />
             </Grid>
           )}
           {deposited?.earnings != null && (
@@ -101,7 +100,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
               <Metric
                 label={t`Supplied Amount`}
                 value={deposited.earnings.deposited}
-                unit={type === LlamaMarketType.Lend ? borrowedUnit : 'dollar'}
+                valueOptions={{ unit: type === LlamaMarketType.Lend ? borrowedUnit : 'dollar' }}
               />
             </Grid>
           )}

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperStatistics.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperStatistics.tsx
@@ -23,14 +23,14 @@ export const PegKeeperStatistics = () => {
         <Metric
           loading={isLoading}
           label="Peg Stabilisation Reserve"
-          unit={CRVUSD_OPTION}
+          valueOptions={{ unit: CRVUSD_OPTION }}
           value={pegKeepersDebt && Number(pegKeepersDebt)}
         />
         <Metric
           loading={isLoading}
           label="% of  crvUSD supply in reserve"
-          unit="percentage"
           value={formattedDebtFraction}
+          valueOptions={{ unit: 'percentage' }}
         />
       </Box>
     </Box>

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -46,6 +46,7 @@ export const SIZES = Object.keys(MetricSize) as (keyof typeof MetricSize)[]
 export type UnitOptions = {
   symbol: string
   position: 'prefix' | 'suffix'
+  /** If the value should be abbreviated to 1.23k or 3.45m */
   abbreviate: boolean
 }
 
@@ -76,6 +77,16 @@ const UNIT_MAP = {
 type Unit = keyof typeof UNIT_MAP | UnitOptions
 export const UNITS = Object.keys(UNIT_MAP) as unknown as keyof typeof UNIT_MAP
 
+/** Options for any being used, whether it's the main value or a notional it doesn't matter */
+type ValueOptions = {
+  /** A unit can be a currency symbol or percentage, prefix or suffix */
+  unit?: Unit | undefined
+  /** The number of decimals the value should contain */
+  decimals?: number
+  /** Optional formatter for value */
+  formatter?: (value: number) => string
+}
+
 // Default value formatter.
 const formatValue = (value: number, decimals?: number): string =>
   value.toLocaleString(undefined, {
@@ -100,15 +111,6 @@ const formatChange = (value: number) => {
   })
 }
 
-type MetricValueProps = Required<Pick<Props, 'value' | 'formatter' | 'abbreviate'>> & {
-  change?: number
-  unit: UnitOptions | undefined
-  size: keyof typeof MetricSize
-  fontVariant: TypographyVariantKey
-  fontVariantUnit: TypographyVariantKey
-  copyValue: () => void
-}
-
 function runFormatter(value: number, formatter: (value: number) => string, abbreviate: boolean, symbol?: string) {
   if (symbol === '$' && value > MAX_USD_VALUE) {
     console.warn(`USD value is too large: ${value}`)
@@ -117,11 +119,20 @@ function runFormatter(value: number, formatter: (value: number) => string, abbre
   return formatter(abbreviate ? abbreviateNumber(value) : value)
 }
 
+type MetricValueProps = Pick<Props, 'value'> &
+  Required<Omit<ValueOptions, 'decimals' | 'unit'>> & {
+    change?: number
+    unit: UnitOptions | undefined
+    size: keyof typeof MetricSize
+    fontVariant: TypographyVariantKey
+    fontVariantUnit: TypographyVariantKey
+    copyValue: () => void
+  }
+
 const MetricValue = ({
   value,
   formatter,
   change,
-  abbreviate,
   unit,
   size,
   fontVariant,
@@ -135,6 +146,8 @@ const MetricValue = ({
     return null
   }, [value])
 
+  const { symbol, position, abbreviate = false } = unit ?? {}
+
   return (
     <Stack direction="row" gap={Spacing.xxs} alignItems="baseline">
       <Tooltip
@@ -145,16 +158,16 @@ const MetricValue = ({
         sx={{ cursor: 'pointer' }}
       >
         <Stack direction="row" alignItems="baseline">
-          {unit?.position === 'prefix' && numberValue !== null && (
+          {position === 'prefix' && numberValue !== null && (
             <Typography variant={fontVariantUnit} color="textSecondary">
-              {unit.symbol}
+              {symbol}
             </Typography>
           )}
 
           <Typography variant={fontVariant} color="textPrimary">
             {useMemo(
-              () => (numberValue === null ? t`N/A` : runFormatter(numberValue, formatter, abbreviate, unit?.symbol)),
-              [numberValue, formatter, abbreviate, unit?.symbol],
+              () => (numberValue === null ? t`N/A` : runFormatter(numberValue, formatter, abbreviate, symbol)),
+              [numberValue, formatter, abbreviate, symbol],
             )}
           </Typography>
 
@@ -164,9 +177,9 @@ const MetricValue = ({
             </Typography>
           )}
 
-          {unit?.position === 'suffix' && numberValue !== null && (
+          {position === 'suffix' && numberValue !== null && (
             <Typography variant={fontVariantUnit} color="textSecondary">
-              {unit.symbol}
+              {symbol}
             </Typography>
           )}
         </Stack>
@@ -187,17 +200,10 @@ const MetricValue = ({
 type Props = {
   /** The actual metric value to display */
   value: number | '' | false | undefined | null
-  /** A unit can be a currency symbol or percentage, prefix or suffix */
-  unit?: Unit | undefined
-  /** The number of decimals the value should contain */
-  decimals?: number
-  /** If the value should be abbreviated to 1.23k or 3.45m */
-  abbreviate?: boolean
+  valueOptions: ValueOptions
+
   /** Optional value that denotes a change in metric value since 'last' time */
   change?: number
-  /** Optional formatter for metric value */
-  formatter?: (value: number) => string
-
   /** Label that goes above the value */
   label: string
   /** Optional tooltip content shown next to the label */
@@ -220,11 +226,8 @@ type Props = {
 
 export const Metric = ({
   value,
-  unit,
-  abbreviate,
+  valueOptions = {},
   change,
-  decimals = 1,
-  formatter = (value: number) => formatValue(value, decimals),
 
   label,
   tooltip,
@@ -241,8 +244,8 @@ export const Metric = ({
   loading = false,
   testId,
 }: Props) => {
-  unit = typeof unit === 'string' ? UNIT_MAP[unit] : unit
-  abbreviate ??= unit?.abbreviate ?? false
+  const { decimals = 1, formatter = (value: number) => formatValue(value, decimals) } = valueOptions
+  const unit = typeof valueOptions.unit === 'string' ? UNIT_MAP[valueOptions.unit] : valueOptions.unit
 
   notionalUnit = typeof notionalUnit === 'string' ? UNIT_MAP[notionalUnit] : notionalUnit
   notionalAbbreviate ??= notionalUnit?.abbreviate ?? false
@@ -259,7 +262,6 @@ export const Metric = ({
   const metricValueProps = {
     value,
     unit,
-    abbreviate,
     change,
     formatter,
     size,

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -243,7 +243,7 @@ export const Metric = ({
   const { decimals = 1, formatter = (value: number) => formatValue(value, decimals) } = valueOptions
   const unit = typeof valueOptions.unit === 'string' ? UNIT_MAP[valueOptions.unit] : valueOptions.unit
 
-  // Coverge the various notional types to an array of Notional
+  // Converge the various notional types to an array of Notional
   const notionals =
     typeof notional === 'number'
       ? [{ value: notional }]

--- a/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
@@ -36,18 +36,8 @@ const meta: Meta<typeof Metric> = {
       description: 'Optional value to denote a change in percentage since last time, whenever that may be',
     },
     notional: {
-      control: 'number',
-      description: 'Optional notional value that gives context or underlying value of the key metric',
-    },
-    notionalAbbreviate: {
-      control: 'boolean',
-    },
-    notionalDecimals: {
-      control: 'number',
-    },
-    notionalUnit: {
-      control: 'select',
-      options: Object.values(UNITS),
+      control: 'object',
+      description: 'Optional notional values that gives context or underlying value of the key metric',
     },
   },
   args: {
@@ -115,14 +105,33 @@ export const Loading: Story = {
 
 export const Notional: Story = {
   args: {
-    notional: 50012345.345353,
-    notionalAbbreviate: true,
-    notionalDecimals: 2,
-    notionalUnit: {
-      symbol: ' ETH',
-      position: 'suffix',
-      abbreviate: true,
+    notional: {
+      value: 50012345.345353,
+      decimals: 2,
+      unit: { symbol: ' ETH', position: 'suffix', abbreviate: true },
     },
+  },
+}
+
+export const Notionals: Story = {
+  args: {
+    value: 650450,
+    valueOptions: { unit: 'dollar' },
+    label: 'Collateral to recover',
+    size: 'large',
+    alignment: 'center',
+    notional: [
+      {
+        value: 26539422,
+        decimals: 0,
+        unit: { symbol: ' ETH', position: 'suffix', abbreviate: false },
+      },
+      {
+        value: 12450,
+        decimals: 2,
+        unit: { symbol: ' crvUSD', position: 'suffix', abbreviate: true },
+      },
+    ],
   },
 }
 

--- a/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
@@ -37,7 +37,7 @@ const meta: Meta<typeof Metric> = {
     },
     unit: {
       control: 'select',
-      options: UNITS,
+      options: Object.values(UNITS),
       description: 'Optional unit like dollars or percentage to give context to the number',
     },
     change: {
@@ -56,7 +56,7 @@ const meta: Meta<typeof Metric> = {
     },
     notionalUnit: {
       control: 'select',
-      options: UNITS,
+      options: Object.values(UNITS),
     },
   },
   args: {

--- a/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/Metric.stories.ts
@@ -27,18 +27,9 @@ const meta: Meta<typeof Metric> = {
       control: 'number',
       description: 'The value of the component',
     },
-    decimals: {
-      control: 'number',
-      description: 'The number of decimals used in value rounding when using the default value formatter',
-    },
-    abbreviate: {
-      control: 'boolean',
-      description: 'Should the value be abbreviated together with a suffix? Does not work with a postfix unit.',
-    },
-    unit: {
-      control: 'select',
-      options: Object.values(UNITS),
-      description: 'Optional unit like dollars or percentage to give context to the number',
+    valueOptions: {
+      control: 'object',
+      description: 'Options for formatting the value including decimals, abbreviation, and unit',
     },
     change: {
       control: 'number',
@@ -63,15 +54,16 @@ const meta: Meta<typeof Metric> = {
     size: 'medium',
     alignment: 'start',
     value: 26539422,
-    decimals: 1,
+    valueOptions: {
+      decimals: 1,
+      unit: 'dollar',
+    },
     label: 'Metrics label',
     copyText: 'Copied metric value',
-    unit: 'dollar',
   },
 }
 
 type Story = StoryObj<typeof Metric>
-
 export const Default: Story = {
   parameters: {
     docs: {
@@ -86,8 +78,10 @@ export const Default: Story = {
 export const Percentage: Story = {
   args: {
     value: 1337.42,
-    decimals: 2,
-    unit: 'percentage',
+    valueOptions: {
+      decimals: 2,
+      unit: 'percentage',
+    },
   },
 }
 
@@ -134,10 +128,12 @@ export const Notional: Story = {
 
 export const CustomUnit: Story = {
   args: {
-    unit: {
-      symbol: '¥',
-      position: 'prefix',
-      abbreviate: true,
+    valueOptions: {
+      unit: {
+        symbol: '¥',
+        position: 'prefix',
+        abbreviate: true,
+      },
     },
     change: 0,
   },


### PR DESCRIPTION
For the manage soft liquidation card we need to support multiple notionals underneath a metric:
![image](https://github.com/user-attachments/assets/0eff0a1a-b041-462c-adb3-3374ba3ccb8a)

By default, notionals are joined with ` + `. For the moment there's no support for further customization like custom joining and/or wrapping. That's a fight only worth fighting when it's an actual problem.

In order to support this, I've also flattened the options in both the main value and notionals. There's now a `ValueOptions` type, and
```typescript
/** A unit can be a currency symbol or percentage, prefix or suffix */
unit?: Unit | undefined
/** The number of decimals the value should contain */
decimals?: number
/** If the value should be abbreviated to 1.23k or 3.45m */
abbreviate?: boolean
/** Optional formatter for metric value */
formatter?: (value: number) => string
```
has been consolidated into a single property:
`valueOptions: ValueOptions`

Likewise,
```typescript
/** Notional values give extra context to the metric, like underlying value */
notional?: number
notionalFormatter?: (value: number) => string
notionalAbbreviate?: boolean
notionalDecimals?: number
notionalUnit?: Unit
```
has been consolidated into `notional?: number | Notional | Notional[]`

**PS:**
You can argue `abbreviate` shouldn't be part of the unit type. Maybe, but I want to keep this PR small and focused so that's a discussion and refactor for another day.