### PR TITLE
fix: lp balance

### DIFF
--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormStake.tsx
@@ -17,7 +17,6 @@ import { getActiveStep, getStepStatus } from '@ui/Stepper/helpers'
 import Stepper from '@ui/Stepper/Stepper'
 import type { Step } from '@ui/Stepper/types'
 import TxInfoBar from '@ui/TxInfoBar'
-import { formatNumber } from '@ui/utils'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
 
@@ -163,7 +162,7 @@ const FormStake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, us
       <FieldsWrapper>
         <FieldLpToken
           amount={formValues.lpToken}
-          balance={formatNumber(balLpToken)}
+          balance={balLpToken}
           balanceLoading={balancesLoading}
           hasError={haveSigner ? new BigNumber(formValues.lpToken).isGreaterThan(balLpToken as string) : false}
           haveSigner={haveSigner}

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormUnstake.tsx
@@ -12,7 +12,6 @@ import { getStepStatus } from '@ui/Stepper/helpers'
 import Stepper from '@ui/Stepper/Stepper'
 import type { Step } from '@ui/Stepper/types'
 import TxInfoBar from '@ui/TxInfoBar'
-import { formatNumber } from '@ui/utils'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
 
@@ -138,7 +137,7 @@ const FormUnstake = ({ curve, poolData, poolDataCacheOrApi, routerParams, seed, 
       <FieldLpToken
         amount={formValues.stakedLpToken}
         balanceLoading={haveSigner && typeof userPoolBalances === 'undefined'}
-        balance={haveSigner ? formatNumber(balGauge) : ''}
+        balance={haveSigner ? balGauge : ''}
         hasError={+formValues.stakedLpToken > +balGauge}
         haveSigner={haveSigner}
         handleAmountChange={useCallback((stakedLpToken) => updateFormValues({ stakedLpToken }), [updateFormValues])}

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
@@ -26,7 +26,6 @@ import { getActiveStep, getStepStatus } from '@ui/Stepper/helpers'
 import Stepper from '@ui/Stepper/Stepper'
 import type { Step } from '@ui/Stepper/types'
 import TxInfoBar from '@ui/TxInfoBar'
-import { formatNumber } from '@ui/utils'
 import { mediaQueries } from '@ui/utils/responsive'
 import { notify } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
@@ -303,7 +302,7 @@ const FormWithdraw = ({
     <>
       <FieldLpToken
         amount={formValues.lpToken}
-        balance={haveSigner ? formatNumber(balLpToken) : ''}
+        balance={haveSigner ? balLpToken : ''}
         balanceLoading={haveSigner ? typeof userPoolBalances === 'undefined' : false}
         hasError={haveSigner && +formValues.lpToken > +balLpToken}
         haveSigner={haveSigner}

--- a/apps/main/src/dex/components/PagePool/components/FieldLpToken.tsx
+++ b/apps/main/src/dex/components/PagePool/components/FieldLpToken.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import InputProvider, { InputDebounced, InputMaxBtn } from '@ui/InputComp'
+import { formatNumber } from '@ui/utils'
 import { useReleaseChannel } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
@@ -43,7 +44,7 @@ const FieldLpToken = ({
         labelProps={{
           label: haveSigner ? t`LP Tokens Avail.` : t`LP Tokens`,
           descriptionLoading: haveSigner ? balanceLoading : false,
-          description: haveSigner ? balance : '',
+          description: haveSigner ? formatNumber(balance) : '',
         }}
         value={typeof amount === 'undefined' ? '' : amount}
         onChange={handleAmountChange}


### PR DESCRIPTION
The balance was being formatted and then converted to number again, that could not be parsed if LP was > 1k