### PR TITLE
fix: market borrow position details fixes

### DIFF
--- a/apps/main/src/lend/hooks/useBorrowPositionDetails.ts
+++ b/apps/main/src/lend/hooks/useBorrowPositionDetails.ts
@@ -9,6 +9,7 @@ import { ChainId, OneWayMarketTemplate } from '@/lend/types/lend.types'
 import type { Address, Chain } from '@curvefi/prices-api'
 import { useLendingSnapshots } from '@ui-kit/entities/lending-snapshots'
 import { BorrowPositionDetailsProps } from '@ui-kit/features/market-position-details/BorrowPositionDetails'
+import { calculateRangeToLiquidation } from '@ui-kit/features/market-position-details/utils'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 
 type UseBorrowPositionDetailsProps = {
@@ -96,7 +97,7 @@ export const useBorrowPositionDetails = ({
       value: liquidationPrices ? liquidationPrices.map(Number) : null,
       rangeToLiquidation:
         prices?.prices?.oraclePrice && liquidationPrices
-          ? (Number(liquidationPrices?.[1]) / Number(prices.prices.oraclePrice)) * 100
+          ? calculateRangeToLiquidation(Number(liquidationPrices?.[1]), Number(prices.prices.oraclePrice))
           : null,
       loading: !market || isUserLoanDetailsLoading,
     },

--- a/apps/main/src/lend/hooks/useMarketDetails.tsx
+++ b/apps/main/src/lend/hooks/useMarketDetails.tsx
@@ -59,6 +59,7 @@ export const useMarketDetails = ({
   const lendApy = marketDetails.rates?.lendApy ?? marketRate?.rates?.lendApy
 
   return {
+    blockchainId: networks[chainId as keyof typeof networks]?.id as Chain,
     collateral: {
       symbol: llamma?.collateral_token.symbol ?? null,
       tokenAddress: llamma?.collateral_token.address,

--- a/apps/main/src/loan/hooks/useLoanPositionDetails.ts
+++ b/apps/main/src/loan/hooks/useLoanPositionDetails.ts
@@ -10,6 +10,7 @@ import { ChainId, Llamma } from '@/loan/types/loan.types'
 import { Address } from '@curvefi/prices-api'
 import { useCrvUsdSnapshots } from '@ui-kit/entities/crvusd-snapshots'
 import { BorrowPositionDetailsProps } from '@ui-kit/features/market-position-details/BorrowPositionDetails'
+import { calculateRangeToLiquidation } from '@ui-kit/features/market-position-details/utils'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 
 type UseLoanPositionDetailsProps = {
@@ -104,7 +105,7 @@ export const useLoanPositionDetails = ({
       value: userPrices ? userPrices.map(Number) : null,
       rangeToLiquidation:
         loanDetails?.priceInfo?.oraclePrice && userPrices
-          ? (Number(userPrices?.[1]) / Number(loanDetails.priceInfo.oraclePrice)) * 100
+          ? calculateRangeToLiquidation(Number(userPrices?.[1]), Number(loanDetails.priceInfo.oraclePrice))
           : null,
       loading: userLoanDetailsLoading ?? true,
     },

--- a/apps/main/src/loan/hooks/useMarketDetails.ts
+++ b/apps/main/src/loan/hooks/useMarketDetails.ts
@@ -4,7 +4,7 @@ import { CRVUSD_ADDRESS } from '@/loan/constants'
 import networks from '@/loan/networks'
 import useStore from '@/loan/store/useStore'
 import { ChainId, Llamma } from '@/loan/types/loan.types'
-import { Address } from '@curvefi/prices-api'
+import { Address, Chain } from '@curvefi/prices-api'
 import { useCrvUsdSnapshots } from '@ui-kit/entities/crvusd-snapshots'
 import { MarketDetailsProps } from '@ui-kit/features/market-details'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -44,6 +44,7 @@ export const useMarketDetails = ({ chainId, llamma, llammaId }: UseMarketDetails
   }, [crvUsdSnapshots])
 
   return {
+    blockchainId: networks[chainId as keyof typeof networks]?.id as Chain,
     collateral: {
       symbol: llamma?.collateralSymbol ?? null,
       tokenAddress: llamma?.collateral,

--- a/packages/curve-ui-kit/src/features/market-details/index.tsx
+++ b/packages/curve-ui-kit/src/features/market-details/index.tsx
@@ -51,6 +51,7 @@ export type MarketDetailsProps = {
   lendingAPY?: LendingAPY
   availableLiquidity: AvailableLiquidity
   maxLeverage?: MaxLeverage
+  blockchainId: string
 }
 
 const formatLiquidity = (value: number) =>
@@ -63,6 +64,7 @@ export const MarketDetails = ({
   lendingAPY,
   availableLiquidity,
   maxLeverage,
+  blockchainId,
 }: MarketDetailsProps) => {
   const utilization =
     availableLiquidity?.value && availableLiquidity.max
@@ -128,6 +130,7 @@ export const MarketDetails = ({
           symbol={collateral?.symbol}
           tokenAddress={collateral?.tokenAddress}
           loading={collateral?.total == null && collateral?.loading}
+          blockchainId={blockchainId}
         />
         <SymbolCell
           size={'medium'}
@@ -135,6 +138,7 @@ export const MarketDetails = ({
           symbol={borrowToken?.symbol}
           tokenAddress={borrowToken?.tokenAddress}
           loading={borrowToken?.symbol == null && borrowToken?.loading}
+          blockchainId={blockchainId}
         />
         {/* Insert empty box to maintain grid layout when there is no lending APY metric */}
         {!lendingAPY && <Box />}

--- a/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
@@ -148,8 +148,14 @@ export const BorrowInformation = ({
         loading={liquidationRange?.value == null && liquidationRange?.loading}
         valueOptions={dollarUnitOptions}
         valueTooltip={{
-          title: t`Liquidation threshold`,
-          body: <LiquidityThresholdTooltip liquidationRange={liquidationRange} bandRange={bandRange} />,
+          title: t`Liquidation Threshold (LT)`,
+          body: (
+            <LiquidityThresholdTooltip
+              liquidationRange={liquidationRange}
+              rangeToLiquidation={liquidationRange?.rangeToLiquidation}
+              bandRange={bandRange}
+            />
+          ),
           placement: 'top',
           arrow: false,
           clickable: true,
@@ -159,8 +165,7 @@ export const BorrowInformation = ({
             ? {
                 value: liquidationRange.rangeToLiquidation,
                 unit: {
-                  // negative rangeToLiquidation happens when the position is inside or below the liquidation range
-                  symbol: `% ${liquidationRange.rangeToLiquidation > 0 ? 'Buffer to liquidation' : 'to liquidation threshold'}`,
+                  symbol: `% distance to LT`,
                   position: 'suffix',
                 },
                 decimals: 2,

--- a/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
@@ -96,6 +96,7 @@ export const BorrowInformation = ({
           body: <CollateralMetricTooltip collateralValue={collateralValue} />,
           placement: 'top',
           arrow: false,
+          clickable: true,
         }}
       />
       <Metric
@@ -136,6 +137,7 @@ export const BorrowInformation = ({
             body: <PnlMetricTooltip pnl={pnl} />,
             placement: 'top',
             arrow: false,
+            clickable: true,
           }}
         />
       )}
@@ -150,6 +152,7 @@ export const BorrowInformation = ({
           body: <LiquidityThresholdTooltip liquidationRange={liquidationRange} bandRange={bandRange} />,
           placement: 'top',
           arrow: false,
+          clickable: true,
         }}
         notional={
           liquidationRange?.rangeToLiquidation

--- a/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/BorrowInformation.tsx
@@ -158,7 +158,11 @@ export const BorrowInformation = ({
           liquidationRange?.rangeToLiquidation
             ? {
                 value: liquidationRange.rangeToLiquidation,
-                unit: { symbol: '% Buffer to liquidation', position: 'suffix' },
+                unit: {
+                  // negative rangeToLiquidation happens when the position is inside or below the liquidation range
+                  symbol: `% ${liquidationRange.rangeToLiquidation > 0 ? 'Buffer to liquidation' : 'to liquidation threshold'}`,
+                  position: 'suffix',
+                },
                 decimals: 2,
               }
             : undefined

--- a/packages/curve-ui-kit/src/features/market-position-details/tooltips/CollateralMetricTooltip.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/tooltips/CollateralMetricTooltip.tsx
@@ -14,7 +14,7 @@ const UnavailableNotation = '-'
 
 const formatMetricValue = (value?: number | null) => {
   if (value === 0) return '0'
-  if (value) return formatNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  if (value) return formatNumber(value, { notation: 'compact' })
   return UnavailableNotation
 }
 
@@ -60,17 +60,39 @@ export const CollateralMetricTooltip = ({ collateralValue }: CollateralMetricToo
 
         <Stack direction="row" justifyContent="space-between" gap={5}>
           <Typography variant="bodySRegular">{t`Deposit token`}</Typography>
-          <Stack direction="row" gap={2}>
-            <Typography variant="bodySBold">{`${collateralValueFormatted} ${collateralValue?.collateral?.symbol ?? UnavailableNotation}`}</Typography>
-            {collateralPercentage && <Typography variant="bodySRegular">{`(${collateralPercentage})`}</Typography>}
+          <Stack
+            direction="row"
+            gap={2}
+            sx={{
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <Typography
+              variant="bodySBold"
+              sx={{ textAlign: 'right', whiteSpace: 'nowrap' }}
+            >{`${collateralValueFormatted} ${collateralValue?.collateral?.symbol ?? UnavailableNotation}`}</Typography>
+            {collateralPercentage && (
+              <Typography variant="bodySRegular" sx={{ textAlign: 'right' }}>{`(${collateralPercentage})`}</Typography>
+            )}
           </Stack>
         </Stack>
 
         <Stack direction="row" justifyContent="space-between" gap={5}>
           <Typography variant="bodySRegular">{collateralValue?.borrow?.symbol ?? UnavailableNotation}</Typography>
-          <Stack direction="row" gap={2}>
-            <Typography variant="bodySBold">{`${crvUSDValueFormatted} ${collateralValue?.borrow?.symbol ?? UnavailableNotation}`}</Typography>
-            <Typography variant="bodySRegular">{`(${crvUSDPercentage})`}</Typography>
+          <Stack
+            direction="row"
+            gap={2}
+            sx={{
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <Typography
+              variant="bodySBold"
+              sx={{ textAlign: 'right', whiteSpace: 'nowrap' }}
+            >{`${crvUSDValueFormatted} ${collateralValue?.borrow?.symbol ?? UnavailableNotation}`}</Typography>
+            <Typography variant="bodySRegular" sx={{ textAlign: 'right' }}>{`(${crvUSDPercentage})`}</Typography>
           </Stack>
         </Stack>
       </Stack>

--- a/packages/curve-ui-kit/src/features/market-position-details/tooltips/LiquidityThresholdMetricTooltip.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/tooltips/LiquidityThresholdMetricTooltip.tsx
@@ -8,17 +8,28 @@ const { Spacing } = SizesAndSpaces
 
 type LiquidityThresholdTooltipProps = {
   liquidationRange: LiquidationRange | undefined | null
+  rangeToLiquidation: number | undefined | null
   bandRange: BandRange | undefined | null
 }
 
 const UnavailableNotation = '-'
 
-export const LiquidityThresholdTooltip = ({ liquidationRange, bandRange }: LiquidityThresholdTooltipProps) => (
+export const LiquidityThresholdTooltip = ({
+  liquidationRange,
+  rangeToLiquidation,
+  bandRange,
+}: LiquidityThresholdTooltipProps) => (
   <Stack gap={3} sx={{ maxWidth: '20rem' }}>
-    <Typography variant="bodySRegular">{t`The price at which your position enters liquidation protection and your collateral starts to be eroded.`}</Typography>
-
+    <Typography variant="bodySRegular">
+      {t`The price at which your position enters the liquidation zone  and your collateral starts to be eroded by LLAMMA. The distance to LT indicates the distance between the current price and the LT.`}
+    </Typography>
     <Stack gap={2} display="column" sx={{ backgroundColor: (t) => t.design.Layer[2].Fill, padding: Spacing.sm }}>
-      <Typography variant="bodySBold">{t`Breakdown`}</Typography>
+      <Stack direction="row" justifyContent="space-between" gap={5}>
+        <Typography variant="bodySRegular">{t`Distance to LT`}</Typography>
+        <Typography variant="bodySBold">
+          {rangeToLiquidation ? formatNumber(rangeToLiquidation, { ...FORMAT_OPTIONS.PERCENT }) : UnavailableNotation}
+        </Typography>
+      </Stack>
 
       <Stack direction="row" justifyContent="space-between" gap={5}>
         <Typography variant="bodySRegular">{t`Liquidation threshold`}</Typography>

--- a/packages/curve-ui-kit/src/features/market-position-details/utils.ts
+++ b/packages/curve-ui-kit/src/features/market-position-details/utils.ts
@@ -1,0 +1,2 @@
+export const calculateRangeToLiquidation = (upperLiquidationPrice: number, oraclePrice: number) =>
+  ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * 100

--- a/packages/curve-ui-kit/src/features/market-position-details/utils.ts
+++ b/packages/curve-ui-kit/src/features/market-position-details/utils.ts
@@ -1,6 +1,2 @@
-export const calculateRangeToLiquidation = (upperLiquidationPrice: number, oraclePrice: number) => {
-  // show negative buffer to liquidation price if already inside soft liquidation range
-  if (oraclePrice > upperLiquidationPrice) return ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * -100
-
-  return ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * 100
-}
+export const calculateRangeToLiquidation = (upperLiquidationPrice: number, oraclePrice: number) =>
+  ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * 100

--- a/packages/curve-ui-kit/src/features/market-position-details/utils.ts
+++ b/packages/curve-ui-kit/src/features/market-position-details/utils.ts
@@ -1,2 +1,6 @@
-export const calculateRangeToLiquidation = (upperLiquidationPrice: number, oraclePrice: number) =>
-  ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * 100
+export const calculateRangeToLiquidation = (upperLiquidationPrice: number, oraclePrice: number) => {
+  // show negative buffer to liquidation price if already inside soft liquidation range
+  if (oraclePrice > upperLiquidationPrice) return ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * -100
+
+  return ((oraclePrice - upperLiquidationPrice) / upperLiquidationPrice) * 100
+}

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -79,8 +79,8 @@ type Notional = Formatting & {
 /** Merges default formatting options with user-provided formatting options. */
 const getFormattingDefaults = (formatting: Formatting) => ({
   abbreviate: true,
-  decimals: 1,
-  formatter: (value: number) => formatValue(value, formatting.decimals ?? 1),
+  decimals: 2,
+  formatter: (value: number) => formatValue(value, formatting.decimals ?? 2),
   ...formatting,
 })
 

--- a/packages/curve-ui-kit/src/shared/ui/SymbolCell.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/SymbolCell.tsx
@@ -10,10 +10,18 @@ type SymbolCellProps = {
   tokenAddress: string | undefined | null
   loading: boolean
   size?: keyof Pick<typeof MetricSize, 'small' | 'medium'>
+  blockchainId: string
 }
 
 /** Mimics the style of Metric but is used for cells that only have a symbol and a token icon. */
-export const SymbolCell = ({ label, symbol, tokenAddress, loading, size = 'medium' }: SymbolCellProps) => (
+export const SymbolCell = ({
+  label,
+  symbol,
+  tokenAddress,
+  loading,
+  size = 'medium',
+  blockchainId,
+}: SymbolCellProps) => (
   <Stack alignItems={'start'}>
     <Typography variant="bodyXsRegular" color="textTertiary">
       {label}
@@ -21,7 +29,7 @@ export const SymbolCell = ({ label, symbol, tokenAddress, loading, size = 'mediu
     <WithSkeleton loading={loading}>
       <Stack direction="row" alignItems="baseline" gap={1}>
         <Typography variant={MetricSize[size]}>{symbol == null ? t`N/A` : symbol}</Typography>
-        <TokenIcon address={tokenAddress} size={'mui-sm'} />
+        <TokenIcon blockchainId={blockchainId} address={tokenAddress} size={'mui-sm'} />
       </Stack>
     </WithSkeleton>
   </Stack>


### PR DESCRIPTION
Changes:
- Set default decimals for Metric component to 2 (from 1)
- Fix "buffer to liquidation" calculation
- Fix collateral value tooltip wrapping issue
- Fix sidechain token icon src paths in SymbolCell
- Refactor liquidation threshold tooltip, rename notional value to "Distance to LT"