### PR TITLE
fix: llamalend supply positions

### DIFF
--- a/packages/curve-ui-kit/src/hooks/useStoredState.ts
+++ b/packages/curve-ui-kit/src/hooks/useStoredState.ts
@@ -74,9 +74,8 @@ export function useStoredState<T>({
 
   useEffect(() => {
     const listener = () => setStateValue(get(fullKey, initialValue))
-    if (version && runMigration({ key, initialValue, get, set, version, migrate })) {
-      listener() // update state if migration ran
-    }
+    if (version) runMigration({ key, initialValue, get, set, version, migrate })
+    listener() // update state if migration ran or if fullKey changes
 
     // Update state when other components update the local storage
     storageEvent.addEventListener(fullKey, listener)


### PR DESCRIPTION
- the `useStoredState` hook was not properly reading the local storage when the storage `key` changed.