### PR TITLE
fix: staking incentives being shown when there are none in tooltip

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/LendRateTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/LendRateTooltip.tsx
@@ -45,7 +45,9 @@ const LendRateTooltipContent = ({ market }: { market: LlamaMarket }) => {
               {formatPercent(borrowed.rebasingYield)}
             </TooltipItem>
           )}
-          <RewardsTooltipItems title={t`Staking incentives`} {...{ poolRewards, extraIncentives }} />
+          {poolRewards.length + extraIncentives.length > 0 && (
+            <RewardsTooltipItems title={t`Staking incentives`} {...{ poolRewards, extraIncentives }} />
+          )}
         </TooltipItems>
         <TooltipItems>
           <TooltipItem primary title={`${t`Total APR`}`}>


### PR DESCRIPTION
Removes empty rendering of staking incentives when there are none. Example would be optimism wsteth pool

<img width="457" height="216" alt="image" src="https://github.com/user-attachments/assets/d6659624-6b5a-4330-a892-5223eafe2fba" />
<img width="279" height="75" alt="image" src="https://github.com/user-attachments/assets/fcb102f4-2226-4c96-b5ca-5873dca34695" />

