### PR TITLE
fix: set hydrated status of lib to false during rehydration

### DIFF
--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveProvider.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveProvider.tsx
@@ -70,6 +70,7 @@ export const CurveProvider = <App extends AppName>({
     /** Initialize the app by hydrating the library if needed. */
     const hydrateApp = async (lib: AppLib<App>, prevLib?: AppLib<App>) => {
       if (globalLibs.hydrated[app] != lib && hydrate[app]) {
+        globalLibs.hydrated[app] = undefined
         setConnectState(HYDRATING)
         await hydrate[app](config, lib, prevLib, wallet) // if thrown, it will be caught in initLib
       }


### PR DESCRIPTION
There appears to be a race condition happening where a previously hydrated lib gets rehydrated because of a wallet change, but `isHydrated` stays true. This causes some queries that depend on `isHydrated` in their `enabled` to somehow fire and use an instance of a lib that's not yet hydrated, causing issues.

(I couldn't reproduce the issue locally so I'm making this change as a best guess)