### PR TITLE
refactor: re-enable deduplication in token-usd-rate

### DIFF
--- a/packages/curve-ui-kit/src/lib/model/entities/token-usd-rate.ts
+++ b/packages/curve-ui-kit/src/lib/model/entities/token-usd-rate.ts
@@ -20,8 +20,11 @@ export const {
   validationSuite: tokenValidationSuite,
 })
 
-export const useTokenUsdRates = ({ chainId, tokenAddresses = [] }: ChainParams & { tokenAddresses?: string[] }) =>
-  useQueries({
-    queries: tokenAddresses.map((tokenAddress) => getTokenUsdRateQueryOptions({ chainId, tokenAddress })),
-    combine: (results) => combineQueriesToObject(results, tokenAddresses),
+export const useTokenUsdRates = ({ chainId, tokenAddresses = [] }: ChainParams & { tokenAddresses?: string[] }) => {
+  const uniqueAddresses = Array.from(new Set(tokenAddresses))
+
+  return useQueries({
+    queries: uniqueAddresses.map((tokenAddress) => getTokenUsdRateQueryOptions({ chainId, tokenAddress })),
+    combine: (results) => combineQueriesToObject(results, uniqueAddresses),
   })
+}


### PR DESCRIPTION
Changes:
- Re-enabled deduplication in token-usd-rate after encountering warnings, previously removed in: https://github.com/curvefi/curve-frontend/pull/1154/commits/01d8e92e33cc3b80e9874fdfc17ac0603a75dbba