### PR TITLE
styling: arrows and borders

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RateCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RateCell.tsx
@@ -34,7 +34,7 @@ export const RateCell = ({
   if (!rateType) throw new Error(`RateCell: Unsupported column ID "${id}"`)
   const Tooltip = TooltipComponents[rateType]
   return (
-    // The box container makes sure the tooltip doens't span the entire cell, so the tooltip arrow is placed correctly
+    // The box container makes sure the tooltip doesn't span the entire cell, so the tooltip arrow is placed correctly
     <Box display="flex" justifyContent="end">
       <Tooltip market={market}>
         <Stack gap={Spacing.xs} alignItems="end">

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RateCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RateCell.tsx
@@ -1,4 +1,5 @@
 import { LlamaMarket } from '@/llamalend/entities/llama-markets'
+import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { CellContext } from '@tanstack/react-table'
@@ -33,14 +34,17 @@ export const RateCell = ({
   if (!rateType) throw new Error(`RateCell: Unsupported column ID "${id}"`)
   const Tooltip = TooltipComponents[rateType]
   return (
-    <Tooltip market={market}>
-      <Stack gap={Spacing.xs} alignItems="flex-end">
-        <Typography variant="tableCellMBold" color="textPrimary">
-          {formatPercent(rate)}
-        </Typography>
+    // The box container makes sure the tooltip doens't span the entire cell, so the tooltip arrow is placed correctly
+    <Box display="flex" justifyContent="end">
+      <Tooltip market={market}>
+        <Stack gap={Spacing.xs} alignItems="end">
+          <Typography variant="tableCellMBold" color="textPrimary">
+            {formatPercent(rate)}
+          </Typography>
 
-        <RewardsIcons market={market} rateType={rateType} />
-      </Stack>
-    </Tooltip>
+          <RewardsIcons market={market} rateType={rateType} />
+        </Stack>
+      </Tooltip>
+    </Box>
   )
 }

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RewardsIcons.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/RewardsIcons.tsx
@@ -12,7 +12,15 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 const { IconSize } = SizesAndSpaces
 
 const RewardChip = ({ icon }: { icon: ReactElement }) => (
-  <Chip icon={icon} size="small" color="highlight" sx={{ '&:not(:last-child)': { marginInline: '-8px' } }} />
+  <Chip
+    icon={icon}
+    size="small"
+    color="highlight"
+    sx={{
+      borderRadius: '100%', // Make reward chips border round, regardless of theme
+      '&:not(:last-child)': { marginInline: '-8px' },
+    }}
+  />
 )
 
 export const RewardsIcons = ({


### PR DESCRIPTION
Round reward icon borders & arrow placement on borrow and lend rates is on the rates itself. I also tried to place the arrow for the utilization tooltip on the percentage value, but it's not possible as you want it also to show when hovering over the progress bar, which spans the entire cell)

![image](https://github.com/user-attachments/assets/67b96cf5-1fb4-409c-9f41-2ec71299d75f)
![image](https://github.com/user-attachments/assets/b401f66f-3f9f-47f9-a68d-4445e7cd760d)
