### PR TITLE
chore: render dao app before hydration is done

### DIFF
--- a/apps/main/src/app/dao/layout.tsx
+++ b/apps/main/src/app/dao/layout.tsx
@@ -33,5 +33,5 @@ export default function DaoLayout({ children }: { children: ReactNode }) {
   useGasInfoAndUpdateLib({ chainId, networks }) // Refresh gas info on a regular interval, relies on a side-effect
   useAutoRefresh(isHydrated)
 
-  return isHydrated && children
+  return children
 }


### PR DESCRIPTION
- This should allow the proposal list to show the loading state while the gauges are still being loaded