### PR TITLE
chore: bigint json serialization cypress test

### DIFF
--- a/packages/curve-ui-kit/src/lib/api/provider.tsx
+++ b/packages/curve-ui-kit/src/lib/api/provider.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 import { type QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { type Persister, PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
-import { isCypress } from '@ui-kit/utils'
 
 type QueryProviderWrapperProps = {
   children: ReactNode
@@ -15,7 +14,7 @@ export function QueryProvider({ children, persister, queryClient }: QueryProvide
   children = (
     <>
       {children}
-      {!isCypress && <ReactQueryDevtools />}
+      {<ReactQueryDevtools />}
     </>
   )
 

--- a/tests/cypress/support/component-index.html
+++ b/tests/cypress/support/component-index.html
@@ -5,6 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>Components App</title>
+    <script>
+      // We have `queryKeyHashFn: hashFn` in ui-kit\src\lib\api\query-client.ts, but somehow it doesn't work in Cypress tests
+      BigInt.prototype['toJSON'] = function () {
+        return this.toString()
+      }
+    </script>
   </head>
   <body>
     <div id="app" data-cy-root></div>


### PR DESCRIPTION
Been getting some weird "bigint not JSON serializable" errors in my component test when calling wagmi's `simulateTransaction`.

PR is a draft, because I'm not sure if this is test environment only bug or if this also happens in prod. And I can't test the issue atm because in prod the est rebalance profit is 0. I need a non-zero number to verify if it's also an issue in prod or test only.