### PR TITLE
fix: remove lend position details rates data api fallback

### DIFF
--- a/apps/main/src/lend/hooks/useBorrowPositionDetails.ts
+++ b/apps/main/src/lend/hooks/useBorrowPositionDetails.ts
@@ -44,7 +44,6 @@ export const useBorrowPositionDetails = ({
     status,
     state: { collateral, borrowed, debt } = {},
   } = userLoanDetails ?? {}
-  const marketRate = useStore((state) => state.markets.ratesMapper[chainId]?.[marketId])
   const prices = useStore((state) => state.markets.pricesMapper[chainId]?.[marketId])
 
   const { data: campaigns } = useCampaigns({})
@@ -76,7 +75,7 @@ export const useBorrowPositionDetails = ({
     [lendSnapshots],
   )
 
-  const borrowApy = onChainRatesData?.rates?.borrowApy ?? marketRate?.rates?.borrowApy ?? null
+  const borrowApy = onChainRatesData?.rates?.borrowApy ?? null
   const collateralTotalValue = useMemo(() => {
     if (!collateralUsdRate || !collateral || !borrowed) return null
     return Number(collateral) * Number(collateralUsdRate) + Number(borrowed)

--- a/apps/main/src/lend/hooks/useSupplyPositionDetails.ts
+++ b/apps/main/src/lend/hooks/useSupplyPositionDetails.ts
@@ -4,7 +4,6 @@ import { useUserMarketBalances } from '@/lend/entities/user-market-balances'
 import { useUserSupplyBoost } from '@/lend/entities/user-supply-boost'
 import { useUserSupplyClaimable } from '@/lend/entities/user-supply-claimable'
 import networks from '@/lend/networks'
-import useStore from '@/lend/store/useStore'
 import { ChainId, OneWayMarketTemplate } from '@/lend/types/lend.types'
 import type { SupplyPositionDetailsProps } from '@/llamalend/features/market-position-details'
 import type { Address, Chain } from '@curvefi/prices-api'
@@ -29,7 +28,6 @@ export const useSupplyPositionDetails = ({
 }: UseSupplyPositionDetailsProps): SupplyPositionDetailsProps => {
   const { data: campaigns } = useCampaigns({})
   const { data: userBalances, isLoading: isUserBalancesLoading } = useUserMarketBalances({ chainId, marketId })
-  const marketRate = useStore((state) => state.markets.ratesMapper[chainId]?.[marketId])
   const { data: marketPricePerShare, isLoading: isMarketPricePerShareLoading } = useMarketPricePerShare({
     chainId,
     marketId,
@@ -82,7 +80,7 @@ export const useSupplyPositionDetails = ({
   )
 
   const rebasingYield = lendingSnapshots?.[lendingSnapshots.length - 1]?.borrowedToken?.rebasingYield // take the most recent rebasing yield
-  const supplyApyValue = onChainRates?.rates?.lendApy ?? marketRate?.rates?.lendApy
+  const supplyApyValue = onChainRates?.rates?.lendApy
   const supplyApy = supplyApyValue === null ? null : Number(supplyApyValue)
   const supplyAprCrvMinBoost = onChainRates?.crvRates?.[0] ?? lendingSnapshots?.[0]?.lendAprCrv0Boost ?? 0
   const supplyAprCrvMaxBoost = onChainRates?.crvRates?.[1] ?? lendingSnapshots?.[0]?.lendAprCrvMaxBoost ?? 0


### PR DESCRIPTION
Falling back on the API data is redundant and prone to confusion on the market page when a user has a wallet connected and is viewing a position.

Changes:
- Removes lend position details rates data api fallback