### PR TITLE
fix: metric value tooltip props not working

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -301,7 +301,7 @@ export const Metric = ({
     setOpenCopyAlert(true)
   }
 
-  const metricValueProps = {
+  const metricValueProps: MetricValueProps = {
     value,
     unit,
     change,
@@ -310,7 +310,7 @@ export const Metric = ({
     fontVariant: MetricSize[size],
     fontVariantUnit: MetricUnitSize[size],
     copyValue,
-    valueTooltip,
+    tooltip: valueTooltip,
   }
 
   return (


### PR DESCRIPTION
oopsie, because of lack of type checking i was using the wrong key name in an object, which means the metric's value tooltip props didn't really work