### PR TITLE
fix: do not show NaN balance

### DIFF
--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
@@ -64,7 +64,7 @@ const CurrencyReservesContent = ({
 
     <Box className={'right'} flex flexDirection="column">
       <Chip size="md" isBold>
-        {!cr || isNaN(cr.balance) ? '-' : formatNumber(cr.balance, { defaultValue: '-' })}{' '}
+        {formatNumber(cr?.balance)}{' '}
       </Chip>
       <TokenBalancePercent opacity={0.7}>
         {cr?.percentShareInPool == null || cr.percentShareInPool === 'NaN'

--- a/packages/ui/src/utils/utilsFormat.ts
+++ b/packages/ui/src/utils/utilsFormat.ts
@@ -32,19 +32,16 @@ export function getFractionDigitsOptions(val: number | string | undefined | null
 }
 
 /** Wrapper function to keep the PR small. In the future all calls to this function should be replaced with a direct call to the new number formatter. */
-export function formatNumber(val: number | string | undefined | null, options?: NumberFormatOptions | undefined) {
-  if (val == null) return options?.defaultValue ?? '-'
-
-  const unit =
-    options?.style === 'currency' || options?.currency === 'USD'
-      ? 'dollar'
-      : options?.style === 'percent'
-        ? 'percentage'
-        : undefined
-
-  return newFormatNumber(Number(val), {
-    ...options,
-    unit,
-    abbreviate: options?.notation === 'compact',
-  })
-}
+export const formatNumber = (val: number | string | undefined | null, options?: NumberFormatOptions) =>
+  val == null || (typeof val === 'number' && isNaN(val))
+    ? (options?.defaultValue ?? '-')
+    : newFormatNumber(Number(val), {
+        ...options,
+        unit:
+          options?.style === 'currency' || options?.currency === 'USD'
+            ? 'dollar'
+            : options?.style === 'percent'
+              ? 'percentage'
+              : undefined,
+        abbreviate: options?.notation === 'compact',
+      })


### PR DESCRIPTION
Due to [this line](https://github.com/curvefi/curve-frontend/blob/9593dec9440d94fc8352a8da2d23e3384315f1f3/apps/main/src/dex/store/createPoolsSlice.ts#L364) the balance can be `NaN` during loading. Show the default value instead.