### PR TITLE
fix: scroll-up button was not visible yet clickable

### DIFF
--- a/apps/main/src/app/ClientWrapper.tsx
+++ b/apps/main/src/app/ClientWrapper.tsx
@@ -25,7 +25,7 @@ const useLayoutStoreResponsive = () => {
   const pageWidth = useLayoutStore((state) => state.pageWidth)
   const setLayoutWidth = useLayoutStore((state) => state.setLayoutWidth)
   const setPageVisible = useLayoutStore((state) => state.setPageVisible)
-  const setScrollY = useLayoutStore((state) => state.setScrollY)
+  const updateShowScrollButton = useLayoutStore((state) => state.updateShowScrollButton)
 
   const handleResizeListener = useCallback(() => {
     if (window?.innerWidth) setLayoutWidth(getPageWidthClassName(window.innerWidth))
@@ -39,7 +39,7 @@ const useLayoutStoreResponsive = () => {
 
   useEffect(() => {
     if (!window || !document) return
-    const handleScrollListener = () => setScrollY(window.scrollY)
+    const handleScrollListener = () => updateShowScrollButton(window.scrollY)
     const handleVisibilityChange = () => setPageVisible(!document.hidden)
 
     handleResizeListener()
@@ -54,7 +54,7 @@ const useLayoutStoreResponsive = () => {
       window.removeEventListener('resize', () => handleResizeListener())
       window.removeEventListener('scroll', () => handleScrollListener())
     }
-  }, [document, handleResizeListener, setPageVisible, setScrollY])
+  }, [document, handleResizeListener, setPageVisible, updateShowScrollButton])
 }
 
 function useNetworkFromUrl<ChainId extends number, NetworkConfig extends NetworkDef>(

--- a/apps/main/src/lend/layout/Settings.tsx
+++ b/apps/main/src/lend/layout/Settings.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const Settings = ({ showScrollButton }: Props) => {
-  const scrollY = useLayoutStore((state) => state.scrollY)
+  const isShowScrollButton = useLayoutStore((state) => state.showScrollButton)
 
   const handleScrollTopClick = () => {
     window.scroll({
@@ -21,8 +21,8 @@ const Settings = ({ showScrollButton }: Props) => {
   return (
     <Wrapper>
       <StyledScrollUpButton
-        className={showScrollButton && scrollY > 30 ? 'pop-in' : ''}
-        show={showScrollButton ? scrollY > 30 : false}
+        className={showScrollButton && isShowScrollButton ? 'pop-in' : ''}
+        show={showScrollButton ? isShowScrollButton : false}
         variant="icon-filled"
         onClick={handleScrollTopClick}
       >

--- a/apps/main/src/loan/layout/Settings.tsx
+++ b/apps/main/src/loan/layout/Settings.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const Settings = ({ showScrollButton }: Props) => {
-  const scrollY = useLayoutStore((state) => state.scrollY)
+  const isShowScrollButton = useLayoutStore((state) => state.showScrollButton)
 
   const handleScrollTopClick = () => {
     window.scroll({
@@ -21,8 +21,8 @@ const Settings = ({ showScrollButton }: Props) => {
   return (
     <Wrapper>
       <StyledScrollUpButton
-        className={showScrollButton && scrollY > 30 ? 'pop-in' : ''}
-        $show={showScrollButton ? scrollY > 30 : false}
+        className={showScrollButton && isShowScrollButton ? 'pop-in' : ''}
+        $show={showScrollButton ? isShowScrollButton : false}
         variant="icon-filled"
         onClick={handleScrollTopClick}
       >

--- a/apps/main/src/loan/store/createAppSlice.ts
+++ b/apps/main/src/loan/store/createAppSlice.ts
@@ -13,7 +13,6 @@ export type StateKey = string
 
 type SliceState = {
   isPageVisible: boolean
-  scrollY: number
 }
 
 // prettier-ignore
@@ -32,7 +31,6 @@ export interface AppSlice extends SliceState {
 
 const DEFAULT_STATE: SliceState = {
   isPageVisible: true,
-  scrollY: 0,
 }
 
 const createAppSlice = (set: SetState<State>, get: GetState<State>): AppSlice => ({

--- a/packages/curve-ui-kit/src/features/layout/store.ts
+++ b/packages/curve-ui-kit/src/features/layout/store.ts
@@ -16,7 +16,6 @@ interface LayoutState {
   isXXSm: boolean
 
   // Scroll state
-  scrollY: number
   showScrollButton: boolean
 
   // Page visibility
@@ -27,7 +26,6 @@ interface LayoutActions {
   setLayoutWidth: (pageWidthClassName: PageWidthClassName) => void
   setNavHeight: (value: number) => void
   updateShowScrollButton: (scrollY: number) => void
-  setScrollY: (scrollY: number) => void
   setPageVisible: (visible: boolean) => void
 }
 
@@ -40,7 +38,6 @@ const DEFAULT_STATE: LayoutState = {
   isSmUp: false,
   isXSmDown: false,
   isXXSm: false,
-  scrollY: 0,
   showScrollButton: false,
   isPageVisible: true,
 }
@@ -69,12 +66,7 @@ const layoutStore = immer<LayoutState & LayoutActions>((set) => ({
     }),
   updateShowScrollButton: (scrollY) =>
     set((state) => {
-      state.scrollY = scrollY
       state.showScrollButton = scrollY > 30
-    }),
-  setScrollY: (scrollY) =>
-    set((state) => {
-      state.scrollY = scrollY
     }),
   setPageVisible: (visible) =>
     set((state) => {


### PR DESCRIPTION
Was broken with the refactor to `ClientWrapper.tsx`. Removed `scrollY` from the layout store as it was literally only used for the scroll button logic. When you haven't scrolled and the button is not visible it's still clickable, but didn't bother to fix that as I suspect this entire thing gets replaced in the future anyway, and it's non-breaking.

![image](https://github.com/user-attachments/assets/c86dd55d-c916-4191-a23f-dd26819a2789)
