### PR TITLE
feat: local storage migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 # testing
 coverage
 cypress.env.json
+tests/cypress/screenshots
 
 # next.js
 .next/

--- a/apps/main/src/llamalend/entities/favorite-markets.ts
+++ b/apps/main/src/llamalend/entities/favorite-markets.ts
@@ -18,7 +18,7 @@ export function useFavoriteMarket(address: Address) {
   const isFavorite = useMemo(() => favorites.includes(address), [favorites, address])
   const toggleFavorite = useCallback(() => {
     isFavorite ? setFavorites(favorites.filter((id) => id !== address)) : setFavorites([...favorites, address])
-    invalidateFavoriteMarkets({})
+    invalidateFavoriteMarkets({}) // todo: set the query value directly
   }, [favorites, isFavorite, address, setFavorites])
   return [isFavorite, toggleFavorite] as const
 }

--- a/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
+++ b/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
@@ -4,9 +4,12 @@ import type { Address } from '@curvefi/prices-api'
 import type { ColumnFiltersState } from '@tanstack/table-core'
 import type { VisibilityVariants } from '@ui-kit/shared/ui/DataTable/visibility.types'
 import { isBetaDefault } from '@ui-kit/utils'
-import { useStoredState } from './useStoredState'
+import { type MigrationOptions, useStoredState } from './useStoredState'
 
 const { kebabCase } = lodash
+
+// old keys that are not used anymore - clean them up
+window.localStorage.removeItem('isNewDomainNotificationSeen')
 
 export function getFromLocalStorage<T>(storageKey: string): T | null {
   if (typeof window === 'undefined') {
@@ -34,7 +37,8 @@ const set = <T>(storageKey: string, value: T) => {
  *
  * It is not exported, as we want to keep an overview of all the local storage keys used in the app.
  */
-const useLocalStorage = <T>(key: string, initialValue: T) => useStoredState<T>({ key, initialValue, get, set })
+const useLocalStorage = <T>(key: string, initialValue: T, migration?: MigrationOptions<T>) =>
+  useStoredState<T>({ key, initialValue, get, set, ...migration })
 
 /* -- Export specific hooks so that we can keep an overview of all the local storage keys used in the app -- */
 export const useShowTestNets = () => useLocalStorage<boolean>('showTestnets', false)
@@ -42,16 +46,21 @@ export const useBetaFlag = () => useLocalStorage<boolean>('beta', isBetaDefault)
 export const useFilterExpanded = (tableTitle: string) =>
   useLocalStorage<boolean>(`filter-expanded-${kebabCase(tableTitle)}`, false)
 
-export const useTableFilters = (tableTitle: string, defaultFilters: ColumnFiltersState) =>
-  useLocalStorage<ColumnFiltersState>(`table-filters-${kebabCase(tableTitle)}`, defaultFilters)
+export const useTableFilters = (
+  tableTitle: string,
+  defaultFilters: ColumnFiltersState,
+  migration: MigrationOptions<ColumnFiltersState>,
+) => useLocalStorage<ColumnFiltersState>(`table-filters-${kebabCase(tableTitle)}`, defaultFilters, migration)
 
 export const useTableColumnVisibility = <Variant extends string, ColumnIds>(
   tableTitle: string,
   defaultVisibility: VisibilityVariants<Variant, ColumnIds>,
+  migration: MigrationOptions<VisibilityVariants<Variant, ColumnIds>>,
 ) =>
   useLocalStorage<VisibilityVariants<Variant, ColumnIds>>(
     `table-column-visibility-${kebabCase(tableTitle)}`,
     defaultVisibility,
+    migration,
   )
 
 export const getFavoriteMarkets = () => getFromLocalStorage<Address[]>('favoriteMarkets') ?? []

--- a/packages/curve-ui-kit/src/hooks/useStoredState.ts
+++ b/packages/curve-ui-kit/src/hooks/useStoredState.ts
@@ -1,41 +1,87 @@
+import { isEqual } from 'lodash'
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
 
 export type GetAndSet<T> = [T, Dispatch<SetStateAction<T>>]
 
 const storageEvent = new EventTarget()
 
+export type MigrationOptions<T> = {
+  /**
+   * Version of the stored value. When increased, the migrate function is called (if provided) to migrate old values to new values.
+   */
+  version: number
+  /**
+   * Optional function to migrate old values to new values when version is increased.
+   * If not provided, old values are simply removed.
+   */
+  migrate?: (oldValue: T, initialValue: T) => T | null
+}
+
+type StoredStateOptions<T> = Partial<MigrationOptions<T>> & {
+  key: string
+  initialValue: T
+  get: (key: string, initialValue: T) => T
+  set: (key: string, value: T | null) => unknown
+}
+
+/**
+ * Run migration of stored values if needed.
+ */
+function runMigration<T>({
+  key,
+  initialValue,
+  get,
+  set,
+  version,
+  migrate,
+}: StoredStateOptions<T> & Pick<MigrationOptions<T>, 'version'>) {
+  const newKey = `${key}-v${version}`
+  const oldKey = `${key}${version <= 1 ? '' : `-v${version - 1}`}` // we didn't have versions before v1
+  const oldValue = get(oldKey, initialValue)
+  if (isEqual(oldValue, initialValue)) {
+    return false // no previous value to migrate
+  }
+  const newValue = migrate?.(oldValue, initialValue) ?? initialValue
+  set(newKey, newValue)
+  set(oldKey, null)
+  console.info(`Migrated storage key ${oldKey} to ${newKey}`, { oldValue, newValue })
+  return true // migration ran
+}
+
 /**
  * Hook for storage similar to useState, but allowing custom get/set functions.
+ * Allows for migration of old values when version is increased.
  */
 export function useStoredState<T>({
   key,
   initialValue,
   get,
   set,
-}: {
-  key: string
-  initialValue: T
-  get: (key: string, initialValue: T) => T
-  set: (key: string, value: T) => unknown
-}): GetAndSet<T> {
-  // we only return the actual storage value after render to avoid hydration issues
-  const [stateValue, setStateValue] = useState<T>(initialValue)
+  version,
+  migrate,
+}: StoredStateOptions<T>): GetAndSet<T> {
+  const fullKey = `${key}${version ? `-v${version}` : ''}`
+  const [stateValue, setStateValue] = useState<T>(get(fullKey, initialValue))
   const setValue = useCallback(
     (setter: SetStateAction<T>) => {
-      const value: T = typeof setter === 'function' ? (setter as (prev: T) => T)(get(key, initialValue)) : setter
-      set(key, value)
+      const value: T = typeof setter === 'function' ? (setter as (prev: T) => T)(get(fullKey, initialValue)) : setter
+      set(fullKey, value)
       setStateValue(value)
-      storageEvent.dispatchEvent(new Event(key))
+      storageEvent.dispatchEvent(new Event(fullKey))
     },
-    [get, initialValue, key, set],
+    [get, initialValue, fullKey, set],
   )
+
   useEffect(() => {
+    const listener = () => setStateValue(get(fullKey, initialValue))
+    if (version && runMigration({ key, initialValue, get, set, version, migrate })) {
+      listener() // update state if migration ran
+    }
+
     // Update state when other components update the local storage
-    const listener = () => setStateValue(get(key, initialValue))
-    listener()
-    storageEvent.addEventListener(key, listener)
-    return () => storageEvent.removeEventListener(key, listener)
-  }, [get, initialValue, key])
+    storageEvent.addEventListener(fullKey, listener)
+    return () => storageEvent.removeEventListener(fullKey, listener)
+  }, [get, initialValue, fullKey, set, migrate, version, key])
 
   return [stateValue, setValue]
 }

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilters.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography'
 import { ColumnFiltersState } from '@tanstack/react-table'
 import { useIsMobile, useIsTiny } from '@ui-kit/hooks/useBreakpoints'
 import { useFilterExpanded, useTableFilters } from '@ui-kit/hooks/useLocalStorage'
+import type { MigrationOptions } from '@ui-kit/hooks/useStoredState'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { FilterIcon } from '../../icons/FilterIcon'
@@ -157,8 +158,12 @@ const DEFAULT: ColumnFiltersState = []
 /**
  * A hook to manage filters for a table. Currently saved in the state, but the URL could be a better place.
  */
-export function useColumnFilters(tableTitle: string, defaultFilters: ColumnFiltersState = DEFAULT) {
-  const [columnFilters, setColumnFilters] = useTableFilters(tableTitle, defaultFilters)
+export function useColumnFilters(
+  tableTitle: string,
+  defaultFilters: ColumnFiltersState = DEFAULT,
+  migration?: MigrationOptions<ColumnFiltersState>,
+) {
+  const [columnFilters, setColumnFilters] = useTableFilters(tableTitle, defaultFilters, migration)
   const setColumnFilter = useCallback(
     (id: string, value: unknown) =>
       setColumnFilters((filters) => [

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableVisibilitySettingsPopover.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableVisibilitySettingsPopover.tsx
@@ -7,6 +7,7 @@ import Switch from '@mui/material/Switch'
 import Typography from '@mui/material/Typography'
 import { ColumnDef } from '@tanstack/react-table'
 import { useTableColumnVisibility } from '@ui-kit/hooks/useLocalStorage'
+import type { MigrationOptions } from '@ui-kit/hooks/useStoredState'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { VisibilityGroup } from './visibility.types'
 
@@ -104,15 +105,19 @@ const flatten = <ColumnIds extends string>(visibilitySettings: VisibilityGroup<C
  * @param groups - The visibility groups for all the different variants (visibility might be e.g. different in mobile).
  * @param variant - The current variant for which visibility settings are applied.
  * @param columns - The column definitions for the table.
+ * @param migration - Migration options for stored visibility settings.
+ * @returns An object containing the current column settings, column visibility state, and a function to
+ * toggle visibility of columns.
  */
 export const useVisibilitySettings = <TData, TVariant extends string, ColumnIds extends string>(
   tableTitle: string,
   groups: Record<TVariant, VisibilityGroup<ColumnIds>[]>,
   variant: TVariant,
   columns: ColumnDef<TData, any>[],
+  migration: MigrationOptions<Record<TVariant, VisibilityGroup<ColumnIds>[]>>,
 ) => {
   /** current visibility settings in grouped format */
-  const [visibilitySettings, setVisibilitySettings] = useTableColumnVisibility(tableTitle, groups)
+  const [visibilitySettings, setVisibilitySettings] = useTableColumnVisibility(tableTitle, groups, migration)
 
   /** toggle visibility of a column by its id */
   const toggleVisibility = useCallback(

--- a/tests/cypress/support/helpers/llamalend-storage.ts
+++ b/tests/cypress/support/helpers/llamalend-storage.ts
@@ -1,0 +1,104 @@
+export const LLAMA_FILTERS_V0 = [
+  {
+    id: 'liquidityUsd',
+    value: [10000, null],
+  },
+]
+
+export const LLAMA_VISIBILITY_SETTINGS_V0 = {
+  hasPositions: [
+    {
+      label: 'Markets',
+      options: [
+        {
+          label: 'Available Liquidity',
+          columns: ['liquidityUsd'],
+          active: true,
+          enabled: true,
+        },
+        {
+          label: 'Utilization',
+          columns: ['utilizationPercent'],
+          active: true,
+          enabled: true,
+        },
+        {
+          label: 'Chart',
+          columns: ['borrowChart'],
+          active: false,
+          enabled: true,
+        },
+      ],
+    },
+    {
+      label: 'Borrow',
+      options: [
+        {
+          label: 'Borrow Details',
+          columns: ['userHealth', 'userBorrowed'],
+          active: true,
+          enabled: true,
+        },
+      ],
+    },
+    {
+      label: 'Lend',
+      options: [
+        {
+          label: 'Lend Details',
+          columns: ['userEarnings', 'userDeposited'],
+          active: true,
+          enabled: true,
+        },
+      ],
+    },
+  ],
+  noPositions: [
+    {
+      label: 'Markets',
+      options: [
+        {
+          label: 'Available Liquidity',
+          columns: ['liquidityUsd'],
+          active: true,
+          enabled: true,
+        },
+        {
+          label: 'Utilization',
+          columns: ['utilizationPercent'],
+          active: true,
+          enabled: true,
+        },
+        {
+          label: 'Chart',
+          columns: ['borrowChart'],
+          active: true,
+          enabled: true,
+        },
+      ],
+    },
+    {
+      label: 'Borrow',
+      options: [
+        {
+          label: 'Borrow Details',
+          columns: ['userHealth', 'userBorrowed'],
+          active: true,
+          enabled: false,
+        },
+      ],
+    },
+    {
+      label: 'Lend',
+      options: [
+        {
+          label: 'Lend Details',
+          columns: ['userEarnings', 'userDeposited'],
+          active: true,
+          enabled: false,
+        },
+      ],
+    },
+  ],
+  unknown: [],
+}


### PR DESCRIPTION
- add migrations for old local storage filters and visibility settings
  - filters remove the old 10k liquidity filter, keeping the new TVL filter
  - visibility gets replaced, old value is only used if it already contains TVL
- add test to make sure the old fields work properly