### PR TITLE
styling: token pairs

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/MarketTitleCell/MarketTitleCell.tsx
@@ -19,7 +19,10 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
   const isMobile = useIsMobile()
   return (
     <Stack direction="row" gap={Spacing.sm} alignItems="center" sx={{ height: Sizing[700] }}>
-      <TokenPair chain={market.chain} assets={market.assets} />
+      <TokenPair
+        chain={market.chain}
+        assets={{ primary: market.assets.collateral, secondary: market.assets.borrowed }}
+      />
       <Stack direction="column" justifyContent="center" gap={Spacing.xxs}>
         <Typography
           component={Stack}

--- a/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
@@ -39,7 +39,7 @@ export const TokenPair = ({ chain, assets: { borrowed, collateral }, hideChainIc
     {!hideChainIcon && (
       <Tooltip title={chain} placement="top" slotProps={{ popper: { sx: { textTransform: 'capitalize' } } }}>
         <Box sx={{ position: 'absolute', top: '-16.66%', left: '-16.66%' }}>
-          <ChainIcon size="xs" blockchainId={chain} />
+          <ChainIcon size="sm" blockchainId={chain} />
         </Box>
       </Tooltip>
     )}

--- a/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
@@ -17,28 +17,31 @@ type Props = {
     borrowed: Asset
     collateral: Asset
   }
+  hideChainIcon?: boolean
 }
 
-export const TokenPair = ({ chain, assets: { borrowed, collateral } }: Props) => (
-  <Box sx={{ position: 'relative', width: IconSize.xxl, height: IconSize.xxl }}>
+export const TokenPair = ({ chain, assets: { borrowed, collateral }, hideChainIcon = false }: Props) => (
+  <Box sx={{ position: 'relative', width: IconSize.xl, height: IconSize.xl }}>
     <TokenIcon
       blockchainId={chain}
       address={borrowed.address}
       tooltip={borrowed.symbol}
-      sx={{ position: 'absolute', top: '30%', left: '30%' }}
+      sx={{ position: 'absolute', top: '33%', left: '33%' }}
     />
 
     <TokenIcon
       blockchainId={chain}
       address={collateral.address}
       tooltip={collateral.symbol}
-      sx={{ position: 'absolute', bottom: '30%', right: '30%' }}
+      sx={{ position: 'absolute', bottom: '33%', right: '33%' }}
     />
 
-    <Tooltip title={chain} placement="top" slotProps={{ popper: { sx: { textTransform: 'capitalize' } } }}>
-      <Box sx={{ position: 'absolute', top: '0%', left: '0%' }}>
-        <ChainIcon size="xs" blockchainId={chain} />
-      </Box>
-    </Tooltip>
+    {!hideChainIcon && (
+      <Tooltip title={chain} placement="top" slotProps={{ popper: { sx: { textTransform: 'capitalize' } } }}>
+        <Box sx={{ position: 'absolute', top: '-16.66%', left: '-16.66%' }}>
+          <ChainIcon size="xs" blockchainId={chain} />
+        </Box>
+      </Tooltip>
+    )}
   </Box>
 )

--- a/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenPair.tsx
@@ -14,25 +14,25 @@ type Asset = {
 type Props = {
   chain: string
   assets: {
-    borrowed: Asset
-    collateral: Asset
+    primary: Asset
+    secondary: Asset
   }
   hideChainIcon?: boolean
 }
 
-export const TokenPair = ({ chain, assets: { borrowed, collateral }, hideChainIcon = false }: Props) => (
+export const TokenPair = ({ chain, assets: { primary, secondary }, hideChainIcon = false }: Props) => (
   <Box sx={{ position: 'relative', width: IconSize.xl, height: IconSize.xl }}>
     <TokenIcon
       blockchainId={chain}
-      address={borrowed.address}
-      tooltip={borrowed.symbol}
+      address={secondary.address}
+      tooltip={secondary.symbol}
       sx={{ position: 'absolute', top: '33%', left: '33%' }}
     />
 
     <TokenIcon
       blockchainId={chain}
-      address={collateral.address}
-      tooltip={collateral.symbol}
+      address={primary.address}
+      tooltip={primary.symbol}
       sx={{ position: 'absolute', bottom: '33%', right: '33%' }}
     />
 

--- a/packages/curve-ui-kit/src/shared/ui/stories/TokenPair.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/TokenPair.stories.ts
@@ -26,6 +26,7 @@ const meta: Meta<typeof TokenPair> = {
         address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       },
     },
+    hideChainIcon: false,
   },
 }
 
@@ -70,6 +71,12 @@ export const WithFallback: Story = {
         address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       },
     },
+  },
+}
+
+export const NoChainIcon: Story = {
+  args: {
+    hideChainIcon: true,
   },
 }
 

--- a/packages/curve-ui-kit/src/shared/ui/stories/TokenPair.stories.ts
+++ b/packages/curve-ui-kit/src/shared/ui/stories/TokenPair.stories.ts
@@ -17,11 +17,11 @@ const meta: Meta<typeof TokenPair> = {
   args: {
     chain: 'ethereum',
     assets: {
-      borrowed: {
+      primary: {
         symbol: 'ETH',
         address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       },
-      collateral: {
+      secondary: {
         symbol: 'USDC',
         address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       },
@@ -47,11 +47,11 @@ export const ArbitrumPair: Story = {
   args: {
     chain: 'arbitrum',
     assets: {
-      borrowed: {
+      primary: {
         symbol: 'WBTC',
         address: '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f',
       },
-      collateral: {
+      secondary: {
         symbol: 'USDT',
         address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
       },
@@ -62,11 +62,11 @@ export const ArbitrumPair: Story = {
 export const WithFallback: Story = {
   args: {
     assets: {
-      borrowed: {
+      primary: {
         symbol: 'UNKNOWN',
         address: '0x0',
       },
-      collateral: {
+      secondary: {
         symbol: 'ETH',
         address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
       },


### PR DESCRIPTION
1. Increase size of chain icon for better visibility
2. Chain icon is optional
3. Assets names generalized to `primary` and `secondary`, and thus no longer tied to the lending domain
4. Increase spacing between primary and secondary icons so secondary is less obscured

Matches Figma design more closely now

Old:
<img width="250" height="460" alt="image" src="https://github.com/user-attachments/assets/0d009adf-7daf-4037-8166-22d0d7f0e8d2" />

New:
<img width="246" height="459" alt="image" src="https://github.com/user-attachments/assets/0c179c78-080a-4053-bd6d-1c572cef9842" />
