### PR TITLE
fix: chad illustration background

### DIFF
--- a/packages/ui/src/utils/utilsConstants.ts
+++ b/packages/ui/src/utils/utilsConstants.ts
@@ -11,5 +11,4 @@ export const getImageBaseUrl = (blockchainId: string) =>
 
 export const getBlockchainIconUrl = (blockchainId: string) => `${CURVE_ASSETS_URL}/chains/${blockchainId}.png`
 
-export const getBackgroundUrl = (theme: ThemeKey) =>
-  `${CURVE_ASSETS_URL}/branding/curve_illustration-${theme === 'dark' ? 'dark' : 'light'}.svg`
+export const getBackgroundUrl = (theme: ThemeKey) => `${CURVE_ASSETS_URL}/branding/curve_illustration-${theme}.svg`


### PR DESCRIPTION
Before vs after:
<img width="808" height="900" alt="image" src="https://github.com/user-attachments/assets/c19a1f3f-5073-4e5a-95c4-1d8501349f6e" />

Depends on https://github.com/curvefi/curve-assets/pull/929