### PR TITLE
fix: update text when swap is not available

### DIFF
--- a/apps/main/src/dao/components/AlertFormError.tsx
+++ b/apps/main/src/dao/components/AlertFormError.tsx
@@ -43,7 +43,7 @@ const AlertFormError = ({ errorKey, ...props }: Props) => {
     // locale will update inside component
     const messages: { [key: AlertFormErrorKey | string]: string } = {
       // quick swap and pool swap
-      [AlertFormErrorKey.SWAP_NOT_AVAILABLE]: t`Swap is not available.`,
+      [AlertFormErrorKey.SWAP_NOT_AVAILABLE]: t`Swap route is not available on Curve. Try an aggregator.`,
       [AlertFormErrorKey.SWAP_EXCHANGE_AND_OUTPUT]: t`Unable to get exchange rates and swap amount`,
       [AlertFormErrorKey.STEP_SWAP]: t`Unable to swap`,
 

--- a/apps/main/src/dex/components/AlertFormError.tsx
+++ b/apps/main/src/dex/components/AlertFormError.tsx
@@ -45,7 +45,7 @@ const AlertFormError = ({ errorKey, ...props }: Props) => {
     // locale will update inside component
     const messages: { [key: AlertFormErrorKey | string]: string } = {
       // quick swap and pool swap
-      [ALERT_FORM_ERROR_KEYS['error-swap-not-available']]: t`Swap is not available.`,
+      [ALERT_FORM_ERROR_KEYS['error-swap-not-available']]: t`Swap route is not available on Curve. Try an aggregator.`,
       [ALERT_FORM_ERROR_KEYS['error-swap-exchange-and-output']]: t`Unable to get exchange rates and swap amount`,
       [ALERT_FORM_ERROR_KEYS['error-step-swap']]: t`Unable to swap`,
 


### PR DESCRIPTION
For some reason the DAO app has the same error but I don't think it's being used. Still updating it anyway because I don't want to FAFO
![image](https://github.com/user-attachments/assets/fb99fd83-4bdc-42c7-9ea1-78f90d6f2aba)