### PR TITLE
fix: mint markets redirect during hydration

### DIFF
--- a/apps/main/src/loan/components/PageLoanCreate/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanCreate/Page.tsx
@@ -91,20 +91,18 @@ const Page = () => {
   )
 
   useEffect(() => {
-    if (pageLoaded) {
-      if (curve) {
-        if (llamma) {
-          resetUserDetailsState(llamma)
-          fetchInitial(curve, isLeverage, llamma)
-          void fetchLoanDetails(curve, llamma)
-          setLoaded(true)
-        } else if (collateralDatasMapper) {
-          console.warn(
-            `Collateral ${rCollateralId} not found for chain ${rChainId}. Redirecting to market list.`,
-            collateralDatasMapper,
-          )
-          push(getCollateralListPathname(params))
-        }
+    if (pageLoaded && curve) {
+      if (llamma) {
+        resetUserDetailsState(llamma)
+        fetchInitial(curve, isLeverage, llamma)
+        void fetchLoanDetails(curve, llamma)
+        setLoaded(true)
+      } else if (collateralDatasMapper) {
+        console.warn(
+          `Collateral ${rCollateralId} not found for chain ${rChainId}. Redirecting to market list.`,
+          collateralDatasMapper,
+        )
+        push(getCollateralListPathname(params))
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/main/src/loan/components/PageLoanManage/Page.tsx
+++ b/apps/main/src/loan/components/PageLoanManage/Page.tsx
@@ -70,9 +70,7 @@ const Page = () => {
 
   useEffect(() => {
     if (curve && pageLoaded) {
-      if (!rChainId || !rCollateralId || !rFormType) {
-        push(getCollateralListPathname(params))
-      } else if (curve.signerAddress && llamma) {
+      if (rChainId && rCollateralId && rFormType && curve.signerAddress && llamma) {
         void (async () => {
           const fetchedLoanDetails = await fetchLoanDetails(curve, llamma)
           if (!fetchedLoanDetails.loanExists.loanExists) {
@@ -82,6 +80,8 @@ const Page = () => {
           setLoaded(true)
         })()
       } else {
+        const args = { rChainId, rCollateralId, rFormType, signer: curve.signerAddress, llamma }
+        console.warn(`Cannot find market ${rCollateralId}, redirecting to list`, args)
         push(getCollateralListPathname(params))
       }
     }


### PR DESCRIPTION
- the app was first hydrating without a library, then after connect it would already render the page too early
- this change will check whether the **current** library is hydrated properly, not just any library