### PR TITLE
fix: chip token USD rate loading indefinitely on hover

### DIFF
--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -86,6 +86,7 @@ const ChipPoolAdditionalInfo = styled.span`
   transition: max-width 1s;
   white-space: nowrap;
   overflow: hidden;
+  margin-left: 4px;
 `
 
 const ChipPoolWrapper = styled.span`

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import type { AriaButtonProps } from 'react-aria'
 import { useButton } from 'react-aria'
 import { styled } from 'styled-components'
@@ -50,11 +50,11 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
   const [usdRate, setUsdRate] = useState<number | undefined>(undefined)
   const parsedUsdRate = formatNumber(usdRate, { ...FORMAT_OPTIONS.USD, defaultValue: '-' })
 
-  const handleMouseEnter = (foundUsdRate?: string) => {
-    if (!foundUsdRate) {
+  const handleMouseEnter = useCallback(() => {
+    if (typeof usdRate === 'undefined') {
       void fetchTokenUsdRate({ chainId, tokenAddress }).then(setUsdRate)
     }
-  }
+  }, [usdRate, chainId, tokenAddress])
 
   const parsedTokenName = useMemo(() => {
     if (tokenName && tokenName.length > 10) {
@@ -64,7 +64,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
   }, [tokenName])
 
   return (
-    <ChipTokenWrapper className={className} onMouseEnter={() => handleMouseEnter(parsedUsdRate)}>
+    <ChipTokenWrapper className={className} onMouseEnter={handleMouseEnter}>
       <span>{isHighlight ? <strong>{parsedTokenName}</strong> : parsedTokenName} </span>
       <ChipTokenAdditionalInfo>
         <Button {...props} onPress={() => copyToClipboard(tokenAddress)}>

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -68,7 +68,9 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
       <span>{isHighlight ? <strong>{parsedTokenName}</strong> : parsedTokenName} </span>
       <ChipTokenAdditionalInfo>
         <Button {...props} onPress={() => copyToClipboard(tokenAddress)}>
-          <ChipTokenUsdRate>{typeof usdRate === 'undefined' ? <Spinner size={10} /> : parsedUsdRate}</ChipTokenUsdRate>
+          <ChipTokenUsdRate>
+            {typeof usdRate === 'undefined' ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
+          </ChipTokenUsdRate>
           <ChipTokenCopyButtonIcon name="Copy" size={16} />
         </Button>
       </ChipTokenAdditionalInfo>
@@ -108,6 +110,10 @@ const ChipTokenUsdRate = styled.span`
   top: -2px;
   font-size: var(--font-size-1);
   font-weight: bold;
+`
+const ChipTokenUsdRateSpinner = styled(Spinner)`
+  position: relative;
+  top: 2px;
 `
 
 const ChipTokenCopyButtonIcon = styled(Icon)`

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -68,17 +68,24 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
       <span>{isHighlight ? <strong>{parsedTokenName}</strong> : parsedTokenName} </span>
       <ChipTokenAdditionalInfo>
         <Button {...props} onPress={() => copyToClipboard(tokenAddress)}>
-          <ChipTokenUsdRate>
-            {typeof usdRate === 'undefined' ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
-          </ChipTokenUsdRate>
-          <ChipTokenAddress>{shortenAddress(tokenAddress)}</ChipTokenAddress>
-          <ChipTokenCopyButtonIcon name="Copy" size={16} />
+          <AlignmentWrapper>
+            <ChipTokenUsdRate>
+              {typeof usdRate === 'undefined' ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
+            </ChipTokenUsdRate>
+            <ChipTokenAddress>{shortenAddress(tokenAddress)}</ChipTokenAddress>
+            <ChipTokenCopyButtonIcon name="Copy" size={16} />
+          </AlignmentWrapper>
         </Button>
       </ChipTokenAdditionalInfo>
     </ChipTokenWrapper>
   )
 }
 
+const AlignmentWrapper = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: end;
+`
 const ChipTokenAdditionalInfo = styled.span`
   align-items: center;
   max-width: 0;
@@ -105,28 +112,21 @@ const ChipTokenWrapper = styled.span`
   }
 `
 const ChipTokenAddress = styled.span`
-  margin: 0 2px;
-  top: -4px;
   font-family: var(--font-mono);
   font-size: var(--font-size-2);
+  margin-bottom: 2px;
 `
 
 const ChipTokenUsdRate = styled.span`
-  margin: 0 2px;
-  position: relative;
-  top: -2px;
   font-size: var(--font-size-1);
   font-weight: bold;
-`
-const ChipTokenUsdRateSpinner = styled(Spinner)`
-  position: relative;
-  top: 2px;
+  margin-bottom: 2px;
 `
 
+const ChipTokenUsdRateSpinner = styled(Spinner)``
+
 const ChipTokenCopyButtonIcon = styled(Icon)`
-  position: relative;
-  top: 1px;
-  margin: 0 2px;
+  margin-bottom: 2px;
 `
 
 export default ChipToken

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -51,7 +51,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
   const parsedUsdRate = formatNumber(usdRate, { ...FORMAT_OPTIONS.USD, defaultValue: '-' })
 
   const handleMouseEnter = useCallback(() => {
-    if (typeof usdRate === 'undefined') {
+    if (usdRate == null) {
       void fetchTokenUsdRate({ chainId, tokenAddress }).then(setUsdRate)
     }
   }, [usdRate, chainId, tokenAddress])
@@ -70,7 +70,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
         <Button {...props} onPress={() => copyToClipboard(tokenAddress)}>
           <AlignmentWrapper>
             <ChipTokenUsdRate>
-              {typeof usdRate === 'undefined' ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
+              {usdRate == null ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
             </ChipTokenUsdRate>
             <ChipTokenAddress>{shortenAddress(tokenAddress)}</ChipTokenAddress>
             <ChipTokenCopyButtonIcon name="Copy" size={16} />

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -7,7 +7,7 @@ import Icon from '@ui/Icon'
 import Spinner from '@ui/Spinner'
 import { FORMAT_OPTIONS, formatNumber } from '@ui/utils'
 import { fetchTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
-import { copyToClipboard } from '@ui-kit/utils'
+import { copyToClipboard, shortenAddress } from '@ui-kit/utils'
 
 interface ButtonProps extends AriaButtonProps {
   className?: string
@@ -71,6 +71,7 @@ const ChipToken = ({ className, isHighlight, tokenName, tokenAddress, ...props }
           <ChipTokenUsdRate>
             {typeof usdRate === 'undefined' ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}
           </ChipTokenUsdRate>
+          <ChipTokenAddress>{shortenAddress(tokenAddress)}</ChipTokenAddress>
           <ChipTokenCopyButtonIcon name="Copy" size={16} />
         </Button>
       </ChipTokenAdditionalInfo>
@@ -102,6 +103,12 @@ const ChipTokenWrapper = styled.span`
       max-width: 18.75rem; // 300px
     }
   }
+`
+const ChipTokenAddress = styled.span`
+  margin: 0 2px;
+  top: -4px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2);
 `
 
 const ChipTokenUsdRate = styled.span`

--- a/packages/ui/src/Spinner/Spinner.tsx
+++ b/packages/ui/src/Spinner/Spinner.tsx
@@ -63,7 +63,7 @@ function getSpinnerColor(isDisabled: boolean) {
   if (isDisabled) {
     return 'var(--input--disabled--color)'
   } else {
-    return 'var(--border-400)'
+    return 'var(--spinner--background-color)'
   }
 }
 


### PR DESCRIPTION
- Fixed the loading of the USD rate price for tokens in the DEX pool list.
- The price getter was not being triggered because we were checking the `formattedUsdRate`, which is set to "-" when no price is fetched. As a result, it wasn’t treated as a nullish value.
- Added `useCallback` to prevent unnecessary re-renders.
- Added the token address
- Squeezed in also the fix:horizontal XS spacing pool label address chip