### PR TITLE
fix: illegal li in li

### DIFF
--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
@@ -15,13 +15,13 @@ const UserInfoLlammaBalances = ({ llammaId, llamma }: { llammaId: string; llamma
 
   return (
     <Box flex gridGap={3}>
-      <ListInfoItem title={collateral}>
+      <ListInfoItem title={collateral} as="div">
         <Box grid>
           {formatNumber(userState?.collateral, { defaultValue: '-' })}
           <InpChipUsdRate hideRate address={collateralAddress} amount={userState?.collateral} />
         </Box>
       </ListInfoItem>
-      <ListInfoItem title={stablecoin}>
+      <ListInfoItem title={stablecoin} as="div">
         <Box grid>
           {formatNumber(userState?.stablecoin, { defaultValue: '' })}
           <InpChipUsdRate hideRate address={stablecoinAddress} amount={userState?.stablecoin} />


### PR DESCRIPTION
You can't have `<li>` in `<li>`. Sometimes, almost randomly, NextJS complains about this in dev mode giving me a full screen error I can't click away and then I have to refresh. Very annoying.