### PR TITLE
feat: manage soft liq improvements

### DIFF
--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
@@ -29,25 +29,25 @@ const actionInfos = {
   },
 }
 
-type Token = TokenOption & { balance: number }
+type Token = TokenOption & { amount: number }
 
 const debtToken: Token = {
   symbol: 'crvUSD',
   address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E' as Address,
-  balance: 321.01,
+  amount: 321.01,
 }
 
 const collateralToRecover = [
   {
     symbol: 'ETH',
     address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' as Address,
-    balance: 26539422,
+    amount: 26539422,
     usd: 638000,
   },
   {
     symbol: 'crvUSD',
     address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E' as Address,
-    balance: 12450,
+    amount: 12450,
     usd: 12450,
   },
 ]
@@ -122,6 +122,7 @@ export const Default: Story = {
     actionInfos,
     improveHealth: {
       debtToken,
+      userBalance: 6900,
       status: 'idle' as const,
       onDebtBalance: fn(),
       onRepay: fn(),

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
@@ -52,6 +52,11 @@ const collateralToRecover = [
   },
 ]
 
+const canClose = {
+  requiredToClose: 100,
+  missing: 42,
+}
+
 type ImproveHealthStatus = ImproveHealthProps['status']
 type ClosePositionStatus = ClosePositionProps['status']
 
@@ -126,6 +131,7 @@ export const Default: Story = {
     closePosition: {
       debtToken,
       collateralToRecover,
+      canClose,
       status: 'idle' as const,
       onClose: fn(),
     },

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ActionInfos.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ActionInfos.tsx
@@ -95,7 +95,7 @@ export type Props = {
   }
   collateral: {
     /** Borrowed collateral token information */
-    borrowed?: TokenAmount
+    borrowed?: TokenAmount & { new?: number }
     /** The leverage multiplier if present, like 9x or 10x */
     leverage?: Delta
     /** Assets the user gets when withdrawing or closing the position */
@@ -187,7 +187,13 @@ export const ActionInfos = ({
           />
         )}
 
-        {borrowed && <ActionInfo label="Collateral" value={`${formatTokens(borrowed)}`} />}
+        {borrowed && (
+          <ActionInfo
+            label="Collateral"
+            value={`${formatTokens({ symbol: borrowed.symbol, amount: borrowed.new ?? borrowed.amount })}`}
+            prevValue={`${formatTokens({ symbol: borrowed.symbol, amount: borrowed.amount })}`}
+          />
+        )}
 
         {assetsToWithdraw && <ActionInfo label="Assets to withdraw" value={`${formatTokens(assetsToWithdraw)}`} />}
       </Stack>

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ActionInfos.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ActionInfos.tsx
@@ -85,17 +85,17 @@ export type Props = {
   health: Delta
   loan: {
     /** Borrow rate values the user is paying to keep the loan open */
-    borrowRate: Delta
+    borrowRate?: Delta
     /** Debt token with amount and optional new amount for comparison */
-    debt: TokenAmount & { new?: number }
+    debt?: TokenAmount & { new?: number }
     /** LTV value indicates how big the loan is compared to the collateral */
-    ltv: Delta
+    ltv?: Delta
     /** Array of collateral assets - only renders when provided */
-    collateral: TokenAmount[]
+    collateral?: TokenAmount[]
   }
   collateral: {
     /** Borrowed collateral token information */
-    borrowed: TokenAmount
+    borrowed?: TokenAmount
     /** The leverage multiplier if present, like 9x or 10x */
     leverage?: Delta
     /** Assets the user gets when withdrawing or closing the position */
@@ -104,7 +104,7 @@ export type Props = {
   /** Meta information about to the potential transaction itself */
   transaction: {
     /** Transaction cost breakdown in ETH, GWEI, and USD */
-    estimatedTxCost: { eth: number; gwei: number; dollars: number }
+    estimatedTxCost?: { eth: number; gwei: number; dollars: number }
   }
 }
 
@@ -150,23 +150,32 @@ export const ActionInfos = ({
   >
     <Stack gap={Spacing.md}>
       <Stack>
-        <ActionInfo
-          label="Borrow Rate"
-          value={`${formatValue(borrowRate.new)}%`}
-          prevValue={`${formatValue(borrowRate.old)}%`}
-        />
+        {borrowRate && (
+          <ActionInfo
+            label="Borrow Rate"
+            value={`${formatValue(borrowRate.new)}%`}
+            prevValue={`${formatValue(borrowRate.old)}%`}
+          />
+        )}
 
-        <ActionInfo
-          label="Debt"
-          value={`${formatTokens({ symbol: debt.symbol, amount: debt.new ?? debt.amount })}`}
-          prevValue={`${formatTokens({ symbol: debt.symbol, amount: debt.amount })}`}
-        />
+        {debt && (
+          <ActionInfo
+            label="Debt"
+            value={`${formatTokens({ symbol: debt.symbol, amount: debt.new ?? debt.amount })}`}
+            prevValue={`${formatTokens({ symbol: debt.symbol, amount: debt.amount })}`}
+          />
+        )}
 
-        <ActionInfo label="LTV" value={`${formatValue(ltv.new)}%`} prevValue={`${formatValue(ltv.old)}%`} />
+        {ltv && <ActionInfo label="LTV" value={`${formatValue(ltv.new)}%`} prevValue={`${formatValue(ltv.old)}%`} />}
 
-        {collateral.map((c, i) => (
-          <ActionInfo key={`collateral-${c.symbol}`} label={i === 0 ? 'Collateral' : ''} value={`${formatTokens(c)}`} />
-        ))}
+        {collateral &&
+          collateral.map((c, i) => (
+            <ActionInfo
+              key={`collateral-${c.symbol}`}
+              label={i === 0 ? 'Collateral' : ''}
+              value={`${formatTokens(c)}`}
+            />
+          ))}
       </Stack>
 
       <Stack>
@@ -178,17 +187,19 @@ export const ActionInfos = ({
           />
         )}
 
-        <ActionInfo label="Collateral" value={`${formatTokens(borrowed)}`} />
+        {borrowed && <ActionInfo label="Collateral" value={`${formatTokens(borrowed)}`} />}
 
         {assetsToWithdraw && <ActionInfo label="Assets to withdraw" value={`${formatTokens(assetsToWithdraw)}`} />}
       </Stack>
 
-      <ActionInfo
-        label="Estimated tx cost"
-        valueLeft={<GasIcon sx={{ width: IconSize.md, height: IconSize.md }} />}
-        value={`$${formatValue(estimatedTxCost.dollars)}`}
-        valueTooltip={`${estimatedTxCost.eth} ETH at ${estimatedTxCost.gwei} GWEI`}
-      />
+      {estimatedTxCost && (
+        <ActionInfo
+          label="Estimated tx cost"
+          valueLeft={<GasIcon sx={{ width: IconSize.md, height: IconSize.md }} />}
+          value={`$${formatValue(estimatedTxCost.dollars)}`}
+          valueTooltip={`${estimatedTxCost.eth} ETH at ${estimatedTxCost.gwei} GWEI`}
+        />
+      )}
     </Stack>
   </Accordion>
 )

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/AlertAdditionalCrvUsd.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/AlertAdditionalCrvUsd.tsx
@@ -1,0 +1,35 @@
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import Stack from '@mui/material/Stack/Stack'
+import Typography from '@mui/material/Typography'
+import { t } from '@ui-kit/lib/i18n'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing } = SizesAndSpaces
+
+type Props = {
+  debtTokenSymbol: string
+  missing: number
+}
+
+export const AlertAdditionalCrvUsd = ({ missing, debtTokenSymbol }: Props) => (
+  <Alert severity="error" variant="outlined" sx={{ boxShadow: 'none' }}>
+    <AlertTitle>{t`Additional crvUSD required`}</AlertTitle>
+
+    <Stack gap={Spacing.sm}>
+      <Typography variant="bodySRegular" color="textSecondary">
+        {t`Your position cannot be closed because the outstanding debt amount is greater than the available collateral value. Additionally, your wallet does not contain sufficient `}
+        <strong>{debtTokenSymbol}</strong>
+        {t` tokens to cover the remaining debt balance that exceeds your collateral.`}
+      </Typography>
+
+      <Typography variant="bodySRegular" color="textSecondary">
+        {t`A minimum balance of `}
+        <strong>
+          {Math.ceil(missing * 100) / 100} {debtTokenSymbol}
+        </strong>
+        {t` is required in your wallet to close the position.`}
+      </Typography>
+    </Stack>
+  </Alert>
+)

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/AlertClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/AlertClosePosition.tsx
@@ -18,7 +18,7 @@ export const AlertClosePosition = () => (
       </Typography>
 
       <Typography variant="bodySRegular" color="textSecondary">
-        {t`While soft liquidation is active, you only repay debt to increase health or withdraw collateral.`}
+        {t`While soft liquidation is active, you may only repay debt to increase health or withdraw collateral.`}
 
         <Button
           href="https://resources.curve.finance/crvusd/loan-concepts"

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ButtonGetCrvUsd.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ButtonGetCrvUsd.tsx
@@ -1,0 +1,33 @@
+import { usePathname } from 'next/navigation'
+import { CallMade } from '@mui/icons-material'
+import Button from '@mui/material/Button'
+import { DEX_ROUTES, getCurrentNetwork, getInternalUrl } from '@ui-kit/shared/routes'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { IconSize } = SizesAndSpaces
+
+const CRVUSD_ADDRESS = '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e'
+
+/**
+ * Button component that redirects users to the DEX swap page with crvUSD pre-selected as the destination token.
+ * Opens in a new tab and dynamically determines the network based on the current pathname.
+ */
+export const ButtonGetCrvUsd = () => {
+  const pathname = usePathname()
+  const networkId = getCurrentNetwork(pathname)
+  const href = `${getInternalUrl('dex', networkId, DEX_ROUTES.PAGE_SWAP)}?to=${CRVUSD_ADDRESS}`
+
+  return (
+    <Button
+      component="a"
+      color="ghost"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      size="extraSmall"
+      endIcon={<CallMade sx={{ width: IconSize.md, height: IconSize.md }} />}
+    >
+      Get crvUSD
+    </Button>
+  )
+}

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
@@ -5,6 +5,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { Spinner } from '@ui-kit/shared/ui/Spinner'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Token } from '../../types'
+import { AlertAdditionalCrvUsd } from '../AlertAdditionalCrvUsd'
 import { AlertClosePosition } from '../AlertClosePosition'
 import { ButtonGetCrvUsd } from '../ButtonGetCrvUsd'
 
@@ -17,6 +18,8 @@ type ClosePositionProps = {
   debtToken?: Token
   /** The tokens the user gets when closing his position */
   collateralToRecover: (Token & { usd: number })[]
+  /** Whether the user has sufficient stablecoins to close the position */
+  canClose: { requiredToClose: number; missing: number }
   /** Current operation status */
   status: Status
 }
@@ -31,7 +34,7 @@ type ClosePositionCallbacks = {
 
 export type Props = ClosePositionProps & ClosePositionCallbacks
 
-export const ClosePosition = ({ debtToken, collateralToRecover, status = 'idle', onClose }: Props) => (
+export const ClosePosition = ({ debtToken, collateralToRecover, canClose, status = 'idle', onClose }: Props) => (
   <Stack gap={Spacing.md} sx={{ padding: Spacing.md }}>
     <Stack direction="row" gap={Spacing.xs} justifyContent="space-around">
       <Metric
@@ -60,10 +63,13 @@ export const ClosePosition = ({ debtToken, collateralToRecover, status = 'idle',
     </Stack>
 
     <AlertClosePosition />
+    {canClose.missing > 0 && debtToken?.symbol && (
+      <AlertAdditionalCrvUsd debtTokenSymbol={debtToken?.symbol} missing={canClose.missing} />
+    )}
 
     <Stack gap={Spacing.xs}>
       <Button
-        disabled={status === 'close'}
+        disabled={status === 'close' || canClose.missing > 0 || (debtToken?.balance ?? 0) <= 0}
         onClick={() => onClose(debtToken, collateralToRecover)}
         sx={{ position: 'relative' }}
       >

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
@@ -13,7 +13,7 @@ type Status = 'idle' | 'close'
 
 type ClosePositionProps = {
   /** The token that's been borrowed that has to be paid back */
-  debtToken: Token
+  debtToken?: Token
   /** The tokens the user gets when closing his position */
   collateralToRecover: (Token & { usd: number })[]
   /** Current operation status */
@@ -35,8 +35,9 @@ export const ClosePosition = ({ debtToken, collateralToRecover, status = 'idle',
     <Stack direction="row" gap={Spacing.xs} justifyContent="space-around">
       <Metric
         label={t`Debt to repay`}
-        value={debtToken.balance}
-        valueOptions={{ decimals: 2, unit: { symbol: debtToken.symbol, position: 'suffix' }, abbreviate: true }}
+        value={debtToken?.balance}
+        valueOptions={{ decimals: 2, abbreviate: true }}
+        notional={debtToken?.symbol ?? ''}
         alignment="center"
         size="large"
       />

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
@@ -15,9 +15,9 @@ type Status = 'idle' | 'close'
 
 type ClosePositionProps = {
   /** The token that's been borrowed that has to be paid back */
-  debtToken?: Token
+  debtToken?: Token & { amount: number }
   /** The tokens the user gets when closing his position */
-  collateralToRecover: (Token & { usd: number })[]
+  collateralToRecover: (Token & { amount?: number; usd: number })[]
   /** Whether the user has sufficient stablecoins to close the position */
   canClose: { requiredToClose: number; missing: number }
   /** Current operation status */
@@ -39,7 +39,7 @@ export const ClosePosition = ({ debtToken, collateralToRecover, canClose, status
     <Stack direction="row" gap={Spacing.xs} justifyContent="space-around">
       <Metric
         label={t`Debt to repay`}
-        value={debtToken?.balance}
+        value={debtToken?.amount}
         valueOptions={{ decimals: 2, abbreviate: true }}
         notional={debtToken?.symbol ?? ''}
         alignment="center"
@@ -51,9 +51,9 @@ export const ClosePosition = ({ debtToken, collateralToRecover, canClose, status
         value={collateralToRecover.reduce((acc, x) => acc + x.usd, 0)}
         valueOptions={{ decimals: 2, unit: 'dollar' }}
         notional={collateralToRecover
-          .filter((x) => x.balance ?? 0 > 0)
+          .filter((x) => x.amount ?? 0 > 0)
           .map((x) => ({
-            value: x.balance!,
+            value: x.amount!,
             unit: { symbol: ` ${x.symbol}`, position: 'suffix' },
             abbreviate: true,
           }))}
@@ -69,7 +69,7 @@ export const ClosePosition = ({ debtToken, collateralToRecover, canClose, status
 
     <Stack gap={Spacing.xs}>
       <Button
-        disabled={status === 'close' || canClose.missing > 0 || (debtToken?.balance ?? 0) <= 0}
+        disabled={status === 'close' || canClose.missing > 0 || (debtToken?.amount ?? 0) <= 0}
         onClick={() => onClose(debtToken, collateralToRecover)}
         sx={{ position: 'relative' }}
       >

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
@@ -65,7 +65,7 @@ export const ClosePosition = ({ debtToken, collateralToRecover, status = 'idle',
       onClick={() => onClose(debtToken, collateralToRecover)}
       sx={{ position: 'relative' }}
     >
-      {t`Repay debt & close position`}
+        {status === 'idle' ? t`Repay debt & close position` : t`Closing position`}
       {status === 'close' && <Spinner sx={{ position: 'absolute', right: Spacing.lg }} />}
     </Button>
   </Stack>

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ClosePosition.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@ui-kit/shared/ui/Spinner'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Token } from '../../types'
 import { AlertClosePosition } from '../AlertClosePosition'
+import { ButtonGetCrvUsd } from '../ButtonGetCrvUsd'
 
 const { Spacing } = SizesAndSpaces
 
@@ -60,13 +61,17 @@ export const ClosePosition = ({ debtToken, collateralToRecover, status = 'idle',
 
     <AlertClosePosition />
 
-    <Button
-      disabled={status === 'close'}
-      onClick={() => onClose(debtToken, collateralToRecover)}
-      sx={{ position: 'relative' }}
-    >
+    <Stack gap={Spacing.xs}>
+      <Button
+        disabled={status === 'close'}
+        onClick={() => onClose(debtToken, collateralToRecover)}
+        sx={{ position: 'relative' }}
+      >
         {status === 'idle' ? t`Repay debt & close position` : t`Closing position`}
-      {status === 'close' && <Spinner sx={{ position: 'absolute', right: Spacing.lg }} />}
-    </Button>
+        {status === 'close' && <Spinner sx={{ position: 'absolute', right: Spacing.lg }} />}
+      </Button>
+
+      <ButtonGetCrvUsd />
+    </Stack>
   </Stack>
 )

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
@@ -22,7 +22,9 @@ type Status = 'idle' | 'repay' | OptionId
 
 type ImproveHealthProps = {
   /** The token that's been borrowed that has to be paid back */
-  debtToken?: Token
+  debtToken?: Token & { amount: number }
+  /** the amount of tokens the user has in his wallet to repay debt with */
+  userBalance?: number
   /** Current status of the improve health operation */
   status: Status
 }
@@ -42,6 +44,7 @@ export type Props = ImproveHealthProps & ImproveHealthCallbacks
 
 export const ImproveHealth = ({
   debtToken,
+  userBalance,
   status = 'idle',
   onDebtBalance,
   onRepay,
@@ -56,7 +59,14 @@ export const ImproveHealth = ({
     'approve-infinite': onApproveInfinite,
   }
 
-  const maxBalance = useMemo(() => ({ ...debtToken, showSlider: false }), [debtToken])
+  const maxBalance = useMemo(
+    () => ({
+      balance: debtToken && userBalance && Math.min(debtToken.amount, userBalance),
+      symbol: debtToken?.symbol,
+      showSlider: false,
+    }),
+    [debtToken, userBalance],
+  )
 
   return (
     <Stack gap={Spacing.md} sx={{ padding: Spacing.md }}>
@@ -91,7 +101,7 @@ export const ImproveHealth = ({
           options={BUTTON_OPTIONS}
           open={isOpen}
           executing={status === 'idle' ? false : status === 'repay' ? 'primary' : status}
-          disabled={!debtToken || debtBalance === 0}
+          disabled={!debtToken || debtBalance === 0 || debtBalance > (userBalance ?? 0)}
           onPrimary={() => onRepay(debtToken!, debtBalance)}
           onOption={(id) => {
             close()

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
@@ -21,7 +21,7 @@ type Status = 'idle' | 'repay' | OptionId
 
 type ImproveHealthProps = {
   /** The token that's been borrowed that has to be paid back */
-  debtToken: Token
+  debtToken?: Token
   /** Current status of the improve health operation */
   status: Status
 }
@@ -63,10 +63,10 @@ export const ImproveHealth = ({
         label={t`Debt to repay`}
         tokenSelector={
           <TokenLabel
-            blockchainId={debtToken.chain}
-            tooltip={debtToken.symbol}
-            address={debtToken.address}
-            label={debtToken.symbol}
+            blockchainId={debtToken?.chain}
+            tooltip={debtToken?.symbol}
+            address={debtToken?.address}
+            label={debtToken?.symbol ?? '?'}
           />
         }
         maxBalance={maxBalance}

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
@@ -8,6 +8,7 @@ import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Token } from '../../types'
 import { AlertRepayDebtToIncreaseHealth } from '../AlertRepayDebtToIncreaseHealth'
+import { ButtonGetCrvUsd } from '../ButtonGetCrvUsd'
 
 const { Spacing } = SizesAndSpaces
 
@@ -84,20 +85,24 @@ export const ImproveHealth = ({
 
       <AlertRepayDebtToIncreaseHealth />
 
-      <ButtonMenu
+      <Stack gap={Spacing.xs}>
+        <ButtonMenu
           primary={status === 'idle' ? t`Repay debt & increase health` : t`Repaying debt`}
-        options={BUTTON_OPTIONS}
-        open={isOpen}
-        executing={status === 'idle' ? false : status === 'repay' ? 'primary' : status}
-        disabled={!debtToken || debtBalance === 0}
-        onPrimary={() => onRepay(debtToken!, debtBalance)}
-        onOption={(id) => {
-          close()
-          BUTTON_OPTION_CALLBACKS[id]()
-        }}
-        onOpen={open}
-        onClose={close}
-      />
+          options={BUTTON_OPTIONS}
+          open={isOpen}
+          executing={status === 'idle' ? false : status === 'repay' ? 'primary' : status}
+          disabled={!debtToken || debtBalance === 0}
+          onPrimary={() => onRepay(debtToken!, debtBalance)}
+          onOption={(id) => {
+            close()
+            BUTTON_OPTION_CALLBACKS[id]()
+          }}
+          onOpen={open}
+          onClose={close}
+        />
+
+        <ButtonGetCrvUsd />
+      </Stack>
     </Stack>
   )
 }

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/tabs/ImproveHealth.tsx
@@ -85,7 +85,7 @@ export const ImproveHealth = ({
       <AlertRepayDebtToIncreaseHealth />
 
       <ButtonMenu
-        primary={t`Repay debt & increase health`}
+          primary={status === 'idle' ? t`Repay debt & increase health` : t`Repaying debt`}
         options={BUTTON_OPTIONS}
         open={isOpen}
         executing={status === 'idle' ? false : status === 'repay' ? 'primary' : status}


### PR DESCRIPTION
Various fixes and changes I had to make while trying to hook up the feature to the loan app itself. Made it a standalone PR so that the actual hooking up PR is smaller.

Major changes:

1. Add a 'Get crvUSD' button that opens a new tab to the quickswap page with crvUSD pre-selected as 'to' token.
2. Debt token in both tabs are now optional, because of the fact that the data may not yet be present when initially loading the page (async data loading)
3. Add an alert in the close position tab that tells the user he needs an additional crvusd balance in order to close the position.
4. When repaying the debt in the Improve Health tab, I incorrectly set the debt amount as the user's wallet balance, oops! Now shows the user balance instead, but clamped to the debt so that if you press "Max" you basically pay off the entire debt. Also renamed `balance` in the `Token` type to `amount` to more clearly indicate it's not the user balance!
5. Health action info only supported a change in value, not a single static value (in case you just opened the page and haven't changed a thing for your loan yet)
6. All action infos have been made optional

Following this PR, I'll create another PR that splits the action infos into a component each. There's a few more changes I need to make, and while justified at the start, a single `ActionInfos.tsx` component is getting unyieldy.