### PR TITLE
fix: lowercase in uppercase components

### DIFF
--- a/packages/curve-ui-kit/src/themes/typography.ts
+++ b/packages/curve-ui-kit/src/themes/typography.ts
@@ -60,7 +60,7 @@ const variant = ({
   ...(letterSpacing !== '0%' && {
     marginRight: `calc(${letterSpacing} * -1)`,
   }),
-  textTransform: textCase,
+  textTransform: textCase ?? 'none',
   transition: `color ${TransitionFunction}, border ${TransitionFunction}`, // border is used in the chip, for example
   ...(!(fontSize in FontSize) && { fontSize }),
   ...(!(lineHeight in LineHeight) && { lineHeight }),


### PR DESCRIPTION
Sometimes it might be necessary to use some lower-case typography inside a upper-case one. For example the FormControl component is rendered upper-case by default. When we want a lower-case label inside the control, we need to reset the text-transform property.