### PR TITLE
styling: lending markets

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/Page.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/Page.tsx
@@ -22,6 +22,7 @@ import { logSuccess } from '@ui-kit/lib'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { Address } from '@ui-kit/utils'
 import { useHeaderHeight } from '@ui-kit/widgets/Header'
+import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 
 /**
  * Reloads the lending vaults and mint markets.
@@ -68,9 +69,7 @@ export const LlamaMarketsPage = (props: LlamalendServerData) => {
   const showSkeleton = !data && (!isError || isLoading) // on initial render isLoading is still false
   return (
     <Box sx={{ marginBlockEnd: Spacing.xxl, ...(!useIsTiny() && { marginInline: Spacing.md }) }}>
-      {showSkeleton ? (
-        <Skeleton variant="rectangular" width={MaxWidth.table} height={ModalHeight.md.height} />
-      ) : (
+      <WithSkeleton loading={showSkeleton} variant="rectangular" height={ModalHeight.md.height}>
         <LlamaMarketsTable
           onReload={() => onReload(address)}
           result={data}
@@ -78,7 +77,8 @@ export const LlamaMarketsPage = (props: LlamalendServerData) => {
           isError={isError}
           minLiquidity={minLiquidity}
         />
-      )}
+      </WithSkeleton>
+
       <LendTableFooter />
     </Box>
   )

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
@@ -21,7 +21,13 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
     <Stack direction="row" gap={Spacing.sm} alignItems="center" sx={{ height: Sizing[700] }}>
       <TokenPair chain={market.chain} assets={market.assets} />
       <Stack direction="column" justifyContent="center">
-        <Typography component={Stack} variant={isMobile ? 'tableCellMBold' : 'tableCellL'} direction="row" gap={2}>
+        <Typography
+          component={Stack}
+          alignItems="center"
+          variant={isMobile ? 'tableCellMBold' : 'tableCellL'}
+          direction="row"
+          gap={2}
+        >
           <RouterLink
             color="inherit"
             underline="none"

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
@@ -20,7 +20,7 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
   return (
     <Stack direction="row" gap={Spacing.sm} alignItems="center" sx={{ height: Sizing[700] }}>
       <TokenPair chain={market.chain} assets={market.assets} />
-      <Stack direction="column" justifyContent="center">
+      <Stack direction="column" justifyContent="center" gap={Spacing.xxs}>
         <Typography
           component={Stack}
           alignItems="center"

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
@@ -47,7 +47,7 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
               paddingBlock: { mobile: '5px', tablet: 0 },
             }}
           >
-            {market.assets.collateral.symbol} - {market.assets.borrowed.symbol}
+            {market.assets.collateral.symbol} &bull; {market.assets.borrowed.symbol}
           </RouterLink>
           <CopyIconButton
             className={`${DesktopOnlyHoverClass} ${ClickableInRowClass}`}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/RotatableIcon.tsx
@@ -24,7 +24,7 @@ export const RotatableIcon = ({
       verticalAlign: 'text-bottom',
       fontSize,
       transition: `transform ${TransitionFunction}, font-size ${TransitionFunction}`,
-      visibility: isEnabled ? 'visible' : 'hidden', // render it invisible to avoid layout shift
+      ...(!isEnabled && { visibility: 'hidden' }), // render it invisible to avoid layout shift
       ...sx,
     }}
     data-testid={testId}

--- a/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
@@ -35,7 +35,7 @@ export const TokenPair = ({ chain, assets: { borrowed, collateral } }: Props) =>
       sx={{ position: 'absolute', bottom: '30%', right: '30%' }}
     />
 
-    <Tooltip title={chain} placement="top">
+    <Tooltip title={chain} placement="top" slotProps={{ popper: { sx: { textTransform: 'capitalize' } } }}>
       <Box sx={{ position: 'absolute', top: '0%', left: '0%' }}>
         <ChainIcon size="xs" blockchainId={chain} />
       </Box>


### PR DESCRIPTION
1. Fix incorrect skeleton size
![image](https://github.com/user-attachments/assets/54c96dbe-3a6c-4cf3-8e2a-c0da9c37d1c6)

2. Fix incorrect market title text alignment
![image](https://github.com/user-attachments/assets/b3e15913-86aa-4151-a707-2da3171cc438)

3. Use • instead of - for market titles as per Figma