### PR TITLE
Revert "Merge pull request #1437 from curvefi/feat/local-campaign-que…

### DIFF
--- a/apps/main/src/dex/components/CampaignRewardsRow.tsx
+++ b/apps/main/src/dex/components/CampaignRewardsRow.tsx
@@ -1,15 +1,15 @@
 import { styled } from 'styled-components'
 import CampaignRewardsComp from 'ui/src/CampaignRewards/CampaignRewardsComp'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { RewardsPool } from 'ui/src/CampaignRewards/types'
 
 interface Props {
-  rewardItems: CampaignPoolRewards[]
+  rewardItems: RewardsPool[]
   mobile?: boolean
 }
 
 const CampaignRewardsRow = ({ rewardItems, mobile = false }: Props) => (
   <Container mobile={mobile}>
-    {rewardItems.map((rewardItem, index) => (
+    {rewardItems.map((rewardItem: RewardsPool, index: number) => (
       <CampaignRewardsComp
         key={`${rewardItem.platform}-${rewardItem.description}-${index}`}
         rewardsPool={rewardItem}

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
@@ -4,6 +4,7 @@ import { DescriptionChip, StyledIconButton, StyledStats } from '@/dex/components
 import ChipVolatileBaseApy from '@/dex/components/PagePoolList/components/ChipVolatileBaseApy'
 import PoolRewardsCrv from '@/dex/components/PoolRewardsCrv'
 import { LARGE_APY } from '@/dex/constants'
+import useCampaignRewardsMapper from '@/dex/hooks/useCampaignRewardsMapper'
 import useStore from '@/dex/store/useStore'
 import { ChainId, RewardsApy, PoolData } from '@/dex/types/main.types'
 import { shortenTokenName } from '@/dex/utils'
@@ -16,7 +17,6 @@ import Tooltip from '@ui/Tooltip/TooltipButton'
 import IconTooltip from '@ui/Tooltip/TooltipIcon'
 import { Chip } from '@ui/Typography'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
-import { useCampaigns } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { copyToClipboard } from '@ui-kit/utils'
 
@@ -29,8 +29,8 @@ type RewardsProps = {
 const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
   const { base, other } = rewardsApy ?? {}
   const { haveBase, haveOther, haveCrv } = haveRewardsApy(rewardsApy ?? {})
-  const { data: campaigns } = useCampaigns({})
-  const campaignRewardsPool = campaigns?.[poolData.pool.address]
+  const campaignRewardsMapper = useCampaignRewardsMapper()
+  const campaignRewardsPool = campaignRewardsMapper[poolData.pool.address]
   const { isLite, scanTokenPath } = useStore((state) => state.networks.networks[chainId])
 
   const baseAPYS = [

--- a/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 import CampaignBannerComp from 'ui/src/CampaignRewards/CampaignBannerComp'
-import { useCampaigns } from '@ui-kit/entities/campaigns'
+import useCampaignRewardsMapper from '@/dex/hooks/useCampaignRewardsMapper'
 import { t } from '@ui-kit/lib/i18n'
 
 interface CampaignRewardsBannerProps {
@@ -8,8 +8,7 @@ interface CampaignRewardsBannerProps {
 }
 
 const CampaignRewardsBanner = ({ address }: CampaignRewardsBannerProps) => {
-  const { data: campaigns } = useCampaigns({})
-  const campaignRewardsPool = campaigns?.[address]
+  const campaignRewardsPool = useCampaignRewardsMapper()[address]
 
   if (!campaignRewardsPool) return null
 

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -69,6 +69,7 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
   const pricesApiPoolsMapper = useStore((state) => state.pools.pricesApiPoolsMapper)
   const fetchPricesPoolSnapshots = useStore((state) => state.pools.fetchPricesPoolSnapshots)
   const snapshotsMapper = useStore((state) => state.pools.snapshotsMapper)
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   const storeMaxSlippage = useUserProfileStore((state) => state.maxSlippage[chainIdPoolId])
 
@@ -199,6 +200,13 @@ const Transfer = (pageTransferProps: PageTransferProps) => {
       </StyledExternalLink>
     </AppPageFormTitleWrapper>
   )
+
+  // init rewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   useEffect(() => {
     if (!isMdUp && chartExpanded) setChartExpanded(false)

--- a/apps/main/src/dex/components/PagePoolList/components/PoolRow.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/PoolRow.tsx
@@ -9,6 +9,7 @@ import type {
   SearchTermMapper,
 } from '@/dex/components/PagePoolList/types'
 import { ROUTE } from '@/dex/constants'
+import useCampaignRewardsMapper from '@/dex/hooks/useCampaignRewardsMapper'
 import { parseSearchTermMapper } from '@/dex/hooks/useSearchTermMapper'
 import { getUserActiveKey } from '@/dex/store/createUserSlice'
 import useStore from '@/dex/store/useStore'
@@ -68,6 +69,7 @@ export const PoolRow = ({
   const volumeCached = useStore((state) => state.storeCache.volumeMapper[rChainId]?.[poolId])
   const volume = useStore((state) => state.pools.volumeMapper[rChainId]?.[poolId])
   const network = useStore((state) => state.networks.networks[rChainId])
+  const campaignRewardsMapper = useCampaignRewardsMapper()
 
   const theme = useUserProfileStore((state) => state.theme)
 
@@ -107,6 +109,7 @@ export const PoolRow = ({
     volumeCached,
     volume,
     handleCellClick,
+    campaignRewardsMapper,
   }
 
   return (

--- a/apps/main/src/dex/components/PagePoolList/components/TableRow.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableRow.tsx
@@ -1,4 +1,5 @@
 import { Fragment, HTMLAttributes, useEffect, useRef, useState } from 'react'
+import type { CampaignRewardsMapper } from 'ui/src/CampaignRewards/types'
 import CampaignRewardsRow from '@/dex/components/CampaignRewardsRow'
 import TCellRewards from '@/dex/components/PagePoolList/components/TableCellRewards'
 import TableCellRewardsBase from '@/dex/components/PagePoolList/components/TableCellRewardsBase'
@@ -12,7 +13,6 @@ import PoolLabel from '@/dex/components/PoolLabel'
 import { PoolData, PoolDataCache, RewardsApy, Tvl, Volume } from '@/dex/types/main.types'
 import Box from '@ui/Box'
 import { CellInPool, Td, Tr } from '@ui/Table'
-import { useCampaigns } from '@ui-kit/entities/campaigns'
 import useIntersectionObserver from '@ui-kit/hooks/useIntersectionObserver'
 import { t } from '@ui-kit/lib/i18n'
 
@@ -29,6 +29,7 @@ export type TableRowProps = {
   rewardsApy: RewardsApy | undefined
   searchParams: SearchParams
   showInPoolColumn: boolean
+  campaignRewardsMapper: CampaignRewardsMapper
   tvlCached: { value: string } | undefined
   tvl: Tvl | undefined
   volumeCached: { value: string } | undefined
@@ -49,6 +50,7 @@ const TableRow = ({
   rewardsApy,
   searchParams,
   showInPoolColumn,
+  campaignRewardsMapper,
   tvlCached,
   tvl,
   volumeCached,
@@ -57,7 +59,6 @@ const TableRow = ({
 }: TableRowProps) => {
   const { searchTextByTokensAndAddresses, searchTextByOther } = formValues
   const { searchText, sortBy } = searchParams
-  const { data: campaigns } = useCampaigns({})
 
   return (
     <LazyItem id={`${poolId}-${index}`} className="row--info" onClick={({ target }) => handleCellClick(target)}>
@@ -96,8 +97,8 @@ const TableRow = ({
                     <TableCellRewardsOthers isHighlight={sortBy === 'rewardsOther'} rewardsApy={rewardsApy} />
                   </>
                 )}
-                {poolData && campaigns?.[poolData.pool.address] && (
-                  <CampaignRewardsRow rewardItems={campaigns[poolData.pool.address]} />
+                {poolData && campaignRewardsMapper[poolData.pool.address] && (
+                  <CampaignRewardsRow rewardItems={campaignRewardsMapper[poolData.pool.address]} />
                 )}
               </Box>
             </Td>
@@ -123,8 +124,8 @@ const TableRow = ({
                   {rewardsApy && (
                     <TableCellRewardsOthers isHighlight={sortBy === 'rewardsOther'} rewardsApy={rewardsApy} />
                   )}
-                  {poolData && campaigns?.[poolData.pool.address] && (
-                    <CampaignRewardsRow rewardItems={campaigns[poolData.pool.address]} />
+                  {poolData && campaignRewardsMapper[poolData.pool.address] && (
+                    <CampaignRewardsRow rewardItems={campaignRewardsMapper[poolData.pool.address]} />
                   )}
                 </Box>
               </Td>
@@ -140,8 +141,8 @@ const TableRow = ({
                   isHighlightOther={sortBy === 'rewardsOther'}
                   rewardsApy={rewardsApy}
                 />
-                {poolData && campaigns?.[poolData.pool.address] && (
-                  <CampaignRewardsRow rewardItems={campaigns[poolData.pool.address]} />
+                {poolData && campaignRewardsMapper[poolData.pool.address] && (
+                  <CampaignRewardsRow rewardItems={campaignRewardsMapper[poolData.pool.address]} />
                 )}
               </Box>
             </Td>

--- a/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
@@ -13,12 +13,12 @@ import { COLUMN_KEYS } from '@/dex/components/PagePoolList/utils'
 import PoolLabel from '@/dex/components/PoolLabel'
 import Box from '@ui/Box'
 import Button from '@ui/Button'
+import type { CampaignRewardsMapper } from '@ui/CampaignRewards/types'
 import Icon from '@ui/Icon'
 import IconButton from '@ui/IconButton'
 import ListInfoItem, { ListInfoItems } from '@ui/ListInfo'
 import { CellInPool } from '@ui/Table'
 import { formatNumber } from '@ui/utils'
-import { useCampaigns } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import type { ThemeKey } from '@ui-kit/themes/basic-theme'
 
@@ -27,6 +27,7 @@ type TableRowMobileProps = Omit<TableRowProps, 'isMdUp'> & {
   themeType: ThemeKey
   setShowDetail: Dispatch<SetStateAction<string>>
   tableLabel: PoolListTableLabel
+  campaignRewardsMapper: CampaignRewardsMapper
 }
 
 const TableRowMobile = ({
@@ -49,8 +50,8 @@ const TableRowMobile = ({
   volume,
   handleCellClick,
   setShowDetail,
+  campaignRewardsMapper,
 }: TableRowMobileProps) => {
-  const { data: campaigns } = useCampaigns({})
   const { searchTextByTokensAndAddresses, searchTextByOther } = formValues
   const { searchText, sortBy } = searchParams
   const isShowDetail = showDetail === poolId
@@ -152,9 +153,9 @@ const TableRowMobile = ({
                           />
                         </ListInfoItem>
                       )}
-                      {poolData && campaigns?.[poolData.pool.address] && (
+                      {poolData && campaignRewardsMapper[poolData.pool.address] && (
                         <ListInfoItem title={t`Additional external rewards`}>
-                          <CampaignRewardsRow rewardItems={campaigns[poolData.pool.address]} mobile />
+                          <CampaignRewardsRow rewardItems={campaignRewardsMapper[poolData.pool.address]} mobile />
                         </ListInfoItem>
                       )}
                     </>

--- a/apps/main/src/dex/components/PagePoolList/index.tsx
+++ b/apps/main/src/dex/components/PagePoolList/index.tsx
@@ -6,6 +6,7 @@ import TableRowNoResult from '@/dex/components/PagePoolList/components/TableRowN
 import TableSettings from '@/dex/components/PagePoolList/components/TableSettings/TableSettings'
 import type { ColumnKeys, PagePoolList, SearchParams } from '@/dex/components/PagePoolList/types'
 import { COLUMN_KEYS } from '@/dex/components/PagePoolList/utils'
+import useCampaignRewardsMapper from '@/dex/hooks/useCampaignRewardsMapper'
 import { DEFAULT_FORM_STATUS, getPoolListActiveKey } from '@/dex/store/createPoolListSlice'
 import { getUserActiveKey } from '@/dex/store/createUserSlice'
 import useStore from '@/dex/store/useStore'
@@ -25,6 +26,7 @@ const PoolList = ({
   tableLabels,
   updatePath,
 }: PagePoolList) => {
+  const campaignRewardsMapper = useCampaignRewardsMapper()
   const activeKey = getPoolListActiveKey(rChainId, searchParams)
   const prevActiveKey = useStore((state) => state.poolList.activeKey)
   const formStatus = useStore((state) => state.poolList.formStatus[activeKey] ?? DEFAULT_FORM_STATUS)
@@ -44,6 +46,7 @@ const PoolList = ({
   const volumeMapper = useStore((state) => state.pools.volumeMapper[rChainId])
   const fetchPoolsRewardsApy = useStore((state) => state.pools.fetchPoolsRewardsApy)
   const setFormValues = useStore((state) => state.poolList.setFormValues)
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
   const hideSmallPools = useUserProfileStore((state) => state.hideSmallPools)
   const isCrvRewardsEnabled = useStore((state) => state.networks.networks[rChainId]?.isCrvRewardsEnabled)
 
@@ -112,6 +115,7 @@ const PoolList = ({
         tvlMapper ?? {},
         tvlMapperCached ?? {},
         userPoolList ?? {},
+        campaignRewardsMapper,
       )
     },
     [
@@ -128,6 +132,7 @@ const PoolList = ({
       tvlMapper,
       tvlMapperCached,
       userPoolList,
+      campaignRewardsMapper,
     ],
   )
 
@@ -148,6 +153,13 @@ const PoolList = ({
     updateFormValues(searchParams)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady, isReadyWithApiData, chainId, signerAddress, searchParams, hideSmallPools])
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   let colSpan = isMdUp ? 7 : 4
   if (showHideSmallPools) {

--- a/apps/main/src/dex/hooks/useCampaignRewardsMapper.tsx
+++ b/apps/main/src/dex/hooks/useCampaignRewardsMapper.tsx
@@ -1,0 +1,5 @@
+import useStore from '@/dex/store/useStore'
+
+const useCampaignRewardsMapper = () => useStore((state) => state.campaigns.campaignRewardsMapper)
+
+export default useCampaignRewardsMapper

--- a/apps/main/src/dex/store/createCampaignRewardsSlice.ts
+++ b/apps/main/src/dex/store/createCampaignRewardsSlice.ts
@@ -1,0 +1,96 @@
+import { produce } from 'immer'
+import { CampaignRewardsItem, CampaignRewardsPool, CampaignRewardsMapper } from 'ui/src/CampaignRewards/types'
+import type { GetState, SetState } from 'zustand'
+import type { State } from '@/dex/store/useStore'
+import { ChainId } from '@/dex/types/main.types'
+import { CURVE_ASSETS_URL } from '@ui/utils'
+import campaigns from '@external-rewards'
+
+type StateKey = keyof typeof DEFAULT_STATE
+
+type SliceState = {
+  initiated: boolean
+  campaignRewardsMapper: CampaignRewardsMapper
+}
+
+const sliceKey = 'campaigns'
+
+// prettier-ignore
+export type CampaignRewardsSlice = {
+  [sliceKey]: SliceState & {
+    initCampaignRewards(chainId: ChainId): void
+
+    setStateByActiveKey<T>(key: StateKey, activeKey: string, value: T): void
+    setStateByKey<T>(key: StateKey, value: T): void
+    setStateByKeys(SliceState: Partial<SliceState>): void
+    resetState(): void
+  }
+}
+
+const DEFAULT_STATE: SliceState = {
+  initiated: false,
+  campaignRewardsMapper: {},
+}
+
+const createCampaignsSlice = (set: SetState<State>, get: GetState<State>): CampaignRewardsSlice => ({
+  [sliceKey]: {
+    ...DEFAULT_STATE,
+    initCampaignRewards: (chainId: ChainId) => {
+      const campaignRewardsMapper: CampaignRewardsMapper = {}
+      const {
+        networks: { networks },
+      } = get()
+      const network = networks[chainId].id
+
+      // compile a list of pool/markets using pool/vault address as key
+      campaigns.forEach((campaign: CampaignRewardsItem) => {
+        campaign.pools.forEach((pool: CampaignRewardsPool) => {
+          if (pool.network.toLowerCase() === network.toLowerCase()) {
+            if (!campaignRewardsMapper[pool.address.toLowerCase()]) {
+              campaignRewardsMapper[pool.address.toLowerCase()] = []
+            }
+
+            campaignRewardsMapper[pool.address.toLowerCase()].push({
+              campaignName: campaign.campaignName,
+              platform: campaign.platform,
+              platformImageSrc: `${CURVE_ASSETS_URL}/platforms/${campaign.platformImageId}`,
+              dashboardLink: campaign.dashboardLink,
+              ...pool,
+              description: pool.description !== 'null' ? pool.description : campaign.description,
+              address: pool.address.toLowerCase(),
+              lock: pool.lock === 'true',
+            })
+          }
+        })
+      })
+
+      // sort pools by multiplier to prepare for pool list sorting
+      Object.keys(campaignRewardsMapper).forEach((address: string) => {
+        campaignRewardsMapper[address].sort((a, b) => +a.multiplier - +b.multiplier)
+      })
+
+      set(
+        produce((state: State) => {
+          state[sliceKey].initiated = true
+          state[sliceKey].campaignRewardsMapper = campaignRewardsMapper
+        }),
+      )
+    },
+
+    // slice helpers
+    setStateByActiveKey: (key, activeKey, value) => {
+      get().setAppStateByActiveKey(sliceKey, key, activeKey, value)
+    },
+    setStateByKey: (key, value) => {
+      get().setAppStateByKey(sliceKey, key, value)
+    },
+    setStateByKeys: (sliceState) => {
+      get().setAppStateByKeys(sliceKey, sliceState)
+    },
+    resetState: () => {
+      get().resetAppState(sliceKey, DEFAULT_STATE)
+    },
+  },
+})
+
+export default createCampaignsSlice

--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -86,6 +86,7 @@ const createGlobalSlice = (set: SetState<State>, get: GetState<State>): GlobalSl
       state.userBalances.resetState()
       state.lockedCrv.resetState()
       state.createPool.resetState()
+      state.campaigns.resetState()
       state.dashboard.resetState()
     }
 

--- a/apps/main/src/dex/store/useStore.ts
+++ b/apps/main/src/dex/store/useStore.ts
@@ -2,6 +2,7 @@ import lodash from 'lodash'
 import { create, type GetState, type SetState } from 'zustand'
 import { devtools, persist, type PersistOptions } from 'zustand/middleware'
 import createCacheSlice, { CacheSlice } from '@/dex/store/createCacheSlice'
+import createCampaignRewardsSlice, { CampaignRewardsSlice } from '@/dex/store/createCampaignRewardsSlice'
 import createCreatePoolSlice, { CreatePoolSlice } from '@/dex/store/createCreatePoolSlice'
 import createDashboardSlice, { DashboardSlice } from '@/dex/store/createDashboardSlice'
 import createDeployGaugeSlice, { DeployGaugeSlice } from '@/dex/store/createDeployGaugeSlice'
@@ -37,7 +38,8 @@ export type State = GlobalSlice &
   LockedCrvSlice &
   CreatePoolSlice &
   IntegrationsSlice &
-  DeployGaugeSlice
+  DeployGaugeSlice &
+  CampaignRewardsSlice
 
 const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createGlobalSlice(set, get),
@@ -57,6 +59,7 @@ const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createCreatePoolSlice(set, get),
   ...createIntegrationsSlice(set, get),
   ...createDeployGaugeSlice(set, get),
+  ...createCampaignRewardsSlice(set, get),
 })
 
 // the storage crashes in some browsers if the size of the object is too big

--- a/apps/main/src/lend/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsBanner.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react'
 import CampaignBannerComp from 'ui/src/CampaignRewards/CampaignBannerComp'
-import { useCampaigns } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
+import useStore from '../store/useStore'
 
 interface CampaignRewardsBannerProps {
   borrowAddress: string
@@ -9,20 +8,20 @@ interface CampaignRewardsBannerProps {
 }
 
 const CampaignRewardsBanner = ({ borrowAddress, supplyAddress }: CampaignRewardsBannerProps) => {
-  const { data: campaigns } = useCampaigns({})
-  const supplyCampaignRewardsPool = campaigns?.[supplyAddress]
-  const borrowCampaignRewardsPool = campaigns?.[borrowAddress]
+  const campaigns = useStore((state) => state.campaigns.campaignRewardsMapper)
+  const supplyCampaignRewardsPool = campaigns[supplyAddress]
+  const borrowCampaignRewardsPool = campaigns[borrowAddress]
 
-  const campaignRewardsPools = useMemo(() => {
+  if (!supplyCampaignRewardsPool && !borrowCampaignRewardsPool) return null
+
+  const campaignRewardsPools = () => {
     if (supplyCampaignRewardsPool && borrowCampaignRewardsPool) {
       return [...supplyCampaignRewardsPool, ...borrowCampaignRewardsPool]
     }
     if (supplyCampaignRewardsPool) return supplyCampaignRewardsPool
     if (borrowCampaignRewardsPool) return borrowCampaignRewardsPool
     return []
-  }, [supplyCampaignRewardsPool, borrowCampaignRewardsPool])
-
-  if (!supplyCampaignRewardsPool && !borrowCampaignRewardsPool) return null
+  }
 
   const message =
     supplyCampaignRewardsPool && borrowCampaignRewardsPool
@@ -31,7 +30,7 @@ const CampaignRewardsBanner = ({ borrowAddress, supplyAddress }: CampaignRewards
         ? t`Supplying in this pool earns points!`
         : t`Borrowing in this pool earns points!`
 
-  return <CampaignBannerComp campaignRewardsPool={campaignRewardsPools} message={message} />
+  return <CampaignBannerComp campaignRewardsPool={campaignRewardsPools()} message={message} />
 }
 
 export default CampaignRewardsBanner

--- a/apps/main/src/lend/components/PageLoanCreate/index.tsx
+++ b/apps/main/src/lend/components/PageLoanCreate/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import LoanFormCreate from '@/lend/components/PageLoanCreate/LoanFormCreate'
 import type { FormValues } from '@/lend/components/PageLoanCreate/types'
 import { DEFAULT_FORM_VALUES } from '@/lend/components/PageLoanCreate/utils'
@@ -42,6 +42,7 @@ const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) =
   const onUpdate = useOnFormUpdate(pageProps)
 
   const resetState = useStore((state) => state.loanCreate.resetState)
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   type Tab = 'create' | 'leverage'
   const tabs: TabOption<Tab>[] = useMemo(
@@ -55,6 +56,13 @@ const LoanCreate = (pageProps: PageContentProps & { params: MarketUrlParams }) =
           ],
     [market?.leverage, releaseChannel],
   )
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   return (
     <>

--- a/apps/main/src/lend/components/PageLoanManage/index.tsx
+++ b/apps/main/src/lend/components/PageLoanManage/index.tsx
@@ -5,6 +5,7 @@ import LoanCollateralRemove from '@/lend/components/PageLoanManage/LoanCollatera
 import LoanRepay from '@/lend/components/PageLoanManage/LoanRepay'
 import LoanSelfLiquidation from '@/lend/components/PageLoanManage/LoanSelfLiquidation'
 import type { CollateralFormType, LeverageFormType, LoanFormType } from '@/lend/components/PageLoanManage/types'
+import useStore from '@/lend/store/useStore'
 import { type MarketUrlParams, PageContentProps } from '@/lend/types/lend.types'
 import { getLoanManagePathname } from '@/lend/utils/utilsRouter'
 import Stack from '@mui/material/Stack'
@@ -25,8 +26,10 @@ const tabsCollateral: TabOption<CollateralFormType>[] = [
 ]
 
 const ManageLoan = (pageProps: PageContentProps & { params: MarketUrlParams }) => {
-  const { rOwmId, rFormType, market, params } = pageProps
+  const { rOwmId, rFormType, market, rChainId, params } = pageProps
   const push = useNavigate()
+
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   type Tab = 'loan' | 'collateral' | 'leverage'
   const tabs: TabOption<Tab>[] = useMemo(
@@ -47,6 +50,13 @@ const ManageLoan = (pageProps: PageContentProps & { params: MarketUrlParams }) =
   )
 
   useEffect(() => setSubTab(subTabs[0]?.value), [subTabs])
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   return (
     <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>

--- a/apps/main/src/lend/components/PageVault/index.tsx
+++ b/apps/main/src/lend/components/PageVault/index.tsx
@@ -4,6 +4,7 @@ import VaultDepositMint from '@/lend/components/PageVault/VaultDepositMint'
 import VaultStake from '@/lend/components/PageVault/VaultStake'
 import VaultUnstake from '@/lend/components/PageVault/VaultUnstake'
 import VaultWithdrawRedeem from '@/lend/components/PageVault/VaultWithdrawRedeem'
+import useStore from '@/lend/store/useStore'
 import {
   type MarketUrlParams,
   PageContentProps,
@@ -36,14 +37,23 @@ const tabsWithdraw: TabOption<VaultWithdrawFormType>[] = [
 ]
 
 const Vault = (pageProps: PageContentProps & { params: MarketUrlParams }) => {
-  const { rOwmId, rFormType, params } = pageProps
+  const { rOwmId, rFormType, rChainId, params } = pageProps
   const push = useNavigate()
+
+  const { initCampaignRewards, initiated } = useStore((state) => state.campaigns)
 
   type SubTab = VaultDepositFormType | VaultWithdrawFormType
   const [subTab, setSubTab] = useState<SubTab>('deposit')
 
   const subTabs = useMemo(() => (!rFormType || rFormType === 'deposit' ? tabsDeposit : tabsWithdraw), [rFormType])
   useEffect(() => setSubTab(subTabs[0]?.value), [subTabs])
+
+  // init campaignRewardsMapper
+  useEffect(() => {
+    if (!initiated) {
+      initCampaignRewards(rChainId)
+    }
+  }, [initCampaignRewards, rChainId, initiated])
 
   return (
     <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>

--- a/apps/main/src/lend/store/createCampaignRewardsSlice.ts
+++ b/apps/main/src/lend/store/createCampaignRewardsSlice.ts
@@ -1,0 +1,94 @@
+import { produce } from 'immer'
+import { CampaignRewardsItem, CampaignRewardsPool, CampaignRewardsMapper } from 'ui/src/CampaignRewards/types'
+import type { GetState, SetState } from 'zustand'
+import networks from '@/lend/networks'
+import type { State } from '@/lend/store/useStore'
+import { ChainId } from '@/lend/types/lend.types'
+import { CURVE_ASSETS_URL } from '@ui/utils'
+import campaigns from '@external-rewards'
+
+type StateKey = keyof typeof DEFAULT_STATE
+
+type SliceState = {
+  initiated: boolean
+  campaignRewardsMapper: CampaignRewardsMapper
+}
+
+const sliceKey = 'campaigns'
+
+// prettier-ignore
+export type CampaignRewardsSlice = {
+  [sliceKey]: SliceState & {
+    initCampaignRewards(chainId: ChainId): void
+
+    setStateByActiveKey<T>(key: StateKey, activeKey: string, value: T): void
+    setStateByKey<T>(key: StateKey, value: T): void
+    setStateByKeys(SliceState: Partial<SliceState>): void
+    resetState(): void
+  }
+}
+
+const DEFAULT_STATE: SliceState = {
+  initiated: false,
+  campaignRewardsMapper: {},
+}
+
+const createCampaignsSlice = (set: SetState<State>, get: GetState<State>): CampaignRewardsSlice => ({
+  [sliceKey]: {
+    ...DEFAULT_STATE,
+    initCampaignRewards: (chainId: ChainId) => {
+      const campaignRewardsMapper: CampaignRewardsMapper = {}
+      const network = networks[chainId].id
+
+      // compile a list of pool/markets using pool/vault address as key
+      campaigns.forEach((campaign: CampaignRewardsItem) => {
+        campaign.pools.forEach((pool: CampaignRewardsPool) => {
+          if (pool.network.toLowerCase() === network.toLowerCase()) {
+            if (!campaignRewardsMapper[pool.address.toLowerCase()]) {
+              campaignRewardsMapper[pool.address.toLowerCase()] = []
+            }
+
+            campaignRewardsMapper[pool.address.toLowerCase()].push({
+              campaignName: campaign.campaignName,
+              platform: campaign.platform,
+              platformImageSrc: `${CURVE_ASSETS_URL}/platforms/${campaign.platformImageId}`,
+              dashboardLink: campaign.dashboardLink,
+              ...pool,
+              description: pool.description !== 'null' ? pool.description : campaign.description,
+              address: pool.address.toLowerCase(),
+              lock: pool.lock === 'true',
+            })
+          }
+        })
+      })
+
+      // sort pools by multiplier to prepare for pool list sorting
+      Object.keys(campaignRewardsMapper).forEach((address: string) => {
+        campaignRewardsMapper[address].sort((a, b) => +a.multiplier - +b.multiplier)
+      })
+
+      set(
+        produce((state: State) => {
+          state[sliceKey].initiated = true
+          state[sliceKey].campaignRewardsMapper = campaignRewardsMapper
+        }),
+      )
+    },
+
+    // slice helpers
+    setStateByActiveKey: (key, activeKey, value) => {
+      get().setAppStateByActiveKey(sliceKey, key, activeKey, value)
+    },
+    setStateByKey: (key, value) => {
+      get().setAppStateByKey(sliceKey, key, value)
+    },
+    setStateByKeys: (sliceState) => {
+      get().setAppStateByKeys(sliceKey, sliceState)
+    },
+    resetState: () => {
+      get().resetAppState(sliceKey, DEFAULT_STATE)
+    },
+  },
+})
+
+export default createCampaignsSlice

--- a/apps/main/src/lend/store/useStore.ts
+++ b/apps/main/src/lend/store/useStore.ts
@@ -2,6 +2,7 @@ import type { GetState, SetState } from 'zustand'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import createAppSlice, { AppSlice } from '@/lend/store/createAppSlice'
+import createCampaignRewardsSlice, { CampaignRewardsSlice } from '@/lend/store/createCampaignRewardsSlice'
 import createChartBandsSlice, { ChartBandsSlice } from '@/lend/store/createChartBandsStore'
 import createIntegrationsSlice, { IntegrationsSlice } from '@/lend/store/createIntegrationsSlice'
 import createLoanBorrowMoreSlice, { LoanBorrowMoreSlice } from '@/lend/store/createLoanBorrowMoreSlice'
@@ -37,7 +38,8 @@ export type State = AppSlice &
   VaultWithdrawRedeemSlice &
   VaultUnstakeSlice &
   VaultClaimSlice &
-  OhlcChartSlice
+  OhlcChartSlice &
+  CampaignRewardsSlice
 
 const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createAppSlice(set, get),
@@ -57,6 +59,7 @@ const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createIntegrationsSlice(set, get),
   ...createVaultClaimSlice(set, get),
   ...createOhlcChartSlice(set, get),
+  ...createCampaignRewardsSlice(set, get),
 })
 
 const useStore = process.env.NODE_ENV === 'development' ? create(devtools(store)) : create(store)

--- a/apps/main/src/llamalend/entities/llama-markets.ts
+++ b/apps/main/src/llamalend/entities/llama-markets.ts
@@ -4,7 +4,7 @@ import { Chain } from '@curvefi/prices-api'
 import { recordValues } from '@curvefi/prices-api/objects.util'
 import { useQueries } from '@tanstack/react-query'
 import { type DeepKeys } from '@tanstack/table-core'
-import { getCampaignOptions, type CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import { getCampaignOptions, type PoolRewards } from '@ui-kit/entities/campaigns'
 import { combineQueriesMeta, PartialQueryResult } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { CRVUSD_ROUTES, getInternalUrl, LEND_ROUTES } from '@ui-kit/shared/routes'
@@ -57,7 +57,7 @@ export type LlamaMarket = {
   }
   type: LlamaMarketType
   url: string
-  rewards: CampaignPoolRewards[]
+  rewards: PoolRewards[]
   isFavorite: boolean
   leverage: number
   deprecatedMessage?: string
@@ -98,7 +98,7 @@ const convertLendingVault = (
     extraRewardApr,
   }: LendingVault,
   favoriteMarkets: Set<Address>,
-  campaigns: Record<string, CampaignPoolRewards[]> = {},
+  campaigns: Record<string, PoolRewards[]> = {},
   userBorrows: Set<Address>,
   userSupplied: Set<Address>,
 ): LlamaMarket => {
@@ -193,7 +193,7 @@ const convertMintMarket = (
     chain,
   }: MintMarket,
   favoriteMarkets: Set<Address>,
-  campaigns: Record<string, CampaignPoolRewards[]> = {},
+  campaigns: Record<string, PoolRewards[]> = {},
   userMintMarkets: Set<Address>,
   collateralIndex: number, // index in the list of markets with the same collateral token, used to create a unique name
 ): LlamaMarket => {

--- a/apps/main/src/llamalend/features/market-details/index.tsx
+++ b/apps/main/src/llamalend/features/market-details/index.tsx
@@ -2,7 +2,7 @@ import { MarketBorrowRateTooltipContent } from '@/llamalend/widgets/tooltips/Mar
 import { MarketSupplyRateTooltipContent } from '@/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent'
 import { Box, CardHeader } from '@mui/material'
 import { formatNumber, FORMAT_OPTIONS } from '@ui/utils/utilsFormat'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SymbolCell } from '@ui-kit/shared/ui/SymbolCell'
@@ -43,7 +43,7 @@ type BorrowAPY = {
   // total = rate - rebasingYield
   totalBorrowRate: number | null
   totalAverageBorrowRate: number | null
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   loading: boolean
 }
 type SupplyAPY = {
@@ -63,7 +63,7 @@ type SupplyAPY = {
   totalAverageSupplyRateMaxBoost: number | null
   extraIncentives: ExtraIncentive[]
   averageTotalExtraIncentivesApr: number | undefined | null
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   loading: boolean
 }
 type AvailableLiquidity = {

--- a/apps/main/src/llamalend/features/market-list/cells/RateCell/RewardsTooltipItems.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/RateCell/RewardsTooltipItems.tsx
@@ -5,7 +5,7 @@ import { TooltipItem } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
@@ -19,7 +19,7 @@ export const RewardsTooltipItems = ({
   title,
 }: {
   title: string
-  poolRewards: CampaignPoolRewards[]
+  poolRewards: PoolRewards[]
   extraIncentives: { title: string; percentage: number; address: string; blockchainId: string }[]
 }) => {
   const percentage = extraIncentives.length > 0 && formatPercent(lodash.sum(extraIncentives.map((i) => i.percentage)))
@@ -49,7 +49,7 @@ export const RewardsTooltipItems = ({
             direction="row"
           >
             <RewardIcon size="md" imageId={r.platformImageId} />
-            {r.multiplier ? `${r.multiplier}x` : ''}
+            {r.multiplier}
             <ArrowOutwardIcon />
           </Stack>
         </TooltipItem>

--- a/apps/main/src/llamalend/features/market-position-details/BorrowPositionDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/BorrowPositionDetails.tsx
@@ -1,5 +1,5 @@
 import { Alert, Stack, Typography } from '@mui/material'
-import { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { LlamaMarketType } from '@ui-kit/types/market'
@@ -29,7 +29,7 @@ export type BorrowAPY = {
   // total = rate - rebasingYield
   totalBorrowRate: number | null
   totalAverageBorrowRate: number | null
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   loading: boolean
 }
 export type LiquidationRange = {

--- a/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
@@ -1,6 +1,6 @@
 import { MarketSupplyRateTooltipContent } from '@/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent'
 import { CardHeader, Box } from '@mui/material'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -31,7 +31,7 @@ type SupplyAPY = {
   totalAverageSupplyRateMaxBoost: number | null
   extraIncentives: ExtraIncentive[]
   averageTotalExtraIncentivesApr: number | undefined | null
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   loading: boolean
 }
 type Shares = {

--- a/apps/main/src/llamalend/hooks/useFilteredRewards.ts
+++ b/apps/main/src/llamalend/hooks/useFilteredRewards.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import { PoolRewards } from '@ui-kit/entities/campaigns'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 
 const RewardsActionMap = {
@@ -13,11 +13,7 @@ const RewardsActionMap = {
   },
 } as const
 
-export const useFilteredRewards = (
-  rewards: CampaignPoolRewards[],
-  marketType: LlamaMarketType,
-  rateType: MarketRateType,
-) =>
+export const useFilteredRewards = (rewards: PoolRewards[], marketType: LlamaMarketType, rateType: MarketRateType) =>
   useMemo(
     () => rewards.filter(({ action }) => action == RewardsActionMap[rateType][marketType]),
     [rewards, marketType, rateType],

--- a/apps/main/src/llamalend/widgets/tooltips/MarketBorrowRateTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketBorrowRateTooltipContent.tsx
@@ -6,7 +6,7 @@ import {
   TooltipDescription,
 } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import Stack from '@mui/material/Stack'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { RewardsTooltipItems } from './RewardTooltipItems'
@@ -18,7 +18,7 @@ export type MarketBorrowRateTooltipContentProps = {
   totalAverageBorrowRate: number | null | undefined
   averageRate: number | null | undefined
   periodLabel: string // e.g. "7D", "30D"
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   rebasingYield: number | null | undefined
   collateralSymbol: string | null | undefined
   isLoading?: boolean

--- a/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
@@ -7,7 +7,7 @@ import {
   TooltipWrapper,
 } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import Stack from '@mui/material/Stack'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { ExtraIncentive, MarketRateType } from '@ui-kit/types/market'
 import { RewardsTooltipItems } from './RewardTooltipItems'
@@ -16,7 +16,7 @@ export type MarketSupplyRateTooltipContentProps = {
   supplyRate: number | null | undefined
   averageRate: number | null | undefined
   periodLabel: string
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   extraIncentives: ExtraIncentive[]
   minBoostApr: number | null | undefined
   maxBoostApr: number | null | undefined

--- a/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
@@ -2,11 +2,11 @@ import { formatPercent } from '@/llamalend/format.utils'
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import { Stack } from '@mui/material'
 import Link from '@mui/material/Link'
-import { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
+import type { RewardsAction } from '@ui/CampaignRewards/types'
+import { PoolRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import type { RewardsAction } from '@external-rewards'
 import { TooltipItem } from './TooltipComponents'
 
 const { Spacing } = SizesAndSpaces
@@ -22,7 +22,7 @@ export type ExtraIncentiveItem = {
 type RewardsTooltipItemsProps = {
   title: string
   boostedApr?: number | null | undefined
-  extraRewards: CampaignPoolRewards[]
+  extraRewards: PoolRewards[]
   tooltipType: Extract<RewardsAction, 'borrow' | 'supply'>
   extraIncentives: ExtraIncentiveItem[]
 }
@@ -64,7 +64,7 @@ export const RewardsTooltipItems = ({
                 alignItems="center"
                 gap={Spacing.xs}
               >
-                {r.multiplier ? `${r.multiplier}x` : ''}
+                {r.multiplier}
                 <ArrowOutwardIcon />
               </Stack>
             </TooltipItem>

--- a/apps/main/src/loan/store/createCampaignRewardsSlice.ts
+++ b/apps/main/src/loan/store/createCampaignRewardsSlice.ts
@@ -1,0 +1,94 @@
+import { produce } from 'immer'
+import { CampaignRewardsItem, CampaignRewardsPool, CampaignRewardsMapper } from 'ui/src/CampaignRewards/types'
+import type { GetState, SetState } from 'zustand'
+import networks from '@/loan/networks'
+import type { State } from '@/loan/store/useStore'
+import { ChainId } from '@/loan/types/loan.types'
+import { CURVE_ASSETS_URL } from '@ui/utils'
+import campaigns from '@external-rewards'
+
+type StateKey = keyof typeof DEFAULT_STATE
+
+type SliceState = {
+  initiated: boolean
+  campaignRewardsMapper: CampaignRewardsMapper
+}
+
+const sliceKey = 'campaigns'
+
+// prettier-ignore
+export type CampaignRewardsSlice = {
+  [sliceKey]: SliceState & {
+    initCampaignRewards(chainId: ChainId): void
+
+    setStateByActiveKey<T>(key: StateKey, activeKey: string, value: T): void
+    setStateByKey<T>(key: StateKey, value: T): void
+    setStateByKeys(SliceState: Partial<SliceState>): void
+    resetState(): void
+  }
+}
+
+const DEFAULT_STATE: SliceState = {
+  initiated: false,
+  campaignRewardsMapper: {},
+}
+
+const createCampaignsSlice = (set: SetState<State>, get: GetState<State>): CampaignRewardsSlice => ({
+  [sliceKey]: {
+    ...DEFAULT_STATE,
+    initCampaignRewards: (chainId: ChainId) => {
+      const campaignRewardsMapper: CampaignRewardsMapper = {}
+      const network = networks[chainId].id
+
+      // compile a list of pool/markets using pool/vault address as key
+      campaigns.forEach((campaign: CampaignRewardsItem) => {
+        campaign.pools.forEach((pool: CampaignRewardsPool) => {
+          if (pool.network.toLowerCase() === network.toLowerCase()) {
+            if (!campaignRewardsMapper[pool.address.toLowerCase()]) {
+              campaignRewardsMapper[pool.address.toLowerCase()] = []
+            }
+
+            campaignRewardsMapper[pool.address.toLowerCase()].push({
+              campaignName: campaign.campaignName,
+              platform: campaign.platform,
+              platformImageSrc: `${CURVE_ASSETS_URL}/platforms/${campaign.platformImageId}`,
+              dashboardLink: campaign.dashboardLink,
+              ...pool,
+              description: pool.description !== 'null' ? pool.description : campaign.description,
+              address: pool.address.toLowerCase(),
+              lock: pool.lock === 'true',
+            })
+          }
+        })
+      })
+
+      // sort pools by multiplier to prepare for pool list sorting
+      Object.keys(campaignRewardsMapper).forEach((address: string) => {
+        campaignRewardsMapper[address].sort((a, b) => +a.multiplier - +b.multiplier)
+      })
+
+      set(
+        produce((state: State) => {
+          state[sliceKey].initiated = true
+          state[sliceKey].campaignRewardsMapper = campaignRewardsMapper
+        }),
+      )
+    },
+
+    // slice helpers
+    setStateByActiveKey: (key, activeKey, value) => {
+      get().setAppStateByActiveKey(sliceKey, key, activeKey, value)
+    },
+    setStateByKey: (key, value) => {
+      get().setAppStateByKey(sliceKey, key, value)
+    },
+    setStateByKeys: (sliceState) => {
+      get().setAppStateByKeys(sliceKey, sliceState)
+    },
+    resetState: () => {
+      get().resetAppState(sliceKey, DEFAULT_STATE)
+    },
+  },
+})
+
+export default createCampaignsSlice

--- a/apps/main/src/loan/store/useStore.ts
+++ b/apps/main/src/loan/store/useStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import { devtools, persist, type PersistOptions } from 'zustand/middleware'
 import createAppSlice, { AppSlice } from '@/loan/store/createAppSlice'
 import createCacheSlice, { CacheSlice } from '@/loan/store/createCacheSlice'
+import createCampaignRewardsSlice, { CampaignRewardsSlice } from '@/loan/store/createCampaignRewardsSlice'
 import createChartBandsSlice, { ChartBandsSlice } from '@/loan/store/createChartBandsStore'
 import createCollateralsSlice, { CollateralsSlice } from '@/loan/store/createCollateralsSlice'
 import createIntegrationsSlice, { IntegrationsSlice } from '@/loan/store/createIntegrationsSlice'
@@ -36,7 +37,8 @@ export type State = CacheSlice &
   LoanLiquidateSlice &
   IntegrationsSlice &
   OhlcChartSlice &
-  ScrvUsdSlice
+  ScrvUsdSlice &
+  CampaignRewardsSlice
 
 const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createCacheSlice(set, get),
@@ -54,6 +56,7 @@ const store = (set: SetState<State>, get: GetState<State>): State => ({
   ...createIntegrationsSlice(set, get),
   ...createOhlcChartSlice(set, get),
   ...createScrvUsdSlice(set, get),
+  ...createCampaignRewardsSlice(set, get),
 })
 
 // cache all items in CacheSlice store

--- a/packages/curve-ui-kit/src/entities/campaigns.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns.ts
@@ -1,41 +1,40 @@
 import lodash from 'lodash'
+import { CampaignRewardsItem, type CampaignRewardsPool, RewardsAction, RewardsTags } from '@ui/CampaignRewards/types'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model'
-import { campaigns, type Campaign, type CampaignPool } from '@external-rewards'
+import campaigns from '@external-rewards'
 
-export type CampaignPoolRewards = Pick<Campaign, 'campaignName' | 'platform' | 'platformImageId' | 'dashboardLink'> &
-  Pick<CampaignPool, 'action' | 'tags' | 'address'> & {
-    description: CampaignPool['description'] | null
-    lock: boolean
-    multiplier?: number
-    period?: readonly [Date, Date]
-  }
+export type PoolRewards = {
+  action: RewardsAction
+  multiplier: string // usually formatted like '1x', but it might be just a string
+  tags: RewardsTags[]
+  description: string | null
+  platformImageId: string
+  period?: readonly [Date, Date]
+  dashboardLink: string
+}
 
-const REWARDS = campaigns.reduce<Record<string, CampaignPoolRewards[]>>(
-  (campaigns, campaign) => ({
-    ...campaigns,
-    ...campaign.pools.reduce<Record<string, CampaignPoolRewards[]>>(
-      (pools, pool) => ({
-        ...pools,
-        [pool.address.toLowerCase()]: [
-          ...(pools[pool.address.toLowerCase()] ?? []),
+const REWARDS: Record<string, PoolRewards[]> = campaigns.reduce(
+  (result, { pools, platformImageId, dashboardLink }: CampaignRewardsItem) => ({
+    ...result,
+    ...pools.reduce(
+      (
+        result: Record<string, PoolRewards[]>,
+        { address, multiplier, tags, action, description, campaignStart, campaignEnd }: CampaignRewardsPool,
+      ) => ({
+        ...result,
+        [address.toLowerCase()]: [
+          ...(result[address.toLowerCase()] ?? []),
           {
-            // Campaign specific properties
-            campaignName: campaign.campaignName,
-            platform: campaign.platform,
-            platformImageId: campaign.platformImageId,
-            dashboardLink: campaign.dashboardLink,
-
-            // Pool specific properties
-            ...pool,
-            address: pool.address.toLowerCase(),
-            description: pool.description !== 'null' ? pool.description : campaign.description,
-            lock: pool.lock === 'true',
-            // Remove possible 'x' suffix and convert to number
-            multiplier: Number(pool.multiplier.replace(/x$/i, '')),
-            ...(+pool.campaignStart &&
-              +pool.campaignEnd && {
-                period: [new Date(1000 * +pool.campaignStart), new Date(1000 * +pool.campaignEnd)] as const,
+            dashboardLink,
+            multiplier,
+            tags,
+            action,
+            description: description === 'null' ? null : description,
+            platformImageId,
+            ...(+campaignStart &&
+              +campaignEnd && {
+                period: [new Date(1000 * +campaignStart), new Date(1000 * +campaignEnd)] as const,
               }),
           },
         ],
@@ -46,13 +45,9 @@ const REWARDS = campaigns.reduce<Record<string, CampaignPoolRewards[]>>(
   {},
 )
 
-export const {
-  useQuery: useCampaigns,
-  getQueryOptions: getCampaignOptions,
-  getQueryData: getCampaigns,
-} = queryFactory({
+export const { useQuery: useCampaigns, getQueryOptions: getCampaignOptions } = queryFactory({
   queryKey: () => ['external-rewards', 'v2'] as const,
-  queryFn: async () => {
+  queryFn: async (): Promise<Record<string, PoolRewards[]>> => {
     const now = Date.now() // refresh is handled by refetchInterval
     return Object.fromEntries(
       Object.entries(REWARDS).map(([address, rewards]) => [

--- a/packages/external-rewards/src/index.ts
+++ b/packages/external-rewards/src/index.ts
@@ -1,34 +1,8 @@
 import { default as campaignList } from './campaign-list.json'
 import * as campaignsJsons from './campaigns'
 
-export type Campaign = {
-  campaignName: string
-  platform: string
-  description: string
-  platformImageId: string
-  dashboardLink: string
-  pools: CampaignPool[]
-}
-
-export type CampaignPool = {
-  id: string
-  action: RewardsAction
-  description: string
-  campaignStart: string
-  campaignEnd: string
-  address: string
-  network: string
-  multiplier: string
-  tags: RewardsTags[]
-  lock: string
-}
-
-export type RewardsTags = 'points' | 'merkle' | 'tokens'
-export type RewardsAction = 'supply' | 'borrow' | 'lp' | 'loan'
-
-const parsedCampaignsJsons = campaignsJsons as Record<string, Campaign>
-
-export const campaigns = campaignList
+const parsedCampaignsJsons: { [key: string]: any } = campaignsJsons
+const campaigns = campaignList
   .map(({ campaign }) => {
     const campaignName = campaign.split('.')?.[0]
     if (!campaignName || !(campaignName in parsedCampaignsJsons)) return null
@@ -50,4 +24,6 @@ export const campaigns = campaignList
       }),
     }
   })
-  .filter((campaign): campaign is NonNullable<typeof campaign> => Boolean(campaign))
+  .filter(Boolean)
+
+export default campaigns

--- a/packages/ui/src/CampaignRewards/CampaignBannerComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignBannerComp.tsx
@@ -1,13 +1,8 @@
 import { styled } from 'styled-components'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
 import { RCPointsIcon } from 'ui/src/images'
 import { ExternalLink } from 'ui/src/Link'
 import RewardsCompSmall from './CampaignRewardsComp'
-
-type CampaignRewardsBannerCompProps = {
-  campaignRewardsPool: CampaignPoolRewards[]
-  message: string
-}
+import type { CampaignRewardsBannerCompProps } from './types'
 
 const RewardsBannerComp = ({ campaignRewardsPool, message }: CampaignRewardsBannerCompProps) => (
   <Wrapper>

--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -1,20 +1,11 @@
 import { styled } from 'styled-components'
-import { CURVE_ASSETS_URL } from '@ui/utils'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
 import TooltipMessage from 'ui/src/CampaignRewards/TooltipMessage'
+import type { CampaignRewardsCompProps } from 'ui/src/CampaignRewards/types'
 import Icon from 'ui/src/Icon'
 import Tooltip from 'ui/src/Tooltip/TooltipButton'
 
-type CampaignRewardsCompProps = {
-  rewardsPool: CampaignPoolRewards
-  highContrast?: boolean
-  mobile?: boolean
-  banner?: boolean
-}
-
 const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: CampaignRewardsCompProps) => {
-  const { platform, multiplier, platformImageId } = rewardsPool
-  const platformImageSrc = `${CURVE_ASSETS_URL}/platforms/${platformImageId}`
+  const { platform, multiplier, platformImageSrc } = rewardsPool
 
   const hasMultiplier = !!multiplier
 
@@ -28,7 +19,7 @@ const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: Campaig
     >
       <Container highContrast={highContrast}>
         <TokenIcon src={platformImageSrc} alt={platform} width={16} height={16} />
-        {hasMultiplier && <Multiplier highContrast={highContrast}>{`${multiplier}x`}</Multiplier>}
+        {hasMultiplier && <Multiplier highContrast={highContrast}>{`${multiplier}`}</Multiplier>}
         {rewardsPool.lock && <StyledIcon size={16} name="Locked" $highContrast={highContrast} />}
       </Container>
     </Tooltip>

--- a/packages/ui/src/CampaignRewards/TooltipMessage.tsx
+++ b/packages/ui/src/CampaignRewards/TooltipMessage.tsx
@@ -1,11 +1,14 @@
 import { styled } from 'styled-components'
-import type { CampaignPoolRewards } from '@ui-kit/entities/campaigns'
 import Box from 'ui/src/Box'
+import type { RewardsPool } from 'ui/src/CampaignRewards/types'
 import { ExternalLink } from 'ui/src/Link'
 import { formatDate } from '../utils'
 
-const TooltipMessage = ({ rewardsPool }: { rewardsPool: CampaignPoolRewards }) => {
-  const { campaignName, platform, description, action, dashboardLink, period } = rewardsPool
+const TooltipMessage = ({ rewardsPool }: { rewardsPool: RewardsPool }) => {
+  const { campaignName, platform, description, action, dashboardLink, campaignStart, campaignEnd } = rewardsPool
+
+  const start = formatDate(new Date(+campaignStart * 1000))
+  const end = formatDate(new Date(+campaignEnd * 1000))
 
   const title = () => {
     if (campaignName && platform) {
@@ -37,10 +40,10 @@ const TooltipMessage = ({ rewardsPool }: { rewardsPool: CampaignPoolRewards }) =
   return (
     <TooltipWrapper>
       {title()}
-      {period && (
+      {campaignStart && campaignStart !== '0' && campaignEnd && campaignEnd !== '0' && (
         <Box flex flexColumn>
-          <TooltipParagraph>{`from: ${formatDate(period[0])}`}</TooltipParagraph>
-          <TooltipParagraph>{`to: ${formatDate(period[1])}`}</TooltipParagraph>
+          <TooltipParagraph>{`from: ${start}`}</TooltipParagraph>
+          <TooltipParagraph>{`to: ${end}`}</TooltipParagraph>
         </Box>
       )}
       <TooltipParagraph>{getDescription()}</TooltipParagraph>

--- a/packages/ui/src/CampaignRewards/types.ts
+++ b/packages/ui/src/CampaignRewards/types.ts
@@ -1,0 +1,55 @@
+export interface CampaignRewardsItem {
+  campaignName: string
+  platform: string
+  description: string
+  platformImageId: string
+  dashboardLink: string
+  pools: CampaignRewardsPool[]
+}
+
+export interface CampaignRewardsPool {
+  id: string
+  action: RewardsAction
+  description: string
+  campaignStart: string
+  campaignEnd: string
+  address: string
+  network: string
+  multiplier: string
+  tags: RewardsTags[]
+  lock: string
+}
+
+export interface RewardsPool {
+  campaignName: string
+  platform: string
+  description: string
+  platformImageSrc: string
+  dashboardLink: string
+  id: string
+  action: RewardsAction
+  campaignStart: string
+  campaignEnd: string
+  address: string
+  network: string
+  multiplier: string
+  tags: RewardsTags[]
+  lock: boolean
+}
+
+export type CampaignRewardsMapper = { [poolAddress: string]: RewardsPool[] }
+
+export interface CampaignRewardsCompProps {
+  rewardsPool: RewardsPool
+  highContrast?: boolean
+  mobile?: boolean
+  banner?: boolean
+}
+
+export interface CampaignRewardsBannerCompProps {
+  campaignRewardsPool: RewardsPool[]
+  message: string
+}
+
+export type RewardsTags = 'points' | 'merkle' | 'tokens'
+export type RewardsAction = 'supply' | 'borrow' | 'lp' | 'loan'


### PR DESCRIPTION
This reverts commit 7968d44be65ba48b398029bc480a23e5856f4ab1, reversing changes made to f0deff85c1c7959f1192b0519da05d1a266564d7.

The issue at hand is that campaigns aren't being filtered by network yet in the `useCampaigns` hook, so we have campaigns showing up on incorrect chains. Fix shoudl be easy but due to time sensitivity of announced campaigns it needs thorough testing and this needs to be resolved (reverted) asap