### PR TITLE
PSR Footer + Base vAPY Tooltip

### DIFF
--- a/apps/main/src/dex/components/PageDashboard/components/TableHead.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableHead.tsx
@@ -23,7 +23,7 @@ const TableHead = ({ tableLabel }: { tableLabel: TableLabel }) => {
     handleBtnClickSort,
   }
 
-  const BASE_TOOLTIP = t`Variable APY (vAPY) is the annualised yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`
+  const BASE_TOOLTIP = t`Base variable APY (vAPY) is the annualized yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`
   const OTHERS_TOOLTIP = t`Token APR based on current prices of tokens and reward rates`
 
   return (

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
@@ -48,7 +48,7 @@ const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
             <RewardsTitle>{t`Base vAPY`}</RewardsTitle>
             <Tooltip
               placement="bottom"
-              tooltip={t`Variable APY (vAPY) is the annualised yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`}
+              tooltip={t`Base variable APY (vAPY) is the annualized yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`}
             >
               <StyledInformationIcon name="InformationSquare" size={16} />
             </Tooltip>

--- a/apps/main/src/dex/components/PagePoolList/components/TableHead.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableHead.tsx
@@ -45,7 +45,7 @@ const TableHead = ({
   }
 
   const REWARDS_OTHER_TOOLTIP = t`Token APR based on current prices of tokens and reward rates`
-  const REWARDS_BASE_TOOLTIP = t`Variable APY (vAPY) is the annualised yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`
+  const REWARDS_BASE_TOOLTIP = t`Base variable APY (vAPY) is the annualized yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`
 
   return (
     <>

--- a/apps/main/src/loan/components/PagePegKeepers/components/Footer.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/Footer.tsx
@@ -42,19 +42,19 @@ export const Footer = () => (
       <GridItem title={t`Autonomous peg stabilization`} icon={RebalancingIcon}>
         <strong>{t`Peg Stability Reserves`}</strong>{' '}
         {t`(PSRs) are fully autonomous smart contracts designed to keep crvUSD close to $1. Each PSR monitors the price in a specific Curve pool.`}{' '}
-        {t`When the price deviates too far from $1,`} <strong>{t`anyone can trigger a rebalancing`}</strong>{' '}
-        {t`action—minting or burning crvUSD—to restore the peg. These actions are only allowed when on‑chain conditions are met, and callers receive a small reward for valid execution.`}
+        {t`When the price deviates too far from $1,`} <strong>{t`anyone can trigger a rebalance`}</strong>{' '}
+        {t`action to restore the peg. These actions are only allowed when on‑chain conditions are met, and callers receive a small reward for valid execution.`}
       </GridItem>
 
       <GridItem title={t`Automated Market-Based Arbitrage, On-Chain`} icon={ArbitrageIcon}>
         {t`If crvUSD trades`} <strong>{t`above $1`}</strong> {t`PSR mints and adds crvUSD to the pool. If it trades`}{' '}
         <strong>{t`below $1`}</strong> {t`PSR withdraws and burns crvUSD.`}{' '}
-        {t`Each PSR targets a single Curve pool with set thresholds and a debt cap. Updates are permissionless, rewarded, and triggered the moment conditions are met.`}
+        {t`Each PSR targets a single Curve pool with set thresholds and a debt cap. Rebalances are permissionless, rewarded, and triggered the moment conditions are met.`}
       </GridItem>
 
       <GridItem title={t`Non-Custodial & Risk-Isolated`} icon={SecurityIcon}>
         <strong>{t`PSRs never touch user funds or LLAMMA positions.`}</strong>{' '}
-        {t`They only operate on crvUSD they mint and the LP tokens they hold—within the confines of a single Curve pool.`}{' '}
+        {t`They only operate on crvUSD they mint and the LP tokens they hold — within the confines of a single Curve pool.`}{' '}
         <strong>{t`All logic is on-chain,`}</strong>{' '}
         {t`auditable, and capped by a hard-coded debt ceiling. If the ceiling is reached, minting halts. Users stay safe. The peg stays defended.`}
       </GridItem>


### PR DESCRIPTION
- fixed PSR footer to use consistent wording
- fixed Base vAPY tooltips by adding "Base" at the beginning

cute llama pic:
![llama](https://github.com/user-attachments/assets/1ed8f9b0-557c-459c-b6db-b5b8b45c096d)
