### PR TITLE
refactor: remove hacky filler box in sidebar footer

### DIFF
--- a/packages/curve-ui-kit/src/widgets/Header/MobileHeader.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/MobileHeader.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import AppBar from '@mui/material/AppBar'
-import Box from '@mui/material/Box'
 import Drawer from '@mui/material/Drawer'
 import Stack from '@mui/material/Stack'
 import Toolbar from '@mui/material/Toolbar'
@@ -83,13 +82,22 @@ export const MobileHeader = ({
           anchor="left"
           onClose={closeSidebar}
           open={isSidebarOpen}
-          slotProps={{ paper: { sx: { top, ...MOBILE_SIDEBAR_WIDTH, ...HIDE_SCROLLBAR } } }}
+          slotProps={{
+            paper: {
+              sx: {
+                top,
+                ...MOBILE_SIDEBAR_WIDTH,
+                ...HIDE_SCROLLBAR,
+                height: `calc(100dvh - ${top}px)`,
+              },
+            },
+          }}
           sx={{ top }}
           variant="temporary"
           hideBackdrop
           data-testid="mobile-drawer"
         >
-          <Box>
+          <Stack sx={{ overflowY: 'auto', ...HIDE_SCROLLBAR }}>
             <Stack padding={4}>
               <HeaderStats appStats={appStats} />
             </Stack>
@@ -105,7 +113,7 @@ export const MobileHeader = ({
             ))}
 
             <SocialSidebarSection title={t`Community`} />
-          </Box>
+          </Stack>
 
           <SideBarFooter onConnect={closeSidebar} />
         </Drawer>

--- a/packages/curve-ui-kit/src/widgets/Header/SideBarFooter.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/SideBarFooter.tsx
@@ -3,12 +3,10 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Accordion from '@mui/material/Accordion'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import AccordionSummary from '@mui/material/AccordionSummary'
-import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import type { Theme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import { ConnectWalletIndicator } from '@ui-kit/features/connect-wallet'
-import { useLayoutStore } from '@ui-kit/features/layout'
 import { AdvancedModeSwitch } from '@ui-kit/features/user-profile/settings/AdvancedModeSwitch'
 import { ThemeToggleButtons } from '@ui-kit/features/user-profile/settings/ThemeToggleButtons'
 import { t } from '@ui-kit/lib/i18n'
@@ -19,59 +17,44 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 const { Spacing, ButtonSize } = SizesAndSpaces
 
 const backgroundColor = 'background.paper'
-const footerMargin = Spacing.lg.mobile
-const connectButtonHeight = ButtonSize.sm
-const accordionHeight = ButtonSize.md
-const footerHeight = `${footerMargin} + ${accordionHeight} + ${connectButtonHeight}`
-
-/**
- * Calculates the height needed to prevent content from being hidden behind the fixed footer.
- * Otherwise, the `SocialSidebarSection` is hidden by `ConnectWalletIndicator` & `AccordionSummary`.
- *
- * Since the drawer takes 100vh, we need to account for the header height as well.
- */
-const useFillerHeight = () => `calc(${useLayoutStore((state) => state.navHeight)}px + ${footerHeight})`
 
 export const SideBarFooter = ({ onConnect }: { onConnect: () => void }) => (
-  <>
-    <Box
-      position="fixed"
-      bottom={0}
-      sx={(t) => ({ ...MOBILE_SIDEBAR_WIDTH, zIndex: t.zIndex.drawer + 1, backgroundColor })}
-    >
-      <Box display="flex" paddingX={4} marginTop={4}>
-        <ConnectWalletIndicator sx={{ flexGrow: 1 }} onConnect={onConnect} />
-      </Box>
+  <Stack sx={{ ...MOBILE_SIDEBAR_WIDTH, backgroundColor }}>
+    <ConnectWalletIndicator sx={{ flexGrow: 1, margin: Spacing.sm }} onConnect={onConnect} />
 
-      <Accordion sx={{ backgroundColor }} disableGutters>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor, paddingInline: 4 }}>
-          <GearIcon sx={{ fontSize: 22, fill: 'transparent', stroke: 'currentColor' }} />
-          <Typography
-            sx={{ marginLeft: 1, alignContent: 'center' }}
-            variant="bodyMBold"
-            color="navigation"
-            data-testid="sidebar-settings"
-          >
-            {t`Settings`}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails sx={{ backgroundColor, borderTop: (t: Theme) => `1px solid ${t.palette.text.secondary}` }}>
-          <SettingsOption label={t`Theme`}>
-            <ThemeToggleButtons size="small" compact />
-          </SettingsOption>
+    <Accordion sx={{ backgroundColor }} disableGutters>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ backgroundColor, paddingInline: Spacing.sm }}>
+        <GearIcon sx={{ fontSize: 22, fill: 'transparent', stroke: 'currentColor' }} />
+        <Typography
+          sx={{ marginLeft: Spacing.sm, alignContent: 'center' }}
+          variant="bodyMBold"
+          color="navigation"
+          data-testid="sidebar-settings"
+        >
+          {t`Settings`}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ backgroundColor, borderTop: (t: Theme) => `1px solid ${t.palette.text.secondary}` }}>
+        <SettingsOption label={t`Theme`}>
+          <ThemeToggleButtons size="small" compact />
+        </SettingsOption>
 
-          <SettingsOption label={t`Advanced Mode`}>
-            <AdvancedModeSwitch />
-          </SettingsOption>
-        </AccordionDetails>
-      </Accordion>
-    </Box>
-    <Box minHeight={useFillerHeight()} />
-  </>
+        <SettingsOption label={t`Advanced Mode`}>
+          <AdvancedModeSwitch />
+        </SettingsOption>
+      </AccordionDetails>
+    </Accordion>
+  </Stack>
 )
 
 const SettingsOption = ({ label, children }: { label: string; children: ReactNode }) => (
-  <Stack height={ButtonSize.sm} direction="row" justifyContent="space-between" alignItems="center" marginInline={2}>
+  <Stack
+    height={ButtonSize.sm}
+    direction="row"
+    justifyContent="space-between"
+    alignItems="center"
+    marginInline={Spacing.sm}
+  >
     <Typography variant="bodyMBold" color="navigation">
       {label}
     </Typography>


### PR DESCRIPTION
Having an empty filler box in the mobile footer component felt super hacky and a source of maintenance hell, so figured we could get away with it being absolutely positioned. Basically it sits at the bottom of the drawer content, always visible as the sections above are now just part of a scrollable area.