### PR TITLE
chore: export screenshots on RPC test failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,12 @@ jobs:
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
 
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-rpc
+          path: tests/cypress/screenshots
+
   cypress-e2e:
     strategy:
       fail-fast: false

--- a/.github/workflows/rpc-tests.yaml
+++ b/.github/workflows/rpc-tests.yaml
@@ -28,3 +28,9 @@ jobs:
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-rpc
+          path: tests/cypress/screenshots


### PR DESCRIPTION
- add an upload-artifact step to the RPC tests so we can examine the test failures