### PR TITLE
feat: default markets collateral and borrow token invalidations

### DIFF
--- a/apps/main/src/llamalend/features/supply/hooks/useClaimTab.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useClaimTab.ts
@@ -41,6 +41,8 @@ export const useClaimTab = <ChainId extends LlamaChainId>({
     usdRateError,
     hasClaimableCrv,
     hasClaimableRewards,
+    crvTokenAddress,
+    rewardTokenAddresses,
   } = useClaimableTokens(params, market, enabled)
 
   const tableData = useMemo(
@@ -58,12 +60,12 @@ export const useClaimTab = <ChainId extends LlamaChainId>({
     onSubmit: onSubmitCrv,
     isPending: isClaimCrvPending,
     error: claimCrvError,
-  } = useClaimCrvMutation({ marketId, network, userAddress })
+  } = useClaimCrvMutation({ marketId, network, userAddress, crvTokenAddress })
   const {
     onSubmit: onSubmitRewards,
     isPending: isClaimRewardsPending,
     error: claimRewardsError,
-  } = useClaimRewardsMutation({ marketId, network, userAddress })
+  } = useClaimRewardsMutation({ marketId, network, userAddress, rewardTokenAddresses })
 
   return {
     params,

--- a/apps/main/src/llamalend/features/supply/hooks/useClaimableTokens.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useClaimableTokens.ts
@@ -32,16 +32,13 @@ export const useClaimableTokens = <ChainId extends LlamaChainId>(
   } = useClaimableCrv(params, enabled)
 
   const crvAddress = useMemo(() => market && getCrvAddress(market), [market])
+  const rewardsAddresses = useMemo(() => claimableRewards?.map((r) => r.token) ?? [], [claimableRewards])
 
-  const tokenAddresses = useMemo(
-    () => notFalsy(crvAddress, ...(claimableRewards?.map((r) => r.token) ?? [])),
-    [claimableRewards, crvAddress],
-  )
   const {
     data: usdRates,
     isLoading: usdRateLoading,
     error: usdRateError,
-  } = useTokenUsdRates({ chainId, tokenAddresses })
+  } = useTokenUsdRates({ chainId, tokenAddresses: notFalsy(crvAddress, ...rewardsAddresses) })
 
   const claimableTokens = useMemo(() => {
     const tokens = notFalsy(
@@ -68,6 +65,8 @@ export const useClaimableTokens = <ChainId extends LlamaChainId>(
     claimableRewardsError,
     hasClaimableCrv: Number(claimableCrv) > 0,
     hasClaimableRewards: hasClaimableRewards(claimableRewards),
+    crvTokenAddress: crvAddress,
+    rewardTokenAddresses: rewardsAddresses,
     claimableTokens,
     totalNotionals,
     isClaimablesLoading: [isClaimableCrvLoading, isClaimableRewardsLoading].some(Boolean),

--- a/apps/main/src/llamalend/mutations/claim.mutation.ts
+++ b/apps/main/src/llamalend/mutations/claim.mutation.ts
@@ -10,7 +10,7 @@ import {
 } from '@/llamalend/queries/validation/supply.validation'
 import type { IChainId as LlamaChainId, INetworkName as LlamaNetworkId } from '@curvefi/llamalend-api/lib/interfaces'
 import { type Address, type Hex } from '@primitives/address.utils'
-import { assert } from '@primitives/objects.utils'
+import { assert, notFalsy } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { rootKeys } from '@ui-kit/lib/model'
 import { fetchClaimableCrv, fetchClaimableRewards } from '../queries/supply/supply-claimable-rewards.query'
@@ -38,7 +38,15 @@ const claimRewards = async (market: LlamaMarketTemplate, userAddress: Address | 
   return (await requireGauge(market.id).vault.claimRewards()) as Hex
 }
 
-export const useClaimCrvMutation = ({ network, network: { chainId }, marketId, userAddress }: ClaimOptions) => {
+export const useClaimCrvMutation = ({
+  network,
+  network: { chainId },
+  marketId,
+  userAddress,
+  crvTokenAddress,
+}: ClaimOptions & {
+  crvTokenAddress: Address | undefined
+}) => {
   const { mutate, error, isPending } = useLlammaMutation<ClaimMutation>({
     network,
     marketId,
@@ -47,6 +55,7 @@ export const useClaimCrvMutation = ({ network, network: { chainId }, marketId, u
     validationSuite: claimValidationSuite,
     pendingMessage: () => t`Claiming CRV rewards...`,
     successMessage: () => t`Claimed rewards!`,
+    mutationTokenAddresses: () => notFalsy(crvTokenAddress),
     ...noFormFieldOptions, // no form fields
   })
 
@@ -55,7 +64,13 @@ export const useClaimCrvMutation = ({ network, network: { chainId }, marketId, u
   return { onSubmit, mutate, error, isPending }
 }
 
-export const useClaimRewardsMutation = ({ network, network: { chainId }, marketId, userAddress }: ClaimOptions) => {
+export const useClaimRewardsMutation = ({
+  network,
+  network: { chainId },
+  marketId,
+  userAddress,
+  rewardTokenAddresses,
+}: ClaimOptions & { rewardTokenAddresses: Address[] }) => {
   const { mutate, error, isPending } = useLlammaMutation<ClaimMutation>({
     network,
     marketId,
@@ -64,6 +79,7 @@ export const useClaimRewardsMutation = ({ network, network: { chainId }, marketI
     validationSuite: claimableRewardsValidationSuite,
     pendingMessage: () => t`Claiming rewards...`,
     successMessage: () => t`Claimed rewards!`,
+    mutationTokenAddresses: () => rewardTokenAddresses,
     ...noFormFieldOptions, // no form fields
   })
 

--- a/apps/main/src/llamalend/mutations/useLlammaMutation.ts
+++ b/apps/main/src/llamalend/mutations/useLlammaMutation.ts
@@ -10,7 +10,7 @@ import {
   useTransactionMutation,
   type TransactionMutationOptions,
 } from '@ui-kit/lib/model/mutation/useTransactionMutation'
-import { getLlamaMarket, updateUserEventsApi } from '../llama.utils'
+import { getLlamaMarket, getTokens, updateUserEventsApi } from '../llama.utils'
 import type { LlamaMarketTemplate } from '../llamalend.types'
 
 /** Context created in onMutate, extends the base transaction context with llamma market and api */
@@ -20,6 +20,11 @@ type LlammaContext = TransactionContext & {
   userAddress: Address
 }
 
+// Default market's collateral and borrow token addresses to invalidate after mutations.
+const getDefaultAddresses = (market: LlamaMarketTemplate) => {
+  const { collateralToken, borrowToken } = getTokens(market)
+  return [collateralToken.address, borrowToken.address]
+}
 /**
  * Custom hook for handling llamma-related mutations with automatic wallet and API validation.
  * Wraps `useTransactionMutation` and adds llamma market context, cache invalidation,
@@ -36,7 +41,7 @@ export function useLlammaMutation<TVariables extends object>({
   marketId: string | null | undefined
   /** The current network config */
   network: { id: LlamaNetworkId; chainId: LlamaChainId }
-  /** Token balances affected by the mutation that should be refetched after success */
+  /** Token balances affected by the mutation that should be refetched after success. Defaults to market collateral + borrow tokens. */
   mutationTokenAddresses?: (variables: TVariables, context: LlammaContext) => Address[] | undefined
 }) {
   const { llamaApi } = useCurve()
@@ -54,7 +59,7 @@ export function useLlammaMutation<TVariables extends object>({
     }),
     onSuccess: async (data, receipt, variables, context) => {
       const { market, wallet, userAddress } = context
-      const tokenAddresses = mutationTokenAddresses?.(variables, context) ?? []
+      const tokenAddresses = mutationTokenAddresses?.(variables, context) ?? getDefaultAddresses(market)
       updateUserEventsApi(wallet, { id: networkId }, market, receipt.transactionHash)
 
       await Promise.all([


### PR DESCRIPTION
- default `useLlammaMutation` token balance invalidation to the market collateral and borrow tokens
- add explicit invalidation for the claim mutations to invalidate the actual claimable token addresses 