### PR TITLE
fix: handle empty campaigns

### DIFF
--- a/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
@@ -15,20 +15,20 @@ const CampaignRewardsBanner = ({ chainId, address }: CampaignRewardsBannerProps)
   const network = useStore((state) => state.networks.networks[chainId])
   const { data: campaigns } = useCampaignsByNetwork(network.networkId as Chain)
   const campaignRewardsPool = campaigns?.[address]
-
-  if (!campaignRewardsPool) return null
-
-  const isPoints = campaignRewardsPool && campaignRewardsPool.some((rewardItem) => rewardItem.tags.includes('points'))
-
-  const bannerMessage = () => {
-    if (isPoints) return t`Liquidity providers in this pool also earn points!`
-    return t`Liquidity providers in this pool also earn additional tokens!`
-  }
-
   return (
-    <CampaignRewardsBannerWrapper>
-      <CampaignBannerComp campaignRewardsPool={campaignRewardsPool} message={bannerMessage()} />
-    </CampaignRewardsBannerWrapper>
+    campaignRewardsPool &&
+    campaignRewardsPool.length > 0 && (
+      <CampaignRewardsBannerWrapper>
+        <CampaignBannerComp
+          campaignRewardsPool={campaignRewardsPool}
+          message={
+            campaignRewardsPool?.some((rewardItem) => rewardItem.tags.includes('points'))
+              ? t`Liquidity providers in this pool also earn points!`
+              : t`Liquidity providers in this pool also earn additional tokens!`
+          }
+        />
+      </CampaignRewardsBannerWrapper>
+    )
   )
 }
 

--- a/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
@@ -14,19 +14,14 @@ interface CampaignRewardsBannerProps {
 const CampaignRewardsBanner = ({ chainId, address }: CampaignRewardsBannerProps) => {
   const network = useStore((state) => state.networks.networks[chainId])
   const { data: campaigns } = useCampaignsByNetwork(network.networkId as Chain)
-  const campaignRewardsPool = campaigns?.[address]
+  const campaignRewardsPool = campaigns?.[address] ?? []
+  const message = campaignRewardsPool.some((rewardItem) => rewardItem.tags.includes('points'))
+    ? t`Liquidity providers in this pool also earn points!`
+    : t`Liquidity providers in this pool also earn additional tokens!`
   return (
-    campaignRewardsPool &&
     campaignRewardsPool.length > 0 && (
       <CampaignRewardsBannerWrapper>
-        <CampaignBannerComp
-          campaignRewardsPool={campaignRewardsPool}
-          message={
-            campaignRewardsPool?.some((rewardItem) => rewardItem.tags.includes('points'))
-              ? t`Liquidity providers in this pool also earn points!`
-              : t`Liquidity providers in this pool also earn additional tokens!`
-          }
-        />
+        <CampaignBannerComp campaignRewardsPool={campaignRewardsPool} message={message} />
       </CampaignRewardsBannerWrapper>
     )
   )

--- a/apps/main/src/lend/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsBanner.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import CampaignBannerComp from 'ui/src/CampaignRewards/CampaignBannerComp'
 import networks from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
@@ -17,26 +16,20 @@ const CampaignRewardsBanner = ({ chainId, borrowAddress, supplyAddress }: Campai
   const { data: campaigns } = useCampaigns({ blockchainId })
   const supplyCampaignRewardsPool = campaigns?.[supplyAddress]
   const borrowCampaignRewardsPool = campaigns?.[borrowAddress]
-
-  const campaignRewardsPools = useMemo(() => {
-    if (supplyCampaignRewardsPool && borrowCampaignRewardsPool) {
-      return [...supplyCampaignRewardsPool, ...borrowCampaignRewardsPool]
-    }
-    if (supplyCampaignRewardsPool) return supplyCampaignRewardsPool
-    if (borrowCampaignRewardsPool) return borrowCampaignRewardsPool
-    return []
-  }, [supplyCampaignRewardsPool, borrowCampaignRewardsPool])
-
-  if (!supplyCampaignRewardsPool && !borrowCampaignRewardsPool) return null
-
-  const message =
-    supplyCampaignRewardsPool && borrowCampaignRewardsPool
-      ? t`Supplying and borrowing in this pool earns points!`
-      : supplyCampaignRewardsPool
-        ? t`Supplying in this pool earns points!`
-        : t`Borrowing in this pool earns points!`
-
-  return <CampaignBannerComp campaignRewardsPool={campaignRewardsPools} message={message} />
+  return (
+    (supplyCampaignRewardsPool || borrowCampaignRewardsPool) && (
+      <CampaignBannerComp
+        campaignRewardsPool={[...(supplyCampaignRewardsPool ?? []), ...(borrowCampaignRewardsPool ?? [])]}
+        message={
+          supplyCampaignRewardsPool && borrowCampaignRewardsPool
+            ? t`Supplying and borrowing in this pool earns points!`
+            : supplyCampaignRewardsPool
+              ? t`Supplying in this pool earns points!`
+              : t`Borrowing in this pool earns points!`
+        }
+      />
+    )
+  )
 }
 
 export default CampaignRewardsBanner

--- a/apps/main/src/lend/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsBanner.tsx
@@ -14,14 +14,14 @@ interface CampaignRewardsBannerProps {
 const CampaignRewardsBanner = ({ chainId, borrowAddress, supplyAddress }: CampaignRewardsBannerProps) => {
   const blockchainId = networks[chainId].id as Chain
   const { data: campaigns } = useCampaigns({ blockchainId })
-  const supplyCampaignRewardsPool = campaigns?.[supplyAddress]
-  const borrowCampaignRewardsPool = campaigns?.[borrowAddress]
+  const supplyCampaignRewardsPool = campaigns?.[supplyAddress] ?? []
+  const borrowCampaignRewardsPool = campaigns?.[borrowAddress] ?? []
   return (
-    (supplyCampaignRewardsPool || borrowCampaignRewardsPool) && (
+    supplyCampaignRewardsPool.length + borrowCampaignRewardsPool.length > 0 && (
       <CampaignBannerComp
-        campaignRewardsPool={[...(supplyCampaignRewardsPool ?? []), ...(borrowCampaignRewardsPool ?? [])]}
+        campaignRewardsPool={[...supplyCampaignRewardsPool, ...borrowCampaignRewardsPool]}
         message={
-          supplyCampaignRewardsPool && borrowCampaignRewardsPool
+          supplyCampaignRewardsPool.length && borrowCampaignRewardsPool.length
             ? t`Supplying and borrowing in this pool earns points!`
             : supplyCampaignRewardsPool
               ? t`Supplying in this pool earns points!`

--- a/packages/ui/src/CampaignRewards/CampaignBannerComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignBannerComp.tsx
@@ -9,7 +9,7 @@ type CampaignRewardsBannerCompProps = {
   message: string
 }
 
-const RewardsBannerComp = ({ campaignRewardsPool, message }: CampaignRewardsBannerCompProps) => (
+const CampaignBannerComp = ({ campaignRewardsPool, message }: CampaignRewardsBannerCompProps) => (
   <Wrapper>
     <StyledPointsIcon />
     <RewardsMessage>
@@ -60,4 +60,4 @@ const RewardsIconsWrapper = styled.div`
   flex-shrink: 1;
 `
 
-export default RewardsBannerComp
+export default CampaignBannerComp


### PR DESCRIPTION
- #1446 must have changed the behavior to include empty lists of campaigns in the data set
- this PR handles empty list of campaigns by also checking the array length