### PR TITLE
fix: loading indicator

### DIFF
--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -119,6 +119,10 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
         [basicMuiTheme.breakpoints.up('tablet')]: { marginInlineStart: SizesAndSpaces.Spacing.xs.tablet },
         [basicMuiTheme.breakpoints.up('desktop')]: { marginInlineStart: SizesAndSpaces.Spacing.xs.desktop },
       },
+      loading: {
+        // loading will show a `md` IconButton by default, which is too large for our buttons => force the size to `xs`
+        svg: { width: ButtonSize.xs, height: ButtonSize.xs },
+      },
     },
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -119,10 +119,6 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
         [basicMuiTheme.breakpoints.up('tablet')]: { marginInlineStart: SizesAndSpaces.Spacing.xs.tablet },
         [basicMuiTheme.breakpoints.up('desktop')]: { marginInlineStart: SizesAndSpaces.Spacing.xs.desktop },
       },
-      loading: {
-        // loading will show a `md` IconButton by default, which is too large for our buttons => force the size to `xs`
-        svg: { width: ButtonSize.xs, height: ButtonSize.xs },
-      },
     },
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/button/mui-icon-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-icon-button.ts
@@ -49,5 +49,9 @@ export const defineMuiIconButton = ({ Button, Layer, Text }: DesignSystem): Comp
     // colorInfo: { '&:hover': { color: Button.Info.Hover.Label, backgroundColor: Button.Info.Hover.Fill } },
     // colorSuccess: { '&:hover': { color: Button.Success.Hover.Label, backgroundColor: Button.Success.Hover.Fill } },
     // colorWarning: { '&:hover': { color: Button.Warning.Hover.Label, backgroundColor: Button.Warning.Hover.Fill } },
+    loadingIndicator: {
+      // IconButton sizes change the size of all svg, but the loading indicator gets larger than its container
+      svg: { maxWidth: '100%', maxHeight: '100%' },
+    },
   },
 })


### PR DESCRIPTION
- IconButton sizes change the size of all svg, but the loading indicator gets larger than its container