### PR TITLE
feat: top page progress bar loader

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -36,6 +36,7 @@
     "memoizee": "^0.4.17",
     "next": "15.3.5",
     "next-images": "^1.8.5",
+    "nextjs-toploader": "^3.8.16",
     "react": "*",
     "react-dom": "*",
     "react-hook-form": "7.59.0",

--- a/apps/main/src/app/GlobalLayout.tsx
+++ b/apps/main/src/app/GlobalLayout.tsx
@@ -14,6 +14,7 @@ import { APP_LINK, AppMenuOption, type AppName } from '@ui-kit/shared/routes'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { Footer } from '@ui-kit/widgets/Footer'
 import { Header as Header } from '@ui-kit/widgets/Header'
+import NextTopLoader from 'nextjs-toploader'
 
 const { MinHeight } = SizesAndSpaces
 
@@ -65,6 +66,16 @@ export const GlobalLayout = <TId extends string, TChainId extends number>({
   networks: NetworkMapping<TId, TChainId>
 }) => (
   <Stack sx={EXPAND_WHEN_HIDDEN}>
+    <NextTopLoader
+      color="var(--primary-400)"
+      initialPosition={0.1}
+      crawlSpeed={200}
+      height={5}
+      crawl={true}
+      showSpinner={false}
+      easing="ease"
+      speed={200}
+    />
     <Header
       currentApp={currentApp}
       chainId={network.chainId}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15591,6 +15591,7 @@ __metadata:
     memoizee: "npm:^0.4.17"
     next: "npm:15.3.5"
     next-images: "npm:^1.8.5"
+    nextjs-toploader: "npm:^3.8.16"
     pinst: "npm:^3.0.0"
     react: "npm:*"
     react-dom: "npm:*"
@@ -16172,6 +16173,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nextjs-toploader@npm:^3.8.16":
+  version: 3.8.16
+  resolution: "nextjs-toploader@npm:3.8.16"
+  dependencies:
+    nprogress: "npm:^0.2.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    next: ">= 6.0.0"
+    react: ">= 16.0.0"
+    react-dom: ">= 16.0.0"
+  checksum: 10c0/b705a81638dbf68d6c278b391ae00be1e59e823e7085ad3a4f638b804b007603d6bfe7c5d84e94770dd04cae3eb7101acf8df7bdcf0144bcc40f6a9f8a25e85b
+  languageName: node
+  linkType: hard
+
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -16333,6 +16348,13 @@ __metadata:
   dependencies:
     path-key: "npm:^3.0.0"
   checksum: 10c0/6f9353a95288f8455cf64cbeb707b28826a7f29690244c1e4bb61ec573256e021b6ad6651b394eb1ccfd00d6ec50147253aba2c5fe58a57ceb111fad62c519ac
+  languageName: node
+  linkType: hard
+
+"nprogress@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "nprogress@npm:0.2.0"
+  checksum: 10c0/eab9a923a1ad1eed71a455ecfbc358442dd9bcd71b9fa3fa1c67eddf5159360b182c218f76fca320c97541a1b45e19ced04e6dcb044a662244c5419f8ae9e821
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Description:**
When navigating between pages, the current UI does not indicate that the next page is loading on the server.
This lack of feedback can cause users to think their click didn’t register, leading to multiple clicks or leaving the page, especially noticeable on the /llamalend page.

**Solution:**
Implemented a top-page progress bar to visually indicate loading state during page transitions. Using the project’s theme colors.

**Preview:**

https://github.com/user-attachments/assets/c3d6ab98-b11a-4c30-bb65-e6eca2514898



