### PR TITLE
fix: change 'hard liquidation' to 'hard liquidatable'

### DIFF
--- a/apps/main/src/lend/components/DetailInfoHealth.tsx
+++ b/apps/main/src/lend/components/DetailInfoHealth.tsx
@@ -135,7 +135,7 @@ const DetailInfoHealth = ({
           <Box grid gridGap={2}>
             <p>{t`The loan metric indicates the current health of your position.`}</p>
             <p>
-              {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+              {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
               <ExternalLink href="https://resources.curve.finance/lending/overview/#health-hard-liquidation" $noStyles>
                 Click here to learn more.
               </ExternalLink>

--- a/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanAlertSoftLiquidation.tsx
+++ b/apps/main/src/lend/components/DetailsUser/components/DetailsUserLoanAlertSoftLiquidation.tsx
@@ -34,7 +34,7 @@ const DetailsUserLoanAlertSoftLiquidation = ({ market, userActiveKey }: PageCont
       <Box grid gridGap={3}>
         <p>{t`You are in soft-liquidation mode. The amount currently at risk is ${softLiquidationAmountText}. In this mode, you cannot partially withdraw or add more collateral to your position. To reduce the risk of hard liquidation, you can repay or, to exit soft liquidation, you can close (self-liquidate).`}</p>
         <p>
-          {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+          {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
           <ExternalLink href="https://resources.curve.finance/lending/overview/#health-hard-liquidation" $noStyles>
             Click here to learn more.
           </ExternalLink>

--- a/apps/main/src/lend/hooks/useTitleMapper.tsx
+++ b/apps/main/src/lend/hooks/useTitleMapper.tsx
@@ -30,7 +30,7 @@ const useTitleMapper = (): TitleMapper => ({
       <Box grid gridGap={2}>
         <p>{t`The loan metric indicates the current health of your position.`}</p>
         <p>
-          {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+          {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
           <ExternalLink href="https://resources.curve.finance/crvusd/loan-concepts/#hard-liquidations" $noStyles>
             Click here to learn more.
           </ExternalLink>

--- a/apps/main/src/lend/lib/apiLending.ts
+++ b/apps/main/src/lend/lib/apiLending.ts
@@ -2009,7 +2009,7 @@ function _getLiquidationStatus(healthNotFull: string, userIsCloseToLiquidation: 
   }
 
   if (+healthNotFull < 0) {
-    userStatus.label = 'Hard liquidation'
+    userStatus.label = 'Hard liquidatable'
     userStatus.colorKey = 'hard_liquidation'
     userStatus.tooltip =
       'Hard liquidation is like a usual liquidation, which can happen only if you experience significant losses in soft liquidation so that you get below 0 health.'

--- a/apps/main/src/loan/components/DetailInfoHealth.tsx
+++ b/apps/main/src/loan/components/DetailInfoHealth.tsx
@@ -117,7 +117,7 @@ const DetailInfoHealth = ({
           <Box grid gridGap={2}>
             <p>{t`The loan metric indicates the current health of your position.`}</p>
             <p>
-              {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+              {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
               <ExternalLink href="https://resources.curve.finance/crvusd/loan-concepts/#hard-liquidations" $noStyles>
                 Click here to learn more.
               </ExternalLink>

--- a/apps/main/src/loan/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/AlertSoftLiquidation.tsx
@@ -28,7 +28,7 @@ const AlertSoftLiquidation = ({ llammaId, llamma }: { llammaId: string; llamma: 
       <Box grid gridGap={3}>
         <p>{t`You are in soft-liquidation mode. The amount currently at risk is ${softLiquidationAmountText}. In this mode, you cannot partially withdraw or add more collateral to your position. To reduce the risk of hard liquidation, you can repay or, to exit soft liquidation, you can close (self-liquidate).`}</p>
         <p>
-          {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+          {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
           <ExternalLink href="https://resources.curve.finance/crvusd/loan-concepts/#hard-liquidations" $noStyles>
             Click here to learn more.
           </ExternalLink>

--- a/apps/main/src/loan/hooks/useTitleMapper.tsx
+++ b/apps/main/src/loan/hooks/useTitleMapper.tsx
@@ -25,7 +25,7 @@ const useTitleMapper = (): TitleMapper => ({
       <Box grid gridGap={2}>
         <p>{t`The loan metric indicates the current health of your position.`}</p>
         <p>
-          {t`Hard liquidation is triggered when health is 0 or below.`}{' '}
+          {t`Hard liquidation may be triggered when health is 0 or below.`}{' '}
           <ExternalLink href="https://resources.curve.finance/crvusd/loan-concepts/#hard-liquidations" $noStyles>
             Click here to learn more.
           </ExternalLink>

--- a/apps/main/src/loan/utils/utilsCurvejs.ts
+++ b/apps/main/src/loan/utils/utilsCurvejs.ts
@@ -46,7 +46,7 @@ export function getLiquidationStatus(
   }
 
   if (+healthNotFull < 0) {
-    userStatus.label = 'Hard liquidation'
+    userStatus.label = 'Hard liquidatable'
     userStatus.colorKey = 'hard_liquidation'
     userStatus.tooltip =
       'Hard liquidation is like a usual liquidation, which can happen only if you experience significant losses in soft liquidation so that you get below 0 health.'


### PR DESCRIPTION
There was some confusion as the label "hard liquidation" implies the loan has been hard liquidated. However, if a loan is actually hard liquidated it's actually closed so there is no loan to begin with. When a loan is in 'hard liquidation' mode, it just means there's a chance it might be hard liquidated by a liquidator somewhere in the future, unless the user manages to get its health > 0 before that occurs. Therefore, I suggest changing the label to 'hard liquidatable' instead to indicate the loan isn't actually closed yet.

PS: the amount of duplicated code for the tooltip that says ```{t`Hard liquidation may be triggered when health is 0 or below.`}{' '}``` is really nasty lol

![image](https://github.com/user-attachments/assets/75b4d77e-a423-4cdf-a38a-fffa1e853272)