### PR TITLE
feat: stored rate checks for "low exchange rate" warnings

### DIFF
--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -32,6 +32,7 @@ import {
   excludeLowExchangeRateCheck,
   getExchangeRates,
   getSwapIsLowExchangeRate,
+  routerGetToStoredRate,
 } from '@/dex/utils/utilsSwap'
 import type { IProfit } from '@curvefi/api/lib/interfaces'
 import type { DateValue } from '@internationalized/date'
@@ -276,9 +277,10 @@ const router = {
 
         if (Array.isArray(routes) && routes.length === 0 && +output === 0) return resp
 
-        const [fetchedToAmount, priceImpact] = await Promise.all([
+        const [fetchedToAmount, priceImpact, toStoredRate] = await Promise.all([
           curve.router.expected(fromAddress, toAddress, fromAmount),
           curve.router.priceImpact(fromAddress, toAddress, fromAmount),
+          routerGetToStoredRate(routes, curve, toAddress),
         ])
 
         resp = {
@@ -291,6 +293,7 @@ const router = {
             poolsMapper,
             fetchedToAmount,
             toAddress,
+            toStoredRate,
             fromAmount,
             fromAddress,
           ),
@@ -307,9 +310,10 @@ const router = {
 
         if (Array.isArray(routes) && routes.length === 0 && +output === 0) return resp
 
-        const [fetchedToAmount, priceImpact] = await Promise.all([
+        const [fetchedToAmount, priceImpact, toStoredRate] = await Promise.all([
           curve.router.expected(fromAddress, toAddress, fetchedFromAmount),
           curve.router.priceImpact(fromAddress, toAddress, fetchedFromAmount),
+          routerGetToStoredRate(routes, curve, toAddress),
         ])
 
         resp = {
@@ -322,6 +326,7 @@ const router = {
             poolsMapper,
             toAmount,
             toAddress,
+            toStoredRate,
             fetchedFromAmount,
             fromAddress,
             fetchedToAmount,


### PR DESCRIPTION
In stableswap-ng pools with tokens of type "oracle" or "erc4626" we were getting false warnings for low exchange rates. This adds a fetch for the "to" tokens storedRate and uses it in the check if the stored rate is above 1 when checking for low a low exchange rate.

Changes:
- Use stored rates when checking for low exchange rates when the "to" token has a stored rate above 1