### PR TITLE
refactor: remove unused chain parameter from getTokens

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
@@ -74,6 +74,9 @@ export const BorrowTabContents = <ChainId extends IChainId>({
   useFormSync(values, onUpdate)
 
   const marketHasLeverage = market && hasLeverage(market)
+  const collateralTokenWithChain = collateralToken && { ...collateralToken, chain: network.id }
+  const borrowTokenWithChain = borrowToken && { ...borrowToken, chain: network.id }
+
   return (
     <FormProvider {...form}>
       <form onSubmit={onSubmit} style={{ overflowWrap: 'break-word' }}>
@@ -81,7 +84,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
           <Stack divider={<InputDivider />}>
             <BorrowFormTokenInput
               label={t`Collateral`}
-              token={collateralToken}
+              token={collateralTokenWithChain}
               name="userCollateral"
               form={form}
               isLoading={maxTokenValues.isCollateralLoading}
@@ -91,7 +94,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
             />
             <BorrowFormTokenInput
               label={t`Borrow`}
-              token={borrowToken}
+              token={borrowTokenWithChain}
               name="debt"
               form={form}
               isLoading={maxTokenValues.isDebtLoading}
@@ -120,8 +123,8 @@ export const BorrowTabContents = <ChainId extends IChainId>({
                 params={params}
                 setRange={setRange}
                 network={network.id}
-                collateralToken={collateralToken}
-                borrowToken={borrowToken}
+                collateralToken={collateralTokenWithChain}
+                borrowToken={borrowTokenWithChain}
               />
             </Collapse>
           </LoanPresetSelector>
@@ -147,7 +150,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
             <BorrowActionInfoAccordion
               params={params}
               values={values}
-              collateralToken={collateralToken}
+              collateralToken={collateralTokenWithChain}
               tooMuchDebt={tooMuchDebt}
               networks={networks}
               onSlippageChange={(value) => form.setValue('slippage', +value, setValueOptions)}

--- a/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowTabContents.tsx
@@ -74,9 +74,6 @@ export const BorrowTabContents = <ChainId extends IChainId>({
   useFormSync(values, onUpdate)
 
   const marketHasLeverage = market && hasLeverage(market)
-  const collateralTokenWithChain = collateralToken && { ...collateralToken, chain: network.id }
-  const borrowTokenWithChain = borrowToken && { ...borrowToken, chain: network.id }
-
   return (
     <FormProvider {...form}>
       <form onSubmit={onSubmit} style={{ overflowWrap: 'break-word' }}>
@@ -84,7 +81,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
           <Stack divider={<InputDivider />}>
             <BorrowFormTokenInput
               label={t`Collateral`}
-              token={collateralTokenWithChain}
+              token={collateralToken}
               name="userCollateral"
               form={form}
               isLoading={maxTokenValues.isCollateralLoading}
@@ -94,7 +91,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
             />
             <BorrowFormTokenInput
               label={t`Borrow`}
-              token={borrowTokenWithChain}
+              token={borrowToken}
               name="debt"
               form={form}
               isLoading={maxTokenValues.isDebtLoading}
@@ -123,8 +120,8 @@ export const BorrowTabContents = <ChainId extends IChainId>({
                 params={params}
                 setRange={setRange}
                 network={network.id}
-                collateralToken={collateralTokenWithChain}
-                borrowToken={borrowTokenWithChain}
+                collateralToken={collateralToken}
+                borrowToken={borrowToken}
               />
             </Collapse>
           </LoanPresetSelector>
@@ -150,7 +147,7 @@ export const BorrowTabContents = <ChainId extends IChainId>({
             <BorrowActionInfoAccordion
               params={params}
               values={values}
-              collateralToken={collateralTokenWithChain}
+              collateralToken={collateralToken}
               tooMuchDebt={tooMuchDebt}
               networks={networks}
               onSlippageChange={(value) => form.setValue('slippage', +value, setValueOptions)}

--- a/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
@@ -63,7 +63,7 @@ export function useBorrowForm<ChainId extends IChainId>({
     reset: resetCreation,
   } = useCreateLoanMutation({ chainId, poolId: market?.id, reset: form.reset })
 
-  const { borrowToken, collateralToken } = useMemo(() => market && getTokens(market, chain), [market, chain]) ?? {}
+  const { borrowToken, collateralToken } = useMemo(() => market && getTokens(market), [market]) ?? {}
   useCallbackAfterFormUpdate(form, resetCreation) // reset creation state on form change
 
   return {

--- a/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
@@ -63,7 +63,18 @@ export function useBorrowForm<ChainId extends IChainId>({
     reset: resetCreation,
   } = useCreateLoanMutation({ chainId, poolId: market?.id, reset: form.reset })
 
-  const { borrowToken, collateralToken } = useMemo(() => market && getTokens(market), [market]) ?? {}
+  const { borrowToken, collateralToken } =
+    useMemo(() => {
+      const tokens = market && getTokens(market)
+
+      return (
+        tokens && {
+          borrowToken: { ...tokens.borrowToken, chain },
+          collateralToken: { ...tokens.collateralToken, chain },
+        }
+      )
+    }, [market, chain]) ?? {}
+
   useCallbackAfterFormUpdate(form, resetCreation) // reset creation state on form change
 
   return {

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -1,6 +1,5 @@
 import { type Address, zeroAddress } from 'viem'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
-import type { INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
 import { requireLib } from '@ui-kit/features/connect-wallet'
@@ -23,17 +22,15 @@ export const hasLeverage = (market: LlamaMarketTemplate) =>
     ? market.leverage.hasLeverage()
     : market.leverageZap !== zeroAddress || market.leverageV2.hasLeverage()
 
-export const getTokens = (market: LlamaMarketTemplate, chain: INetworkName) =>
+export const getTokens = (market: LlamaMarketTemplate) =>
   market instanceof MintMarketTemplate
     ? {
         collateralToken: {
-          chain,
           symbol: market.collateralSymbol,
           address: market.collateral as Address,
           decimals: market.collateralDecimals,
         },
         borrowToken: {
-          chain,
           symbol: 'crvUSD',
           address: CRVUSD_ADDRESS,
           decimals: 18,
@@ -41,13 +38,11 @@ export const getTokens = (market: LlamaMarketTemplate, chain: INetworkName) =>
       }
     : {
         collateralToken: {
-          chain,
           symbol: market.collateral_token.symbol,
           address: market.collateral_token.address as Address,
           decimals: market.collateral_token.decimals,
         },
         borrowToken: {
-          chain,
           symbol: market.borrowed_token.symbol,
           address: market.borrowed_token.address as Address,
           decimals: market.borrowed_token.decimals,


### PR DESCRIPTION
It's not part of the market object, so you're passing in data you already had to fetch elsewhere and is readily available.

Real reason is I want to use this function too without having to pass a chain name for no reason 😄 
Want to make it a pure `LlamaMarketTemplate` function