### PR TITLE
fix: estimate gas empty state

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/BorrowActionInfoAccordion.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowActionInfoAccordion.tsx
@@ -112,7 +112,7 @@ export const BorrowActionInfoAccordion = <ChainId extends IChainId>({
           )}
           <ActionInfo
             label={t`Estimated tx cost (step 1 of 2)`}
-            value={formatNumber(gas?.createLoanApprove?.estGasCostUsd, { currency: 'USD', defaultValue: '...' })}
+            value={formatNumber(gas?.createLoanApprove?.estGasCostUsd, { currency: 'USD', defaultValue: '-' })}
             valueTooltip={gas?.createLoanApprove?.tooltip}
             loading={gasLoading}
           />


### PR DESCRIPTION
- the current '...' is confusing, it looks like the value is loading
- instead, we show '-' and rely on the skeleton for loading states