### PR TITLE
feat: show token errors on token input fields

### DIFF
--- a/apps/main/src/llamalend/widgets/borrow/borrow.types.ts
+++ b/apps/main/src/llamalend/widgets/borrow/borrow.types.ts
@@ -17,6 +17,8 @@ export type CompleteBorrowForm = {
 export type BorrowForm = Omit<CompleteBorrowForm, 'debt' | 'userCollateral'> & {
   userCollateral: number | undefined
   debt: number | undefined
+  maxDebt: number | undefined
+  maxCollateral: number | undefined
 }
 
 export type BorrowFormQuery = PoolQuery<IChainId> & CompleteBorrowForm
@@ -31,3 +33,5 @@ export enum BorrowPreset {
 }
 
 export type LlamaMarketTemplate = MintMarketTemplate | LendMarketTemplate
+
+export type BorrowFormErrors = (readonly [keyof BorrowForm | 'root', string])[]

--- a/apps/main/src/llamalend/widgets/borrow/components/BorrowFormAlert.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/components/BorrowFormAlert.tsx
@@ -5,7 +5,24 @@ import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
 import type { BaseConfig } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import type { BorrowFormErrors } from '../borrow.types'
 
+/** List of fields that show their own error messages, those will be omitted from the general error alert */
+const handledErrors: BorrowFormErrors[number][0][] = ['userCollateral', 'debt', 'maxDebt', 'userCollateral']
+
+/**
+ * Alert component to display the status of the borrow form submission.
+ * It shows success, warning, and error messages based on the form state.
+ * - Success Alert: Displayed when the loan is successfully created, with a link to view the transaction on the explorer.
+ * - Warning Alert: Displayed when there are form validation errors, listing the errors that need to be corrected.
+ * - Error Alert: Displayed when there is an error during the loan creation process, showing the error message.
+ *
+ * @param isCreated Indicates if the loan was successfully created
+ * @param creationError Error object if there was an error during creation
+ * @param txHash Transaction hash of the created loan, if available
+ * @param network Network configuration for generating the explorer link
+ * @param formErrors Array of form errors with field names and error messages
+ */
 export const BorrowFormAlert = ({
   isCreated,
   creationError,
@@ -17,7 +34,7 @@ export const BorrowFormAlert = ({
   isCreated: false | true
   creationError: Error | null
   txHash: undefined | string
-  formErrors: string[]
+  formErrors: BorrowFormErrors
 }) => (
   <>
     {isCreated && (
@@ -33,9 +50,11 @@ export const BorrowFormAlert = ({
     {formErrors.length > 0 && (
       <Alert severity="warning" data-testid="borrow-form-errors">
         <AlertTitle>{t`Please correct the errors`}</AlertTitle>
-        {formErrors.map((error) => (
-          <Box key={error}>{error}</Box>
-        ))}
+        {formErrors
+          .filter(([field]) => !handledErrors.includes(field))
+          .map(([field, error]) => (
+            <Box key={[field, error].join(': ')}>{error}</Box>
+          ))}
       </Alert>
     )}
     {creationError && (

--- a/apps/main/src/llamalend/widgets/borrow/components/BorrowFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/components/BorrowFormTokenInput.tsx
@@ -5,11 +5,16 @@ import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
 import type { BorrowForm, Token } from '../borrow.types'
 import { setValueOptions } from '../borrow.util'
 
+const maxField = {
+  debt: 'maxDebt',
+  userCollateral: 'maxCollateral',
+} satisfies Partial<Record<keyof BorrowForm, keyof BorrowForm>>
+
 export const BorrowFormTokenInput = ({
   label,
   token,
   name,
-  max: balance,
+  max,
   isLoading,
   isError,
   form,
@@ -20,7 +25,7 @@ export const BorrowFormTokenInput = ({
   isError: boolean
   isLoading: boolean
   max: number | undefined
-  name: keyof BorrowForm
+  name: keyof typeof maxField
   form: UseFormReturn<BorrowForm>
   testId?: string
 }) => (
@@ -37,11 +42,12 @@ export const BorrowFormTokenInput = ({
       />
     }
     onBalance={useCallback((v) => form.setValue(name, v, setValueOptions), [form, name])}
-    isError={isError}
+    isError={isError || !!form.formState.errors[name] || !!form.formState.errors[maxField[name]]}
+    message={form.formState.errors[name]?.message ?? form.formState.errors[maxField[name]]?.message}
     balanceDecimals={2}
     maxBalance={useMemo(
-      () => ({ balance, symbol: token?.symbol, loading: isLoading, showSlider: false }),
-      [balance, isLoading, token],
+      () => ({ balance: max, symbol: token?.symbol, loading: isLoading, showSlider: false }),
+      [max, isLoading, token],
     )}
   />
 )

--- a/apps/main/src/llamalend/widgets/borrow/components/BorrowTabContents.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/components/BorrowTabContents.tsx
@@ -32,7 +32,7 @@ export const BorrowTabContents = ({
     values,
     onSubmit,
     isPending,
-    maxBorrow,
+    maxTokenValues,
     params,
     form,
     collateralToken,
@@ -40,11 +40,8 @@ export const BorrowTabContents = ({
     isCreated,
     creationError,
     txHash,
-    maxDebt,
-    maxCollateral,
     formErrors,
     tooMuchDebt,
-    tooMuchCollateral,
   } = useBorrowForm({ market, network, preset })
   const setRange = (range: number) => form.setValue('range', range, setValueOptions)
   return (
@@ -56,9 +53,9 @@ export const BorrowTabContents = ({
             token={collateralToken}
             name="userCollateral"
             form={form}
-            isLoading={maxBorrow.isLoading || !market}
-            isError={maxBorrow.isError || tooMuchCollateral}
-            max={maxCollateral}
+            isLoading={maxTokenValues.isCollateralLoading}
+            isError={maxTokenValues.isCollateralError}
+            max={values.maxCollateral}
             testId="borrow-collateral-input"
           />
           <BorrowFormTokenInput
@@ -66,9 +63,9 @@ export const BorrowTabContents = ({
             token={borrowToken}
             name="debt"
             form={form}
-            isLoading={maxBorrow.isLoading || !market}
-            isError={maxBorrow.isError || tooMuchDebt}
-            max={maxDebt}
+            isLoading={maxTokenValues.isDebtLoading}
+            isError={maxTokenValues.isDebtError}
+            max={values.maxDebt}
             testId="borrow-debt-input"
           />
 

--- a/apps/main/src/llamalend/widgets/borrow/hooks/useMaxTokenValues.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/hooks/useMaxTokenValues.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import type { UseFormReturn } from 'react-hook-form'
+import { type Address, formatUnits } from 'viem'
+import { useBalance } from 'wagmi'
+import type { BorrowForm, BorrowFormQueryParams } from '@/llamalend/widgets/borrow/borrow.types'
+import { setValueOptions } from '@/llamalend/widgets/borrow/borrow.util'
+import { useMaxBorrowReceive } from '@/llamalend/widgets/borrow/queries/borrow-max-receive.query'
+import type { GetBalanceReturnType } from '@wagmi/core'
+
+/** Convert user collateral from GetBalanceReturnType to number */
+const convertBalance = ({ value, decimals }: Partial<GetBalanceReturnType>) =>
+  parseInt(formatUnits(value || 0n, decimals || 18), 10)
+
+/**
+ * Hook to fetch and set the maximum token values for collateral and debt in a borrow form.
+ * It retrieves the user's balance for the collateral token and the maximum borrowable amount,
+ * then updates the form with these values.
+ *
+ * @param collateralToken - The collateral token object containing its address.
+ * @param params - The parameters required to fetch max borrowable amounts, including chainId, poolId, and userAddress.
+ * @param form - The react-hook-form instance managing the borrow form state.
+ */
+export function useMaxTokenValues(
+  collateralToken: { address: Address } | undefined,
+  params: BorrowFormQueryParams & { userAddress?: Address },
+  form: UseFormReturn<BorrowForm>,
+) {
+  const {
+    data: userBalance,
+    isError: isBalanceError,
+    isLoading: isBalanceLoading,
+  } = useBalance({
+    address: params.userAddress,
+    token: collateralToken?.address,
+    chainId: params.chainId || undefined,
+  })
+  const { data: maxBorrow, isError: isErrorMaxBorrow, isLoading: isLoadingMaxBorrow } = useMaxBorrowReceive(params)
+
+  const maxDebt = maxBorrow?.maxDebt
+  const maxCollateral =
+    userBalance && maxBorrow?.maxTotalCollateral
+      ? Math.min(convertBalance(userBalance ?? {}), maxBorrow?.maxTotalCollateral)
+      : userBalance
+        ? convertBalance(userBalance ?? {})
+        : maxBorrow?.maxTotalCollateral
+
+  useEffect(() => form.setValue('maxDebt', maxDebt, setValueOptions), [form, maxDebt])
+  useEffect(() => form.setValue('maxCollateral', maxCollateral, setValueOptions), [form, maxCollateral])
+
+  return {
+    isCollateralLoading: !collateralToken || isLoadingMaxBorrow || isBalanceLoading,
+    isDebtLoading: !collateralToken || isLoadingMaxBorrow,
+    isCollateralError: isErrorMaxBorrow || isBalanceError,
+    isDebtError: isErrorMaxBorrow,
+  }
+}

--- a/apps/main/src/llamalend/widgets/borrow/llama.util.ts
+++ b/apps/main/src/llamalend/widgets/borrow/llama.util.ts
@@ -1,7 +1,11 @@
+import type { Address } from 'viem'
+import type { NetworkEnum } from '@/llamalend/llamalend.types'
+import { LlamaMarketTemplate } from '@/llamalend/widgets/borrow/borrow.types'
 import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
-import type { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
+import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
 import { requireLib } from '@ui-kit/features/connect-wallet'
 import { LlamaMarketType } from '@ui-kit/types/market'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 
 type MarketAndType =
   | [market: MintMarketTemplate, type: LlamaMarketType.Mint]
@@ -15,3 +19,33 @@ export function getLlamaMarket(id: string): MarketAndType {
   if (lendMarket) return [lendMarket, LlamaMarketType.Lend] as const
   throw new Error(`Market with ID ${id} not found`)
 }
+export const getTokens = (market: LlamaMarketTemplate, chain: NetworkEnum) =>
+  market instanceof MintMarketTemplate
+    ? {
+        collateralToken: {
+          chain,
+          symbol: market.collateralSymbol,
+          address: market.collateral as Address,
+          decimals: market.collateralDecimals,
+        },
+        borrowToken: {
+          chain,
+          symbol: 'crvUSD',
+          address: CRVUSD_ADDRESS,
+          decimals: 18,
+        },
+      }
+    : {
+        collateralToken: {
+          chain,
+          symbol: market.collateral_token.symbol,
+          address: market.collateral_token.address as Address,
+          decimals: market.collateral_token.decimals,
+        },
+        borrowToken: {
+          chain,
+          symbol: market.borrowed_token.symbol,
+          address: market.borrowed_token.address as Address,
+          decimals: market.borrowed_token.decimals,
+        },
+      }

--- a/apps/main/src/llamalend/widgets/borrow/queries/borrow.validation.ts
+++ b/apps/main/src/llamalend/widgets/borrow/queries/borrow.validation.ts
@@ -40,8 +40,27 @@ export const validateRange = (range: number | null | undefined, { MaxLtv, Safe }
   })
 }
 
+export const validateMaxDebt = (debt: number | undefined | null, maxDebt: number | undefined | null) => {
+  test('debt', 'Debt must be less than or equal to maximum borrowable amount', () => {
+    if (debt != null && maxDebt != null) {
+      enforce(debt).lte(maxDebt)
+    }
+  })
+}
+
+export const validateMaxCollateral = (
+  userCollateral: number | undefined | null,
+  maxCollateral: number | undefined | null,
+) => {
+  test('userCollateral', 'Collateral must be less than or equal to your wallet balance', () => {
+    if (userCollateral != null && maxCollateral != null) {
+      enforce(userCollateral).lte(maxCollateral)
+    }
+  })
+}
+
 export const borrowFormValidationGroup = (
-  { userBorrowed, userCollateral, debt, leverage, range, slippage }: FieldsOf<BorrowForm>,
+  { userBorrowed, userCollateral, debt, leverage, range, slippage, maxDebt, maxCollateral }: FieldsOf<BorrowForm>,
   { debtRequired = true }: { debtRequired?: boolean } = {},
 ) =>
   group('borrowFormValidationGroup', () => {
@@ -51,6 +70,8 @@ export const borrowFormValidationGroup = (
     validateLeverage(leverage)
     validateSlippage(slippage)
     validateRange(range)
+    validateMaxDebt(debt, maxDebt)
+    validateMaxCollateral(userCollateral, maxCollateral)
   })
 
 export const borrowFormValidationSuite = createValidationSuite(borrowFormValidationGroup)

--- a/apps/main/src/llamalend/widgets/borrow/useBorrowForm.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/useBorrowForm.tsx
@@ -1,64 +1,23 @@
 import { useEffect, useMemo } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
-import type { Address } from 'viem'
-import { formatUnits } from 'viem'
-import { useAccount, useBalance } from 'wagmi'
+import { useAccount } from 'wagmi'
 import type { NetworkEnum } from '@/llamalend/llamalend.types'
+import { getTokens } from '@/llamalend/widgets/borrow/llama.util'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
 import { notFalsy, recordEntries } from '@curvefi/prices-api/objects.util'
 import { vestResolver } from '@hookform/resolvers/vest'
 import type { BaseConfig } from '@ui/utils'
 import { useDebouncedValue } from '@ui-kit/hooks/useDebounce'
-import { t } from '@ui-kit/lib/i18n'
 import { formDefaultOptions } from '@ui-kit/lib/model'
-import { CRVUSD_ADDRESS, formatNumber } from '@ui-kit/utils'
 import { type BorrowForm, BorrowPreset, type LlamaMarketTemplate } from './borrow.types'
 import { BORROW_PRESET_RANGES, DEFAULT_SLIPPAGE } from './borrow.util'
-import { useMaxBorrowReceive } from './queries/borrow-max-receive.query'
+import { useMaxTokenValues } from './hooks/useMaxTokenValues'
 import { borrowFormValidationSuite } from './queries/borrow.validation'
 import { useCreateLoanMutation } from './queries/create-loan.mutation'
 
-const getTokens = (market: LlamaMarketTemplate, chain: NetworkEnum) =>
-  market instanceof MintMarketTemplate
-    ? {
-        collateralToken: {
-          chain,
-          symbol: market.collateralSymbol,
-          address: market.collateral as Address,
-          decimals: market.collateralDecimals,
-        },
-        borrowToken: {
-          chain,
-          symbol: 'crvUSD',
-          address: CRVUSD_ADDRESS,
-          decimals: 18,
-        },
-      }
-    : {
-        collateralToken: {
-          chain,
-          symbol: market.collateral_token.symbol,
-          address: market.collateral_token.address as Address,
-          decimals: market.collateral_token.decimals,
-        },
-        borrowToken: {
-          chain,
-          symbol: market.borrowed_token.symbol,
-          address: market.borrowed_token.address as Address,
-          decimals: market.borrowed_token.decimals,
-        },
-      }
-
 const useCallbackAfterFormUpdate = (form: UseFormReturn<BorrowForm>, callback: () => void) =>
   useEffect(() => form.subscribe({ formState: { values: true }, callback }), [form, callback])
-
-const useUserBalance = (userAddress: Address | undefined, token: { address: Address } | undefined, chainId: number) => {
-  const { data: userCollateral } = useBalance({ address: userAddress, token: token?.address, chainId })
-  return parseInt(formatUnits(userCollateral?.value || 0n, userCollateral?.decimals || 18), 10)
-}
-
 export function useBorrowForm({
   market,
   network: { id: chain, chainId },
@@ -80,6 +39,8 @@ export function useBorrowForm({
       leverage: undefined,
       slippage: DEFAULT_SLIPPAGE,
       range: BORROW_PRESET_RANGES[preset],
+      maxDebt: undefined,
+      maxCollateral: undefined,
     },
   })
   const values = form.watch()
@@ -98,26 +59,9 @@ export function useBorrowForm({
     txHash,
     reset: resetCreation,
   } = useCreateLoanMutation({ chainId, poolId: market?.id, reset: form.reset })
-  const maxBorrow = useMaxBorrowReceive(params)
 
   const { borrowToken, collateralToken } = useMemo(() => market && getTokens(market, chain), [market, chain]) ?? {}
-  const userCollateralBalance = useUserBalance(userAddress, collateralToken, chainId)
-
   useCallbackAfterFormUpdate(form, resetCreation) // reset creation state on form change
-
-  const maxDebt = maxBorrow.data?.maxDebt
-  const maxDebtError =
-    maxDebt != null &&
-    values.debt &&
-    values.debt > maxDebt &&
-    t`Exceeds maximum borrowable amount of ${formatNumber(maxDebt, { abbreviate: true })}`
-
-  const maxCollateral = userCollateralBalance ?? maxBorrow.data?.maxTotalCollateral
-  const maxCollateralError =
-    maxCollateral != null &&
-    values.userCollateral &&
-    values.userCollateral > maxCollateral &&
-    t`Exceeds maximum collateral of ${formatNumber(maxCollateral, { abbreviate: true })}`
 
   return {
     form,
@@ -125,26 +69,21 @@ export function useBorrowForm({
     params,
     isPending: form.formState.isSubmitting || isCreating,
     onSubmit: form.handleSubmit(onSubmit), // todo: handle form errors
-    maxBorrow,
+    maxTokenValues: useMaxTokenValues(collateralToken, params, form),
     borrowToken,
     collateralToken,
     isCreated,
     creationError,
     txHash,
-    maxDebt,
-    maxCollateral,
-    tooMuchDebt: !!maxDebtError,
-    tooMuchCollateral: !!maxCollateralError,
+    tooMuchDebt: !!form.formState.errors['maxDebt'],
     formErrors: useMemo(
       () =>
         notFalsy(
           ...recordEntries(form.formState.errors)
             .filter(([field, error]) => field in form.formState.dirtyFields && error?.message)
-            .map(([_, error]) => error!.message!),
-          maxDebtError,
-          maxCollateralError,
+            .map(([field, error]) => [field, error!.message!] as const),
         ),
-      [form.formState, maxDebtError, maxCollateralError],
+      [form.formState],
     ),
   }
 }


### PR DESCRIPTION
- Refactor the borrow form logic to show the errors together with the form inputs when applicable
- Add maxDebt and maxCollateral to the form so the validation can be used there too
