### PR TITLE
feat: add swap tab to savings crvusd that opens new window to quickswap

### DIFF
--- a/apps/main/src/dex/lib/networks.ts
+++ b/apps/main/src/dex/lib/networks.ts
@@ -7,6 +7,7 @@ import { fromEntries, recordValues } from '@curvefi/prices-api/objects.util'
 import type { NetworkDef } from '@ui/utils'
 import { getBaseNetworksConfig, NETWORK_BASE_CONFIG } from '@ui/utils/utilsNetworks'
 import { CRVUSD_ROUTES, getInternalUrl } from '@ui-kit/shared/routes'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 import { Chain } from '@ui-kit/utils/network'
 
 export const defaultNetworks = Object.entries({
@@ -59,7 +60,7 @@ export const defaultNetworks = Object.entries({
     ],
     createQuickList: [
       {
-        address: '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
+        address: CRVUSD_ADDRESS,
         haveSameTokenName: false,
         symbol: 'crvUSD',
       },

--- a/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/constants.ts
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/constants.ts
@@ -1,6 +1,0 @@
-import { SubNavItem } from '@/loan/components/PageCrvUsdStaking/components/SubNav/types'
-
-export const SUB_NAV_ITEMS: SubNavItem[] = [
-  { key: 'deposit', label: 'Deposit' },
-  { key: 'withdraw', label: 'Withdraw' },
-]

--- a/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/DepositWithdraw/index.tsx
@@ -2,13 +2,13 @@ import { useEffect } from 'react'
 import { styled } from 'styled-components'
 import useStore from '@/loan/store/useStore'
 import { useConnection } from '@ui-kit/features/connect-wallet'
+import { DEX_ROUTES, getInternalUrl } from '@ui-kit/shared/routes'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import SubNav from '../components/SubNav'
-import type { SubNavItem } from '../components/SubNav/types'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
+import SubNav, { SUB_NAV_ITEMS, type SubNavItem } from '../components/SubNav'
 import { TransactionDetails } from '../components/TransactionDetails'
 import TransactionTracking from '../TransactionTracking'
 import type { DepositWithdrawModule } from '../types'
-import { SUB_NAV_ITEMS } from './constants'
 import DeployButton from './DeployButton'
 import DepositModule from './DepositModule'
 import WithdrawModule from './WithdrawModule'
@@ -36,7 +36,12 @@ const DepositWithdraw = ({ className }: DepositWithdrawProps) => {
   const { llamaApi: curve = null } = useConnection()
 
   const setNavChange = (key: SubNavItem['key']) => {
-    setStakingModule(key as DepositWithdrawModule)
+    // Swapping opens a new browser tab for now, temp solution until it can be replaced with an actual tab and an Enzo zap in the future.
+    if (key === 'swap') {
+      window.open(`${getInternalUrl('dex', 'ethereum', DEX_ROUTES.PAGE_SWAP)}?to=${CRVUSD_ADDRESS}`, '_blank')
+    } else {
+      setStakingModule(key as DepositWithdrawModule)
+    }
   }
 
   const transactionInProgress =

--- a/apps/main/src/loan/components/PageCrvUsdStaking/components/SubNav/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/components/SubNav/index.tsx
@@ -1,14 +1,21 @@
 import { styled } from 'styled-components'
-import { SubNavItem } from '@/loan/components/PageCrvUsdStaking/components/SubNav/types'
 import Box from '@ui/Box'
 import Button from '@ui/Button'
 
+export const SUB_NAV_ITEMS = [
+  { key: 'deposit', label: 'Deposit' },
+  { key: 'withdraw', label: 'Withdraw' },
+  { key: 'swap', label: 'Swap' },
+] as const
+
+export type SubNavItem = (typeof SUB_NAV_ITEMS)[number]
+
 interface SubNavProps {
   activeKey: string
-  navItems: SubNavItem[]
+  navItems: readonly SubNavItem[]
   nested?: boolean
   className?: string
-  setNavChange: (key: string) => void
+  setNavChange: (key: SubNavItem['key']) => void
 }
 
 const SubNav = ({ activeKey, navItems, setNavChange, nested, className }: SubNavProps) => (

--- a/apps/main/src/loan/components/PageCrvUsdStaking/components/SubNav/types.ts
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/components/SubNav/types.ts
@@ -1,4 +1,0 @@
-export interface SubNavItem {
-  key: string
-  label: string
-}

--- a/apps/main/src/loan/components/PagePegKeepers/constants.ts
+++ b/apps/main/src/loan/components/PagePegKeepers/constants.ts
@@ -1,4 +1,5 @@
 import { DEX_ROUTES, getInternalUrl } from '@ui-kit/shared/routes'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 
 export const CRVUSD_UNIT = { symbol: 'crvUSD', position: 'suffix' as const, abbreviate: true }
 
@@ -12,10 +13,7 @@ export const PEG_KEEPERS = [
       name: 'crvUSD/USDC',
       address: '0x4dece678ceceb27446b35c672dc7d61f30bad69e',
       underlyingCoins: ['USDC', 'crvUSD'],
-      underlyingCoinAddresses: [
-        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
-      ],
+      underlyingCoinAddresses: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', CRVUSD_ADDRESS],
     },
   },
   {
@@ -27,10 +25,7 @@ export const PEG_KEEPERS = [
       name: 'crvUSD/USDT',
       address: '0x390f3595bca2df7d23783dfd126427cceb997bf4',
       underlyingCoins: ['USDT', 'crvUSD'],
-      underlyingCoinAddresses: [
-        '0xdac17f958d2ee523a2206206994597c13d831ec7',
-        '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
-      ],
+      underlyingCoinAddresses: ['0xdac17f958d2ee523a2206206994597c13d831ec7', CRVUSD_ADDRESS],
     },
   },
   {
@@ -42,10 +37,7 @@ export const PEG_KEEPERS = [
       name: 'crvUSD/pyUSD',
       address: '0x625e92624bc2d88619accc1788365a69767f6200',
       underlyingCoins: ['PYUSD', 'crvUSD'],
-      underlyingCoinAddresses: [
-        '0x6c3ea9036406852006290770bedfcaba0e23a0e8',
-        '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
-      ],
+      underlyingCoinAddresses: ['0x6c3ea9036406852006290770bedfcaba0e23a0e8', CRVUSD_ADDRESS],
     },
   },
 ] as const

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ManageSoftLiquidation.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { fn } from 'storybook/test'
 import { ethAddress } from 'viem'
 import type { Meta, StoryObj } from '@storybook/nextjs'
-import type { Address } from '@ui-kit/utils'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 import type { TokenOption } from '../select-token'
 import { ManageSoftLiquidation, type Props, type ImproveHealthProps, type ClosePositionProps } from './'
 
@@ -10,7 +10,7 @@ type Token = TokenOption & { amount: number }
 
 const debtToken: Token = {
   symbol: 'crvUSD',
-  address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E' as Address,
+  address: CRVUSD_ADDRESS,
   amount: 321.01,
 }
 
@@ -23,7 +23,7 @@ const collateralToRecover = [
   },
   {
     symbol: 'crvUSD',
-    address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E' as Address,
+    address: CRVUSD_ADDRESS,
     amount: 12450,
     usd: 12450,
   },

--- a/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ButtonGetCrvUsd.tsx
+++ b/packages/curve-ui-kit/src/features/manage-soft-liquidation/ui/ButtonGetCrvUsd.tsx
@@ -4,10 +4,9 @@ import Link from '@mui/material/Link'
 import { usePathname } from '@ui-kit/hooks/router'
 import { DEX_ROUTES, getCurrentNetwork, getInternalUrl } from '@ui-kit/shared/routes'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 
 const { IconSize } = SizesAndSpaces
-
-const CRVUSD_ADDRESS = '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e'
 
 /**
  * Button component that redirects users to the DEX swap page with crvUSD pre-selected as the destination token.

--- a/packages/curve-ui-kit/src/themes/stories/Card.stories.tsx
+++ b/packages/curve-ui-kit/src/themes/stories/Card.stories.tsx
@@ -10,6 +10,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { TokenPair } from '@ui-kit/shared/ui/TokenPair'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 import { SizesAndSpaces } from '../design/1_sizes_spaces'
 
 const { Spacing } = SizesAndSpaces
@@ -82,7 +83,7 @@ const CardStoryTokenPairAvatar = (props: CardProps) => (
           hideChainIcon
           chain="ethereum"
           assets={{
-            primary: { symbol: 'crvUSD', address: '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e' },
+            primary: { symbol: 'crvUSD', address: CRVUSD_ADDRESS },
             secondary: { symbol: 'USDC', address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' },
           }}
         />

--- a/packages/curve-ui-kit/src/utils/address.ts
+++ b/packages/curve-ui-kit/src/utils/address.ts
@@ -34,3 +34,5 @@ export function shortenAddress(address: string | undefined, options?: ShortenAdd
 
   return `${addr.slice(0, digits + 2)}...${addr.slice(-digits)}`
 }
+
+export const CRVUSD_ADDRESS = '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e'


### PR DESCRIPTION
Temporary solution until we find the bandwidth to implement Enzo zaps. I know I know, `window.open()` is kinda ugly...

<img width="503" height="567" alt="image" src="https://github.com/user-attachments/assets/6935e263-6aa8-4909-8fb3-a872516c02b0" />
