### PR TITLE
fix: test id for graph column (desktop only)

### DIFF
--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -322,8 +322,8 @@ const selectCoin = (symbol: string, type: TokenType) => {
 }
 
 function enableGraphColumn() {
-  cy.get(`[data-testid="line-graph-borrow"]`).should('not.exist')
+  cy.get(`[data-testid="line-graph-${MarketRateType.Borrow}"]`).should('not.exist')
   cy.get(`[data-testid="btn-visibility-settings"]`).click()
   cy.get(`[data-testid="visibility-toggle-borrowChart"]`).click()
-  cy.get(`[data-testid="line-graph-borrow"]`).first().scrollIntoView()
+  cy.get(`[data-testid="line-graph-${MarketRateType.Borrow}"]`).first().scrollIntoView()
 }


### PR DESCRIPTION
Fixes a flaky test that was broken after the market rate refactor