### PR TITLE
feat: stepper mui button

### DIFF
--- a/packages/ui/src/Stepper/StepNumberConnector.tsx
+++ b/packages/ui/src/Stepper/StepNumberConnector.tsx
@@ -13,7 +13,6 @@ const StepNumberConnector = styled.div<StepNumberConnector>`
   width: 5px;
   flex-grow: 1;
   margin-right: 20px;
-  box-shadow: 2px 2px 0 var(--box--primary--shadow-color);
   visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
   transition: all 0.5s ease;
 

--- a/packages/ui/src/Stepper/Stepper.tsx
+++ b/packages/ui/src/Stepper/Stepper.tsx
@@ -64,7 +64,6 @@ const Number = styled(Box)<{ status: StepStatus }>`
 
   color: var(--button--color);
   background-color: ${(props) => statusColorMap(props.status)};
-  box-shadow: 2px 2px 0 var(--box--primary--shadow-color);
   transition: all 0.5s ease;
 
   svg:not(.check) {


### PR DESCRIPTION
Replaces the button in the legacy stepper component with a mui button. Initially wanted to only update the buttons for llamalend, but the stepper is also used in other parts like the dex, so we're getting that one for free.

Please no bully that I didn't touch the rest of the component, that's out of scope for the time being. Although I did remove all ugly box shadows. But yeah down the line at some point the stepper component itself will also need a redo / reskin too according to Figma.

<img width="404" height="541" alt="image" src="https://github.com/user-attachments/assets/5567cac1-4045-48a1-a791-e5cee5630124" />
