### PR TITLE
fix: await networks in dex hydration to prevent async undefined networks

### DIFF
--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -107,9 +107,8 @@ const createGlobalSlice = (set: SetState<State>, get: GetState<State>): GlobalSl
      * will only make the dex app refresh and blink many times.
      * This hacky fix is there to because of Plasma network time sensitivity.
      */
-    await state.networks.fetchNetworks()
-
-    const network = state.networks.networks[chainId]
+    const networks = await state.networks.fetchNetworks()
+    const network = networks[chainId]
     const { excludePoolsMapper } = network
 
     // get poolList

--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -99,6 +99,16 @@ const createGlobalSlice = (set: SetState<State>, get: GetState<State>): GlobalSl
     state.setNetworkConfigFromApi(curveApi)
     state.networks.setNetworkConfigs(curveApi)
 
+    /**
+     * We might be double fetching networks due to useFetchNetworks, but there's
+     * a chance if we don't call it the networks aren't loaded yet and thus undefined.
+     * The real proper fix is to refactor into a Tanstack query and await fetchQuery.
+     * The DexLayout has `return isFetched && <Outlet />`, but adding isHydrated
+     * will only make the dex app refresh and blink many times.
+     * This hacky fix is there to because of Plasma network time sensitivity.
+     */
+    await state.networks.fetchNetworks()
+
     const network = state.networks.networks[chainId]
     const { excludePoolsMapper } = network
 


### PR DESCRIPTION
This is a not so nice fix that solves the issue of networks not being always being available during dex hydration. I've tried multiple solutions, but this one is the only one that actually solves the issue. The issue is a high prio because of the Plasma launch, and having the Plasma pool pages broken is ugly.

The proper fix will be to refactor the dex networks store into a tanstack query, but due to time constraints that's not possible for now. I'll make a ticket for that.