### PR TITLE
chore: bump llamalend-js to 1.0.27

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@curvefi/api": "2.68.2",
-    "@curvefi/llamalend-api": "1.0.24",
+    "@curvefi/llamalend-api": "1.0.27",
     "@ethersproject/abi": "^5.8.0",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,15 +1989,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:1.0.24":
-  version: 1.0.24
-  resolution: "@curvefi/llamalend-api@npm:1.0.24"
+"@curvefi/llamalend-api@npm:1.0.27":
+  version: 1.0.27
+  resolution: "@curvefi/llamalend-api@npm:1.0.27"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.15"
     bignumber.js: "npm:^9.3.0"
     ethers: "npm:^6.14.3"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/59b29a9bcde1eedd9c4616a251d5c3b4e025a0e7d43fc7bd48fa770d7b08925639a8f9e6d9b5513fb29c9a98d8b3cf88084eef1f307bced9045679b1c1d20862
+  checksum: 10c0/c8c8f074c96b3575b34c19b69d1ff9283134df18eab220ec32027286a55d3ea84856dcccfa34526d8bf06ab3c576b13029ea290c9f15a3306e73977a69953834
   languageName: node
   linkType: hard
 
@@ -15974,7 +15974,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:2.68.2"
-    "@curvefi/llamalend-api": "npm:1.0.24"
+    "@curvefi/llamalend-api": "npm:1.0.27"
     "@ethersproject/abi": "npm:^5.8.0"
     "@hookform/error-message": "npm:^2.0.1"
     "@hookform/resolvers": "npm:^5.0.1"


### PR DESCRIPTION
Changes:
- Bumped llamalend-js to 1.0.27 https://github.com/curvefi/curve-llamalend.js/pull/36