### PR TITLE
feat: get rid of reward icons border

### DIFF
--- a/apps/main/src/llamalend/LlamaMarketsPage/cells/RateCell/RewardsIcons.tsx
+++ b/apps/main/src/llamalend/LlamaMarketsPage/cells/RateCell/RewardsIcons.tsx
@@ -1,28 +1,14 @@
 import lodash from 'lodash'
-import type { ReactElement } from 'react'
 import { LlamaMarket } from '@/llamalend/entities/llama-markets'
 import { useFilteredRewards } from '@/llamalend/hooks/useFilteredRewards'
 import { useMarketExtraIncentives } from '@/llamalend/LlamaMarketsPage/hooks/useMarketExtraIncentives'
 import { RewardIcon } from '@/llamalend/widgets/tooltips/RewardIcon'
-import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { MarketRateType } from '@ui-kit/types/market'
 
 const { IconSize } = SizesAndSpaces
-
-const RewardChip = ({ icon }: { icon: ReactElement }) => (
-  <Chip
-    icon={icon}
-    size="small"
-    color="highlight"
-    sx={{
-      borderRadius: '100%', // Make reward chips border round, regardless of theme
-      '&:not(:last-child)': { marginInline: '-8px' },
-    }}
-  />
-)
 
 export const RewardsIcons = ({
   market: { rewards, type: marketType, rates },
@@ -35,12 +21,19 @@ export const RewardsIcons = ({
   const extraIncentives = useMarketExtraIncentives(rateType, rates.incentives, rates.lendCrvAprUnboosted)
   return (
     (filteredRewards.length > 0 || extraIncentives.length > 0) && (
-      <Stack direction="row" minWidth={IconSize.md} data-testid="rewards-icons">
+      <Stack
+        direction="row"
+        minWidth={IconSize.md}
+        data-testid="rewards-icons"
+        sx={{
+          '& svg, & img': { '&:not(:last-child)': { marginInline: '-8px' } },
+        }}
+      >
         {extraIncentives.map(({ title, address, blockchainId }) => (
-          <RewardChip key={title} icon={<TokenIcon blockchainId={blockchainId} address={address} size="mui-sm" />} />
+          <TokenIcon key={title} blockchainId={blockchainId} address={address} size="mui-sm" />
         ))}
         {lodash.uniq(filteredRewards.map((r) => r.platformImageId)).map((img) => (
-          <RewardChip key={img} icon={<RewardIcon size="sm" key={img} imageId={img} />} />
+          <RewardIcon size="sm" key={img} imageId={img} />
         ))}
       </Stack>
     )

--- a/apps/main/src/llamalend/widgets/tooltips/RewardIcon.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardIcon.tsx
@@ -5,34 +5,23 @@ import { applySxProps, type SxProps } from '@ui-kit/utils'
 
 const { IconSize } = SizesAndSpaces
 
-const RewardsImg = styled('img')({ border: '1px solid transparent', borderRadius: '50%' })
+const RewardsImg = styled('img')``
 
 type IconSize = keyof typeof IconSize
 
-export function RewardIcon({
-  imageId,
-  size = 'xs',
-  className,
-  sx,
-}: {
-  imageId: string
-  size?: IconSize
-  sx?: SxProps
-  className?: string
-}) {
-  const defaultSize = parseFloat(IconSize[size].mobile) * 16 // convert rem to px
-  return (
-    <RewardsImg
-      className={className}
-      alt={imageId}
-      src={`${CURVE_ASSETS_URL}/platforms/${imageId}`}
-      width={defaultSize}
-      height={defaultSize}
-      sx={(theme) => ({
-        width: IconSize[size],
-        height: IconSize[size],
-        ...applySxProps(sx, theme),
-      })}
-    />
-  )
-}
+// convert rem to px
+const getSize = (size: IconSize) => parseFloat(IconSize[size].mobile) * 16
+
+export const RewardIcon = ({ imageId, size = 'xs', sx }: { imageId: string; size: IconSize; sx?: SxProps }) => (
+  <RewardsImg
+    alt={imageId}
+    src={`${CURVE_ASSETS_URL}/platforms/${imageId}`}
+    width={getSize(size)}
+    height={getSize(size)}
+    sx={(theme) => ({
+      width: IconSize[size],
+      height: IconSize[size],
+      ...applySxProps(sx, theme),
+    })}
+  />
+)

--- a/apps/main/src/llamalend/widgets/tooltips/TooltipComponents.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TooltipComponents.tsx
@@ -71,7 +71,7 @@ export const TooltipItem = ({
           sx={{ marginLeft: Spacing.md }}
         />
       )}
-      {imageId && <RewardIcon size="md" imageId={imageId} sx={{ marginLeft: Spacing.md }} className="MuiChip-icon" />}
+      {imageId && <RewardIcon size="md" imageId={imageId} sx={{ marginLeft: Spacing.md }} />}
       <Typography
         color={titleTypographyColor[variant]}
         variant={titleTypographyVariant[variant]}


### PR DESCRIPTION
- force badges without icon to be a perfect circle
- remove border radius for chad theme
- remove border for reward icons

<img width="616" height="329" alt="image" src="https://github.com/user-attachments/assets/0c166aff-6329-4905-b0f6-a5f958c69b1f" />
<img width="800" height="958" alt="image" src="https://github.com/user-attachments/assets/dd246f0a-aa9e-4fda-b15a-3dc0045e6838" />
<img width="845" height="1034" alt="image" src="https://github.com/user-attachments/assets/23206551-5756-4a9d-b1b1-5a09e3339bc7" />
