### PR TITLE
fix: action info arrow size

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '../Tooltip'
 import { WithSkeleton } from '../WithSkeleton'
 import { WithWrapper } from '../WithWrapper'
 
-const { Spacing, ButtonSize } = SizesAndSpaces
+const { Spacing, ButtonSize, IconSize } = SizesAndSpaces
 
 export type ActionInfoSize = 'small' | 'medium'
 
@@ -142,7 +142,7 @@ export const ActionInfo = ({
   value ??= prevValue ?? emptyValue
 
   const buttonSize = iconButtonSize[size]
-  const iconSize = IconButtonIconSize[buttonSize]
+  const iconSize = IconSize[IconButtonIconSize[buttonSize]]
   return (
     <Stack
       direction="row"

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '../Tooltip'
 import { WithSkeleton } from '../WithSkeleton'
 import { WithWrapper } from '../WithWrapper'
 
-const { Spacing, ButtonSize, IconSize } = SizesAndSpaces
+const { Spacing, ButtonSize } = SizesAndSpaces
 
 export type ActionInfoSize = 'small' | 'medium'
 
@@ -142,7 +142,7 @@ export const ActionInfo = ({
   value ??= prevValue ?? emptyValue
 
   const buttonSize = iconButtonSize[size]
-  const iconSize = IconSize[IconButtonIconSize[buttonSize]]
+  const iconSize = IconButtonIconSize[buttonSize]
   return (
     <Stack
       direction="row"

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '../Tooltip'
 import { WithSkeleton } from '../WithSkeleton'
 import { WithWrapper } from '../WithWrapper'
 
-const { Spacing, ButtonSize } = SizesAndSpaces
+const { Spacing, ButtonSize, IconSize } = SizesAndSpaces
 
 export type ActionInfoSize = 'small' | 'medium'
 
@@ -172,7 +172,8 @@ export const ActionInfo = ({
             >
               {prevValue}
             </Typography>
-            <ArrowForwardIcon sx={{ color: (t) => t.palette.text.tertiary, width: iconSize, height: iconSize }} />
+            {/* arrow icon size constant accross ActionInfo's size */}
+            <ArrowForwardIcon sx={{ color: (t) => t.palette.text.tertiary, width: IconSize.sm, height: IconSize.sm }} />
           </>
         )}
 


### PR DESCRIPTION
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td></td>
    <td></td>
  </tr>
</table>