### PR TITLE
feat: table header tooltips

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/columns.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/columns.tsx
@@ -1,6 +1,6 @@
 import { LlamaMarket } from '@/llamalend/entities/llama-markets'
 import { LlamaMarketColumnId } from '@/llamalend/PageLlamaMarkets/columns.enum'
-import { ColumnDef, createColumnHelper, FilterFnOption } from '@tanstack/react-table'
+import { ColumnDef, createColumnHelper, FilterFnOption, type ColumnMeta } from '@tanstack/react-table'
 import { type DeepKeys } from '@tanstack/table-core'
 import { t } from '@ui-kit/lib/i18n'
 import { MarketRateType } from '@ui-kit/types/market'
@@ -14,8 +14,34 @@ import {
   UtilizationCell,
 } from './cells'
 import { boolFilterFn, filterByText, listFilterFn, multiFilterFn } from './filters'
+import {
+  CollateralBorrowHeaderTooltip,
+  BorrowRateHeaderTooltip,
+  LendRateHeaderTooltip,
+  UtilizationHeaderTooltip,
+  LiquidityUsdHeaderTooltip,
+} from './header-tooltips'
 
 const columnHelper = createColumnHelper<LlamaMarket>()
+
+const headers = {
+  [LlamaMarketColumnId.Assets]: t`Collateral • Borrow`,
+  [LlamaMarketColumnId.UserHealth]: t`Health`,
+  [LlamaMarketColumnId.UserBorrowed]: t`Borrow Amount`,
+  [LlamaMarketColumnId.UserEarnings]: t`My Earnings`,
+  [LlamaMarketColumnId.UserDeposited]: t`Supplied Amount`,
+  [LlamaMarketColumnId.BorrowRate]: t`Borrow Rate`,
+  [LlamaMarketColumnId.LendRate]: t`Supply Yield`,
+  [LlamaMarketColumnId.BorrowChart]: t`7D Rate Chart`,
+  [LlamaMarketColumnId.UtilizationPercent]: t`Utilization`,
+  [LlamaMarketColumnId.LiquidityUsd]: t`Available Liquidity`,
+} as const
+
+type Tooltip = ColumnMeta<never, never>['tooltip']
+const createTooltip = (id: keyof typeof headers, body: React.ReactNode): Tooltip => ({
+  title: headers[id],
+  body,
+})
 
 /** Define a hidden column. */
 const hidden = (field: DeepKeys<LlamaMarket>, id: LlamaMarketColumnId, filterFn: FilterFnOption<LlamaMarket>) =>
@@ -30,34 +56,35 @@ type LlamaColumn = ColumnDef<LlamaMarket, any>
 /** Columns for the lending markets table. */
 export const LLAMA_MARKET_COLUMNS = [
   columnHelper.accessor(LlamaMarketColumnId.Assets, {
-    header: t`Collateral • Borrow`,
+    header: headers[LlamaMarketColumnId.Assets],
     cell: MarketTitleCell,
     filterFn: filterByText,
+    meta: { tooltip: createTooltip(LlamaMarketColumnId.Assets, CollateralBorrowHeaderTooltip) },
   }),
   columnHelper.display({
     id: LlamaMarketColumnId.UserHealth,
-    header: t`Health`,
+    header: headers[LlamaMarketColumnId.UserHealth],
     cell: PercentageCell,
     meta: { type: 'numeric', hideZero: true },
     sortUndefined: 'last',
   }),
   columnHelper.display({
     id: LlamaMarketColumnId.UserBorrowed,
-    header: t`Borrow Amount`,
+    header: headers[LlamaMarketColumnId.UserBorrowed],
     cell: PriceCell,
     meta: { type: 'numeric', borderRight: true },
     sortUndefined: 'last',
   }),
   columnHelper.display({
     id: LlamaMarketColumnId.UserEarnings,
-    header: t`My Earnings`,
+    header: headers[LlamaMarketColumnId.UserEarnings],
     cell: PriceCell,
     meta: { type: 'numeric', hidden: true }, // hidden until we have a backend
     sortUndefined: 'last',
   }),
   columnHelper.display({
     id: LlamaMarketColumnId.UserDeposited,
-    header: t`Supplied Amount`,
+    header: headers[LlamaMarketColumnId.UserDeposited],
     cell: PriceCell,
     meta: { type: 'numeric', borderRight: true },
     filterFn: boolFilterFn,
@@ -65,32 +92,32 @@ export const LLAMA_MARKET_COLUMNS = [
   }),
   columnHelper.accessor('rates.borrow', {
     id: LlamaMarketColumnId.BorrowRate,
-    header: t`Borrow Rate`,
+    header: headers[LlamaMarketColumnId.BorrowRate],
     cell: RateCell,
-    meta: { type: 'numeric' },
+    meta: { type: 'numeric', tooltip: createTooltip(LlamaMarketColumnId.BorrowRate, BorrowRateHeaderTooltip) },
     sortUndefined: 'last',
   }),
   columnHelper.accessor('rates.lend', {
     id: LlamaMarketColumnId.LendRate,
-    header: t`Supply Yield`,
+    header: headers[LlamaMarketColumnId.LendRate],
     cell: RateCell,
-    meta: { type: 'numeric' },
+    meta: { type: 'numeric', tooltip: createTooltip(LlamaMarketColumnId.LendRate, LendRateHeaderTooltip) },
     sortUndefined: 'last',
   }),
   columnHelper.accessor('rates.borrow', {
     id: LlamaMarketColumnId.BorrowChart,
-    header: t`7D Rate Chart`,
+    header: headers[LlamaMarketColumnId.BorrowChart],
     cell: (c) => <LineGraphCell market={c.row.original} type={MarketRateType.Borrow} />,
   }),
   columnHelper.accessor(LlamaMarketColumnId.UtilizationPercent, {
-    header: t`Utilization`,
+    header: headers[LlamaMarketColumnId.UtilizationPercent],
     cell: UtilizationCell,
-    meta: { type: 'numeric' },
+    meta: { type: 'numeric', tooltip: createTooltip(LlamaMarketColumnId.UtilizationPercent, UtilizationHeaderTooltip) },
   }),
   columnHelper.accessor(LlamaMarketColumnId.LiquidityUsd, {
-    header: t`Available Liquidity`,
+    header: headers[LlamaMarketColumnId.LiquidityUsd],
     cell: CompactUsdCell,
-    meta: { type: 'numeric' },
+    meta: { type: 'numeric', tooltip: createTooltip(LlamaMarketColumnId.LiquidityUsd, LiquidityUsdHeaderTooltip) },
   }),
   // Following columns are used in tanstack filter, but they are displayed together in MarketTitleCell
   hidden(LlamaMarketColumnId.Chain, LlamaMarketColumnId.Chain, multiFilterFn),

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/BorrowRateHeaderTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/BorrowRateHeaderTooltip.tsx
@@ -1,0 +1,28 @@
+import { t } from '@ui-kit/lib/i18n'
+import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents'
+
+export default (
+  <TooltipWrapper>
+    <TooltipDescription
+      text={t`The borrow rate is the cost related to your borrow. Depending on the market type it is correlated to different variables.`}
+    />
+    <TooltipDescription
+      text={
+        <>
+          {t`For`} <strong>{t`lending markets`}</strong> {t`it varies according to the market utilization.`}
+        </>
+      }
+    />
+    <TooltipDescription
+      text={
+        <>
+          {t`For`} <strong>{t`minting markets`}</strong> {t`it varies according to the the peg of`}{' '}
+          <em>{t`crvUSD`}.</em>
+        </>
+      }
+    />
+    <TooltipDescription
+      text={t`Collateral does not earn this rate. Intrinsic yield of LSTs is not taken into account for borrow rates.`}
+    />
+  </TooltipWrapper>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/CollateralBorrowHeaderTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/CollateralBorrowHeaderTooltip.tsx
@@ -1,0 +1,26 @@
+import { t } from '@ui-kit/lib/i18n'
+import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents'
+
+export default (
+  <TooltipWrapper>
+    <TooltipDescription text={t`The pair of assets in this market.`} />
+    <TooltipDescription
+      text={
+        <>
+          {t`The first asset is the collateral used to borrow.`}
+          <br />
+          {t`The second is the asset you can either borrow or lend.`}
+        </>
+      }
+    />
+    <TooltipDescription
+      text={
+        <>
+          <em>{t`Note`}</em>
+          {': '}
+          {t`Some markets may not support lending and only allow borrowing (minting). Lending availability is shown by a non-zero Supply Rate.`}
+        </>
+      }
+    />
+  </TooltipWrapper>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/LendRateHeaderTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/LendRateHeaderTooltip.tsx
@@ -1,0 +1,10 @@
+import { t } from '@ui-kit/lib/i18n'
+import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents'
+
+export default (
+  <TooltipWrapper>
+    <TooltipDescription text={t`The annualized yield earned by lenders of the borrowable asset.`} />
+    <TooltipDescription text={t`May include both interest and external incentives.`} />
+    <TooltipDescription text={t`Does not apply to collateral.`} />
+  </TooltipWrapper>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/LiquidityUsdHeaderTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/LiquidityUsdHeaderTooltip.tsx
@@ -1,0 +1,11 @@
+import { t } from '@ui-kit/lib/i18n'
+import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents'
+
+export default (
+  <TooltipWrapper>
+    <TooltipDescription text={t`Total unborrowed supply in the market.`} />
+    <TooltipDescription
+      text={t`Represents how much of the borrowable asset (e.g., crvUSD) is currently available for new loans or withdrawals.`}
+    />
+  </TooltipWrapper>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/UtilizationHeaderTooltip.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/UtilizationHeaderTooltip.tsx
@@ -1,0 +1,9 @@
+import { t } from '@ui-kit/lib/i18n'
+import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents'
+
+export default (
+  <TooltipWrapper>
+    <TooltipDescription text={t`Percentage of supplied funds currently borrowed.`} />
+    <TooltipDescription text={t`High utilization may increase borrow rates and reduce available liquidity.`} />
+  </TooltipWrapper>
+)

--- a/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/index.ts
+++ b/apps/main/src/llamalend/PageLlamaMarkets/header-tooltips/index.ts
@@ -1,0 +1,5 @@
+export { default as CollateralBorrowHeaderTooltip } from './CollateralBorrowHeaderTooltip'
+export { default as BorrowRateHeaderTooltip } from './BorrowRateHeaderTooltip'
+export { default as LendRateHeaderTooltip } from './LendRateHeaderTooltip'
+export { default as UtilizationHeaderTooltip } from './UtilizationHeaderTooltip'
+export { default as LiquidityUsdHeaderTooltip } from './LiquidityUsdHeaderTooltip'

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.d.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.d.ts
@@ -1,6 +1,7 @@
 import '@tanstack/table-core'
 import type { RowData } from '@tanstack/table-core'
 import type { TypographyVariantKey } from '@ui-kit/themes/typography'
+import type { TooltipProps } from '../Tooltip'
 
 /**
  * Extend the tanstack ColumnMeta interface to add our custom properties
@@ -12,6 +13,7 @@ declare module '@tanstack/react-table' {
     variant?: TypographyVariantKey
     borderRight?: boolean
     hideZero?: boolean
+    tooltip?: Omit<TooltipProps, 'children'>
   }
 
   interface TableMeta<TData extends RowData> {}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/HeaderCell.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/HeaderCell.tsx
@@ -4,6 +4,7 @@ import { flexRender, type Header } from '@tanstack/react-table'
 import { ArrowDownIcon } from '@ui-kit/shared/icons/ArrowDownIcon'
 import { RotatableIcon } from '@ui-kit/shared/ui/DataTable/RotatableIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { Tooltip } from '../Tooltip'
 import { getAlignment, getExtraColumnPadding, getFlexAlignment, type TableItem } from './data-table.utils'
 
 const { Spacing, Sizing } = SizesAndSpaces
@@ -20,7 +21,20 @@ export const HeaderCell = <T extends TableItem>({
   const { column } = header
   const isSorted = column.getIsSorted()
   const canSort = column.getCanSort()
-  const { borderRight } = column.columnDef.meta ?? {}
+  const { borderRight, tooltip } = column.columnDef.meta ?? {}
+
+  const cellContent = (
+    <Stack direction="row" justifyContent={getFlexAlignment(column)} alignItems="end">
+      {flexRender(column.columnDef.header, header.getContext())}
+      <RotatableIcon
+        icon={ArrowDownIcon}
+        rotated={isSorted === 'asc'}
+        fontSize={isSorted ? 20 : 0}
+        isEnabled={canSort}
+      />
+    </Stack>
+  )
+
   return (
     <Typography
       component="th"
@@ -52,15 +66,13 @@ export const HeaderCell = <T extends TableItem>({
       data-testid={`data-table-header-${column.id}`}
       variant="tableHeaderS"
     >
-      <Stack direction="row" justifyContent={getFlexAlignment(column)} alignItems="end">
-        {flexRender(column.columnDef.header, header.getContext())}
-        <RotatableIcon
-          icon={ArrowDownIcon}
-          rotated={isSorted === 'asc'}
-          fontSize={isSorted ? 20 : 0}
-          isEnabled={canSort}
-        />
-      </Stack>
+      {tooltip ? (
+        <Tooltip arrow placement="top" {...tooltip}>
+          {cellContent}
+        </Tooltip>
+      ) : (
+        cellContent
+      )}
     </Typography>
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/TooltipComponents.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TooltipComponents.tsx
@@ -97,4 +97,6 @@ export const TooltipWrapper = ({ children }: { children: ReactNode }) => (
   </Stack>
 )
 
-export const TooltipDescription = ({ text }: { text: string }) => <Typography variant="bodySRegular">{text}</Typography>
+export const TooltipDescription = ({ text }: { text: string | React.ReactNode }) => (
+  <Typography variant="bodySRegular">{text}</Typography>
+)


### PR DESCRIPTION
Adds tooltips to column headers for:

1. Borrow / collateral
2. Borrow Rate
3. Supply Yield
4. Utilization
5. Available Liquidity

Notion ticket also wants tooltips for
1. Min - Max Borrow Rate
2. Max LTV (Loan-to-Value)

But we don't have these columns yet

<img width="656" height="401" alt="image" src="https://github.com/user-attachments/assets/f9205d56-d4e2-4e99-ab94-bdc1a5eae2f5" />
