### PR TITLE
refactor: remove unused code

### DIFF
--- a/apps/main/src/lend/lib/apiLending.ts
+++ b/apps/main/src/lend/lib/apiLending.ts
@@ -1,14 +1,11 @@
-import type { Eip1193Provider } from 'ethers'
 import lodash from 'lodash'
 import { zeroAddress } from 'viem'
-import networks from '@/lend/networks'
 import { USE_API } from '@/lend/shared/config'
 import type { LiqRange } from '@/lend/store/types'
 import {
   Api,
   BandsBalances,
   BandsBalancesArr,
-  ChainId,
   DetailInfoLeverageResp,
   DetailInfoResp,
   EstimatedGas,
@@ -47,16 +44,6 @@ import { BN, shortenAccount } from '@ui/utils'
 import { waitForTransaction, waitForTransactions } from '@ui-kit/lib/ethers'
 
 export const helpers = {
-  initApi: async (chainId: ChainId, provider?: Eip1193Provider) => {
-    if (!provider) return
-    if (!(chainId in networks)) {
-      throw new Error(`ChainId ${chainId} not supported`)
-    }
-    const network = networks[chainId].networkId
-    const api = lodash.cloneDeep((await import('@curvefi/llamalend-api')).default) as Api
-    await api.init('Web3', { network, externalProvider: provider }, { chainId })
-    return api
-  },
   getIsUserCloseToLiquidation: (
     userFirstBand: number,
     userLiquidationBand: number | null,

--- a/apps/main/src/loan/utils/utilsCurvejs.ts
+++ b/apps/main/src/loan/utils/utilsCurvejs.ts
@@ -1,20 +1,7 @@
-import type { Eip1193Provider } from 'ethers'
 import lodash from 'lodash'
-import networks from '@/loan/networks'
-import { BandBalance, ChainId, type LlamaApi, HealthColorKey, Llamma, UserLoanDetails } from '@/loan/types/loan.types'
+import { BandBalance, HealthColorKey, Llamma, UserLoanDetails } from '@/loan/types/loan.types'
 import PromisePool from '@supercharge/promise-pool'
 import { BN } from '@ui/utils'
-
-export async function initLlamaApi(
-  chainId: ChainId,
-  externalProvider?: Eip1193Provider,
-): Promise<LlamaApi | undefined> {
-  if (!externalProvider) return
-  const network = networks[chainId].networkId
-  const api = lodash.cloneDeep((await import('@curvefi/llamalend-api')).default) as LlamaApi
-  await api.init('Web3', { network, externalProvider }, { chainId })
-  return api
-}
 
 export function getIsUserCloseToLiquidation(
   userFirstBand: number,


### PR DESCRIPTION
- The lazy import of the libraries is not used anymore, as the apps are imported directly in the ui-kit
- The code can be removed to avoid warnings