### PR TITLE
fix: leverage input grouping lend

### DIFF
--- a/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanBorrowMore/index.tsx
@@ -13,7 +13,6 @@ import { _parseValues, DEFAULT_FORM_VALUES } from '@/lend/components/PageLoanMan
 import { StyledDetailInfoWrapper } from '@/lend/components/PageLoanManage/styles'
 import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
-import { FieldsWrapper } from '@/lend/components/SharedFormStyles/FieldsWrapper'
 import { NOFITY_MESSAGE } from '@/lend/constants'
 import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
@@ -21,6 +20,8 @@ import networks from '@/lend/networks'
 import useStore from '@/lend/store/useStore'
 import { Api, HealthMode, OneWayMarketTemplate, PageContentProps } from '@/lend/types/lend.types'
 import { _showNoLoanFound } from '@/lend/utils/helpers'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 import AlertBox from '@ui/AlertBox'
 import { getActiveStep } from '@ui/Stepper/helpers'
 import Stepper from '@ui/Stepper/Stepper'
@@ -33,6 +34,9 @@ import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import usePageVisibleInterval from '@ui-kit/hooks/usePageVisibleInterval'
 import { t } from '@ui-kit/lib/i18n'
 import { REFRESH_INTERVAL } from '@ui-kit/lib/model'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing } = SizesAndSpaces
 
 const LoanBorrowMore = ({
   rChainId,
@@ -352,58 +356,63 @@ const LoanBorrowMore = ({
   const network = networks[rChainId]
 
   return (
-    <>
-      <FieldsWrapper $showBorder={isLeverage}>
-        <InpToken
-          network={network}
-          id="userCollateral"
-          inpTopLabel={t`Add from wallet:`}
-          inpError={formValues.userCollateralError}
-          inpDisabled={disabled}
-          inpLabelLoading={!!signerAddress && typeof userBalances?.collateral === 'undefined'}
-          inpLabelDescription={formatNumber(userBalances?.collateral, { defaultValue: '-' })}
-          inpValue={formValues.userCollateral}
-          tokenAddress={market?.collateral_token?.address}
-          tokenSymbol={market?.collateral_token?.symbol}
-          tokenBalance={userBalances?.collateral}
-          handleInpChange={useCallback((userCollateral) => updateFormValues({ userCollateral }), [updateFormValues])}
-          handleMaxClick={() => updateFormValues({ userCollateral: userBalances?.collateral ?? '' })}
-        />
+    <Stack gap={Spacing.lg}>
+      <Stack gap={Spacing.sm}>
+        <Typography variant="headingXsMedium">{t`Add from wallet:`}</Typography>
 
-        {isLeverage && (
+        <Stack gap={Spacing.md}>
           <InpToken
             network={network}
-            id="userBorrowed"
-            inpError={formValues.userBorrowedError}
+            id="userCollateral"
+            inpError={formValues.userCollateralError}
             inpDisabled={disabled}
-            inpLabelLoading={!!signerAddress && typeof userBalances?.borrowed === 'undefined'}
-            inpLabelDescription={formatNumber(userBalances?.borrowed, { defaultValue: '-' })}
-            inpValue={formValues.userBorrowed}
-            tokenAddress={market?.borrowed_token?.address}
-            tokenSymbol={market?.borrowed_token?.symbol}
-            tokenBalance={userBalances?.borrowed}
-            handleInpChange={setUserBorrowed}
-            handleMaxClick={() => updateFormValues({ userBorrowed: userBalances?.borrowed ?? '' })}
+            inpLabelLoading={!!signerAddress && typeof userBalances?.collateral === 'undefined'}
+            inpLabelDescription={formatNumber(userBalances?.collateral, { defaultValue: '-' })}
+            inpValue={formValues.userCollateral}
+            tokenAddress={market?.collateral_token?.address}
+            tokenSymbol={market?.collateral_token?.symbol}
+            tokenBalance={userBalances?.collateral}
+            handleInpChange={useCallback((userCollateral) => updateFormValues({ userCollateral }), [updateFormValues])}
+            handleMaxClick={() => updateFormValues({ userCollateral: userBalances?.collateral ?? '' })}
           />
-        )}
-      </FieldsWrapper>
 
-      <InpTokenBorrow
-        network={network}
-        id="debt"
-        inpTopLabel={t`Borrow amount:`}
-        inpError={formValues.debtError}
-        inpDisabled={disabled}
-        inpValue={formValues.debt}
-        tokenAddress={market?.borrowed_token?.address}
-        tokenSymbol={market?.borrowed_token?.symbol}
-        maxRecv={maxRecv}
-        handleInpChange={useCallback((debt) => updateFormValues({ debt }), [updateFormValues])}
-        handleMaxClick={async () => {
-          const debt = await refetchMaxRecv(market, isLeverage)
-          updateFormValues({ debt })
-        }}
-      />
+          {isLeverage && (
+            <InpToken
+              network={network}
+              id="userBorrowed"
+              inpError={formValues.userBorrowedError}
+              inpDisabled={disabled}
+              inpLabelLoading={!!signerAddress && typeof userBalances?.borrowed === 'undefined'}
+              inpLabelDescription={formatNumber(userBalances?.borrowed, { defaultValue: '-' })}
+              inpValue={formValues.userBorrowed}
+              tokenAddress={market?.borrowed_token?.address}
+              tokenSymbol={market?.borrowed_token?.symbol}
+              tokenBalance={userBalances?.borrowed}
+              handleInpChange={setUserBorrowed}
+              handleMaxClick={() => updateFormValues({ userBorrowed: userBalances?.borrowed ?? '' })}
+            />
+          )}
+        </Stack>
+      </Stack>
+
+      <Stack gap={Spacing.sm}>
+        <Typography variant="headingXsMedium">{t`Borrow amount:`}</Typography>
+        <InpTokenBorrow
+          network={network}
+          id="debt"
+          inpError={formValues.debtError}
+          inpDisabled={disabled}
+          inpValue={formValues.debt}
+          tokenAddress={market?.borrowed_token?.address}
+          tokenSymbol={market?.borrowed_token?.symbol}
+          maxRecv={maxRecv}
+          handleInpChange={useCallback((debt) => updateFormValues({ debt }), [updateFormValues])}
+          handleMaxClick={async () => {
+            const debt = await refetchMaxRecv(market, isLeverage)
+            updateFormValues({ debt })
+          }}
+        />
+      </Stack>
 
       {/* detail info */}
       <StyledDetailInfoWrapper>
@@ -427,7 +436,7 @@ const LoanBorrowMore = ({
           {steps && <Stepper steps={steps} />}
         </LoanFormConnect>
       )}
-    </>
+    </Stack>
   )
 }
 

--- a/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/LoanRepay/index.tsx
@@ -8,10 +8,9 @@ import LoanFormConnect from '@/lend/components/LoanFormConnect'
 import DetailInfo from '@/lend/components/PageLoanManage/LoanRepay/components/DetailInfo'
 import type { FormStatus, FormValues, StepKey } from '@/lend/components/PageLoanManage/LoanRepay/types'
 import { _parseValues, DEFAULT_FORM_VALUES } from '@/lend/components/PageLoanManage/LoanRepay/utils'
-import { StyledDetailInfoWrapper, StyledInpChip } from '@/lend/components/PageLoanManage/styles'
+import { StyledDetailInfoWrapper } from '@/lend/components/PageLoanManage/styles'
 import type { FormEstGas } from '@/lend/components/PageLoanManage/types'
 import { DEFAULT_CONFIRM_WARNING, DEFAULT_HEALTH_MODE } from '@/lend/components/PageLoanManage/utils'
-import { FieldsWrapper } from '@/lend/components/SharedFormStyles/FieldsWrapper'
 import { NOFITY_MESSAGE } from '@/lend/constants'
 import { useUserLoanDetails } from '@/lend/hooks/useUserLoanDetails'
 import { helpers } from '@/lend/lib/apiLending'
@@ -28,8 +27,8 @@ import {
 import { _showNoLoanFound } from '@/lend/utils/helpers'
 import { getCollateralListPathname } from '@/lend/utils/utilsRouter'
 import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
 import AlertBox from '@ui/AlertBox'
-import Box from '@ui/Box'
 import Checkbox from '@ui/Checkbox'
 import { getActiveStep } from '@ui/Stepper/helpers'
 import Stepper from '@ui/Stepper/Stepper'
@@ -379,47 +378,51 @@ const LoanRepay = ({
   )
 
   return (
-    <>
-      <Box grid gridGap={1}>
-        <FieldsWrapper $showBorder={hasLeverage}>
-          {hasLeverage && (
-            <Stack gap={Spacing.xl}>
-              <InpToken
-                network={network}
-                id="stateCollateral"
-                inpTopLabel={t`Repay from collateral:`}
-                inpError={formValues.stateCollateralError}
-                inpDisabled={disable}
-                inpLabelLoading={loanExists && !!signerAddress && typeof userState?.collateral === 'undefined'}
-                inpLabelDescription={formatNumber(userState?.collateral, { defaultValue: '-' })}
-                inpValue={formValues.stateCollateral}
-                tokenAddress={collateral_token?.address}
-                tokenSymbol={collateral_token?.symbol}
-                tokenBalance={userState?.collateral}
-                handleInpChange={setStateCollateral}
-                handleMaxClick={() =>
-                  updateFormValues({ stateCollateral: userState?.collateral ?? '', isFullRepay: false })
-                }
-              />
+    <Stack gap={Spacing.lg}>
+      {hasLeverage && (
+        <Stack gap={Spacing.sm}>
+          <Typography variant="headingXsMedium"> {t`Repay from collateral:`} </Typography>
 
-              <InpToken
-                network={network}
-                id="userCollateral"
-                inpTopLabel={t`Repay from wallet:`}
-                inpError={formValues.userCollateralError}
-                inpDisabled={disable}
-                inpLabelLoading={!!signerAddress && typeof userBalances?.collateral === 'undefined'}
-                inpLabelDescription={formatNumber(userBalances?.collateral, { defaultValue: '-' })}
-                inpValue={formValues.userCollateral}
-                tokenAddress={collateral_token?.address}
-                tokenSymbol={collateral_token?.symbol}
-                tokenBalance={userBalances?.collateral}
-                handleInpChange={setUserCollateral}
-                handleMaxClick={() =>
-                  updateFormValues({ userCollateral: userBalances?.collateral ?? '', isFullRepay: false })
-                }
-              />
-            </Stack>
+          <InpToken
+            network={network}
+            id="stateCollateral"
+            inpError={formValues.stateCollateralError}
+            inpDisabled={disable}
+            inpLabelLoading={loanExists && !!signerAddress && typeof userState?.collateral === 'undefined'}
+            inpLabelDescription={formatNumber(userState?.collateral, { defaultValue: '-' })}
+            inpValue={formValues.stateCollateral}
+            tokenAddress={collateral_token?.address}
+            tokenSymbol={collateral_token?.symbol}
+            tokenBalance={userState?.collateral}
+            handleInpChange={setStateCollateral}
+            handleMaxClick={() =>
+              updateFormValues({ stateCollateral: userState?.collateral ?? '', isFullRepay: false })
+            }
+          />
+        </Stack>
+      )}
+
+      <Stack gap={Spacing.sm}>
+        <Typography variant="headingXsMedium">{t`Repay from wallet:`}</Typography>
+
+        <Stack gap={Spacing.md}>
+          {hasLeverage && (
+            <InpToken
+              network={network}
+              id="userCollateral"
+              inpError={formValues.userCollateralError}
+              inpDisabled={disable}
+              inpLabelLoading={!!signerAddress && typeof userBalances?.collateral === 'undefined'}
+              inpLabelDescription={formatNumber(userBalances?.collateral, { defaultValue: '-' })}
+              inpValue={formValues.userCollateral}
+              tokenAddress={collateral_token?.address}
+              tokenSymbol={collateral_token?.symbol}
+              tokenBalance={userBalances?.collateral}
+              handleInpChange={setUserCollateral}
+              handleMaxClick={() =>
+                updateFormValues({ userCollateral: userBalances?.collateral ?? '', isFullRepay: false })
+              }
+            />
           )}
 
           <InpToken
@@ -482,11 +485,12 @@ const LoanRepay = ({
               updateFormValues({ userBorrowed: '', isFullRepay: false })
             }}
           />
-        </FieldsWrapper>
-        <StyledInpChip size="xs">
-          {t`Debt balance`} {formatNumber(userState?.debt, { defaultValue: '-' })} {borrowed_token?.symbol}
-        </StyledInpChip>
-      </Box>
+        </Stack>
+      </Stack>
+
+      <Typography variant="headingXsMedium">
+        {t`Debt balance`} {formatNumber(userState?.debt, { defaultValue: '-' })} {borrowed_token?.symbol}
+      </Typography>
 
       <Checkbox
         isDisabled={disableCheckbox}
@@ -541,7 +545,7 @@ const LoanRepay = ({
           {steps && <Stepper steps={steps} />}
         </LoanFormConnect>
       )}
-    </>
+    </Stack>
   )
 }
 


### PR DESCRIPTION
I know not too important but it bothered me. It's only temporary as cards get replaced in the future.
Gets rid of the stupid double borders

New
<img width="419" height="956" alt="image" src="https://github.com/user-attachments/assets/d351d52b-7e60-4229-8209-4641f45e87c2" />
<img width="419" height="802" alt="image" src="https://github.com/user-attachments/assets/ecf30683-259b-49da-9e99-be5d35435e89" />

Old
<img width="428" height="491" alt="image" src="https://github.com/user-attachments/assets/f2efd106-547a-4cec-bd6d-fe91951fddf8" />
