### PR TITLE
fix: borrow form precision issues

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/BorrowFormAlert.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowFormAlert.tsx
@@ -5,10 +5,11 @@ import Box from '@mui/material/Box'
 import Link from '@mui/material/Link'
 import type { BaseConfig } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
+import { Decimal } from '@ui-kit/utils'
 import type { BorrowFormErrors } from '../types'
 
 /** List of fields that show their own error messages, those will be omitted from the general error alert */
-const handledErrors: BorrowFormErrors[number][0][] = ['userCollateral', 'debt', 'maxDebt', 'userCollateral']
+const handledErrors: BorrowFormErrors[Decimal][0][] = ['userCollateral', 'debt', 'maxDebt', 'userCollateral']
 
 /**
  * Alert component to display the status of the borrow form submission.

--- a/apps/main/src/llamalend/features/borrow/components/BorrowFormTokenInput.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowFormTokenInput.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
 import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
+import { Decimal } from '@ui-kit/utils'
 import { setValueOptions } from '../react-form.utils'
 import type { BorrowForm, Token } from '../types'
 
@@ -24,13 +25,13 @@ export const BorrowFormTokenInput = ({
   token: Token | undefined
   isError: boolean
   isLoading: boolean
-  max: number | undefined
+  max: Decimal | undefined
   name: keyof typeof maxField
   form: UseFormReturn<BorrowForm>
   testId?: string
 }) => (
   <LargeTokenInput
-    dataType="number"
+    dataType="decimal"
     name={name}
     label={label}
     testId={testId}
@@ -42,7 +43,7 @@ export const BorrowFormTokenInput = ({
         label={token?.symbol ?? '?'}
       />
     }
-    onBalance={useCallback((v?: number) => form.setValue(name, v, setValueOptions), [form, name])}
+    onBalance={useCallback((v?: Decimal) => form.setValue(name, v, setValueOptions), [form, name])}
     isError={isError || !!form.formState.errors[name] || !!form.formState.errors[maxField[name]]}
     message={form.formState.errors[name]?.message ?? form.formState.errors[maxField[name]]?.message}
     balanceDecimals={2}

--- a/apps/main/src/llamalend/features/borrow/components/LeverageInput.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LeverageInput.tsx
@@ -9,6 +9,7 @@ import { t } from '@ui-kit/lib/i18n'
 import ActionInfo from '@ui-kit/shared/ui/ActionInfo'
 import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { Decimal } from '@ui-kit/utils'
 import { useBorrowExpectedCollateral } from '../queries/borrow-expected-collateral.query'
 import type { BorrowForm, BorrowFormQueryParams } from '../types'
 
@@ -25,7 +26,7 @@ export const LeverageInput = ({
   leverageEnabled: boolean
   form: UseFormReturn<BorrowForm>
   params: BorrowFormQueryParams
-  maxLeverage: number | undefined
+  maxLeverage: Decimal | undefined
   isError: boolean
   isLoading: boolean
 }) => {

--- a/apps/main/src/llamalend/features/borrow/hooks/useLiquidationRangeChartData.ts
+++ b/apps/main/src/llamalend/features/borrow/hooks/useLiquidationRangeChartData.ts
@@ -20,7 +20,7 @@ export const useLiquidationRangeChartData = (params: BorrowFormQueryParams): Liq
         name: t`Liquidation Range`,
         currLabel: '',
         curr: [0, 0], // Empty array for new borrow (no current position)
-        new: prices ?? [0, 0],
+        new: prices?.map((n) => +n) ?? [0, 0],
         newLabel: 'LR',
         oraclePrice: oraclePrice ?? '',
         oraclePriceBand: oraclePriceBand ?? null,

--- a/apps/main/src/llamalend/features/borrow/hooks/useLoanToValue.ts
+++ b/apps/main/src/llamalend/features/borrow/hooks/useLoanToValue.ts
@@ -1,6 +1,8 @@
+import BigNumber from 'bignumber.js'
 import { useBorrowExpectedCollateral } from '@/llamalend/features/borrow/queries/borrow-expected-collateral.query'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
+import { Decimal } from '@ui-kit/utils'
 import type { BorrowFormQueryParams, Token } from '../types'
 
 /**
@@ -30,5 +32,5 @@ export const useLoanToValue = <ChainId extends IChainId>({
   const collateral = leverageEnabled ? expectedCollateral?.totalCollateral : userCollateral
   return debt == null || !collateral || !collateralUsdRate
     ? null
-    : ((debt * borrowUsdRate) / (collateral * collateralUsdRate)) * 100
+    : (new BigNumber(debt).times(borrowUsdRate).div(collateral).div(collateralUsdRate).times(100).toString() as Decimal)
 }

--- a/apps/main/src/llamalend/features/borrow/hooks/useMaxTokenValues.tsx
+++ b/apps/main/src/llamalend/features/borrow/hooks/useMaxTokenValues.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { type Address } from 'viem'
 import { useTokenBalance } from '@ui-kit/hooks/useTokenBalance'
+import { Decimal } from '@ui-kit/utils'
 import { useMaxLeverage } from '../queries/borrow-max-leverage.query'
 import { useMaxBorrowReceive } from '../queries/borrow-max-receive.query'
 import { setValueOptions } from '../react-form.utils'
@@ -35,9 +36,9 @@ export function useMaxTokenValues(
 
   const { maxDebt, maxLeverage: maxBorrowLeverage, maxTotalCollateral } = maxBorrow ?? {}
   const maxCollateral =
-    userBalance && maxBorrow?.maxTotalCollateral
-      ? Math.min(userBalance, maxBorrow?.maxTotalCollateral)
-      : (userBalance ?? maxBorrow?.maxTotalCollateral)
+    userBalance && maxTotalCollateral
+      ? (`${Math.min(+userBalance, +maxTotalCollateral)}` satisfies Decimal)
+      : (userBalance ?? maxTotalCollateral)
 
   const maxLeverage = maxBorrowLeverage ?? maxTotalLeverage
 

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-apy.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-apy.query.ts
@@ -5,15 +5,16 @@ import { type FieldsOf } from '@ui-kit/lib'
 import type { PoolQuery } from '@ui-kit/lib/model'
 import { queryFactory, rootKeys } from '@ui-kit/lib/model'
 import { llamaApiValidationSuite } from '@ui-kit/lib/model/query/curve-api-validation'
+import { decimal, Decimal } from '@ui-kit/utils'
 
 type BorrowApyQuery = PoolQuery<IChainId>
 type BorrowApyParams = FieldsOf<BorrowApyQuery>
 
 export type BorrowRatesResult = {
-  borrowApr: number
-  borrowApy?: number
-  lendApr?: number
-  lendApy?: number
+  borrowApr: Decimal
+  borrowApy?: Decimal
+  lendApr?: Decimal
+  lendApy?: Decimal
 }
 
 const convertRates = ({
@@ -22,10 +23,10 @@ const convertRates = ({
   lendApr,
   lendApy,
 }: { [K in keyof BorrowRatesResult]: string }): BorrowRatesResult => ({
-  borrowApr: +borrowApr,
-  ...(borrowApy && { borrowApy: +borrowApy }),
-  ...(lendApy && { lendApy: +lendApy }),
-  ...(lendApr && { lendApr: +lendApr }),
+  borrowApr: borrowApr as Decimal,
+  borrowApy: decimal(borrowApy),
+  lendApy: decimal(lendApy),
+  lendApr: decimal(lendApr),
 })
 
 const [isGetter, useAPI] = [true, true] as const

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-bands.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-bands.query.ts
@@ -12,9 +12,9 @@ export const { useQuery: useBorrowBands } = queryFactory({
   queryKey: ({
     chainId,
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
     leverageEnabled,
     range,
   }: BorrowFormQueryParams) =>
@@ -29,9 +29,9 @@ export const { useQuery: useBorrowBands } = queryFactory({
     ] as const,
   queryFn: ({
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
     leverageEnabled,
     range,
   }: BorrowFormQuery): Promise<BorrowBandsResult> => {

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-gas-estimate.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-gas-estimate.query.ts
@@ -16,7 +16,7 @@ type BorrowGasEstimateQuery<T = IChainId> = BorrowFormQuery<T>
 type GasEstimateParams<T = IChainId> = FieldsOf<BorrowGasEstimateQuery<T>>
 
 const { useQuery: useGasEstimate } = queryFactory({
-  queryKey: ({ chainId, poolId, userBorrowed = 0, userCollateral = 0, leverageEnabled }: GasEstimateParams) =>
+  queryKey: ({ chainId, poolId, userBorrowed = '0', userCollateral = '0', leverageEnabled }: GasEstimateParams) =>
     [
       ...rootKeys.pool({ chainId, poolId }),
       'borrow-gas-estimation',
@@ -24,7 +24,7 @@ const { useQuery: useGasEstimate } = queryFactory({
       { userCollateral },
       { leverageEnabled },
     ] as const,
-  queryFn: async ({ poolId, userBorrowed = 0, userCollateral = 0, leverageEnabled }: BorrowGasEstimateQuery) => {
+  queryFn: async ({ poolId, userBorrowed = '0', userCollateral = '0', leverageEnabled }: BorrowGasEstimateQuery) => {
     const market = getLlamaMarket(poolId)
     return {
       createLoanApprove: !leverageEnabled

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-health.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-health.query.ts
@@ -19,9 +19,9 @@ export const { useQuery: useBorrowHealth } = queryFactory({
     ] as const,
   queryFn: async ({
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
     leverageEnabled,
     range,
   }: BorrowFormQuery): Promise<number> => {

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-price-impact.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-price-impact.query.ts
@@ -8,7 +8,7 @@ import { borrowQueryValidationSuite } from './borrow.validation'
 type BorrowPriceImpactResult = number // percentage
 
 export const { useQuery: useBorrowPriceImpact } = queryFactory({
-  queryKey: ({ chainId, poolId, userBorrowed = 0, userCollateral = 0, debt = 0 }: BorrowFormQueryParams) =>
+  queryKey: ({ chainId, poolId, userBorrowed = '0', userCollateral = '0', debt = '0' }: BorrowFormQueryParams) =>
     [
       ...rootKeys.pool({ chainId, poolId }),
       'createLoanPriceImpact',
@@ -18,9 +18,9 @@ export const { useQuery: useBorrowPriceImpact } = queryFactory({
     ] as const,
   queryFn: async ({
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
   }: BorrowFormQuery): Promise<BorrowPriceImpactResult> => {
     const market = getLlamaMarket(poolId)
     return market instanceof LendMarketTemplate

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-prices.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-prices.query.ts
@@ -2,6 +2,7 @@ import { getLlamaMarket } from '@/llamalend/llama.utils'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys } from '@ui-kit/lib/model'
+import { Decimal } from '@ui-kit/utils'
 import type { BorrowFormQuery } from '../types'
 import { borrowExpectedCollateralQueryKey } from './borrow-expected-collateral.query'
 import { maxBorrowReceiveKey } from './borrow-max-receive.query'
@@ -10,17 +11,16 @@ import { borrowQueryValidationSuite } from './borrow.validation'
 type BorrowPricesReceiveQuery = BorrowFormQuery
 type BorrowPricesReceiveParams = FieldsOf<BorrowPricesReceiveQuery>
 
-type BorrowPricesResult = [number, number]
-
-const convertNumbers = (prices: string[]): BorrowPricesResult => [+prices[0], +prices[1]]
+type BorrowPricesResult = [Decimal, Decimal]
+const convertNumbers = (prices: string[]) => [prices[0], prices[1]] as BorrowPricesResult
 
 export const { useQuery: useBorrowPrices } = queryFactory({
   queryKey: ({
     chainId,
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
     leverageEnabled,
     range,
   }: BorrowPricesReceiveParams) =>
@@ -35,9 +35,9 @@ export const { useQuery: useBorrowPrices } = queryFactory({
     ] as const,
   queryFn: async ({
     poolId,
-    userBorrowed = 0,
-    userCollateral = 0,
-    debt = 0,
+    userBorrowed = '0',
+    userCollateral = '0',
+    debt = '0',
     leverageEnabled,
     range,
   }: BorrowPricesReceiveQuery): Promise<BorrowPricesResult> => {

--- a/apps/main/src/llamalend/features/borrow/queries/borrow-route-image.query.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow-route-image.query.ts
@@ -5,9 +5,9 @@ import type { BorrowFormQuery, BorrowFormQueryParams } from '../types'
 import { borrowQueryValidationSuite } from './borrow.validation'
 
 export const { useQuery: useBorrowRouteImage } = queryFactory({
-  queryKey: ({ chainId, poolId, userBorrowed = 0, debt = 0 }: BorrowFormQueryParams) =>
+  queryKey: ({ chainId, poolId, userBorrowed = '0', debt = '0' }: BorrowFormQueryParams) =>
     [...rootKeys.pool({ chainId, poolId }), 'createLoanRouteImage', { userBorrowed }, { debt }] as const,
-  queryFn: async ({ poolId, userBorrowed = 0, debt = 0 }: BorrowFormQuery): Promise<string | undefined> => {
+  queryFn: async ({ poolId, userBorrowed = '0', debt = '0' }: BorrowFormQuery): Promise<string | undefined> => {
     const market = getLlamaMarket(poolId)
     return market instanceof LendMarketTemplate
       ? await market.leverage.createLoanRouteImage(userBorrowed, debt)

--- a/apps/main/src/llamalend/features/borrow/queries/borrow.validation.ts
+++ b/apps/main/src/llamalend/features/borrow/queries/borrow.validation.ts
@@ -6,17 +6,17 @@ import { Decimal } from '@ui-kit/utils'
 import { BORROW_PRESET_RANGES } from '../constants'
 import { type BorrowForm, type BorrowFormQueryParams } from '../types'
 
-const validateUserBorrowed = (userBorrowed: number | null | undefined) =>
+const validateUserBorrowed = (userBorrowed: Decimal | null | undefined) =>
   test('userBorrowed', 'Borrow amount must be a non-negative number', () => {
     enforce(userBorrowed).isNumeric().gte(0)
   })
 
-const validateUserCollateral = (userCollateral: number | undefined | null) =>
+const validateUserCollateral = (userCollateral: Decimal | undefined | null) =>
   test('userCollateral', `Collateral amount must be a positive number`, () => {
     enforce(userCollateral).isNumeric().gt(0)
   })
 
-const validateDebt = (debt: number | undefined | null, required: boolean) =>
+const validateDebt = (debt: Decimal | undefined | null, required: boolean) =>
   test('debt', `Debt must be a positive number${required ? '' : ' or null'}`, () => {
     if (required || debt != null) {
       enforce(debt).isNumeric().gt(0)
@@ -34,7 +34,7 @@ export const validateRange = (range: number | null | undefined, { MaxLtv, Safe }
   })
 }
 
-export const validateMaxDebt = (debt: number | undefined | null, maxDebt: number | undefined | null) => {
+export const validateMaxDebt = (debt: Decimal | undefined | null, maxDebt: Decimal | undefined | null) => {
   test('debt', 'Debt must be less than or equal to maximum borrowable amount', () => {
     if (debt != null && maxDebt != null) {
       enforce(debt).lte(maxDebt)
@@ -43,8 +43,8 @@ export const validateMaxDebt = (debt: number | undefined | null, maxDebt: number
 }
 
 export const validateMaxCollateral = (
-  userCollateral: number | undefined | null,
-  maxCollateral: number | undefined | null,
+  userCollateral: Decimal | undefined | null,
+  maxCollateral: Decimal | undefined | null,
 ) => {
   test('userCollateral', 'Collateral must be less than or equal to your wallet balance', () => {
     if (userCollateral != null && maxCollateral != null) {

--- a/apps/main/src/llamalend/features/borrow/types.ts
+++ b/apps/main/src/llamalend/features/borrow/types.ts
@@ -6,15 +6,15 @@ import { Decimal } from '@ui-kit/utils'
 
 /** Complete borrow creation form with all fields already filled in (after validation) */
 export type CompleteBorrowForm = {
-  userCollateral: number
-  userBorrowed: number // currently hidden and always 0
-  debt: number
+  userCollateral: Decimal
+  userBorrowed: Decimal // currently hidden and always 0
+  debt: Decimal
   range: number
   slippage: Decimal
   leverageEnabled: boolean
 }
 
-type CalculatedValues = { maxDebt: number | undefined; maxCollateral: number | undefined }
+type CalculatedValues = { maxDebt: Decimal | undefined; maxCollateral: Decimal | undefined }
 
 /** Borrow creation form as used in the UI, with some fields still optional or being filled in */
 export type BorrowForm = MakeOptional<CompleteBorrowForm, 'debt' | 'userCollateral'> & CalculatedValues

--- a/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/useBorrowForm.tsx
@@ -11,6 +11,7 @@ import { vestResolver } from '@hookform/resolvers/vest'
 import type { BaseConfig } from '@ui/utils'
 import { useDebouncedValue } from '@ui-kit/hooks/useDebounce'
 import { formDefaultOptions } from '@ui-kit/lib/model'
+import { Decimal } from '@ui-kit/utils'
 import { SLIPPAGE_PRESETS } from '@ui-kit/widgets/SlippageSettings/slippage.utils'
 import { BORROW_PRESET_RANGES } from './constants'
 import { useMaxTokenValues } from './hooks/useMaxTokenValues'
@@ -37,7 +38,7 @@ export function useBorrowForm<ChainId extends IChainId>({
     resolver: vestResolver(borrowFormValidationSuite),
     defaultValues: {
       userCollateral: undefined,
-      userBorrowed: 0,
+      userBorrowed: `0` satisfies Decimal,
       debt: undefined,
       leverageEnabled: false,
       slippage: SLIPPAGE_PRESETS.STABLE,

--- a/packages/curve-ui-kit/src/hooks/useTokenBalance.tsx
+++ b/packages/curve-ui-kit/src/hooks/useTokenBalance.tsx
@@ -1,10 +1,12 @@
 import { type Address, ethAddress, formatUnits } from 'viem'
 import { useBalance } from 'wagmi'
 import type { FieldsOf } from '@ui-kit/lib'
+import { Decimal } from '@ui-kit/utils'
 import type { GetBalanceReturnType } from '@wagmi/core'
 
 /** Convert user collateral from GetBalanceReturnType to number */
-const convertBalance = ({ value, decimals }: Partial<GetBalanceReturnType>) => +formatUnits(value || 0n, decimals || 18)
+const convertBalance = ({ value, decimals }: Partial<GetBalanceReturnType>) =>
+  formatUnits(value || 0n, decimals || 18) as Decimal
 
 /**
  * Hook to fetch the token balance and convert it to a number, wrapping wagmi's useBalance hook.


### PR DESCRIPTION
- convert the form to use the `Decimal` type alias to avoid losing precision