### PR TITLE
chore: disable telemetry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: CI
 on: [push]
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  DO_NOT_TRACK: 1
+  IBM_TELEMETRY_DISABLED: true
+
 jobs:
   lint:
     timeout-minutes: 6


### PR DESCRIPTION
- disable data collection for turbopack and IBM carbon packages
- these variables have also been added to vercel
- add them to your own machine if wished