### PR TITLE
styling: move market details into the same container as the rest of market information

### DIFF
--- a/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/lend/components/ChartOhlcWrapper/index.tsx
@@ -382,7 +382,7 @@ const ChartOhlcWrapper = ({ rChainId, userActiveKey, rOwmId, betaBackgroundColor
       </LpEventsWrapperExpanded>
     </ExpandedWrapper>
   ) : (
-    <Wrapper className={isAdvancedMode ? '' : 'normal-mode'} chartExpanded={chartExpanded}>
+    <Wrapper chartExpanded={chartExpanded}>
       <SelectorRow>
         <SelectorButton
           variant={'text'}
@@ -430,12 +430,6 @@ const Wrapper = styled(Box)<{ chartExpanded: boolean }>`
   display: flex;
   flex-direction: column;
   padding: ${(props) => (props.chartExpanded ? 'var(--spacing-3)' : '0')};
-  &.normal-mode {
-    padding: var(--spacing-3);
-    @media screen and (min-width: 53.125rem) {
-      padding: 2rem;
-    }
-  }
 `
 
 const SelectorRow = styled.div`

--- a/apps/main/src/lend/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/Page.tsx
@@ -225,14 +225,16 @@ const Page = (params: MarketUrlParams) => {
                 <NoPosition type="borrow" />
               </Stack>
             </MarketInformationTabs>
-            <MarketDetails {...marketDetails} />
-            <MarketInformationComp
-              pageProps={pageProps}
-              chartExpanded={chartExpanded}
-              userActiveKey={userActiveKey}
-              type="borrow"
-              page="create"
-            />
+            <Stack>
+              <MarketDetails {...marketDetails} />
+              <MarketInformationComp
+                pageProps={pageProps}
+                chartExpanded={chartExpanded}
+                userActiveKey={userActiveKey}
+                type="borrow"
+                page="create"
+              />
+            </Stack>
           </Stack>
         </Stack>
       )}

--- a/apps/main/src/lend/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/Page.tsx
@@ -258,14 +258,16 @@ const Page = (params: MarketUrlParams) => {
                 </Stack>
               )}
             </MarketInformationTabs>
-            <MarketDetails {...marketDetails} />
-            <MarketInformationComp
-              pageProps={pageProps}
-              chartExpanded={chartExpanded}
-              userActiveKey={userActiveKey}
-              type="borrow"
-              loanExists={loanExists}
-            />
+            <Stack>
+              <MarketDetails {...marketDetails} />
+              <MarketInformationComp
+                pageProps={pageProps}
+                chartExpanded={chartExpanded}
+                userActiveKey={userActiveKey}
+                type="borrow"
+                loanExists={loanExists}
+              />
+            </Stack>
           </Stack>
         </Stack>
       )}

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -249,13 +249,15 @@ const Page = (params: MarketUrlParams) => {
                 </Stack>
               )}
             </MarketInformationTabs>
-            <MarketDetails {...marketDetails} />
-            <MarketInformationComp
-              pageProps={pageProps}
-              chartExpanded={chartExpanded}
-              userActiveKey={''}
-              type="supply"
-            />
+            <Stack>
+              <MarketDetails {...marketDetails} />
+              <MarketInformationComp
+                pageProps={pageProps}
+                chartExpanded={chartExpanded}
+                userActiveKey={''}
+                type="supply"
+              />
+            </Stack>
           </Stack>
         </Stack>
       )}

--- a/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
+++ b/apps/main/src/loan/components/ChartOhlcWrapper/index.tsx
@@ -331,7 +331,7 @@ const ChartOhlcWrapper = ({ rChainId, llamma, llammaId, betaBackgroundColor }: C
       </LpEventsWrapperExpanded>
     </ExpandedWrapper>
   ) : (
-    <Wrapper className={isAdvancedMode ? '' : 'normal-mode'} chartExpanded={chartExpanded}>
+    <Wrapper chartExpanded={chartExpanded}>
       <SelectorRow>
         <SelectorButton
           variant={'text'}
@@ -377,12 +377,6 @@ const Wrapper = styled(Box)<{ chartExpanded: boolean }>`
   display: flex;
   flex-direction: column;
   padding: ${(props) => (props.chartExpanded ? 'var(--spacing-3)' : '0')};
-  &.normal-mode {
-    padding: var(--spacing-3);
-    @media screen and (min-width: 53.125rem) {
-      padding: 2rem;
-    }
-  }
 `
 
 const SelectorRow = styled.div`

--- a/apps/main/src/loan/components/LoanInfoLlamma/index.tsx
+++ b/apps/main/src/loan/components/LoanInfoLlamma/index.tsx
@@ -27,7 +27,7 @@ const LoanInfoLlamma = (props: Props) => {
       </div>
 
       {!chartExpanded && (
-        <div className={isAdvancedMode ? 'wrapper' : ''}>
+        <div className="wrapper">
           <ChartOhlcWrapper {...props} />
         </div>
       )}

--- a/apps/main/src/loan/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/Page.tsx
@@ -264,15 +264,16 @@ const Page = (params: CollateralUrlParams) => {
                 <NoPosition type="borrow" />
               </Stack>
             )}
-
-            <MarketDetails {...marketDetails} />
-            <MarketInformationComp
-              llamma={llamma}
-              llammaId={llammaId}
-              chainId={rChainId}
-              chartExpanded={chartExpanded}
-              page="create"
-            />
+            <Stack>
+              <MarketDetails {...marketDetails} />
+              <MarketInformationComp
+                llamma={llamma}
+                llammaId={llammaId}
+                chainId={rChainId}
+                chartExpanded={chartExpanded}
+                page="create"
+              />
+            </Stack>
           </Stack>
         </Stack>
       )}

--- a/apps/main/src/loan/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/Page.tsx
@@ -274,14 +274,16 @@ const Page = (params: CollateralUrlParams) => {
                 <NoPosition type="borrow" />
               </Stack>
             )}
-            <MarketDetails {...marketDetails} />
-            <MarketInformationComp
-              llamma={llamma}
-              llammaId={llammaId}
-              chainId={rChainId}
-              chartExpanded={chartExpanded}
-              page="manage"
-            />
+            <Stack>
+              <MarketDetails {...marketDetails} />
+              <MarketInformationComp
+                llamma={llamma}
+                llammaId={llammaId}
+                chainId={rChainId}
+                chartExpanded={chartExpanded}
+                page="manage"
+              />
+            </Stack>
           </Stack>
         </Stack>
       )}


### PR DESCRIPTION
Changes:
- Moved market details section on /loan and /lend market pages to the same container as the rest of the market information (chart, bands, parameters)
- Fixed padding for chart container in the old market layout when in "normal" mode

<img width="819" height="667" alt="SCR-20250816-mxxc" src="https://github.com/user-attachments/assets/48af3571-5106-4a40-aa86-89fe83f2259b" />