### PR TITLE
feat: "Max LTV" and "Safe" labels added to band slider

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/AdvancedBorrowOptions.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/AdvancedBorrowOptions.tsx
@@ -45,7 +45,7 @@ export const AdvancedBorrowOptions = ({
   } = useBorrowExpectedCollateral(params, leverageEnabled)
 
   return (
-    <Stack gap={Spacing.sm} marginBlock={Spacing.lg}>
+    <Stack gap={Spacing.sm} marginBlock={Spacing.sm}>
       <LiquidationRangeSlider market={market} range={range} setRange={setRange} />
       <Stack
         sx={{

--- a/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
-import { Stack } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import Slider from '@mui/material/Slider'
 import Typography from '@mui/material/Typography'
@@ -32,11 +31,15 @@ export const LiquidationRangeSlider = ({
   const maxValue = liqRanges?.[liqRanges.length - 1]?.n ?? market?.maxBands ?? BORROW_PRESET_RANGES.Safe
   return (
     <Grid container columnSpacing={Spacing.sm}>
-      <Grid size={8}>
-        <Stack direction="row" alignItems="flex-end" justifyContent="space-between">
-          <Typography variant="bodyXsRegular" color="textTertiary">{t`Max LTV`}</Typography>
-          <Typography variant="bodyXsRegular" color="textTertiary">{t`Safe`}</Typography>
-        </Stack>
+      <Grid container size={8}>
+        <Grid size={12} container>
+          <Grid size={6}>
+            <Typography variant="bodyXsRegular" color="textTertiary">{t`Max LTV`}</Typography>
+          </Grid>
+          <Grid size={6} sx={{ textAlign: 'right' }}>
+            <Typography variant="bodyXsRegular" color="textTertiary">{t`Safe`}</Typography>
+          </Grid>
+        </Grid>
         {/* we need 10 px padding, and -4px marginBottom, because the slider is overflowing its container */}
         <Grid size={12} paddingInline="10px" marginBottom="-4px">
           <Slider

--- a/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
+import { Stack } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import Slider from '@mui/material/Slider'
 import Typography from '@mui/material/Typography'
@@ -32,19 +33,25 @@ export const LiquidationRangeSlider = ({
   return (
     <Grid container columnSpacing={Spacing.sm}>
       {/* we need 10 px padding because the slider is overflowing its container */}
-      <Grid size={8} paddingInline="10px">
-        <Slider
-          aria-label={t`Bands`}
-          getAriaValueText={format}
-          value={sliderValue}
-          onChange={(_, n) => setSliderValue(n as number)}
-          onChangeCommitted={(_, n) => setRange(n as number)}
-          min={minValue}
-          max={maxValue}
-          size="medium"
-        />
+      <Grid size={8}>
+        <Stack direction="row" alignItems="flex-end" justifyContent="space-between">
+          <Typography variant="tableHeaderS" color="textTertiary">{t`Max LTV`}</Typography>
+          <Typography variant="tableHeaderS" color="textTertiary">{t`Safe`}</Typography>
+        </Stack>
+        <Grid size={12} paddingInline="10px">
+          <Slider
+            aria-label={t`Bands`}
+            getAriaValueText={format}
+            value={sliderValue}
+            onChange={(_, n) => setSliderValue(n as number)}
+            onChangeCommitted={(_, n) => setRange(n as number)}
+            min={minValue}
+            max={maxValue}
+            size="medium"
+          />
+        </Grid>
       </Grid>
-      <Grid size={4}>
+      <Grid size={4} display="flex" alignItems="flex-end" direction="row">
         <NumericTextField
           dataType="number"
           aria-label={t`Bands`}

--- a/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
@@ -35,8 +35,8 @@ export const LiquidationRangeSlider = ({
       {/* we need 10 px padding because the slider is overflowing its container */}
       <Grid size={8}>
         <Stack direction="row" alignItems="flex-end" justifyContent="space-between">
-          <Typography variant="tableHeaderS" color="textTertiary">{t`Max LTV`}</Typography>
-          <Typography variant="tableHeaderS" color="textTertiary">{t`Safe`}</Typography>
+          <Typography variant="bodyXsRegular" color="textTertiary">{t`Max LTV`}</Typography>
+          <Typography variant="bodyXsRegular" color="textTertiary">{t`Safe`}</Typography>
         </Stack>
         <Grid size={12} paddingInline="10px">
           <Slider

--- a/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
@@ -32,13 +32,13 @@ export const LiquidationRangeSlider = ({
   const maxValue = liqRanges?.[liqRanges.length - 1]?.n ?? market?.maxBands ?? BORROW_PRESET_RANGES.Safe
   return (
     <Grid container columnSpacing={Spacing.sm}>
-      {/* we need 10 px padding because the slider is overflowing its container */}
       <Grid size={8}>
         <Stack direction="row" alignItems="flex-end" justifyContent="space-between">
           <Typography variant="bodyXsRegular" color="textTertiary">{t`Max LTV`}</Typography>
           <Typography variant="bodyXsRegular" color="textTertiary">{t`Safe`}</Typography>
         </Stack>
-        <Grid size={12} paddingInline="10px">
+        {/* we need 10 px padding, and -4px marginBottom, because the slider is overflowing its container */}
+        <Grid size={12} paddingInline="10px" marginBottom="-4px">
           <Slider
             aria-label={t`Bands`}
             getAriaValueText={format}


### PR DESCRIPTION
Added "Max LTV" and "Safe" labels to the Liquidation range on the LLamalend Borrowing page

<img width="734" height="404" alt="Screenshot 2025-10-02 at 12 31 45" src="https://github.com/user-attachments/assets/ccd1c83d-da2d-45ef-b2d6-bab76fe5eb05" />
