### PR TITLE
fix: remove faulty formatting for expected collateral when using llamalend leverage

### DIFF
--- a/apps/main/src/llamalend/widgets/RouteDetails/utils.ts
+++ b/apps/main/src/llamalend/widgets/RouteDetails/utils.ts
@@ -1,5 +1,5 @@
 import { formatNumber, NumberFormatOptions } from '@ui/utils'
 
 export function format(val: string | number | undefined, options?: NumberFormatOptions | undefined) {
-  return formatNumber(val, { ...options, maximumSignificantDigits: 5 })
+  return formatNumber(val, options)
 }


### PR DESCRIPTION
<img width="482" height="720" alt="image" src="https://github.com/user-attachments/assets/1d877c13-fee2-41cf-85c3-a3378d6f9dac" />

Changes:
- Fixed aggressive rounding happening in RouteDetails (it was only allowing max 5 significant digits)