### PR TITLE
fix: stop loading when leaving page

### DIFF
--- a/apps/main/src/lend/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/Page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import CampaignRewardsBanner from '@/lend/components/CampaignRewardsBanner'
 import ChartOhlcWrapper from '@/lend/components/ChartOhlcWrapper'
 import DetailsMarket from '@/lend/components/DetailsMarket'
@@ -74,27 +74,6 @@ const Page = () => {
     llammaId: rOwmId,
   })
 
-  const fetchInitial = useCallback(
-    async (api: Api, market: OneWayMarketTemplate) => {
-      const { signerAddress } = api
-
-      if (signerAddress) {
-        await fetchUserLoanExists(api, market, true)
-      }
-      setLoaded(true)
-
-      // delay fetch rest after form details are fetch first
-      setTimeout(() => {
-        void fetchAllMarketDetails(api, market, true)
-
-        if (signerAddress) {
-          void fetchUserMarketBalances(api, market, true)
-        }
-      }, REFRESH_INTERVAL['3s'])
-    },
-    [fetchUserLoanExists, fetchAllMarketDetails, fetchUserMarketBalances],
-  )
-
   useEffect(() => {
     if (isSuccess && !market) {
       console.warn(`Market ${rMarket} not found. Redirecting to market list.`)
@@ -103,8 +82,26 @@ const Page = () => {
   }, [isSuccess, market, params, push, rMarket])
 
   useEffect(() => {
+    const fetchInitial = async (api: Api, market: OneWayMarketTemplate) => {
+      if (api.signerAddress) {
+        await fetchUserLoanExists(api, market, true).catch(console.error)
+      }
+      setLoaded(true)
+    }
     if (api && market && isPageVisible) void fetchInitial(api, market)
-  }, [api, fetchInitial, isPageVisible, market])
+  }, [api, fetchUserLoanExists, isPageVisible, market])
+
+  useEffect(() => {
+    // delay fetch rest after form details are fetched first
+    const timer = setTimeout(async () => {
+      if (!api || !market || !isPageVisible || !isLoaded) return
+      await fetchAllMarketDetails(api, market, true)
+      if (api.signerAddress) {
+        await fetchUserMarketBalances(api, market, true)
+      }
+    }, REFRESH_INTERVAL['3s'])
+    return () => clearTimeout(timer)
+  }, [api, fetchAllMarketDetails, fetchUserMarketBalances, isLoaded, isPageVisible, market])
 
   useEffect(() => {
     if (!isMdUp && chartExpanded) {

--- a/apps/main/src/lend/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/Page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import CampaignRewardsBanner from '@/lend/components/CampaignRewardsBanner'
 import ChartOhlcWrapper from '@/lend/components/ChartOhlcWrapper'
 import DetailsMarket from '@/lend/components/DetailsMarket'
@@ -93,29 +93,26 @@ const Page = () => {
   }
   const selectedTab = _getSelectedTab(marketDetailsView, signerAddress)
 
-  const fetchInitial = useCallback(
-    async (api: Api, market: OneWayMarketTemplate) => {
-      const { signerAddress } = api
-      // check for an existing loan
-      const loanExists = signerAddress ? (await fetchUserLoanExists(api, market, true))?.loanExists : false
+  useEffect(() => {
+    const fetchInitial = async (api: Api, market: OneWayMarketTemplate) => {
+      const loanExists = api.signerAddress ? (await fetchUserLoanExists(api, market, true))?.loanExists : false
       if (loanExists) setMarketsStateKey('marketDetailsView', 'user')
       setLoaded(true)
-
-      // delay fetch rest after form details are fetch first
-      setTimeout(() => {
-        void fetchAllMarketDetails(api, market, true)
-
-        if (signerAddress && loanExists) {
-          void fetchAllUserMarketDetails(api, market, true)
-        }
-      }, REFRESH_INTERVAL['3s'])
-    },
-    [fetchAllMarketDetails, fetchAllUserMarketDetails, fetchUserLoanExists, setMarketsStateKey],
-  )
+    }
+    if (api && market && isPageVisible) void fetchInitial(api, market)
+  }, [api, fetchUserLoanExists, isPageVisible, market, setMarketsStateKey])
 
   useEffect(() => {
-    if (api && market && isPageVisible) void fetchInitial(api, market)
-  }, [api, fetchInitial, isPageVisible, market])
+    // delay fetch rest after form details are fetched first
+    const timer = setTimeout(async () => {
+      if (!api || !market || !isPageVisible || !isLoaded) return
+      void fetchAllMarketDetails(api, market, true)
+      if (api.signerAddress && loanExists) {
+        void fetchAllUserMarketDetails(api, market, true)
+      }
+    }, REFRESH_INTERVAL['3s'])
+    return () => clearTimeout(timer)
+  }, [api, fetchAllMarketDetails, fetchAllUserMarketDetails, isLoaded, isPageVisible, loanExists, market])
 
   useEffect(() => {
     if (!isMdUp && chartExpanded) {


### PR DESCRIPTION
- when switching between pages, the timeouts can get in front of each other, making the app slower and slower
- we need to call `clearTimeout` when the callback isn't needed anymore
- we should avoid `setInterval` as that won't take in consideration the function run time