### PR TITLE
fix: incorrect collateral value by simply reusing existing asset data

### DIFF
--- a/apps/main/src/llamalend/LlamaMarketsPage/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/LlamaMarketsPage/LlamaMarketExpandedPanel.tsx
@@ -63,19 +63,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
   // todo: update metric component(?) to show the errors when appropriate
   const { data: earnings, error: earningsError } = useUserMarketStats(market, LlamaMarketColumnId.UserEarnings)
   const { data: deposited, error: depositedError } = useUserMarketStats(market, LlamaMarketColumnId.UserDeposited)
-  const {
-    address,
-    assets,
-    leverage,
-    liquidityUsd,
-    type,
-    url,
-    userHasPositions,
-    utilizationPercent,
-    tvl,
-    totalCollateralUsd,
-    totalDebtUsd,
-  } = market
+  const { address, assets, leverage, liquidityUsd, type, url, userHasPositions, utilizationPercent, tvl } = market
   const graphSize = useMobileGraphSize()
 
   const UnitMapping = {
@@ -124,10 +112,10 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
           <Metric label={t`Available Liquidity`} value={liquidityUsd} valueOptions={{ unit: 'dollar' }} />
         </Grid>
         <Grid size={6}>
-          <Metric label={t`Total Debt`} value={totalDebtUsd} valueOptions={{ unit: 'dollar' }} />
+          <Metric label={t`Total Debt`} value={assets.borrowed.balanceUsd} valueOptions={{ unit: 'dollar' }} />
         </Grid>
         <Grid size={6}>
-          <Metric label={t`Total Collateral`} value={totalCollateralUsd} valueOptions={{ unit: 'dollar' }} />
+          <Metric label={t`Total Collateral`} value={assets.collateral.balanceUsd} valueOptions={{ unit: 'dollar' }} />
         </Grid>
         <Grid size={6}>
           <Metric label={t`TVL`} value={tvl} valueOptions={{ unit: 'dollar' }} />

--- a/apps/main/src/llamalend/LlamaMarketsPage/columns.enum.ts
+++ b/apps/main/src/llamalend/LlamaMarketsPage/columns.enum.ts
@@ -16,7 +16,7 @@ export enum LlamaMarketColumnId {
   IsFavorite = 'isFavorite',
   Rewards = 'rewards',
   TVL = 'tvl',
-  TotalDebt = 'totalDebtUsd',
-  TotalCollateralUsd = 'totalCollateralUsd',
+  TotalDebt = 'assets.borrowed.balanceUsd',
+  TotalCollateralUsd = 'assets.collateral.balanceUsd',
   Type = 'type',
 }

--- a/apps/main/src/llamalend/entities/llama-markets.ts
+++ b/apps/main/src/llamalend/entities/llama-markets.ts
@@ -42,8 +42,6 @@ export type LlamaMarket = {
   utilizationPercent: number
   liquidityUsd: number
   tvl: number
-  totalDebtUsd: number
-  totalCollateralUsd: number
   debtCeiling: number | null // only for mint markets, null for lend markets
   rates: {
     lend: number | null // lendApr + CRV unboosted + yield from collateral
@@ -130,8 +128,6 @@ const convertLendingVault = (
     utilizationPercent: totalAssetsUsd && (100 * totalDebtUsd) / totalAssetsUsd,
     debtCeiling: null, // debt ceiling is not applicable for lend markets
     liquidityUsd: totalAssetsUsd - totalDebtUsd,
-    totalDebtUsd: totalDebtUsd,
-    totalCollateralUsd: collateralBalanceUsd + borrowedBalanceUsd,
     tvl:
       borrowedBalanceUsd + // collateral converted to crvusd
       collateralBalanceUsd + // collateral
@@ -230,8 +226,6 @@ const convertMintMarket = (
     debtCeiling,
     liquidityUsd: borrowable,
     tvl: collateralAmountUsd,
-    totalDebtUsd: borrowed * stablecoin_price,
-    totalCollateralUsd: collateralAmountUsd,
     rates: {
       borrow: rate * 100,
       lend: null,


### PR DESCRIPTION
Currently in prod: 6m vs 9.45m collateral. The correct number should be 9.45m imo. Instead of computing new props we should re-use existing data from the assets prop.

<img width="1521" height="140" alt="image" src="https://github.com/user-attachments/assets/71bab1e2-de88-4d58-9542-100269208943" />
<img width="120" height="135" alt="image" src="https://github.com/user-attachments/assets/80e07cb6-1cd1-4fac-978f-77e9dfde6154" />
