### PR TITLE
fix: missing dependencies in quickViewValue in mobile DEX table row

### DIFF
--- a/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
@@ -73,7 +73,7 @@ const TableRowMobile = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showDetail, sortBy])
+  }, [showDetail, sortBy, volume?.value, tvl?.value, rewardsApy, poolData])
 
   return (
     <LazyItem id={`${index}`} className="row--info">

--- a/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
+++ b/apps/main/src/dex/components/PagePoolList/components/TableRowMobile.tsx
@@ -72,7 +72,6 @@ const TableRowMobile = ({
         return formatNumber(tvl?.value, { notation: 'compact', currency: 'USD' })
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showDetail, sortBy, volume?.value, tvl?.value, rewardsApy, poolData])
 
   return (


### PR DESCRIPTION
- fixes the volumes not loading automatically on mobile until a row is expanded
- Easy fix for this one. Added missing dependencies to `quickViewValue`, now the value will correctly update whenever the data loads