### PR TITLE
fix: turbopack css import

### DIFF
--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react'
 import { ClientWrapper } from '@/app/ClientWrapper'
 import { StyledComponentsRegistry } from '@/app/StyledComponentsRegistry'
 import { getNetworkDefs } from '@/dex/lib/networks'
-import baseCss from '@ui/styles/base.css'
+import '@ui/styles/base.css'
 import { CURVE_LOGO_URL } from '@ui/utils/utilsConstants'
 import { RootCssProperties } from '@ui-kit/themes/fonts'
 
@@ -68,7 +68,6 @@ const Layout = async ({ children }: { children: ReactNode }) => (
       <meta name="viewport" content="initial-scale=1, minimum-scale=1, width=device-width" />
       <script suppressHydrationWarning dangerouslySetInnerHTML={{ __html: injectIpfsPrefix }} />
       <script dangerouslySetInnerHTML={{ __html: injectHeader }} />
-      <style dangerouslySetInnerHTML={{ __html: baseCss }} />
     </head>
     <body>
       <StyledComponentsRegistry>


### PR DESCRIPTION
- configure turbopack to import the css file as a [global import](https://nextjs.org/docs/app/getting-started/css#global-css)
- the import should now load fine both in production and dev builds