### PR TITLE
chore: enable component tests with RPC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
 
   cypress-component-rpc:
     name: Cypress component tests with RPC
-    if: github.ref_name == 'main'  # only run on main branch
+    if: github.ref_name == 'main' || github.ref_name == 'feat/cypress-rpc'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -74,11 +74,10 @@ jobs:
       - run: yarn install --immutable
 
       - name: Run RPC tests
-        if: env.CYPRESS_TENDERLY_ACCESS_KEY
         run: yarn run cy:run:rpc --browser electron # rpc tests are expensive, so we stick to electron
         working-directory: tests
         env:
-          ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
+          ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
 
   cypress-component-rpc:
     name: Cypress component tests with RPC
-    if: github.ref_name == 'main' || github.ref_name == 'feat/cypress-rpc'
+    if: github.ref_name == 'main'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
       - run: yarn install --immutable
 
       - name: Run RPC tests
-        run: yarn run cy:run:rpc --browser electron # rpc tests are expensive, so we stick to electron
+        run: yarn run cy:run:rpc --browser electron # rpc tests are expensive, stick to one browser
         working-directory: tests
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,8 +80,8 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
-          CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ secrets.TENDERLY_ACCOUNT_SLUG }}
-          CYPRESS_TENDERLY_PROJECT_SLUG: ${{ secrets.TENDERLY_PROJECT_SLUG }}
+          CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
+          CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
 
   cypress-e2e:

--- a/.github/workflows/rpc-tests.yaml
+++ b/.github/workflows/rpc-tests.yaml
@@ -20,10 +20,10 @@ jobs:
       - run: yarn set version stable
       - run: yarn install --immutable
 
-      - run: yarn run cy:run:rpc --browser electron # rpc tests are expensive, so we stick to electron
+      - run: yarn run cy:run:rpc --browser electron # rpc tests are expensive, stick to one browser
         working-directory: tests
         env:
-          ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
+          ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}

--- a/.github/workflows/rpc-tests.yaml
+++ b/.github/workflows/rpc-tests.yaml
@@ -25,6 +25,6 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
-          CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ secrets.TENDERLY_ACCOUNT_SLUG }}
-          CYPRESS_TENDERLY_PROJECT_SLUG: ${{ secrets.TENDERLY_PROJECT_SLUG }}
+          CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
+          CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}


### PR DESCRIPTION
- Enable RPC tests on main branch
- The project and account slugs aren't secrets, they can be passed via the `vars` context.