### PR TITLE
fix: import correct svg

### DIFF
--- a/apps/main/src/dex/components/PageCreatePool/ConfirmModal/CreateInfoLinkBar.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/ConfirmModal/CreateInfoLinkBar.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components'
-import { default as ExternalIcon } from '@ui/images/external.svg'
+import { RCExternal } from '@ui/images'
 import ExternalLink from '@ui/Link/ExternalLink'
 
 type Props = {
@@ -20,7 +20,7 @@ const InfoLinkBar = ({ description, link, theme, className }: Props) => (
   </StyledExternalLink>
 )
 
-const StyledExternalIcon = styled(ExternalIcon)`
+const StyledExternalIcon = styled(RCExternal)`
   margin: auto 0;
   margin-left: var(--spacing-2);
   min-width: 24px;


### PR DESCRIPTION
- We were importing the svg from another project without the `?react` suffix
- It's better to use the shared [constant](https://github.com/curvefi/curve-frontend/blob/58a3c0100e96c53fba8baf9708bdc96652f60230/packages/ui/src/images/index.ts#L25)