### PR TITLE
fix: dex pools overflow 

### DIFF
--- a/apps/main/src/dex/components/PagePoolList/components/PoolRow.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/PoolRow.tsx
@@ -14,9 +14,9 @@ import { getUserActiveKey } from '@/dex/store/createUserSlice'
 import useStore from '@/dex/store/useStore'
 import { CurveApi, ChainId } from '@/dex/types/main.types'
 import { getPath } from '@/dex/utils/utilsRouter'
-import { useLayoutStore } from '@ui-kit/features/layout'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { useNavigate } from '@ui-kit/hooks/router'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 
 interface PoolRowProps {
   poolId: string
@@ -57,7 +57,7 @@ export const PoolRow = ({
   const userActiveKey = getUserActiveKey(curve)
 
   const formValues = useStore((state) => state.poolList.formValues)
-  const isXSmDown = useLayoutStore((state) => state.isXSmDown)
+  const isMobile = useIsMobile()
   const poolDataCached = useStore((state) => state.storeCache.poolsMapper[rChainId]?.[poolId])
   const poolData = useStore((state) => state.pools.poolsMapper[rChainId]?.[poolId])
   const rewardsApy = useStore((state) => state.pools.rewardsApyMapper[rChainId]?.[poolId])
@@ -111,7 +111,7 @@ export const PoolRow = ({
 
   return (
     <>
-      {isXSmDown ? (
+      {isMobile ? (
         <TableRowMobile
           tableLabel={tableLabels}
           showDetail={showDetail}
@@ -127,7 +127,7 @@ export const PoolRow = ({
         <TrSearchedTextResult
           colSpan={10}
           id={poolId}
-          isMobile={isXSmDown}
+          isMobile={isMobile}
           result={searchedByAddresses}
           searchTermMapper={parsedSearchTermMapper}
           scanAddressPath={network.scanAddressPath}

--- a/apps/main/src/dex/components/PagePoolList/index.tsx
+++ b/apps/main/src/dex/components/PagePoolList/index.tsx
@@ -13,6 +13,7 @@ import Spinner, { SpinnerWrapper } from '@ui/Spinner'
 import Table, { Tbody } from '@ui/Table'
 import { useLayoutStore } from '@ui-kit/features/layout'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import usePageVisibleInterval from '@ui-kit/hooks/usePageVisibleInterval'
 import { REFRESH_INTERVAL } from '@ui-kit/lib/model'
 
@@ -28,8 +29,7 @@ const PoolList = ({
   const activeKey = getPoolListActiveKey(rChainId, searchParams)
   const prevActiveKey = useStore((state) => state.poolList.activeKey)
   const formStatus = useStore((state) => state.poolList.formStatus[activeKey] ?? DEFAULT_FORM_STATUS)
-  const isMdUp = useLayoutStore((state) => state.isMdUp)
-  const isXSmDown = useLayoutStore((state) => state.isXSmDown)
+  const isMobile = useIsMobile()
   const isPageVisible = useLayoutStore((state) => state.isPageVisible)
   const poolDataMapperCached = useStore((state) => state.storeCache.poolsMapper[rChainId])
   const poolDataMapper = useStore((state) => state.pools.poolsMapper[rChainId])
@@ -93,9 +93,9 @@ const PoolList = ({
       return keys.concat([COLUMN_KEYS.rewardsLite, COLUMN_KEYS.tvl])
     }
 
-    isMdUp ? keys.push(COLUMN_KEYS.rewardsDesktop) : keys.push(COLUMN_KEYS.rewardsMobile)
+    !isMobile ? keys.push(COLUMN_KEYS.rewardsDesktop) : keys.push(COLUMN_KEYS.rewardsMobile)
     return keys.concat([COLUMN_KEYS.volume, COLUMN_KEYS.tvl])
-  }, [isLite, isMdUp, showInPoolColumn])
+  }, [isLite, isMobile, showInPoolColumn])
 
   const updateFormValues = useCallback(
     (searchParams: SearchParams) => {
@@ -149,7 +149,7 @@ const PoolList = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isReady, isReadyWithApiData, chainId, signerAddress, searchParams, hideSmallPools])
 
-  let colSpan = isMdUp ? 7 : 4
+  let colSpan = !isMobile ? 7 : 4
   if (showHideSmallPools) {
     colSpan++
   }
@@ -170,7 +170,7 @@ const PoolList = ({
       />
 
       <Table cellPadding={0} cellSpacing={0}>
-        {isXSmDown ? (
+        {isMobile ? (
           <TableHeadMobile showInPoolColumn={showInPoolColumn} />
         ) : (
           <TableHead


### PR DESCRIPTION
Using hook `useIsMobile()` from `@ui-kit` breakpoint to toggle between desktop and mobile (screen width < 820 px) for the DEX pools