### PR TITLE
fix: snapshot endpoints called too early

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/BorrowRateTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/BorrowRateTooltip.tsx
@@ -9,7 +9,8 @@ import { useSnapshots } from '../../hooks/useSnapshots'
 
 const rateType = MarketRateType.Borrow
 
-export const BorrowRateTooltip = ({ market, children }: { market: LlamaMarket; children: ReactElement }) => {
+const BorrowRateTooltipContent = ({ market }: { market: LlamaMarket }) => {
+  const { averageRate, period } = useSnapshots(market, rateType) // important: only call this one tooltip is open!
   const {
     rewards,
     type: marketType,
@@ -18,28 +19,23 @@ export const BorrowRateTooltip = ({ market, children }: { market: LlamaMarket; c
       collateral: { rebasingYield, symbol: collateralSymbol },
     },
   } = market
-  const { averageRate, period } = useSnapshots(market, rateType)
   const poolRewards = useFilteredRewards(rewards, marketType, rateType)
-
   return (
-    <Tooltip
-      clickable
-      title={t`Borrow Rate`}
-      body={
-        <MarketBorrowRateTooltipContent
-          marketType={marketType}
-          borrowRate={borrowRate}
-          averageRate={averageRate}
-          periodLabel={period}
-          totalBorrowRate={borrowTotalApy}
-          extraRewards={poolRewards}
-          rebasingYield={rebasingYield}
-          collateralSymbol={collateralSymbol}
-        />
-      }
-      placement="top"
-    >
-      {children}
-    </Tooltip>
+    <MarketBorrowRateTooltipContent
+      marketType={marketType}
+      borrowRate={borrowRate}
+      averageRate={averageRate}
+      periodLabel={period}
+      totalBorrowRate={borrowTotalApy}
+      extraRewards={poolRewards}
+      rebasingYield={rebasingYield}
+      collateralSymbol={collateralSymbol}
+    />
   )
 }
+
+export const BorrowRateTooltip = ({ market, children }: { market: LlamaMarket; children: ReactElement }) => (
+  <Tooltip clickable title={t`Borrow Rate`} body={<BorrowRateTooltipContent market={market} />} placement="top">
+    {children}
+  </Tooltip>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/LendRateTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/RateCell/LendRateTooltip.tsx
@@ -9,8 +9,8 @@ import { useSnapshots } from '../../hooks/useSnapshots'
 
 const rateType = MarketRateType.Supply
 
-export const LendRateTooltip = ({ market, children }: { market: LlamaMarket; children: ReactElement }) => {
-  const { averageRate, period } = useSnapshots(market, rateType)
+const LendRateTooltipContent = ({ market }: { market: LlamaMarket }) => {
+  const { averageRate, period } = useSnapshots(market, rateType) // important: only call this one tooltip is open!
   const {
     rates,
     rates: { lend, lendApr, lendCrvAprUnboosted, lendCrvAprBoosted, lendTotalApyMaxBoosted },
@@ -22,27 +22,24 @@ export const LendRateTooltip = ({ market, children }: { market: LlamaMarket; chi
   const poolRewards = useFilteredRewards(rewards, marketType, rateType)
 
   return (
-    <Tooltip
-      clickable
-      title={t`Supply Yield`}
-      body={
-        <MarketSupplyRateTooltipContent
-          supplyRate={lendApr}
-          averageRate={averageRate}
-          periodLabel={period}
-          extraRewards={poolRewards}
-          extraIncentives={rates.incentives}
-          minBoostApr={lendCrvAprUnboosted}
-          maxBoostApr={lendCrvAprBoosted}
-          totalSupplyRateMinBoost={lend}
-          totalSupplyRateMaxBoost={lendTotalApyMaxBoosted}
-          rebasingYield={borrowed?.rebasingYield}
-          isLoading={averageRate == null}
-        />
-      }
-      placement="top"
-    >
-      {children}
-    </Tooltip>
+    <MarketSupplyRateTooltipContent
+      supplyRate={lendApr}
+      averageRate={averageRate}
+      periodLabel={period}
+      extraRewards={poolRewards}
+      extraIncentives={rates.incentives}
+      minBoostApr={lendCrvAprUnboosted}
+      maxBoostApr={lendCrvAprBoosted}
+      totalSupplyRateMinBoost={lend}
+      totalSupplyRateMaxBoost={lendTotalApyMaxBoosted}
+      rebasingYield={borrowed?.rebasingYield}
+      isLoading={averageRate == null}
+    />
   )
 }
+
+export const LendRateTooltip = ({ market, children }: { market: LlamaMarket; children: ReactElement }) => (
+  <Tooltip clickable title={t`Supply Yield`} body={<LendRateTooltipContent market={market} />} placement="top">
+    {children}
+  </Tooltip>
+)


### PR DESCRIPTION
- Split content of the tooltips so the snapshots are not called for every single market, causing performance issues on the frontend and backend