### PR TITLE
fix: balance values in loan form message were wrapping incorrectly

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -14,7 +14,6 @@ import { AlertBox } from '@ui/AlertBox'
 import type { AlertType } from '@ui/AlertBox/types'
 import { useCreateLoanPreset } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
-import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { q, type Range } from '@ui-kit/types/util'
 import { updateForm } from '@ui-kit/utils/react-form.utils'
@@ -121,17 +120,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           hideBalance
           testId="borrow-debt-input"
           network={network}
-          message={
-            <Balance
-              prefix={t`Max borrow:`}
-              tooltip={t`Max borrow`}
-              symbol={borrowToken?.symbol}
-              balance={values.maxDebt}
-              loading={maxDebt.isLoading}
-              onClick={useCallback(() => updateForm(form, { debt: values.maxDebt }), [form, values.maxDebt])}
-              buttonTestId="borrow-set-debt-to-max"
-            />
-          }
+          message={`${t`Max borrow:`} ${values.maxDebt ?? '-'} ${borrowToken?.symbol}`}
         />
       </Stack>
 

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -12,7 +12,6 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { notFalsy } from '@primitives/objects.utils'
 import { joinButtonText } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { q, type QueryProp, type Range } from '@ui-kit/types/util'
 import { isDevelopment } from '@ui-kit/utils'
@@ -124,16 +123,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           testId="borrow-more-input-debt"
           network={network}
           hideBalance
-          message={
-            <Balance
-              prefix={t`Max borrow amount:`}
-              tooltip={t`Max available to borrow`}
-              symbol={borrowToken?.symbol}
-              balance={max.debt.data}
-              loading={max.debt.isLoading}
-              onClick={() => updateForm(form, { debt: max.debt.data })}
-            />
-          }
+          message={`${t`Max borrow amount:`} ${max.debt.data ?? '-'} ${borrowToken?.symbol}`}
         />
       </Stack>
 

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -5,9 +5,7 @@ import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { q, type Range } from '@ui-kit/types/util'
-import { updateForm } from '@ui-kit/utils/react-form.utils'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
 import { useRemoveCollateralForm } from '../hooks/useRemoveCollateralForm'
@@ -70,16 +68,7 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
           network={network}
           positionBalance={{ position: positionCollateral, tooltip: t`Collateral in position` }}
           max={{ ...q(maxRemovable), fieldName: 'maxCollateral' }}
-          message={
-            <Balance
-              prefix={t`Max removable:`}
-              tooltip={t`Max removable collateral`}
-              symbol={collateralToken?.symbol}
-              balance={maxRemovable.data}
-              loading={maxRemovable.isLoading}
-              onClick={() => updateForm(form, { userCollateral: maxRemovable.data })}
-            />
-          }
+          message={`${t`Max removable:`} ${maxRemovable.data ?? '-'} ${collateralToken?.symbol}`}
         />
       </Stack>
 

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -16,7 +16,6 @@ import { joinButtonText } from '@primitives/string.utils'
 import { TokenSelector } from '@ui-kit/features/select-token'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
-import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
 import { q, type QueryProp, type Range } from '@ui-kit/types/util'
 import { updateForm } from '@ui-kit/utils/react-form.utils'
@@ -93,11 +92,7 @@ export const RepayForm = <ChainId extends IChainId>({
   const swapRequired = selectedToken !== borrowToken
 
   // The max repay amount in the helper message should always be denominated in terms of the borrow token.
-  const {
-    data: maxAmountInBorrowToken,
-    isLoading: maxAmountInBorrowTokenLoading,
-    error: maxAmountInBorrowTokenError,
-  } = useTokenAmountConversion({
+  const { data: maxAmountInBorrowToken } = useTokenAmountConversion({
     chainId,
     amountIn: max[selectedField],
     tokenInAddress: selectedToken?.address,
@@ -162,22 +157,8 @@ export const RepayForm = <ChainId extends IChainId>({
             tokens={tokens}
           />
         }
-        message={
-          maxAmountInBorrowTokenError?.message ?? (
-            <Balance
-              prefix={maxAmountPrefix}
-              tooltip={t`Max available to repay`}
-              symbol={borrowToken?.symbol}
-              balance={maxAmountInBorrowToken}
-              loading={max[selectedField].isLoading || maxAmountInBorrowTokenLoading}
-              onClick={() =>
-                updateForm(form, {
-                  [selectedField]: max[selectedField].data,
-                })
-              }
-            />
-          )
-        }
+        message={`${maxAmountPrefix} ${maxAmountInBorrowToken ?? '-'} ${borrowToken?.symbol}`}
+        onMessageNumberClick={() => updateForm(form, { [selectedField]: max[selectedField].data })}
       />
       <HighPriceImpactAlert priceImpact={priceImpact} values={{ leverageEnabled: swapRequired, ...params }} />
 

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/tabs/ImproveHealthForm.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/tabs/ImproveHealthForm.tsx
@@ -11,7 +11,6 @@ import Stack from '@mui/material/Stack'
 import { notFalsy } from '@primitives/objects.utils'
 import { joinButtonText } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { q } from '@ui-kit/types/util'
 import { updateForm } from '@ui-kit/utils/react-form.utils'
@@ -91,16 +90,7 @@ export const ImproveHealthForm = ({
         max={{ ...q(maxRepay), fieldName: maxRepay.field }}
         testId="improve-health-input-debt"
         network={network}
-        message={
-          <Balance
-            prefix={t`Max repay amount:`}
-            tooltip={t`Max available to repay`}
-            symbol={borrowToken?.symbol}
-            balance={maxRepay.data}
-            loading={maxRepay.isLoading}
-            onClick={() => updateForm(form, { userBorrowed: maxRepay.data })}
-          />
-        }
+        message={`${t`Max repay amount:`} ${maxRepay.data ?? '-'} ${borrowToken?.symbol}`}
       />
 
       <AlertRepayDebtToIncreaseHealth />

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -39,6 +39,7 @@ export const LoanFormTokenInput = <
   tokenSelector,
   hideBalance,
   onValueChange,
+  onMessageNumberClick,
 }: {
   label: string
   token: { address: Address; symbol?: string } | undefined
@@ -70,6 +71,7 @@ export const LoanFormTokenInput = <
    * Called after the form value is set.
    */
   onValueChange?: (value: Decimal | undefined) => void
+  onMessageNumberClick?: (value: Decimal | undefined) => void
 }) => {
   const { address: userAddress } = useConnection()
   const {
@@ -138,9 +140,9 @@ export const LoanFormTokenInput = <
       inputBalanceUsd={decimal(usdRate && usdRate * +(value ?? 0))}
     >
       {errorMessage ? (
-        <HelperMessage message={errorMessage} onNumberClick={onBalance} isError />
+        <HelperMessage message={errorMessage} onNumberClick={onMessageNumberClick ?? onBalance} isError />
       ) : (
-        message && <HelperMessage onNumberClick={onBalance} message={message} />
+        message && <HelperMessage onNumberClick={onMessageNumberClick ?? onBalance} message={message} />
       )}
     </LargeTokenInput>
   )

--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -125,10 +125,12 @@ export function writeCreateLoanForm({
   borrow: Decimal
   leverageEnabled: boolean
 }) {
-  cy.get('[data-testid="borrow-debt-input"] [data-testid="balance-value"]', TRANSACTION_LOAD_TIMEOUT).should('exist')
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-info"]', TRANSACTION_LOAD_TIMEOUT).should(
+    'exist',
+  )
   getCollateralInput().type(collateral)
   getCollateralInput().blur()
-  cy.get('[data-testid="borrow-debt-input"] [data-testid="balance-value"]').should('not.contain.text', '?')
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-info"]').should('not.contain.text', '?')
   getActionValue('borrow-health').should('equal', '∞')
   getBorrowInput().type(borrow)
   getBorrowInput().blur()
@@ -141,12 +143,12 @@ export function writeCreateLoanForm({
  */
 export function checkLoanRangeSlider({ leverageEnabled }: { leverageEnabled: boolean }) {
   cy.get(`[data-testid="loan-preset-${LoanPreset.MaxLtv}"]`).click()
-  cy.get('[data-testid="borrow-set-debt-to-max"]').should('not.exist') // make sure we don't click the previous max
-  cy.get('[data-testid="borrow-set-debt-to-max"]', LOAD_TIMEOUT).click()
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-number-0"]').should('not.exist') // make sure we don't click the previous max
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-number-0"]', LOAD_TIMEOUT).click()
   cy.get(`[data-testid="loan-preset-${LoanPreset.Safe}"]`).click({ force: true }) // force, tooltip sometimes covers part of it
-  cy.get('[data-testid="borrow-set-debt-to-max"]').should('not.exist') // new max is being calculated
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-number-0"]').should('not.exist') // new max is being calculated
   // wait for max borrow to load and verify the input value matches (using data-value for precision)
-  cy.get('[data-testid="borrow-set-debt-to-max"] [data-testid="balance-value"]', LOAD_TIMEOUT)
+  cy.get('[data-testid="borrow-debt-input"] [data-testid="helper-message-number-0"]', LOAD_TIMEOUT)
     .invoke(LOAD_TIMEOUT, 'attr', 'data-value')
     .then((maxValue) => getBorrowInput().should('have.value', maxValue))
   cy.get('[data-testid="helper-message-error"]').should('not.exist')


### PR DESCRIPTION
Turns out that for all our `<LoanFormTokenInput>` usages we passed on a direct `<Balance>` component to the `message` prop, rather than relying on the internal `buildClickableMessage` of the `<HelperMessage>` component it uses.

While the `<Balance>` component works, it wasn't really made for inline usage. I've tried various things to make it inline (with `inline-flex` and `component='span' on the `<Typography>`), none of it really worked out well.

Instead, I've decided to just rely on the `buildClickableMessage` of `<MessageHelper`>. The only downside is that there's no loading skeleton, but honestly that's not a big loss.

The only downside / exception I had to build was to add a `onMessageNumberClick` prop to `<LoanFormTokenInput>`. The default behavior of clickable numbers is to use the given numbers directly, but in the case of repaying inside `<RepayForm`> we want to show something like "Repay 5 crvUSD", but when you click it the input might actually have to be 4.5 sreUSD or whatever. Hence:
```tsx
onMessageNumberClick={() => updateForm(form, { [selectedField]: max[selectedField].data })}
```
Technically there can be more than one clickable number, but I didn't want to built complex code around this special case where we have to identify what number exactly got clicked.

<img width="458" height="265" alt="image" src="https://github.com/user-attachments/assets/cf4ee561-be2b-409b-8ad1-7f6a62f33fbd" />
