### PR TITLE
refactor: dont default to empty object on undefined user details

### DIFF
--- a/apps/main/src/loan/components/LoanInfoUser/components/ChartUserBands.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/ChartUserBands.tsx
@@ -22,7 +22,7 @@ const DEFAULT_BAND_CHART_DATA = {
 
 const ChartUserBands = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma | null }) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const { userBandsBalances, userLiquidationBand } = useUserLoanDetails(llammaId)
+  const { userBandsBalances, userLiquidationBand } = useUserLoanDetails(llammaId) ?? {}
 
   const [brushIndex, setBrushIndex] = useState<BrushStartEndIndex>({
     startIndex: undefined,

--- a/apps/main/src/loan/components/LoanInfoUser/components/ChartUserLiquidationRange.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/ChartUserLiquidationRange.tsx
@@ -7,7 +7,7 @@ import { useUserProfileStore } from '@ui-kit/features/user-profile'
 
 const ChartUserLiquidationRange = ({ healthMode, llammaId }: { healthMode: HealthMode; llammaId: string }) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const { userPrices: currPrices } = useUserLoanDetails(llammaId)
+  const { userPrices: currPrices } = useUserLoanDetails(llammaId) ?? {}
 
   const theme = useUserProfileStore((state) => state.theme)
 

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoDebt.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoDebt.tsx
@@ -14,7 +14,7 @@ const UserInfoDebt = ({
   stablecoin: string | undefined
   stablecoinAddress: string | undefined
 }) => {
-  const { userState } = useUserLoanDetails(llammaId)
+  const { userState } = useUserLoanDetails(llammaId) ?? {}
 
   return (
     <ListInfoItem title={t`Debt`} titleDescription={`(${stablecoin})`} mainValue={formatNumber(userState?.debt)}>

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLiquidationRange.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLiquidationRange.tsx
@@ -10,7 +10,7 @@ const UserInfoLiquidationRange = ({
   llammaId: string
   type: 'liquidationRange' | 'liquidationBandRange'
 }) => {
-  const { userPrices, userBands } = useUserLoanDetails(llammaId)
+  const { userPrices, userBands } = useUserLoanDetails(llammaId) ?? {}
 
   const liqPriceRange = useMemo(() => {
     const [price1, price2] = userPrices ?? []

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfoLlammaBalances.tsx
@@ -6,7 +6,7 @@ import ListInfoItem from '@ui/ListInfo'
 import { formatNumber } from '@ui/utils'
 
 const UserInfoLlammaBalances = ({ llammaId, llamma }: { llammaId: string; llamma: Llamma | null }) => {
-  const { userState } = useUserLoanDetails(llammaId)
+  const { userState } = useUserLoanDetails(llammaId) ?? {}
 
   const {
     coins: [stablecoin, collateral],

--- a/apps/main/src/loan/components/LoanInfoUser/components/UserInfos.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/components/UserInfos.tsx
@@ -26,7 +26,7 @@ const UserInfos = ({
   healthMode: HealthMode
   titleMapper: TitleMapper
 }) => {
-  const { userBandsPct, userStatus } = useUserLoanDetails(llammaId)
+  const { userBandsPct, userStatus } = useUserLoanDetails(llammaId) ?? {}
   const colorKey = useUserLoanStatus(llammaId)
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)
 

--- a/apps/main/src/loan/components/LoanInfoUser/index.tsx
+++ b/apps/main/src/loan/components/LoanInfoUser/index.tsx
@@ -23,7 +23,7 @@ interface Props extends Pick<PageLoanManageProps, 'llamma' | 'llammaId' | 'title
 
 const LoanInfoUser = ({ llamma, llammaId, rChainId, titleMapper }: Props) => {
   const loanDetails = useStore((state) => state.loans.detailsMapper[llammaId])
-  const { userBands, healthFull, healthNotFull } = useUserLoanDetails(llammaId)
+  const { userBands, healthFull, healthNotFull } = useUserLoanDetails(llammaId) ?? {}
   const { chartExpanded } = useStore((state) => state.ohlcCharts)
 
   const isAdvancedMode = useUserProfileStore((state) => state.isAdvancedMode)

--- a/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDecrease/index.tsx
@@ -64,7 +64,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)
 
   const { chainId, haveSigner } = curveProps(curve)
-  const { userState } = userLoanDetails || {}
+  const { userState } = userLoanDetails ?? {}
 
   const updateFormValues = (updatedFormValues: FormValues) => {
     if (chainId && llamma) {
@@ -236,7 +236,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
           <InputMaxBtn
             onClick={() => {
               // if wallet balance < debt, use wallet balance, else use full repay.
-              if (+userWalletBalances?.stablecoin < +userState?.debt) {
+              if (+userWalletBalances?.stablecoin < +(userState?.debt ?? 0)) {
                 handleInpChangeDebt(userWalletBalances.stablecoin)
               } else {
                 handleInpChangeFullRepay(true)
@@ -247,7 +247,7 @@ const LoanDecrease = ({ curve, llamma, llammaId, params, rChainId }: Props) => {
         {formValues.debtError ? (
           formValues.debtError === 'too-much' ? (
             <StyledInpChip size="xs" isDarkBg isError>
-              The specified amount exceeds your total debt. Your debt balance is {formatNumber(userState.debt)}.
+              The specified amount exceeds your total debt. Your debt balance is {formatNumber(userState?.debt ?? 0)}.
             </StyledInpChip>
           ) : formValues.debtError === 'not-enough' ? (
             <StyledInpChip size="xs" isDarkBg isError>

--- a/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/LoanDeleverage/index.tsx
@@ -78,7 +78,7 @@ const LoanDeleverage = ({
   const [txInfoBar, setTxInfoBar] = useState<ReactNode>(null)
 
   const { chainId, haveSigner } = curveProps(curve)
-  const { userState } = userLoanDetails || {}
+  const { userState } = userLoanDetails ?? {}
   const { collateral: collateralName } = getTokenName(llamma)
 
   const updateFormValues = useCallback(
@@ -146,7 +146,9 @@ const LoanDeleverage = ({
     ) => {
       const { isComplete, step } = formStatus
       const isValidForm =
-        +formValues.collateral > 0 && !formValues.collateralError && +userState.collateral >= +formValues.collateral
+        +formValues.collateral > 0 &&
+        !formValues.collateralError &&
+        +(userState?.collateral ?? 0) >= +formValues.collateral
       const isValid = !!curve.signerAddress && isValidForm && !formStatus.error && !detailInfo.loading
 
       const stepsObj: { [key: string]: Step } = {
@@ -299,11 +301,11 @@ const LoanDeleverage = ({
             value={formValues.collateral}
             onChange={(collateral) => updateFormValues({ collateral }, '', false)}
           />
-          <InputMaxBtn onClick={() => updateFormValues({ collateral: userState.collateral }, '', false)} />
+          <InputMaxBtn onClick={() => updateFormValues({ collateral: userState?.collateral }, '', false)} />
         </InputProvider>
         {formValues.collateralError === 'too-much' ? (
           <StyledInpChip size="xs" isDarkBg isError>
-            {t`Amount must be <= ${formatNumber(userState.collateral)}`}
+            {t`Amount must be <= ${formatNumber(userState?.collateral)}`}
           </StyledInpChip>
         ) : (
           <StyledInpChip size="xs">

--- a/apps/main/src/loan/hooks/useUserLoanDetails.ts
+++ b/apps/main/src/loan/hooks/useUserLoanDetails.ts
@@ -1,13 +1,13 @@
 import useStore from '@/loan/store/useStore'
-import type { HealthColorKey } from '@/loan/types/loan.types'
+import type { HealthColorKey, UserLoanDetails } from '@/loan/types/loan.types'
 
 /**
  * Retrieves user loan details for a specific llamma market
  * @param llammaId - The llamma market identifier
- * @returns User loan details object or empty object if not found
+ * @returns User loan details object or undefined if not found
  */
-export const useUserLoanDetails = (llammaId: string) =>
-  useStore((state) => state.loans.userDetailsMapper[llammaId]) ?? {}
+export const useUserLoanDetails = (llammaId: string): UserLoanDetails | undefined =>
+  useStore((state) => state.loans.userDetailsMapper[llammaId])
 
 /**
  * Gets the health status color key for a user's loan


### PR DESCRIPTION
I've come to regret the decision I've made earlier last month. The DX is a lot better if you explicitly default to an empty object at the last possible moment, rather than at the top level.

For example:

`const { userState: { debtToken: { symbol } } } = useUserLoan() ?? {}` doesn't work, because you can't destructure further than one level deep. You'll get an error like 'debtToken' cannot be destructured from `undefined`. And worst of all, you get a typescript error that this is a possibility.

It's better to keep the type possibly undefined, and then chain with the elvis operator as such: `const { symbol } = useUserLoan()?.userState?.debtToken ?? {}`, which makes the type of `symbol: undefined | string` and eliminates the chance of a runtime error that typescript fails to detect.