### PR TITLE
fix: remove prices api pagination

### DIFF
--- a/packages/prices-api/package.json
+++ b/packages/prices-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curvefi/prices-api",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/prices-api/src/chains/api.ts
+++ b/packages/prices-api/src/chains/api.ts
@@ -12,7 +12,7 @@ export async function getSupportedChains(options?: Options) {
 
 export async function getChainInfo(chain: Chain, options?: Options) {
   const host = getHost(options)
-  const resp = await fetch<Responses.GetChainInfoResponse>(`${host}/v1/chains/${chain}?page=1&per_page=1`)
+  const resp = await fetch<Responses.GetChainInfoResponse>(`${host}/v1/chains/${chain}`)
 
   return Parsers.parseChainInfo(resp)
 }


### PR DESCRIPTION
Lots of the CurveMonitor website is broken atm because pagination was removed from the api for chain info

After merging this PR I'll need to update the curvemonitor website to use the new library version