### PR TITLE
feat: show amm and controller addresses in supply

### DIFF
--- a/apps/main/src/lend/components/DetailsMarket/components/DetailsContracts.tsx
+++ b/apps/main/src/lend/components/DetailsMarket/components/DetailsContracts.tsx
@@ -40,7 +40,9 @@ const DetailsContracts = ({
       ],
       [
         { label: t`Vault`, address: addresses?.vault },
-        { label: t`Gauge`, address: addresses?.gauge, invalidText: addresses?.gauge === zeroAddress ? t`No gauge` : '' }
+        { label: t`Gauge`, address: addresses?.gauge, invalidText: addresses?.gauge === zeroAddress ? t`No gauge` : '' },
+        { label: 'AMM', address: addresses?.amm },
+        { label: t`Controller`, address: addresses?.controller },
       ],
     ]
   }


### PR DESCRIPTION
Changes:
- Added 'controller' and 'amm' to displayed contracts in the supply section for lending markets