### PR TITLE
feat: replace borrow tabs in beta mode

### DIFF
--- a/apps/main/src/lend/components/PageLoanCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/index.tsx
@@ -1,28 +1,60 @@
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import LoanFormCreate from '@/lend/components/PageLoanCreate/LoanFormCreate'
+import type { FormValues } from '@/lend/components/PageLoanCreate/types'
+import { DEFAULT_FORM_VALUES } from '@/lend/components/PageLoanCreate/utils'
+import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
 import { type MarketUrlParams, type PageContentProps } from '@/lend/types/lend.types'
 import { getLoanCreatePathname } from '@/lend/utils/utilsRouter'
+import { BorrowTabContents } from '@/llamalend/features/borrow/components/BorrowTabContents'
+import type { OnBorrowFormUpdate } from '@/llamalend/features/borrow/types'
 import Stack from '@mui/material/Stack'
 import { AppFormContentWrapper } from '@ui/AppForm'
 import { useNavigate } from '@ui-kit/hooks/router'
+import { useReleaseChannel } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { TabsSwitcher, type TabOption } from '@ui-kit/shared/ui/TabsSwitcher'
+import { ReleaseChannel } from '@ui-kit/utils'
+
+/**
+ * Callback that synchronizes the `ChartOhlc` component with the `RangeSlider` component in the new `BorrowTabContents`.
+ */
+const useOnFormUpdate = ({ api, market }: PageContentProps): OnBorrowFormUpdate =>
+  useCallback(
+    async ({ debt, userCollateral, range, slippage, leverageEnabled }) => {
+      const { setFormValues, setStateByKeys } = useStore.getState().loanCreate
+      const formValues: FormValues = {
+        ...DEFAULT_FORM_VALUES,
+        n: range,
+        debt: `${debt ?? ''}`,
+        userCollateral: `${userCollateral ?? ''}`,
+      }
+      await setFormValues(api, market, formValues, `${slippage}`, leverageEnabled)
+      setStateByKeys({ isEditLiqRange: true })
+    },
+    [api, market],
+  )
 
 const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) => {
   const { rChainId, rOwmId, rFormType, market, params } = pageProps
   const push = useNavigate()
+  const [releaseChannel] = useReleaseChannel()
+  const onUpdate = useOnFormUpdate(pageProps)
 
   const resetState = useStore((state) => state.loanCreate.resetState)
   const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   type Tab = 'create' | 'leverage'
   const tabs: TabOption<Tab>[] = useMemo(
-    () => [
-      { value: 'create' as const, label: t`Create Loan` },
-      ...(market?.leverage.hasLeverage() ? [{ value: 'leverage' as const, label: t`Leverage` }] : []),
-    ],
-    [market?.leverage],
+    () =>
+      releaseChannel === ReleaseChannel.Beta
+        ? // the new borrow form contains both create and leverage functionality
+          [{ value: 'create' as const, label: t`Borrow` }]
+        : [
+            { value: 'create' as const, label: t`Create Loan` },
+            ...(market?.leverage.hasLeverage() ? [{ value: 'leverage' as const, label: t`Leverage` }] : []),
+          ],
+    [market?.leverage, releaseChannel],
   )
 
   // init campaignRewardsMapper
@@ -47,8 +79,13 @@ const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) =
       />
 
       <AppFormContentWrapper>
-        {(rFormType === '' || rFormType === 'create') && <LoanFormCreate {...pageProps} />}
-        {rFormType === 'leverage' && <LoanFormCreate isLeverage {...pageProps} />}
+        {releaseChannel === ReleaseChannel.Beta ? (
+          <BorrowTabContents networks={networks} chainId={rChainId} market={market ?? undefined} onUpdate={onUpdate} />
+        ) : rFormType === 'leverage' ? (
+          <LoanFormCreate isLeverage {...pageProps} />
+        ) : (
+          <LoanFormCreate {...pageProps} />
+        )}
       </AppFormContentWrapper>
     </Stack>
   )

--- a/apps/main/src/lend/components/PageLoanCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/index.tsx
@@ -65,7 +65,7 @@ const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) =
   }, [initCampaignRewards, rChainId, initiated])
 
   return (
-    <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
+    <>
       <TabsSwitcher
         variant="contained"
         size="medium"
@@ -75,19 +75,25 @@ const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) =
           push(getLoanCreatePathname(params, rOwmId, key))
         }}
         options={tabs}
-        fullWidth
+        fullWidth={releaseChannel !== ReleaseChannel.Beta}
       />
-
-      <AppFormContentWrapper>
-        {releaseChannel === ReleaseChannel.Beta ? (
-          <BorrowTabContents networks={networks} chainId={rChainId} market={market ?? undefined} onUpdate={onUpdate} />
-        ) : rFormType === 'leverage' ? (
-          <LoanFormCreate isLeverage {...pageProps} />
-        ) : (
-          <LoanFormCreate {...pageProps} />
-        )}
-      </AppFormContentWrapper>
-    </Stack>
+      <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
+        <AppFormContentWrapper>
+          {releaseChannel === ReleaseChannel.Beta ? (
+            <BorrowTabContents
+              networks={networks}
+              chainId={rChainId}
+              market={market ?? undefined}
+              onUpdate={onUpdate}
+            />
+          ) : rFormType === 'leverage' ? (
+            <LoanFormCreate isLeverage {...pageProps} />
+          ) : (
+            <LoanFormCreate {...pageProps} />
+          )}
+        </AppFormContentWrapper>
+      </Stack>
+    </>
   )
 }
 

--- a/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
@@ -12,7 +12,7 @@ import { useBorrowPreset } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { setValueOptions } from '../react-form.utils'
-import { BorrowPreset, type OnBorrowFormUpdate } from '../types'
+import { type BorrowFormExternalFields, BorrowPreset, type OnBorrowFormUpdate } from '../types'
 import { useBorrowForm } from '../useBorrowForm'
 import { AdvancedBorrowOptions } from './AdvancedBorrowOptions'
 import { BorrowActionInfoAccordion } from './BorrowActionInfoAccordion'
@@ -23,6 +23,18 @@ import { LeverageInput } from './LeverageInput'
 import { LoanPresetSelector } from './LoanPresetSelector'
 
 const { Spacing, MinWidth } = SizesAndSpaces
+
+/**
+ * Hook to call the parent form to keep in sync with the chart and other components
+ */
+function useFormSync(
+  { userCollateral, range, debt, userBorrowed, slippage, leverageEnabled }: BorrowFormExternalFields,
+  onUpdate: OnBorrowFormUpdate,
+) {
+  useEffect(() => {
+    void onUpdate({ userCollateral, debt, range, userBorrowed, slippage, leverageEnabled })
+  }, [onUpdate, userCollateral, debt, range, userBorrowed, slippage, leverageEnabled])
+}
 
 /**
  * The contents of the Borrow tab, including the form and all related components.
@@ -59,13 +71,8 @@ export const BorrowTabContents = <ChainId extends IChainId>({
     tooMuchDebt,
   } = useBorrowForm({ market, network, preset })
   const setRange = useCallback((range: number) => form.setValue('range', range, setValueOptions), [form])
+  useFormSync(values, onUpdate)
 
-  const { userCollateral, range, debt } = values
-  useEffect(
-    // callback the parent form to keep in sync with the chart and other components
-    () => void onUpdate({ userCollateral, debt, range }).then(() => {}),
-    [onUpdate, userCollateral, debt, range],
-  )
   const marketHasLeverage = market && hasLeverage(market)
   return (
     <FormProvider {...form}>

--- a/apps/main/src/llamalend/features/borrow/types.ts
+++ b/apps/main/src/llamalend/features/borrow/types.ts
@@ -19,7 +19,7 @@ type CalculatedValues = { maxDebt: number | undefined; maxCollateral: number | u
 export type BorrowForm = MakeOptional<CompleteBorrowForm, 'debt' | 'userCollateral'> & CalculatedValues
 
 /** Fields of the borrow form that are passed back to the origin application for synchronization */
-export type BorrowFormExternalFields = Pick<BorrowForm, 'range' | 'userCollateral' | 'debt'>
+export type BorrowFormExternalFields = Omit<BorrowForm, keyof CalculatedValues>
 /** Callback type to pass on the external fields of the borrow form */
 export type OnBorrowFormUpdate = (form: BorrowFormExternalFields) => Promise<void>
 

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -4,14 +4,14 @@ import type { INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
 import { requireLib } from '@ui-kit/features/connect-wallet'
-import { assert, CRVUSD_ADDRESS } from '@ui-kit/utils'
+import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 
 /**
  * Gets a Llama market (either a mint or lend market) by its ID.
  * Throws an error if no market is found with the given ID.
  */
 export const getLlamaMarket = (id: string, lib = requireLib('llamaApi')): LlamaMarketTemplate =>
-  assert(lib.getMintMarket(id) ?? lib.getLendMarket(id), `Market with ID ${id} not found`)
+  id.startsWith('one-way') ? lib.getLendMarket(id) : lib.getMintMarket(id)
 
 /**
  * Checks if a market supports leverage or not. A market supports leverage if:

--- a/apps/main/src/loan/components/PageLoanCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { BorrowTabContents } from '@/llamalend/features/borrow/components/BorrowTabContents'
 import type { OnBorrowFormUpdate } from '@/llamalend/features/borrow/types'
 import LoanFormCreate from '@/loan/components/PageLoanCreate/LoanFormCreate'
@@ -11,7 +11,6 @@ import { LlamaApi, Llamma } from '@/loan/types/loan.types'
 import { getLoanCreatePathname, getLoanManagePathname } from '@/loan/utils/utilsRouter'
 import Stack from '@mui/material/Stack'
 import { AppFormContentWrapper } from '@ui/AppForm'
-import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { useNavigate } from '@ui-kit/hooks/router'
 import { useReleaseChannel } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
@@ -20,15 +19,11 @@ import { ReleaseChannel } from '@ui-kit/utils'
 
 /**
  * Callback that synchronizes the `ChartOhlc` component with the `RangeSlider` component in the new `BorrowTabContents`.
- * @param curve
- * @param llamma
- * @param rFormType
  */
-const useOnFormUpdate = ({ curve, llamma, rFormType }: PageLoanCreateProps): OnBorrowFormUpdate =>
+const useOnFormUpdate = ({ curve, llamma }: PageLoanCreateProps): OnBorrowFormUpdate =>
   useCallback(
-    async ({ debt, userCollateral, range }) => {
+    async ({ debt, userCollateral, range, slippage, leverageEnabled }) => {
       if (!curve || !llamma) return
-      const { maxSlippage } = useUserProfileStore.getState()
       const { setFormValues, setStateByKeys } = useStore.getState().loanCreate
       const formValues: FormValues = {
         ...DEFAULT_FORM_VALUES,
@@ -36,11 +31,10 @@ const useOnFormUpdate = ({ curve, llamma, rFormType }: PageLoanCreateProps): OnB
         debt: `${debt ?? ''}`,
         collateral: `${userCollateral ?? ''}`,
       }
-      const isLeverage = rFormType === 'leverage'
-      await setFormValues(curve, isLeverage, llamma, formValues, maxSlippage.crypto)
+      await setFormValues(curve, leverageEnabled, llamma, formValues, `${slippage}`)
       setStateByKeys({ isEditLiqRange: true })
     },
-    [curve, llamma, rFormType],
+    [curve, llamma],
   )
 
 const LoanCreate = ({
@@ -56,12 +50,18 @@ const LoanCreate = ({
   const [releaseChannel] = useReleaseChannel()
   const onUpdate = useOnFormUpdate(props)
 
-  type Tab = 'create' | 'leverage' | 'borrow'
-  const tabs: TabOption<Tab>[] = [
-    { value: 'create' as const, label: t`Create Loan` },
-    ...(hasLeverage(llamma) ? [{ value: 'leverage' as const, label: t`Leverage` }] : []),
-    ...(releaseChannel === ReleaseChannel.Beta ? [{ value: 'borrow' as const, label: t`Beta` }] : []),
-  ]
+  type Tab = 'create' | 'leverage'
+  const tabs: TabOption<Tab>[] = useMemo(
+    () =>
+      releaseChannel === ReleaseChannel.Beta
+        ? // the new borrow form contains both create and leverage functionality
+          [{ value: 'create' as const, label: t`Borrow` }]
+        : [
+            { value: 'create' as const, label: t`Create Loan` },
+            ...(hasLeverage(llamma) ? [{ value: 'leverage' as const, label: t`Leverage` }] : []),
+          ],
+    [llamma, releaseChannel],
+  )
 
   const handleTabClick = useCallback(
     (formType: FormType) => {
@@ -89,7 +89,7 @@ const LoanCreate = ({
       />
 
       <AppFormContentWrapper>
-        {rFormType === 'borrow' ? (
+        {releaseChannel === ReleaseChannel.Beta ? (
           <BorrowTabContents networks={networks} chainId={rChainId} market={llamma ?? undefined} onUpdate={onUpdate} />
         ) : (
           <LoanFormCreate {...props} collateralAlert={collateralAlert} />

--- a/apps/main/src/loan/components/PageLoanCreate/index.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/index.tsx
@@ -78,24 +78,30 @@ const LoanCreate = ({
   )
 
   return (
-    <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
+    <>
       <TabsSwitcher
         variant="contained"
         size="medium"
         value={rFormType || 'create'}
         onChange={(key) => handleTabClick(key as FormType)}
         options={tabs}
-        fullWidth
+        fullWidth={releaseChannel !== ReleaseChannel.Beta}
       />
-
-      <AppFormContentWrapper>
-        {releaseChannel === ReleaseChannel.Beta ? (
-          <BorrowTabContents networks={networks} chainId={rChainId} market={llamma ?? undefined} onUpdate={onUpdate} />
-        ) : (
-          <LoanFormCreate {...props} collateralAlert={collateralAlert} />
-        )}
-      </AppFormContentWrapper>
-    </Stack>
+      <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
+        <AppFormContentWrapper>
+          {releaseChannel === ReleaseChannel.Beta ? (
+            <BorrowTabContents
+              networks={networks}
+              chainId={rChainId}
+              market={llamma ?? undefined}
+              onUpdate={onUpdate}
+            />
+          ) : (
+            <LoanFormCreate {...props} collateralAlert={collateralAlert} />
+          )}
+        </AppFormContentWrapper>
+      </Stack>
+    </>
   )
 }
 


### PR DESCRIPTION
- Get rid of the old create/leverage tabs in beta mode, only show the new borrow form
- Implement the new borrow form for lend markets, also in beta
- fix background issues with the tab switcher