### PR TITLE
fix: hide total apr if the total only includes base rate

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/tooltips/MarketBorrowRateTooltipContent.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/tooltips/MarketBorrowRateTooltipContent.tsx
@@ -68,14 +68,16 @@ export const MarketBorrowRateTooltipContent = ({
         </TooltipItems>
       )}
 
-      <TooltipItems>
-        <TooltipItem variant="primary" title={t`Total borrow rate`}>
-          {formatPercent(totalBorrowRate ?? 0)}
-        </TooltipItem>
-        <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-          {totalAverageBorrowRate ? formatPercent(totalAverageBorrowRate) : 'N/A'}
-        </TooltipItem>
-      </TooltipItems>
+      {(rebasingYield || extraRewards.length > 0) && (
+        <TooltipItems>
+          <TooltipItem variant="primary" title={t`Total borrow rate`}>
+            {formatPercent(totalBorrowRate ?? 0)}
+          </TooltipItem>
+          <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
+            {totalAverageBorrowRate ? formatPercent(totalAverageBorrowRate) : 'N/A'}
+          </TooltipItem>
+        </TooltipItems>
+      )}
     </Stack>
   </TooltipWrapper>
 )

--- a/packages/curve-ui-kit/src/shared/ui/tooltips/MarketSupplyRateTooltipContent.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/tooltips/MarketSupplyRateTooltipContent.tsx
@@ -72,14 +72,19 @@ export const MarketSupplyRateTooltipContent = ({
             />
           </TooltipItems>
         )}
-        <TooltipItems>
-          <TooltipItem variant="primary" title={t`Total APR`}>
-            {formatPercent(totalSupplyRateMinBoost)}
-          </TooltipItem>
-          <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-            {totalAverageSupplyRateMinBoost ? formatPercent(totalAverageSupplyRateMinBoost) : 'N/A'}
-          </TooltipItem>
-        </TooltipItems>
+        {(rebasingYield ||
+          extraRewards.length + extraIncentivesFormatted.length > 0 ||
+          !!minBoostApr ||
+          !!maxBoostApr) && (
+          <TooltipItems>
+            <TooltipItem variant="primary" title={t`Total APR`}>
+              {formatPercent(totalSupplyRateMinBoost)}
+            </TooltipItem>
+            <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
+              {totalAverageSupplyRateMinBoost ? formatPercent(totalAverageSupplyRateMinBoost) : 'N/A'}
+            </TooltipItem>
+          </TooltipItems>
+        )}
         {(minBoostApr ?? 0) > 0 && (
           <TooltipItems secondary>
             <TooltipItem variant="subItem" title={t`Extra CRV (veCRV Boost)`}>


### PR DESCRIPTION
Changes:
- Hides "Total APR" from rate and supply tooltips if total only includes base rate