### PR TITLE
feat: add blacklist and immediately blacklist a7a5

### DIFF
--- a/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
@@ -143,6 +143,13 @@ const defaultTokens: TokenOption[] = [
     label: 'f(x)',
     volume: 0.8,
   },
+  {
+    chain: 'ethereum',
+    address: '0x0D57436F2d39c0664C6f0f2E349229483f87EA38',
+    symbol: 'A7A5',
+    label: 'Ruble regulation circumvention token',
+    volume: 2.5,
+  },
 ]
 
 const defaultBalances = {

--- a/packages/curve-ui-kit/src/features/select-token/blacklist.ts
+++ b/packages/curve-ui-kit/src/features/select-token/blacklist.ts
@@ -1,0 +1,29 @@
+import type { Address } from '@ui-kit/utils'
+
+/** Represents a token that should be blacklisted from token selection. */
+type BlacklistEntry = {
+  /** The contract address of the blacklisted token */
+  address: Address
+  /** Optional reason explaining why the token is blacklisted */
+  reason?: string
+}
+
+/**
+ * List of tokens that should be blacklisted from any token selection modal.
+ *
+ * Due to regulatory concerns, certain tokens need to be disabled in token selection.
+ * Blacklisted tokens will be shown as disabled with a tooltip explaining they are
+ * blacklisted, rather than being hidden entirely to prevent user confusion.
+ *
+ * We considered allowing blacklisted tokens as 'from' tokens to enable users to exit positions,
+ * but opted for a simpler approach with a uniform blacklist for now.
+ *
+ * Note: This is not the most decentralized or scalable solution, but immediate
+ * regulatory compliance means there's not much time for debate.
+ */
+export const blacklist: BlacklistEntry[] = [
+  {
+    address: '0x0D57436F2d39c0664C6f0f2E349229483f87EA38', // A7A5 token
+    reason: 'Regulatory concerns',
+  },
+]

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenList.tsx
@@ -13,6 +13,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { SearchField } from '@ui-kit/shared/ui/SearchField'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { searchByText } from '@ui-kit/utils/searchText'
+import { blacklist } from '../../blacklist'
 import type { TokenOption as Option } from '../../types'
 import { ErrorAlert } from './ErrorAlert'
 import { FavoriteTokens } from './FavoriteTokens'
@@ -69,16 +70,23 @@ const TokenSection = ({
       )}
 
       <MenuList variant="menu" sx={{ paddingBlock: 0 }}>
-        {displayTokens.map((token) => (
-          <TokenOption
-            key={token.address}
-            {...token}
-            balance={balances[token.address]}
-            tokenPrice={tokenPrices[token.address]}
-            disabled={disabledTokens.includes(token.address)}
-            onToken={() => onToken(token)}
-          />
-        ))}
+        {displayTokens.map((token) => {
+          const blacklistEntry = blacklist.find(
+            (x) => x.address.toLocaleLowerCase() === token.address.toLocaleLowerCase(),
+          )
+
+          return (
+            <TokenOption
+              key={token.address}
+              {...token}
+              balance={balances[token.address]}
+              tokenPrice={tokenPrices[token.address]}
+              disabled={disabledTokens.includes(token.address) || !!blacklistEntry}
+              disabledReason={blacklistEntry?.reason}
+              onToken={() => onToken(token)}
+            />
+          )
+        })}
 
         {hasMore && (
           <Button

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { InvertOnHover } from '@ui-kit/shared/ui/InvertOnHover'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
+import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { shortenAddress } from '@ui-kit/utils'
@@ -20,11 +21,22 @@ export type TokenOptionsProps = {
   balance?: string
   tokenPrice?: number
   disabled?: boolean
+  disabledReason?: string
 }
 
 export type Props = Option & TokenOptionCallbacks & TokenOptionsProps
 
-export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice, disabled, onToken }: Props) => {
+export const TokenOption = ({
+  chain,
+  symbol,
+  label,
+  address,
+  balance,
+  tokenPrice,
+  disabled,
+  disabledReason,
+  onToken,
+}: Props) => {
   const hasBalance = +(balance ?? '0') > 0
   const hasBalanceUsd = hasBalance && (tokenPrice ?? 0) > 0
   const showAddress = !hasBalanceUsd
@@ -33,60 +45,62 @@ export const TokenOption = ({ chain, symbol, label, address, balance, tokenPrice
 
   return (
     <InvertOnHover hoverEl={menuItem.current}>
-      <MenuItem
-        ref={menuItem}
-        // disabled={disabled} breaks `cursor: 'not-allowed'`
-        onClick={disabled ? undefined : onToken}
-        tabIndex={0}
-        sx={{
-          minHeight: IconSize.xxl,
-          '&': { transition: `background-color ${TransitionFunction}` },
-          ...(disabled && {
-            cursor: 'not-allowed',
-          }),
-        }}
-      >
-        <TokenIcon
-          blockchainId={chain}
-          address={address}
-          size="xl"
+      <Tooltip title={disabled && 'This token is not available because of'} body={disabledReason} placement="top">
+        <MenuItem
+          ref={menuItem}
+          // disabled={disabled} breaks `cursor: 'not-allowed'`
+          onClick={disabled ? undefined : onToken}
+          tabIndex={0}
           sx={{
+            minHeight: IconSize.xxl,
+            '&': { transition: `background-color ${TransitionFunction}` },
             ...(disabled && {
-              filter: 'saturate(0)',
+              cursor: 'not-allowed',
             }),
           }}
-        />
+        >
+          <TokenIcon
+            blockchainId={chain}
+            address={address}
+            size="xl"
+            sx={{
+              ...(disabled && {
+                filter: 'saturate(0)',
+              }),
+            }}
+          />
 
-        <Stack flexGrow={1}>
-          <Typography variant="bodyMBold" color={disabled ? 'textDisabled' : 'textPrimary'}>
-            {symbol}
-          </Typography>
-
-          <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textSecondary'}>
-            {label}
-          </Typography>
-        </Stack>
-
-        <Stack direction="column" alignItems="end">
-          {hasBalance && (
+          <Stack flexGrow={1}>
             <Typography variant="bodyMBold" color={disabled ? 'textDisabled' : 'textPrimary'}>
-              {formatNumber(balance)}
+              {symbol}
             </Typography>
-          )}
 
-          {hasBalanceUsd && (
             <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textSecondary'}>
-              {formatNumber(tokenPrice! * +balance!, FORMAT_OPTIONS.USD)}
+              {label}
             </Typography>
-          )}
+          </Stack>
 
-          {showAddress && (
-            <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textTertiary'}>
-              {shortenAddress(address)}
-            </Typography>
-          )}
-        </Stack>
-      </MenuItem>
+          <Stack direction="column" alignItems="end">
+            {hasBalance && (
+              <Typography variant="bodyMBold" color={disabled ? 'textDisabled' : 'textPrimary'}>
+                {formatNumber(balance)}
+              </Typography>
+            )}
+
+            {hasBalanceUsd && (
+              <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textSecondary'}>
+                {formatNumber(tokenPrice! * +balance!, FORMAT_OPTIONS.USD)}
+              </Typography>
+            )}
+
+            {showAddress && (
+              <Typography variant="bodyXsRegular" color={disabled ? 'textDisabled' : 'textTertiary'}>
+                {shortenAddress(address)}
+              </Typography>
+            )}
+          </Stack>
+        </MenuItem>
+      </Tooltip>
     </InvertOnHover>
   )
 }


### PR DESCRIPTION
Because of regulatory concern regarding the A7A5 token (`0x0D57436F2d39c0664C6f0f2E349229483f87EA38`), we need a way to blacklist tokens in the token selection modal.

Because of its immediate nature, the scalability and centralized nature of this solution is not up to debate. A hardcoded blacklist is fine.

There’s three considerations to be made when implementing the blacklist:

1. Tokens should be disabled with a tooltip on hover, explaining they’re disabled specifically because they’re blacklisted. This is preferred over simply hiding the token, to prevent confusion and suggesting something might be broken on the UI.
2. ~~The blacklisted tokens should **not** be blacklisted when picking a “from” token when swapping. This gives users an opportunity to get out, such that they are not stuck holding said token. In other words, the token selector should have an `ignoreBlacklist` property for such cases.~~ It was decided to not facilitate **any** token interaction for now, so this idea has been scrapped.
3. There’s no need to put the blacklisted tokens at the bottom, they’re disabled after all. This way we don’t have to make the sorting algorithm more complex than it already is.

![image](https://github.com/user-attachments/assets/985eafbc-6c7b-4930-bc34-2fb981500258)
