### PR TITLE
feat: use new prices API fields

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/LlamaMarketExpandedPanel.tsx
@@ -124,7 +124,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
             <Grid size={6}>
               <Metric
                 label={t`Supplied Amount`}
-                value={deposited.earnings.deposited}
+                value={deposited.earnings.totalCurrentAssets}
                 valueOptions={{ unit: type === LlamaMarketType.Lend ? borrowedUnit : 'dollar' }}
               />
             </Grid>

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/PriceCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/PriceCell.tsx
@@ -15,12 +15,11 @@ export const PriceCell = ({ getValue, row, column }: CellContext<LlamaMarket, nu
   const columnId = column.id as LlamaMarketColumnId
   const { data: stats, error: statsError } = useUserMarketStats(market, columnId)
   const { borrowed, earnings: earningsData } = stats ?? {}
-  const { earnings, deposited } = earningsData ?? {}
   const value =
     {
       [LlamaMarketColumnId.UserBorrowed]: borrowed,
-      [LlamaMarketColumnId.UserEarnings]: earnings, // todo: handle other claimable rewards
-      [LlamaMarketColumnId.UserDeposited]: deposited,
+      [LlamaMarketColumnId.UserEarnings]: earningsData?.earnings, // todo: handle other claimable rewards
+      [LlamaMarketColumnId.UserDeposited]: earningsData?.totalCurrentAssets,
     }[column.id] ?? getValue()
   if (!value) {
     return statsError && <ErrorCell error={statsError} />

--- a/apps/main/src/llamalend/entities/lending-vaults.ts
+++ b/apps/main/src/llamalend/entities/lending-vaults.ts
@@ -95,7 +95,7 @@ const {
     return fromEntries(
       recordEntries(positions).map(([chain, positions]) => [
         chain,
-        positions.filter((p) => p.currentShares).map((position) => position.vaultAddress),
+        positions.filter((p) => p.currentShares || p.currentSharesInGauge).map((position) => position.vaultAddress),
       ]),
     )
   },

--- a/packages/prices-api/src/llamalend/models.ts
+++ b/packages/prices-api/src/llamalend/models.ts
@@ -88,6 +88,7 @@ export type UserLendingPosition = {
   firstDeposit: Date
   lastActivity: Date
   currentShares: number
+  currentSharesInGauge: number
 }
 
 export type UserMarketStats = {
@@ -118,6 +119,22 @@ export type UserMarketEarnings = {
   transfersOutAssets: number
   transfersInAssets: number
   transfersOutShares: number
+  transfersSharesToGauge: number
+  transfersSharesFromGauge: number
+  transfersAssetsToGauge: number
+  transfersAssetsFromGauge: number
+  transfersSharesToConvex: number
+  transfersSharesFromConvex: number
+  transfersAssetsToConvex: number
+  transfersAssetsFromConvex: number
+  currentShares: number
+  currentSharesInGauge: number
+  currentSharesInConvex: number
+  currentAssets: number
+  currentAssetsInGauge: number
+  currentAssetsInConvex: number
+  totalCurrentShares: number
+  totalCurrentAssets: number
 }
 
 export type UserMarketSnapshots = UserMarketStats[]

--- a/packages/prices-api/src/llamalend/parsers.ts
+++ b/packages/prices-api/src/llamalend/parsers.ts
@@ -97,6 +97,7 @@ export const parseUserLendingPositions = (
     firstDeposit: toDate(market.first_deposit),
     lastActivity: toDate(market.last_activity),
     currentShares: parseFloat(market.current_shares),
+    currentSharesInGauge: parseFloat(market.current_shares_in_gauge),
   }))
 
 export const parseAllUserMarkets = (x: Responses.GetAllUserMarketsResponse) =>
@@ -130,6 +131,22 @@ export const parseUserMarketEarnings = (x: Responses.GetUserMarketEarningsRespon
   transfersOutAssets: parseFloat(x.transfers_out_assets),
   transfersInAssets: parseFloat(x.transfers_in_assets),
   transfersOutShares: parseFloat(x.transfers_out_shares),
+  transfersSharesToGauge: parseFloat(x.transfers_shares_to_gauge),
+  transfersSharesFromGauge: parseFloat(x.transfers_shares_from_gauge),
+  transfersAssetsToGauge: parseFloat(x.transfers_assets_to_gauge),
+  transfersAssetsFromGauge: parseFloat(x.transfers_assets_from_gauge),
+  transfersSharesToConvex: parseFloat(x.transfers_shares_to_convex),
+  transfersSharesFromConvex: parseFloat(x.transfers_shares_from_convex),
+  transfersAssetsToConvex: parseFloat(x.transfers_assets_to_convex),
+  transfersAssetsFromConvex: parseFloat(x.transfers_assets_from_convex),
+  currentShares: parseFloat(x.current_shares),
+  currentSharesInGauge: parseFloat(x.current_shares_in_gauge),
+  currentSharesInConvex: parseFloat(x.current_shares_in_convex),
+  currentAssets: parseFloat(x.current_assets),
+  currentAssetsInGauge: parseFloat(x.current_assets_in_gauge),
+  currentAssetsInConvex: parseFloat(x.current_assets_in_convex),
+  totalCurrentShares: parseFloat(x.total_current_shares),
+  totalCurrentAssets: parseFloat(x.total_current_assets),
 })
 
 export const parseUserMarketSnapshots = (x: Responses.GetUserMarketSnapshotsResponse): Models.UserMarketSnapshots =>

--- a/packages/prices-api/src/llamalend/responses.ts
+++ b/packages/prices-api/src/llamalend/responses.ts
@@ -111,6 +111,7 @@ export type GetUserLendingPositionsResponse = {
     first_deposit: string
     last_activity: string
     current_shares: string
+    current_shares_in_gauge: string
   }[]
   page: number
   per_page: number
@@ -144,7 +145,7 @@ type UserMarketStats = {
 export type GetUserMarketStatsResponse = UserMarketStats
 
 type UserMarketEarnings = {
-  user: string
+  user: Address
   earnings: string
   deposited: string
   withdrawn: string
@@ -152,6 +153,22 @@ type UserMarketEarnings = {
   transfers_out_shares: string
   transfers_in_assets: string
   transfers_out_assets: string
+  transfers_shares_to_gauge: string
+  transfers_shares_from_gauge: string
+  transfers_assets_to_gauge: string
+  transfers_assets_from_gauge: string
+  transfers_shares_to_convex: string
+  transfers_shares_from_convex: string
+  transfers_assets_to_convex: string
+  transfers_assets_from_convex: string
+  current_shares: string
+  current_shares_in_gauge: string
+  current_shares_in_convex: string
+  current_assets: string
+  current_assets_in_gauge: string
+  current_assets_in_convex: string
+  total_current_shares: string
+  total_current_assets: string
 }
 
 export type GetUserMarketEarningsResponse = UserMarketEarnings


### PR DESCRIPTION
- Use the new fields from the prices API https://github.com/curvefi/curve-prices/pull/531
  - Use the `current_shares_in_gauge` field from the prices API to define which markets have user positions
  - Fix the user supplied value by using the new `total_current_assets` field from the API