### PR TITLE
fix: gauge page crash

### DIFF
--- a/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
@@ -8,7 +8,7 @@ import useStore from '@/dao/store/useStore'
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
 import Box from '@ui/Box'
-import { formatNumber, convertToLocaleTimestamp, formatDateFromTimestamp } from '@ui/utils/'
+import { convertToLocaleTimestamp, formatDateFromTimestamp, formatNumber } from '@ui/utils/'
 import { t } from '@ui-kit/lib/i18n'
 import { Chain, shortenAddress } from '@ui-kit/utils'
 
@@ -61,10 +61,8 @@ const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
           title={t`Created`}
           data={
             <StyledMetricsColumnData>
-              {!dataLoading &&
-                formatDateFromTimestamp(
-                  convertToLocaleTimestamp(new Date(gaugeData?.creation_date || '').getTime() / 1000),
-                )}
+              {gaugeData &&
+                formatDateFromTimestamp(convertToLocaleTimestamp(new Date(gaugeData.creation_date).getTime() / 1000))}
             </StyledMetricsColumnData>
           }
         />


### PR DESCRIPTION
- fixes a crash when going directly to the [gauge page](https://www.curve.finance/dao/ethereum/gauges/0x156527deF9a2AB4F54C849575f23dC4BB439d9d9)
- the crash was caused by an invalid value `''` being passed to the `Date` object. That returns an invalid object that may not be used