### PR TITLE
refactor: metric number formatting and add unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,10 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
 
+      - name: Unit tests
+        run: yarn run vitest:run
+        working-directory: tests
+
       - name: Start dev server
         run: yarn start 2>&1 | tee dev-server.log &
         working-directory: apps/main

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react": "*",
     "react-dom": "*",
     "typescript": "*",
-    "vite": "*"
+    "vite": "*",
+    "vitest": "*"
   },
   "packageManager": "yarn@4.6.0",
   "lint-staged": {
@@ -59,6 +60,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "typescript": "5.8.3",
-    "vite": "7.1.3"
+    "vite": "7.1.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/curve-ui-kit/package.json
+++ b/packages/curve-ui-kit/package.json
@@ -59,6 +59,7 @@
     "tsconfig": "*",
     "type-fest": "4.41.0",
     "typescript": "*",
-    "vite": "*"
+    "vite": "*",
+    "vitest": "*"
   }
 }

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -55,7 +55,6 @@ const multiplier: UnitOptions = { symbol: 'x', position: 'suffix' }
 const UNIT_MAP = { none, dollar, percentage, multiplier } as const
 
 type Unit = keyof typeof UNIT_MAP | UnitOptions
-const UNITS = Object.keys(UNIT_MAP) as unknown as keyof typeof UNIT_MAP
 
 /** Helper function to get UnitOptions from the more liberal Unit type. */
 const getUnit = (unit?: Unit) => (typeof unit === 'string' ? UNIT_MAP[unit] : unit)

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -11,6 +11,7 @@ import { Tooltip, type TooltipProps } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { TypographyVariantKey } from '@ui-kit/themes/typography'
 import { abbreviateNumber, copyToClipboard, scaleSuffix, type SxProps } from '@ui-kit/utils'
+import { getUnitOptions, type Unit } from '@ui-kit/utils/units'
 import { Duration } from '../../themes/design/0_primitives'
 import { WithSkeleton } from './WithSkeleton'
 
@@ -42,22 +43,6 @@ const MetricChangeSize = {
 } as const satisfies Record<string, TypographyVariantKey>
 
 export const SIZES = Object.keys(MetricSize) as (keyof typeof MetricSize)[]
-
-export type UnitOptions = {
-  symbol: string
-  position: 'prefix' | 'suffix'
-}
-
-const none: UnitOptions = { symbol: '', position: 'suffix' }
-const dollar: UnitOptions = { symbol: '$', position: 'prefix' }
-const percentage: UnitOptions = { symbol: '%', position: 'suffix' }
-const multiplier: UnitOptions = { symbol: 'x', position: 'suffix' }
-const UNIT_MAP = { none, dollar, percentage, multiplier } as const
-
-type Unit = keyof typeof UNIT_MAP | UnitOptions
-
-/** Helper function to get UnitOptions from the more liberal Unit type. */
-const getUnit = (unit?: Unit) => (typeof unit === 'string' ? UNIT_MAP[unit] : unit)
 
 /** Options for any value being used, whether it's the main value or a notional it doesn't matter */
 type Formatting = {
@@ -141,7 +126,7 @@ function notionalsToString(notionals: Props['notional']) {
     .map((notional) => {
       const { value } = notional
       const { abbreviate, formatter } = getFormattingDefaults(notional)
-      const { symbol, position } = getUnit(notional.unit) ?? {}
+      const { symbol, position } = getUnitOptions(notional.unit) ?? {}
 
       return [
         position === 'prefix' ? symbol : '',
@@ -165,7 +150,7 @@ const MetricValue = ({ value, valueOptions, change, size, copyValue, tooltip, te
   const numberValue = useMemo(() => (typeof value === 'number' && isFinite(value) ? value : null), [value])
   const { color = 'textPrimary', unit } = valueOptions
   const { abbreviate, formatter } = getFormattingDefaults(valueOptions)
-  const { symbol, position } = getUnit(unit) ?? {}
+  const { symbol, position } = getUnitOptions(unit) ?? {}
   const fontVariant = MetricSize[size]
   const fontVariantUnit = MetricUnitSize[size]
 

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -84,7 +84,7 @@ function notionalsToString(notionals: Props['notional']) {
 }
 
 /** At the moment of writing the default formatter already formats to 2 decimals, but I really want to make this explicit for potential future changes. */
-export const formatChange = (value: number): string => defaultNumberFormatter(value, 2)
+export const formatChange = (value: number): string => defaultNumberFormatter(value, { decimals: 2 })
 
 type MetricValueProps = Pick<Props, 'value' | 'valueOptions' | 'change' | 'testId'> & {
   size: NonNullable<Props['size']>

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -1,0 +1,564 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  defaultNumberFormatter,
+  formatNumber,
+  decomposeNumber,
+  abbreviateNumber,
+  scaleSuffix,
+  log10Exp,
+} from './number'
+
+describe('log10Exp', () => {
+  describe('basic functionality', () => {
+    it('calculates correct exponents for powers of 1000', () => {
+      expect(log10Exp(1000)).toBe(1) // 10^3 = 1000
+      expect(log10Exp(1000000)).toBe(2) // 10^6 = 1000000
+      expect(log10Exp(1000000000)).toBe(3) // 10^9 = 1000000000
+      expect(log10Exp(1000000000000)).toBe(4) // 10^12 = 1000000000000
+    })
+
+    it('returns 0 for numbers less than 1000', () => {
+      expect(log10Exp(1)).toBe(0)
+      expect(log10Exp(10)).toBe(0)
+      expect(log10Exp(100)).toBe(0)
+      expect(log10Exp(123)).toBe(0)
+      expect(log10Exp(999)).toBe(0)
+    })
+
+    it('returns correct exponents for numbers between powers of 1000', () => {
+      expect(log10Exp(1001)).toBe(1)
+      expect(log10Exp(50000)).toBe(1)
+      expect(log10Exp(999999)).toBe(1)
+      expect(log10Exp(1000001)).toBe(2)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles negative numbers using absolute value', () => {
+      expect(log10Exp(-1000)).toBe(1)
+      expect(log10Exp(-1000000)).toBe(2)
+      expect(log10Exp(-123)).toBe(0)
+    })
+
+    it('handles zero', () => {
+      expect(log10Exp(0)).toBe(-Infinity)
+    })
+
+    it('handles decimal numbers', () => {
+      expect(log10Exp(0.5)).toBe(-1)
+      expect(log10Exp(0.001)).toBe(-1)
+      expect(log10Exp(0.0001)).toBe(-2)
+    })
+
+    it('handles very large numbers', () => {
+      expect(log10Exp(1e15)).toBe(5)
+      expect(log10Exp(1e18)).toBe(6)
+    })
+
+    it('handles Infinity', () => {
+      expect(log10Exp(Infinity)).toBe(Infinity)
+      expect(log10Exp(-Infinity)).toBe(Infinity)
+    })
+
+    it('handles NaN', () => {
+      expect(log10Exp(NaN)).toBe(NaN)
+    })
+  })
+})
+
+describe('scaleSuffix', () => {
+  describe('basic functionality', () => {
+    it('returns empty string for numbers less than 1000', () => {
+      expect(scaleSuffix(0)).toBe('')
+      expect(scaleSuffix(1)).toBe('')
+      expect(scaleSuffix(500)).toBe('')
+      expect(scaleSuffix(999)).toBe('')
+    })
+
+    it('returns correct suffixes for different scales', () => {
+      expect(scaleSuffix(1000)).toBe('k')
+      expect(scaleSuffix(1500)).toBe('k')
+      expect(scaleSuffix(999999)).toBe('k')
+      expect(scaleSuffix(1000000)).toBe('m')
+      expect(scaleSuffix(1500000)).toBe('m')
+      expect(scaleSuffix(1000000000)).toBe('b')
+      expect(scaleSuffix(1500000000)).toBe('b')
+      expect(scaleSuffix(1000000000000)).toBe('t')
+      expect(scaleSuffix(1500000000000)).toBe('t')
+    })
+
+    it('caps at trillion for very large numbers', () => {
+      expect(scaleSuffix(1e15)).toBe('t')
+      expect(scaleSuffix(1e18)).toBe('t')
+      expect(scaleSuffix(1e21)).toBe('t')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles negative numbers using absolute value', () => {
+      expect(scaleSuffix(-500)).toBe('')
+      expect(scaleSuffix(-1500)).toBe('k')
+      expect(scaleSuffix(-1500000)).toBe('m')
+      expect(scaleSuffix(-1500000000)).toBe('b')
+      expect(scaleSuffix(-1500000000000)).toBe('t')
+    })
+
+    it('handles decimal numbers', () => {
+      expect(scaleSuffix(0.5)).toBe('')
+      expect(scaleSuffix(999.9)).toBe('')
+      expect(scaleSuffix(1000.1)).toBe('k')
+    })
+
+    it('handles zero', () => {
+      expect(scaleSuffix(0)).toBe('')
+      expect(scaleSuffix(-0)).toBe('')
+    })
+
+    it('handles special numeric values', () => {
+      expect(scaleSuffix(Infinity)).toBe('t')
+      expect(scaleSuffix(-Infinity)).toBe('t')
+      expect(scaleSuffix(NaN)).toBe('') // log10Exp(NaN) is NaN, index becomes NaN, units[NaN] is undefined, need to handle
+    })
+  })
+})
+
+describe('abbreviateNumber', () => {
+  describe('basic functionality', () => {
+    it('does not abbreviate small numbers (< 1000)', () => {
+      expect(abbreviateNumber(0)).toBe(0)
+      expect(abbreviateNumber(1)).toBe(1)
+      expect(abbreviateNumber(500)).toBe(500)
+      expect(abbreviateNumber(999)).toBe(999)
+    })
+
+    it('abbreviates thousands correctly', () => {
+      expect(abbreviateNumber(1000)).toBe(1)
+      expect(abbreviateNumber(1234)).toBeCloseTo(1.234, 3)
+      expect(abbreviateNumber(1234.5678)).toBeCloseTo(1.2345678, 6)
+      expect(abbreviateNumber(5000)).toBe(5)
+      expect(abbreviateNumber(999000)).toBe(999)
+    })
+
+    it('abbreviates millions correctly', () => {
+      expect(abbreviateNumber(1000000)).toBe(1)
+      expect(abbreviateNumber(1500000)).toBe(1.5)
+      expect(abbreviateNumber(2000000)).toBe(2)
+      expect(abbreviateNumber(2500000)).toBe(2.5)
+    })
+
+    it('abbreviates billions correctly', () => {
+      expect(abbreviateNumber(1000000000)).toBe(1)
+      expect(abbreviateNumber(2500000000)).toBe(2.5)
+      expect(abbreviateNumber(999000000000)).toBe(999)
+    })
+
+    it('abbreviates trillions correctly', () => {
+      expect(abbreviateNumber(1000000000000)).toBe(1)
+      expect(abbreviateNumber(2500000000000)).toBe(2.5)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles negative numbers correctly', () => {
+      expect(abbreviateNumber(-1000)).toBe(-1)
+      expect(abbreviateNumber(-1500000)).toBe(-1.5)
+      expect(abbreviateNumber(-2500000000)).toBe(-2.5)
+    })
+
+    it('handles decimal input numbers', () => {
+      expect(abbreviateNumber(1234.56)).toBeCloseTo(1.23456, 5)
+      expect(abbreviateNumber(999.9)).toBeCloseTo(999.9, 1)
+    })
+
+    it('handles zero', () => {
+      expect(abbreviateNumber(0)).toBe(0)
+      expect(abbreviateNumber(-0)).toBe(-0)
+    })
+
+    it('handles very large numbers', () => {
+      expect(abbreviateNumber(1e15)).toBe(1) // 1e15 / 10^15 = 1 (uses full exponent, not capped)
+      expect(abbreviateNumber(1e18)).toBe(1) // 1e18 / 10^18 = 1 (uses full exponent, not capped)
+    })
+
+    it('handles special numeric values', () => {
+      expect(abbreviateNumber(Infinity)).toBe(NaN) // log10Exp(Infinity) returns NaN, causing division issues
+      expect(abbreviateNumber(-Infinity)).toBe(NaN) // Same for negative infinity
+      expect(abbreviateNumber(NaN)).toBe(NaN)
+    })
+  })
+})
+
+describe('defaultNumberFormatter', () => {
+  describe('basic functionality', () => {
+    it('formats positive numbers with default 2 decimals', () => {
+      expect(defaultNumberFormatter(123.456, { decimals: 2 })).toBe('123.46')
+      expect(defaultNumberFormatter(1000.5, { decimals: 2 })).toBe('1,000.50') // Default useGrouping is true in browsers
+    })
+
+    it('formats negative numbers', () => {
+      expect(defaultNumberFormatter(-123.456, { decimals: 2 })).toBe('-123.46')
+      expect(defaultNumberFormatter(-1000.5, { decimals: 2 })).toBe('-1,000.50') // Default useGrouping is true in browsers
+    })
+
+    it('respects custom decimal places', () => {
+      expect(defaultNumberFormatter(123.456789, { decimals: 0 })).toBe('123')
+      expect(defaultNumberFormatter(123.456789, { decimals: 1 })).toBe('123.5')
+      expect(defaultNumberFormatter(123.456789, { decimals: 4 })).toBe('123.4568')
+    })
+
+    it('applies grouping when specified', () => {
+      expect(defaultNumberFormatter(1234567.89, { decimals: 2, useGrouping: true })).toBe('1,234,567.89')
+      expect(defaultNumberFormatter(1000, { decimals: 0, useGrouping: true })).toBe('1,000')
+      expect(defaultNumberFormatter(1234567.89, { decimals: 2, useGrouping: false })).toBe('1234567.89')
+    })
+  })
+
+  describe('edge case handling', () => {
+    it('returns "0" for exactly zero regardless of decimal configuration', () => {
+      expect(defaultNumberFormatter(0)).toBe('0')
+      expect(defaultNumberFormatter(0, { decimals: 2 })).toBe('0')
+      expect(defaultNumberFormatter(0, { decimals: 5 })).toBe('0')
+      expect(defaultNumberFormatter(-0)).toBe('0')
+    })
+
+    it('returns "NaN" for NaN input only', () => {
+      expect(defaultNumberFormatter(NaN)).toBe('NaN')
+      // But not for Infinity (per JSDoc comment)
+      expect(defaultNumberFormatter(Infinity)).not.toBe('NaN')
+      expect(defaultNumberFormatter(-Infinity)).not.toBe('NaN')
+    })
+
+    it('handles extremely small positive numbers', () => {
+      expect(defaultNumberFormatter(0.0000000005)).toBe('<0.000000001')
+      expect(defaultNumberFormatter(0.0000000001)).toBe('<0.000000001')
+      expect(defaultNumberFormatter(1e-10)).toBe('<0.000000001')
+    })
+
+    it('handles extremely small negative numbers', () => {
+      expect(defaultNumberFormatter(-0.0000000005)).toBe('>-0.000000001')
+      expect(defaultNumberFormatter(-0.0000000001)).toBe('>-0.000000001')
+      expect(defaultNumberFormatter(-1e-10)).toBe('>-0.000000001')
+    })
+
+    it('uses 4 significant digits for small numbers <= 0.0009 (absolute)', () => {
+      expect(defaultNumberFormatter(0.0005)).toBe('0.0005')
+      expect(defaultNumberFormatter(0.0009)).toBe('0.0009')
+      expect(defaultNumberFormatter(0.00012)).toBe('0.00012')
+      expect(defaultNumberFormatter(-0.0005)).toBe('-0.0005')
+      expect(defaultNumberFormatter(-0.0009)).toBe('-0.0009')
+    })
+
+    it('switches to significant digits when formatted result would misleadingly show zero', () => {
+      // Very small number that would format to "0.00" with 2 decimals
+      expect(defaultNumberFormatter(0.001, { decimals: 2 })).toBe('0.001')
+      expect(defaultNumberFormatter(-0.001, { decimals: 2 })).toBe('-0.001')
+      expect(defaultNumberFormatter(0.0001, { decimals: 2 })).toBe('0.0001')
+    })
+
+    it('handles boundary cases around 0.0009 threshold', () => {
+      expect(defaultNumberFormatter(0.001)).toBe('0.001') // 0.001 is above the 0.0009 threshold, so uses normal formatting which happens to be the same
+      expect(defaultNumberFormatter(0.0009)).toBe('0.0009') // Uses significant digits
+      expect(defaultNumberFormatter(0.00089)).toBe('0.00089') // Uses significant digits
+    })
+  })
+
+  describe('Intl.NumberFormat options', () => {
+    it('handles trailingZeroDisplay option', () => {
+      expect(defaultNumberFormatter(12.5, { decimals: 4, trailingZeroDisplay: 'stripIfInteger' })).toBe('12.5000') // stripIfInteger only removes trailing zeros if result is integer
+      expect(defaultNumberFormatter(12.0, { decimals: 4, trailingZeroDisplay: 'stripIfInteger' })).toBe('12')
+    })
+
+    it('handles useGrouping false', () => {
+      expect(defaultNumberFormatter(1234567, { useGrouping: false })).toBe('1234567')
+    })
+  })
+
+  describe('Infinity handling', () => {
+    it('formats Infinity values', () => {
+      const result = defaultNumberFormatter(Infinity)
+      expect(result).not.toBe('NaN')
+      expect(result).toBe('∞')
+    })
+
+    it('formats negative Infinity', () => {
+      const result = defaultNumberFormatter(-Infinity)
+      expect(result).not.toBe('NaN')
+      expect(result).toBe('-∞')
+    })
+  })
+})
+
+describe('decomposeNumber', () => {
+  // Mock console.warn for USD overflow tests
+  const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  afterEach(() => {
+    consoleSpy.mockClear()
+  })
+
+  describe('basic functionality', () => {
+    it('decomposes number with default options', () => {
+      const result = decomposeNumber(1500)
+      expect(result).toEqual({
+        prefix: '',
+        mainValue: '1.50',
+        suffix: '',
+        scaleSuffix: 'k',
+      })
+    })
+
+    it('decomposes number without abbreviation', () => {
+      const result = decomposeNumber(1500, { abbreviate: false })
+      expect(result).toEqual({
+        prefix: '',
+        mainValue: '1,500.00',
+        suffix: '',
+        scaleSuffix: '',
+      })
+    })
+
+    it('decomposes number with prefix unit', () => {
+      const result = decomposeNumber(1000000, { unit: { symbol: '$', position: 'prefix' } })
+      expect(result).toEqual({
+        prefix: '$',
+        mainValue: '1.00',
+        suffix: '',
+        scaleSuffix: 'm',
+      })
+    })
+
+    it('decomposes number with suffix unit', () => {
+      const result = decomposeNumber(50, { unit: { symbol: '%', position: 'suffix' }, abbreviate: false })
+      expect(result).toEqual({
+        prefix: '',
+        mainValue: '50.00',
+        suffix: '%',
+        scaleSuffix: '',
+      })
+    })
+
+    it('decomposes number with string unit types', () => {
+      const dollarResult = decomposeNumber(1000, { unit: 'dollar' })
+      expect(dollarResult.prefix).toBe('$')
+      expect(dollarResult.suffix).toBe('')
+
+      const percentResult = decomposeNumber(50, { unit: 'percentage' })
+      expect(percentResult.prefix).toBe('')
+      expect(percentResult.suffix).toBe('%')
+    })
+  })
+
+  describe('custom formatting', () => {
+    it('applies custom formatter', () => {
+      const customFormatter = (value: number) => `custom-${value}`
+      const result = decomposeNumber(1500, { formatter: customFormatter })
+      expect(result.mainValue).toBe('custom-1.5')
+    })
+
+    it('respects custom decimals', () => {
+      const result = decomposeNumber(1234.5678, { decimals: 1, abbreviate: false })
+      expect(result.mainValue).toBe('1,234.6')
+    })
+
+    it('handles useGrouping option', () => {
+      const result = decomposeNumber(1234567, { abbreviate: false, useGrouping: false })
+      expect(result.mainValue).toBe('1234567.00')
+    })
+  })
+
+  describe('USD overflow handling', () => {
+    // MAX_USD_VALUE is 100_000_000_000_000 (100T)
+    it('handles USD values over MAX_USD_VALUE', () => {
+      const overflowValue = 200_000_000_000_000 // 200T
+      const result = decomposeNumber(overflowValue, { unit: { symbol: '$', position: 'prefix' } })
+
+      expect(result).toEqual({
+        prefix: '',
+        mainValue: '?',
+        suffix: '',
+        scaleSuffix: '',
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(`USD value is too large: ${overflowValue}`)
+    })
+
+    it('handles USD values exactly at MAX_USD_VALUE', () => {
+      const maxValue = 100_000_000_000_000 // Exactly 100T
+      const result = decomposeNumber(maxValue, { unit: { symbol: '$', position: 'prefix' } })
+
+      expect(result.mainValue).not.toBe('?')
+      expect(result.prefix).toBe('$')
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not trigger overflow for non-USD currencies', () => {
+      const overflowValue = 200_000_000_000_000 // 200T
+      const result = decomposeNumber(overflowValue, { unit: { symbol: '€', position: 'prefix' } })
+
+      expect(result.mainValue).not.toBe('?')
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+
+    it('only triggers overflow for exact "$" symbol', () => {
+      const overflowValue = 200_000_000_000_000 // 200T
+      const result = decomposeNumber(overflowValue, { unit: { symbol: 'USD', position: 'prefix' } })
+
+      expect(result.mainValue).not.toBe('?')
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles zero value', () => {
+      const result = decomposeNumber(0)
+      expect(result.mainValue).toBe('0')
+      expect(result.scaleSuffix).toBe('')
+    })
+
+    it('handles negative values', () => {
+      const result = decomposeNumber(-1500)
+      expect(result.mainValue).toBe('-1.50')
+      expect(result.scaleSuffix).toBe('k')
+    })
+
+    it('handles NaN', () => {
+      const result = decomposeNumber(NaN)
+      expect(result.mainValue).toBe('NaN')
+    })
+
+    it('handles Infinity', () => {
+      const result = decomposeNumber(Infinity)
+      expect(result.mainValue).toBe('NaN') // defaultNumberFormatter returns 'NaN' for Infinity
+    })
+
+    it('handles undefined unit gracefully', () => {
+      const result = decomposeNumber(1500, { unit: undefined })
+      expect(result.prefix).toBe('')
+      expect(result.suffix).toBe('')
+    })
+  })
+})
+
+describe('formatNumber', () => {
+  describe('basic functionality', () => {
+    it('formats with default options (abbreviation enabled)', () => {
+      expect(formatNumber(1234.56)).toBe('1.23k')
+      expect(formatNumber(1000000)).toBe('1.00m')
+      expect(formatNumber(2500000000)).toBe('2.50b')
+    })
+
+    it('formats without abbreviation', () => {
+      expect(formatNumber(1500, { abbreviate: false })).toBe('1,500.00')
+      expect(formatNumber(1234567.89, { abbreviate: false, useGrouping: true })).toBe('1,234,567.89')
+    })
+
+    it('formats with currency prefix', () => {
+      expect(formatNumber(1000000, { unit: { symbol: '$', position: 'prefix' } })).toBe('$1.00m')
+      expect(formatNumber(1000, { unit: 'dollar' })).toBe('$1.00k')
+    })
+
+    it('formats with percentage suffix', () => {
+      expect(formatNumber(50, { unit: { symbol: '%', position: 'suffix' }, abbreviate: false })).toBe('50.00%')
+      expect(formatNumber(50, { unit: 'percentage', abbreviate: false })).toBe('50.00%')
+    })
+
+    it('combines all components correctly', () => {
+      expect(formatNumber(2500000000, { unit: { symbol: '%', position: 'suffix' }, decimals: 1 })).toBe('2.5b%')
+      expect(formatNumber(1500000, { unit: 'dollar', decimals: 0 })).toBe('$2m')
+    })
+  })
+
+  describe('formatting options', () => {
+    it('handles custom decimals', () => {
+      expect(formatNumber(1234.5678, { decimals: 3, abbreviate: false })).toBe('1,234.568')
+      expect(formatNumber(1234.5678, { decimals: 0, abbreviate: false })).toBe('1,235')
+    })
+
+    it('handles trailingZeroDisplay', () => {
+      expect(formatNumber(12.5, { decimals: 4, trailingZeroDisplay: 'stripIfInteger', abbreviate: false })).toBe(
+        '12.5000',
+      ) // stripIfInteger only removes trailing zeros if result is integer
+      expect(formatNumber(12.0, { decimals: 4, trailingZeroDisplay: 'stripIfInteger', abbreviate: false })).toBe('12')
+    })
+
+    it('handles useGrouping', () => {
+      expect(formatNumber(1234567, { abbreviate: false, useGrouping: false })).toBe('1234567.00')
+      expect(formatNumber(1234567, { abbreviate: false, useGrouping: true })).toBe('1,234,567.00')
+    })
+
+    it('handles custom formatter', () => {
+      const customFormatter = (value: number) => `[${value}]`
+      expect(formatNumber(1500, { formatter: customFormatter })).toBe('[1.5]k')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles zero', () => {
+      expect(formatNumber(0)).toBe('0')
+      expect(formatNumber(0, { unit: 'dollar' })).toBe('$0') // Implementation adds unit prefix even for zero
+    })
+
+    it('handles negative numbers', () => {
+      expect(formatNumber(-1500)).toBe('-1.50k')
+      expect(formatNumber(-1000000, { unit: 'dollar' })).toBe('$-1.00m')
+    })
+
+    it('handles very small numbers', () => {
+      expect(formatNumber(0.0000000001)).toBe('<0.000000001')
+      expect(formatNumber(-0.0000000001)).toBe('>-0.000000001')
+    })
+
+    it('handles NaN', () => {
+      expect(formatNumber(NaN)).toBe('NaN')
+      expect(formatNumber(NaN, { unit: 'dollar' })).toBe('$NaN') // Implementation adds unit prefix even for NaN
+    })
+
+    it('handles Infinity', () => {
+      expect(formatNumber(Infinity)).toBe('NaNt') // Implementation returns 'NaNt' for Infinity due to trillions suffix
+      expect(formatNumber(-Infinity)).toBe('NaNt') // Negative Infinity also returns 'NaNt' (sign gets lost)
+    })
+
+    it('handles USD overflow', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const overflowValue = 200_000_000_000_000 // 200T
+
+      expect(formatNumber(overflowValue, { unit: 'dollar' })).toBe('?')
+      expect(consoleSpy).toHaveBeenCalledWith(`USD value is too large: ${overflowValue}`)
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('unit types', () => {
+    it('handles all predefined unit types', () => {
+      expect(formatNumber(1000, { unit: 'none' })).toBe('1.00k')
+      expect(formatNumber(1000, { unit: 'dollar' })).toBe('$1.00k')
+      expect(formatNumber(50, { unit: 'percentage', abbreviate: false })).toBe('50.00%')
+      expect(formatNumber(20000, { unit: 'multiplier', abbreviate: false })).toBe('20,000.00x')
+    })
+
+    it('handles custom unit objects', () => {
+      expect(formatNumber(1000, { unit: { symbol: 'ETH', position: 'suffix' } })).toBe('1.00kETH')
+      expect(formatNumber(1000, { unit: { symbol: '£', position: 'prefix' } })).toBe('£1.00k')
+    })
+  })
+
+  describe('real-world examples from JSDoc', () => {
+    it('matches JSDoc examples exactly', () => {
+      expect(formatNumber(1234.56)).toBe('1.23k')
+      expect(formatNumber(1000000, { unit: { symbol: '$', position: 'prefix' } })).toBe('$1.00m')
+      expect(formatNumber(500, { abbreviate: false })).toBe('500.00')
+      expect(formatNumber(2500000000, { unit: { symbol: '%', position: 'suffix' }, decimals: 1 })).toBe('2.5b%')
+      expect(formatNumber(1234567.89, { useGrouping: true, abbreviate: false })).toBe('1,234,567.89')
+      expect(formatNumber(12.5, { decimals: 4, trailingZeroDisplay: 'stripIfInteger', abbreviate: false })).toBe(
+        '12.5000',
+      )
+      expect(formatNumber(12.0, { decimals: 4, trailingZeroDisplay: 'stripIfInteger', abbreviate: false })).toBe('12')
+      expect(formatNumber(12.5, { decimals: 4, trailingZeroDisplay: 'auto', abbreviate: false })).toBe('12.5000')
+    })
+
+    it('handles JSDoc examples with custom formatter', () => {
+      const customFormatter = (value: number) => `[${value}]`
+      expect(formatNumber(1500, { formatter: customFormatter })).toBe('[1.5]k')
+    })
+  })
+})

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -1,6 +1,9 @@
 import { MAX_USD_VALUE } from '@ui/utils'
 import { getUnitOptions, type Unit } from './units'
 
+/** Locale used for consistent number formatting across the application */
+const LOCALE = 'en-US'
+
 /**
  * Calculates the exponent (in base 10) divided by 3 for a given number.
  * Used to determine the scale/magnitude of a number in terms of thousands.
@@ -92,7 +95,7 @@ export type NumberFormatOptions = {
  * - For negative values between -0.000000001 and 0, returns ">-0.000000001"
  * - For values <= 0.0009 (absolute), uses 4 significant digits for better precision
  * - When formatted output would show "0.00" but value is non-zero, switches to 4 significant digits
- * - Uses browser's locale for number formatting
+ * - Uses en-US locale for consistent number formatting (period as decimal separator, comma as thousands separator)
  */
 export const defaultNumberFormatter = (
   value: number,
@@ -109,7 +112,7 @@ export const defaultNumberFormatter = (
   if (absValue > 0 && absValue < 0.000000001) return value > 0 ? '<0.000000001' : '>-0.000000001'
   const maximumSignificantDigits = absValue <= 0.0009 ? 4 : undefined
 
-  const formatted = value.toLocaleString(undefined, {
+  const formatted = value.toLocaleString(LOCALE, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
     maximumSignificantDigits,
@@ -120,7 +123,7 @@ export const defaultNumberFormatter = (
   // If the formatted result is "0" or "0.00" but value isn't actually zero
   if (value !== 0 && (formatted === '0' || /^-?0\.0+$/.test(formatted))) {
     // Use significant digits instead
-    return value.toLocaleString(undefined, {
+    return value.toLocaleString(LOCALE, {
       maximumSignificantDigits: 4,
       useGrouping,
     })

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -238,7 +238,10 @@ export const decomposeNumber = (value: number, options: NumberFormatOptions = {}
  * // Returns "1,234,567.89"
  *
  * formatNumber(12.5, { decimals: 4, trailingZeroDisplay: 'stripIfInteger' })
- * // Returns "12.5"
+ * // Returns "12.5000" (trailing zeros kept because 12.5 is not an integer)
+ *
+ * formatNumber(12.0, { decimals: 4, trailingZeroDisplay: 'stripIfInteger' })
+ * // Returns "12" (trailing zeros stripped because 12.0 is effectively an integer)
  *
  * formatNumber(12.5, { decimals: 4, trailingZeroDisplay: 'auto' })
  * // Returns "12.5000"

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -95,6 +95,8 @@ export type NumberFormatOptions = {
  *
  * @remarks
  * - Returns "NaN" for invalid numeric inputs (NaN, but not Infinity)
+ * - Returns "∞" for positive infinity values
+ * - Returns "-∞" for negative infinity values
  * - Returns "0" for exactly zero values regardless of decimal configuration
  * - For positive values smaller than 0.000000001, returns "<0.000000001"
  * - For negative values between -0.000000001 and 0, returns ">-0.000000001"
@@ -111,6 +113,8 @@ export const defaultNumberFormatter = (
   }: Pick<NumberFormatOptions, 'decimals' | 'useGrouping' | 'trailingZeroDisplay'> = {},
 ): string => {
   if (isNaN(value)) return 'NaN'
+  if (value === Infinity) return '∞'
+  if (value === -Infinity) return '-∞'
   if (value === 0) return '0'
 
   const absValue = Math.abs(value)

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -18,19 +18,20 @@ export function log10Exp(value: number): number {
 }
 
 /**
- * Returns the appropriate unit suffix for a given number value.
+ * Returns the appropriate scale suffix for a given number value.
+ * Uses log10Exp to determine the magnitude and returns the corresponding suffix.
  *
- * @param value - The number to determine the unit for.
- * @returns The unit suffix as a string ('t' for trillion, 'b' for billion, 'm' for million, 'k' for thousand, or '' for smaller values).
+ * @param value - The number to determine the scale suffix for.
+ * @returns The scale suffix as a string ('t' for trillion, 'b' for billion, 'm' for million, 'k' for thousand, or '' for smaller values).
  *
  * @example
- * unit(1500000000000) // Returns 't'
- * unit(2000000000) // Returns 'b'
- * unit(3000000) // Returns 'm'
- * unit(4000) // Returns 'k'
- * unit(500) // Returns ''
- * unit(-1000000) // Returns 'm'
- * unit(0) // Returns ''
+ * scaleSuffix(1500000000000) // Returns 't'
+ * scaleSuffix(2000000000) // Returns 'b'
+ * scaleSuffix(3000000) // Returns 'm'
+ * scaleSuffix(4000) // Returns 'k'
+ * scaleSuffix(500) // Returns ''
+ * scaleSuffix(-1000000) // Returns 'm'
+ * scaleSuffix(0) // Returns ''
  */
 export function scaleSuffix(value: number): string {
   const units = ['', 'k', 'm', 'b', 't']
@@ -43,8 +44,10 @@ export function scaleSuffix(value: number): string {
  * Abbreviates a number such that it can go along with a suffix like k, m, b or t.
  *
  * @example
- * round(1234.5678) // Returns "1.23", goes with suffix "k"
- * round(1000000) // Returns "1.0", goes with suffix "m"
+ * abbreviateNumber(1234.5678) // Returns 1.2345678 (goes with suffix "k")
+ * abbreviateNumber(1000000) // Returns 1 (goes with suffix "m")
+ * abbreviateNumber(2500000000) // Returns 2.5 (goes with suffix "b")
+ * abbreviateNumber(500) // Returns 500 (goes with suffix "")
  */
 export function abbreviateNumber(value: number): number {
   const exp = log10Exp(value) * 3

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -40,7 +40,12 @@ export function log10Exp(value: number): number {
  */
 export function scaleSuffix(value: number): string {
   const units = ['', 'k', 'm', 'b', 't']
-  const index = Math.max(0, Math.min(units.length - 1, log10Exp(value)))
+  const exp = log10Exp(value)
+
+  // Handle NaN case
+  if (isNaN(exp)) return ''
+
+  const index = Math.max(0, Math.min(units.length - 1, exp))
 
   return units[index]
 }

--- a/packages/curve-ui-kit/src/utils/units.ts
+++ b/packages/curve-ui-kit/src/utils/units.ts
@@ -1,0 +1,29 @@
+export type UnitOptions = {
+  symbol: string
+  position: 'prefix' | 'suffix'
+}
+
+const none: UnitOptions = { symbol: '', position: 'suffix' }
+const dollar: UnitOptions = { symbol: '$', position: 'prefix' }
+const percentage: UnitOptions = { symbol: '%', position: 'suffix' }
+const multiplier: UnitOptions = { symbol: 'x', position: 'suffix' }
+const UNIT_MAP = { none, dollar, percentage, multiplier } as const
+
+export type Unit = keyof typeof UNIT_MAP | UnitOptions
+
+/**
+ * Helper function to get UnitOptions from the more liberal Unit type.
+ *
+ * Retrieves the corresponding unit value from the UNIT_MAP if the provided unit is a string,
+ * otherwise returns the unit itself. Useful for normalizing unit representations.
+ *
+ * @param unit - The unit to retrieve, which can be either a string key of UNIT_MAP or a Unit object.
+ * @returns The resolved unit value from UNIT_MAP if a string is provided, or the original unit if not.
+ *
+ * @example
+ * getUnit('dollar') // { symbol: '$', position: 'prefix' }
+ * getUnit('percentage') // { symbol: '%', position: 'suffix' }
+ * getUnit({ symbol: 'ETH', position: 'suffix' }) // { symbol: 'ETH', position: 'suffix' }
+ * getUnit() // undefined
+ */
+export const getUnitOptions = (unit?: Unit) => (typeof unit === 'string' ? UNIT_MAP[unit] : unit)

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,6 +4,8 @@
     "baseUrl": "./src",
     "paths": {
       "@/*": ["*"],
+      "@ui": ["./index.tsx"],
+      "@ui/*": ["./*"],
       "@external-rewards": ["../../external-rewards/src/index.ts"],
       "@curvefi/prices-api": ["../../prices-api/src/index.ts"],
       "@curvefi/prices-api/*": ["../../prices-api/src/*"],

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,13 +8,16 @@
     "hoistingLimits": "dependencies"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "run:nodes": "node runHardhatNodes.js",
     "kill:nodes": "node killHardhatNodes.js",
+    "vitest:ui": "vitest --ui",
+    "vitest:run": "vitest run",
+    "vitest:watch": "vitest --watch",
     "cy:open:e2e": "cypress open --e2e",
     "cy:run:e2e": "wait-on http://localhost:3000 --timeout 1m && cypress run --e2e",
     "cy:open:component": "cypress open --component",
-    "cy:run:component": "cypress run --component",
-    "typecheck": "tsc --noEmit"
+    "cy:run:component": "cypress run --component"
   },
   "devDependencies": {
     "@cypress/react": "^9.0.1",
@@ -22,6 +25,7 @@
     "@types/cypress": "^1.1.6",
     "@types/wait-on": "^5.3.4",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/ui": "^3.2.4",
     "cypress": "^14.5.0",
     "dotenv-flow": "^4.1.0",
     "ethers": "*",
@@ -30,6 +34,7 @@
     "typescript": "*",
     "vite": "*",
     "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "*",
     "wait-on": "^8.0.3"
   }
 }

--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['../packages/*/src/**/*.{test,spec}.{js,ts}'],
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,6 +3545,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.29
+  resolution: "@polka/url@npm:1.0.0-next.29"
+  checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
+  languageName: node
+  linkType: hard
+
 "@popperjs/core@npm:^2.11.8":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
@@ -7182,12 +7189,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:3.2.4":
+"@vitest/pretty-format@npm:3.2.4, @vitest/pretty-format@npm:^3.2.4":
   version: 3.2.4
   resolution: "@vitest/pretty-format@npm:3.2.4"
   dependencies:
     tinyrainbow: "npm:^2.0.0"
   checksum: 10c0/5ad7d4278e067390d7d633e307fee8103958806a419ca380aec0e33fae71b44a64415f7a9b4bc11635d3c13d4a9186111c581d3cef9c65cc317e68f077456887
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/runner@npm:3.2.4"
+  dependencies:
+    "@vitest/utils": "npm:3.2.4"
+    pathe: "npm:^2.0.3"
+    strip-literal: "npm:^3.0.0"
+  checksum: 10c0/e8be51666c72b3668ae3ea348b0196656a4a5adb836cb5e270720885d9517421815b0d6c98bfdf1795ed02b994b7bfb2b21566ee356a40021f5bf4f6ed4e418a
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/snapshot@npm:3.2.4"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.4"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/f8301a3d7d1559fd3d59ed51176dd52e1ed5c2d23aa6d8d6aa18787ef46e295056bc726a021698d8454c16ed825ecba163362f42fa90258bb4a98cfd2c9424fc
   languageName: node
   linkType: hard
 
@@ -7197,6 +7226,23 @@ __metadata:
   dependencies:
     tinyspy: "npm:^4.0.3"
   checksum: 10c0/6ebf0b4697dc238476d6b6a60c76ba9eb1dd8167a307e30f08f64149612fd50227682b876420e4c2e09a76334e73f72e3ebf0e350714dc22474258292e202024
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/ui@npm:3.2.4"
+  dependencies:
+    "@vitest/utils": "npm:3.2.4"
+    fflate: "npm:^0.8.2"
+    flatted: "npm:^3.3.3"
+    pathe: "npm:^2.0.3"
+    sirv: "npm:^3.0.1"
+    tinyglobby: "npm:^0.2.14"
+    tinyrainbow: "npm:^2.0.0"
+  peerDependencies:
+    vitest: 3.2.4
+  checksum: 10c0/c3de1b757905d050706c7ab0199185dd8c7e115f2f348b8d5a7468528c6bf90c2c46096e8901602349ac04f5ba83ac23cd98c38827b104d5151cf8ba21739a0c
   languageName: node
   linkType: hard
 
@@ -8465,6 +8511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^19.0.1":
   version: 19.0.1
   resolution: "cacache@npm:19.0.1"
@@ -9237,6 +9290,7 @@ __metadata:
     react-dom: "npm:*"
     typescript: "npm:*"
     vite: "npm:*"
+    vitest: "npm:*"
   languageName: unknown
   linkType: soft
 
@@ -9280,6 +9334,7 @@ __metadata:
     typescript: "npm:*"
     viem: "npm:^2.30.0"
     vite: "npm:*"
+    vitest: "npm:*"
     wagmi: "npm:^2.15.4"
     zustand: "npm:^4.5.7"
   peerDependencies:
@@ -10196,6 +10251,13 @@ __metadata:
     iterator.prototype: "npm:^1.1.4"
     safe-array-concat: "npm:^1.1.3"
   checksum: 10c0/97e3125ca472d82d8aceea11b790397648b52c26d8768ea1c1ee6309ef45a8755bb63225a43f3150c7591cffc17caf5752459f1e70d583b4184370a8f04ebd2f
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
   languageName: node
   linkType: hard
 
@@ -11145,6 +11207,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect-type@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "expect-type@npm:1.2.2"
+  checksum: 10c0/6019019566063bbc7a690d9281d920b1a91284a4a093c2d55d71ffade5ac890cf37a51e1da4602546c4b56569d2ad2fc175a2ccee77d1ae06cb3af91ef84f44b
+  languageName: node
+  linkType: hard
+
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.2
   resolution: "exponential-backoff@npm:3.1.2"
@@ -11354,6 +11423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "fflate@npm:0.8.2"
+  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+  languageName: node
+  linkType: hard
+
 "figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
@@ -11469,7 +11545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9":
+"flatted@npm:^3.2.9, flatted@npm:^3.3.3":
   version: 3.3.3
   resolution: "flatted@npm:3.3.3"
   checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
@@ -12884,6 +12960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "js-tokens@npm:9.0.1"
+  checksum: 10c0/68dcab8f233dde211a6b5fd98079783cbcd04b53617c1250e3553ee16ab3e6134f5e65478e41d82f6d351a052a63d71024553933808570f04dbf828d7921e80e
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -13860,6 +13943,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mrmime@npm:2.0.1"
+  checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -14503,6 +14593,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
+  languageName: node
+  linkType: hard
+
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
   languageName: node
   linkType: hard
 
@@ -16041,6 +16138,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.2":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -16061,6 +16165,17 @@ __metadata:
   dependencies:
     is-arrayish: "npm:^0.3.1"
   checksum: 10c0/df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
+  languageName: node
+  linkType: hard
+
+"sirv@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "sirv@npm:3.0.1"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/7cf64b28daa69b15f77b38b0efdd02c007b72bb3ec5f107b208ebf59f01b174ef63a1db3aca16d2df925501831f4c209be6ece3302b98765919ef5088b45bf80
   languageName: node
   linkType: hard
 
@@ -16308,6 +16423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "stacktrace-parser@npm:^0.1.10":
   version: 0.1.11
   resolution: "stacktrace-parser@npm:0.1.11"
@@ -16321,6 +16443,13 @@ __metadata:
   version: 2.0.1
   resolution: "statuses@npm:2.0.1"
   checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "std-env@npm:3.9.0"
+  checksum: 10c0/4a6f9218aef3f41046c3c7ecf1f98df00b30a07f4f35c6d47b28329bc2531eef820828951c7d7b39a1c5eb19ad8a46e3ddfc7deb28f0a2f3ceebee11bab7ba50
   languageName: node
   linkType: hard
 
@@ -16565,6 +16694,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-literal@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-literal@npm:3.0.0"
+  dependencies:
+    js-tokens: "npm:^9.0.1"
+  checksum: 10c0/d81657f84aba42d4bbaf2a677f7e7f34c1f3de5a6726db8bc1797f9c0b303ba54d4660383a74bde43df401cf37cce1dff2c842c55b077a4ceee11f9e31fba828
+  languageName: node
+  linkType: hard
+
 "styled-components@npm:6.1.19":
   version: 6.1.19
   resolution: "styled-components@npm:6.1.19"
@@ -16731,6 +16869,7 @@ __metadata:
     "@types/cypress": "npm:^1.1.6"
     "@types/wait-on": "npm:^5.3.4"
     "@vitejs/plugin-react": "npm:^4.6.0"
+    "@vitest/ui": "npm:^3.2.4"
     cypress: "npm:^14.5.0"
     dotenv-flow: "npm:^4.1.0"
     ethers: "npm:*"
@@ -16739,6 +16878,7 @@ __metadata:
     typescript: "npm:*"
     vite: "npm:*"
     vite-tsconfig-paths: "npm:^5.1.4"
+    vitest: "npm:*"
     wait-on: "npm:^8.0.3"
   languageName: unknown
   linkType: soft
@@ -16815,6 +16955,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.0.0":
   version: 1.0.1
   resolution: "tinyexec@npm:1.0.1"
@@ -16839,6 +16993,13 @@ __metadata:
     fdir: "npm:^6.4.3"
     picomatch: "npm:^4.0.2"
   checksum: 10c0/7c9be4fd3625630e262dcb19015302aad3b4ba7fc620f269313e688f2161ea8724d6cb4444baab5ef2826eb6bed72647b169a33ec8eea37501832a2526ff540f
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
   languageName: node
   linkType: hard
 
@@ -16914,6 +17075,13 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
   languageName: node
   linkType: hard
 
@@ -17775,6 +17943,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:3.2.4":
+  version: 3.2.4
+  resolution: "vite-node@npm:3.2.4"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.4.1"
+    es-module-lexer: "npm:^1.7.0"
+    pathe: "npm:^2.0.3"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/6ceca67c002f8ef6397d58b9539f80f2b5d79e103a18367288b3f00a8ab55affa3d711d86d9112fce5a7fa658a212a087a005a045eb8f4758947dd99af2a6c6b
+  languageName: node
+  linkType: hard
+
 "vite-plugin-svgr@npm:^4.3.0":
   version: 4.3.0
   resolution: "vite-plugin-svgr@npm:4.3.0"
@@ -17882,6 +18065,62 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/a0aa418beab80673dc9a3e9d1fa49472955d6ef9d41a4c9c6bd402953f411346f612864dae267adfb2bb8ceeb894482369316ffae5816c84fd45990e352b727d
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "vitest@npm:3.2.4"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/expect": "npm:3.2.4"
+    "@vitest/mocker": "npm:3.2.4"
+    "@vitest/pretty-format": "npm:^3.2.4"
+    "@vitest/runner": "npm:3.2.4"
+    "@vitest/snapshot": "npm:3.2.4"
+    "@vitest/spy": "npm:3.2.4"
+    "@vitest/utils": "npm:3.2.4"
+    chai: "npm:^5.2.0"
+    debug: "npm:^4.4.1"
+    expect-type: "npm:^1.2.1"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.2"
+    std-env: "npm:^3.9.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.14"
+    tinypool: "npm:^1.1.1"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node: "npm:3.2.4"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.2.4
+    "@vitest/ui": 3.2.4
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/5bf53ede3ae6a0e08956d72dab279ae90503f6b5a05298a6a5e6ef47d2fd1ab386aaf48fafa61ed07a0ebfe9e371772f1ccbe5c258dd765206a8218bf2eb79eb
   languageName: node
   linkType: hard
 
@@ -18061,6 +18300,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/e556e4cd8b7dbf5df52408c9a9dd5ac6518c8c5267c8953f5b0564073c66ed5bf9503b14d876d0e9c7844d4db9725fb0dcf45d6e911e17e26ab363dc3965ae7b
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Refactor the Metric component by extracting number formatting and unit handling into utility functions.
* Introduce Vitest for testing and add unit tests for number formatting, ensuring consistent behavior across edge cases.
* Update documentation and fix minor issues related to number formatting.

This PR does not change anything visibly. This is the pre-work required to replace the number formatting from `utilsFormat.ts`, so that we can consolidate the number formatting to use the same logic everywhere.