### PR TITLE
fix: fractional and native token balances

### DIFF
--- a/apps/main/src/llamalend/widgets/borrow/hooks/useMaxTokenValues.tsx
+++ b/apps/main/src/llamalend/widgets/borrow/hooks/useMaxTokenValues.tsx
@@ -1,15 +1,10 @@
 import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
-import { type Address, formatUnits } from 'viem'
-import { useBalance } from 'wagmi'
+import { type Address } from 'viem'
 import type { BorrowForm, BorrowFormQueryParams } from '@/llamalend/widgets/borrow/borrow.types'
 import { useMaxBorrowReceive } from '@/llamalend/widgets/borrow/queries/borrow-max-receive.query'
-import type { GetBalanceReturnType } from '@wagmi/core'
+import { useTokenBalance } from '@ui-kit/hooks/useTokenBalance'
 import { setValueOptions } from '../llama.util'
-
-/** Convert user collateral from GetBalanceReturnType to number */
-const convertBalance = ({ value, decimals }: Partial<GetBalanceReturnType>) =>
-  parseInt(formatUnits(value || 0n, decimals || 18), 10)
 
 /**
  * Hook to fetch and set the maximum token values for collateral and debt in a borrow form.
@@ -29,20 +24,14 @@ export function useMaxTokenValues(
     data: userBalance,
     isError: isBalanceError,
     isLoading: isBalanceLoading,
-  } = useBalance({
-    address: params.userAddress,
-    token: collateralToken?.address,
-    chainId: params.chainId || undefined,
-  })
+  } = useTokenBalance(params, collateralToken)
   const { data: maxBorrow, isError: isErrorMaxBorrow, isLoading: isLoadingMaxBorrow } = useMaxBorrowReceive(params)
 
   const maxDebt = maxBorrow?.maxDebt
   const maxCollateral =
     userBalance && maxBorrow?.maxTotalCollateral
-      ? Math.min(convertBalance(userBalance ?? {}), maxBorrow?.maxTotalCollateral)
-      : userBalance
-        ? convertBalance(userBalance ?? {})
-        : maxBorrow?.maxTotalCollateral
+      ? Math.min(userBalance, maxBorrow?.maxTotalCollateral)
+      : (userBalance ?? maxBorrow?.maxTotalCollateral)
 
   useEffect(() => form.setValue('maxDebt', maxDebt, setValueOptions), [form, maxDebt])
   useEffect(() => form.setValue('maxCollateral', maxCollateral, setValueOptions), [form, maxCollateral])

--- a/packages/curve-ui-kit/src/hooks/useTokenBalance.tsx
+++ b/packages/curve-ui-kit/src/hooks/useTokenBalance.tsx
@@ -1,0 +1,26 @@
+import { type Address, ethAddress, formatUnits } from 'viem'
+import { useBalance } from 'wagmi'
+import type { FieldsOf } from '@ui-kit/lib'
+import type { GetBalanceReturnType } from '@wagmi/core'
+
+/** Convert user collateral from GetBalanceReturnType to number */
+const convertBalance = ({ value, decimals }: Partial<GetBalanceReturnType>) => +formatUnits(value || 0n, decimals || 18)
+
+/**
+ * Hook to fetch the token balance and convert it to a number, wrapping wagmi's useBalance hook.
+ * @param chainId The ID of the blockchain network.
+ * @param userAddress The address of the user whose balance is to be fetched.
+ * @param token The token object containing its address. If the address is the Ethereum address, it fetches the native balance.
+ * @returns An object containing the balance data (as a number), loading state, and error state.
+ */
+export function useTokenBalance(
+  { chainId, userAddress }: FieldsOf<{ chainId: number; userAddress: Address }>,
+  token: { address: Address } | undefined,
+) {
+  const { data, isError, isLoading } = useBalance({
+    ...(userAddress && { address: userAddress }),
+    ...(chainId && { chainId: chainId }),
+    ...(token && token.address != ethAddress && { token: token.address }),
+  })
+  return { ...(data && { data: convertBalance(data) }), isError, isLoading }
+}


### PR DESCRIPTION
- avoid using parseInt as that's going to round off the user's balance
- create a hook to wrap useBalance and do the conversion properly so the code doesn't need to be repeated
- omit passing eth address to useBalance, as that causes an error (it's just for ERC-20 tokens)