### PR TITLE
fix: use ellipsis for symbol overflow in token selector, removing horizontal scrollbars

### DIFF
--- a/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/SelectToken.stories.tsx
@@ -133,6 +133,12 @@ const defaultTokens: TokenOption[] = [
     symbol: 'A7A5',
     volume: 2.5,
   },
+  {
+    chain: 'ethereum',
+    address: MAINNET_CRV_ADDRESS,
+    symbol: 'CRV with a very superlong name that should be truncated',
+    volume: 11.5,
+  },
 ]
 
 const defaultBalances = {

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -62,8 +62,8 @@ export const TokenOption = ({
             sx={{ ...(disabled && { filter: 'saturate(0)' }) }}
           />
 
-          <Stack flexGrow={1}>
-            <Typography variant="bodyMBold" color={primary}>
+          <Stack flexGrow={1} overflow="hidden">
+            <Typography variant="bodyMBold" color={primary} overflow="hidden" textOverflow="ellipsis">
               {symbol}
             </Typography>
 

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSection.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenSection.tsx
@@ -65,7 +65,7 @@ export const TokenSection = <T extends Option = Option>({
               <Stack direction="row" justifyContent="space-between" alignItems="center">
                 {title}
                 {isLoading && (
-                  <Box sx={{ marginBlockEnd: Spacing.xs }}>
+                  <Box sx={{ marginBlockEnd: Spacing.xs, marginInlineEnd: Spacing.sm }}>
                     <Spinner size={15} />
                   </Box>
                 )}


### PR DESCRIPTION
Manually verified in case the user has a balance as well

<img width="454" height="757" alt="image" src="https://github.com/user-attachments/assets/70ee8e96-36c0-49b4-b174-c808387ce324" />
