### PR TITLE
fix: alert title wrapping causes title and message to overlap

### DIFF
--- a/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
+++ b/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
@@ -89,7 +89,7 @@ export const defineMuiAlertTitle = (
   styleOverrides: {
     root: handleBreakpoints({
       ...bodySBold,
-      height: IconSize.sm,
+      minHeight: IconSize.sm,
       marginBlockEnd: '4px',
       marginBlockStart: 0, // For some reason margin-top is -2px in MUI by default
     }),


### PR DESCRIPTION
Setting height also means setting max height, which in turn can cause an alert title to overlap with the actual message.

![Screenshot 2025-07-05 182705](https://github.com/user-attachments/assets/a9af47c6-6122-4c94-adcf-830b38c6ccee)
