### PR TITLE
fix: health cell tooltip

### DIFF
--- a/apps/main/src/llamalend/PageLlamaMarkets/cells/HealthCell.tsx
+++ b/apps/main/src/llamalend/PageLlamaMarkets/cells/HealthCell.tsx
@@ -1,12 +1,16 @@
 import { useUserMarketStats } from '@/llamalend/entities/llama-market-stats'
 import { LlamaMarket } from '@/llamalend/entities/llama-markets'
 import { LlamaMarketColumnId } from '@/llamalend/PageLlamaMarkets/columns.enum'
+import { Stack } from '@mui/material'
 import { CellContext } from '@tanstack/react-table'
 import { HealthBar } from '@ui-kit/features/market-position-details'
 import { t } from '@ui-kit/lib/i18n.ts'
-import { Tooltip, TooltipContent } from '@ui-kit/shared/ui/Tooltip'
-import { TooltipDescription, TooltipWrapper } from '@ui-kit/shared/ui/TooltipComponents.tsx'
+import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
+import { TooltipDescription } from '@ui-kit/shared/ui/TooltipComponents.tsx'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces.ts'
 import { ErrorCell } from './ErrorCell'
+
+const { Spacing } = SizesAndSpaces
 
 export const HealthCell = ({ row }: CellContext<LlamaMarket, number>) => {
   const { data, error } = useUserMarketStats(row.original, LlamaMarketColumnId.UserHealth)
@@ -14,16 +18,23 @@ export const HealthCell = ({ row }: CellContext<LlamaMarket, number>) => {
   return health == null ? (
     error && <ErrorCell error={error} />
   ) : (
-    <Tooltip title={<HealthTooltip softLiquidation={softLiquidation} />} placement="top">
-      <HealthBar small health={health} softLiquidation={softLiquidation} />
+    <Tooltip
+      title={softLiquidation ? 'Liquidation Protection On' : 'Position active'}
+      body={<HealthTooltipContent softLiquidation={softLiquidation} />}
+      placement="top"
+    >
+      <Stack gap={Spacing.xs}>
+        {health.toFixed(2)}
+        <HealthBar small health={health} softLiquidation={softLiquidation} />
+      </Stack>
     </Tooltip>
   )
 }
 
-const HealthTooltip = ({ softLiquidation }: { softLiquidation: boolean }) => (
-  <TooltipContent title={softLiquidation ? 'Liquidation Protection On' : 'Position active'}>
+const HealthTooltipContent = ({ softLiquidation }: { softLiquidation: boolean }) => (
+  <>
     {softLiquidation ? (
-      <TooltipWrapper>
+      <>
         <TooltipDescription text={t`Liquidation protection enabled.`} />
         <TooltipDescription
           text={[
@@ -31,9 +42,9 @@ const HealthTooltip = ({ softLiquidation }: { softLiquidation: boolean }) => (
             t`Soft-liquidation still applies, and collateral may still be partially converted within the liquidation band.`,
           ].join(' ')}
         />
-      </TooltipWrapper>
+      </>
     ) : (
       <TooltipDescription text={t`You have an active position in this market.`} />
     )}
-  </TooltipContent>
+  </>
 )

--- a/packages/curve-ui-kit/src/features/market-position-details/HealthBar.tsx
+++ b/packages/curve-ui-kit/src/features/market-position-details/HealthBar.tsx
@@ -71,14 +71,11 @@ export const HealthBar = ({ health, softLiquidation, small }: HealthBarProps) =>
   // Clamps health percentage between 0 and 100
   small ? (
     health != null && (
-      <Stack gap={Spacing.xs}>
-        {health.toFixed(2)}
-        <LinearProgress
-          percent={clampPercentage(health)}
-          size="medium"
-          barColor={getHealthTrackColor(health, softLiquidation)}
-        />
-      </Stack>
+      <LinearProgress
+        percent={clampPercentage(health)}
+        size="medium"
+        barColor={getHealthTrackColor(health, softLiquidation)}
+      />
     )
   ) : (
     <Stack sx={{ gap: LABEL_GAP }} paddingBottom={TRACK_BOTTOM_PADDING}>

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -55,7 +55,7 @@ const multiplier: UnitOptions = { symbol: 'x', position: 'suffix' }
 const UNIT_MAP = { none, dollar, percentage, multiplier } as const
 
 type Unit = keyof typeof UNIT_MAP | UnitOptions
-export const UNITS = Object.keys(UNIT_MAP) as unknown as keyof typeof UNIT_MAP
+const UNITS = Object.keys(UNIT_MAP) as unknown as keyof typeof UNIT_MAP
 
 /** Helper function to get UnitOptions from the more liberal Unit type. */
 const getUnit = (unit?: Unit) => (typeof unit === 'string' ? UNIT_MAP[unit] : unit)


### PR DESCRIPTION
The Tooltip component requires an element to be present on initial render. Introducing this dependency across components wasn't a good idea, so I decided to bite the bullet and fix Alu's comment by moving the stack to the cell component.