### PR TITLE
fix: zapv2 minRecv in formatted units

### DIFF
--- a/apps/main/src/llamalend/mutations/create-loan.mutation.ts
+++ b/apps/main/src/llamalend/mutations/create-loan.mutation.ts
@@ -59,7 +59,7 @@ const create = async (
         userBorrowed,
         debt,
         range,
-        ...parseMutationRoute(routeId, slippage),
+        ...parseMutationRoute(routeId, slippage, market.coinDecimals),
       })) as Address
     case 'V2':
     case 'V1':

--- a/apps/main/src/llamalend/mutations/create-loan.mutation.ts
+++ b/apps/main/src/llamalend/mutations/create-loan.mutation.ts
@@ -59,7 +59,7 @@ const create = async (
         userBorrowed,
         debt,
         range,
-        ...parseMutationRoute(routeId, slippage, market.coinDecimals),
+        ...parseMutationRoute(routeId, slippage, impl),
       })) as Address
     case 'V2':
     case 'V1':

--- a/apps/main/src/llamalend/mutations/repay.mutation.ts
+++ b/apps/main/src/llamalend/mutations/repay.mutation.ts
@@ -69,7 +69,7 @@ const repay = async (
         stateCollateral,
         userCollateral,
         userBorrowed,
-        ...parseMutationRoute(routeId, slippage),
+        ...parseMutationRoute(routeId, slippage, market.coinDecimals),
       })) as Hex
     case 'V1':
     case 'V2':

--- a/apps/main/src/llamalend/mutations/repay.mutation.ts
+++ b/apps/main/src/llamalend/mutations/repay.mutation.ts
@@ -69,7 +69,7 @@ const repay = async (
         stateCollateral,
         userCollateral,
         userBorrowed,
-        ...parseMutationRoute(routeId, slippage, market.coinDecimals),
+        ...parseMutationRoute(routeId, slippage, impl),
       })) as Hex
     case 'V1':
     case 'V2':

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-query.helpers.ts
@@ -47,8 +47,7 @@ export function getBorrowMoreImplementationArgs(
     slippage?: BorrowMoreQuery['slippage']
   },
 ) {
-  const market = getLlamaMarket(marketId)
-  const [type, impl] = getBorrowMoreImplementation(market, leverageEnabled)
+  const [type, impl] = getBorrowMoreImplementation(marketId, leverageEnabled)
   if (type === 'unleveraged') {
     if (+userBorrowed) throw new Error(`Invalid userBorrowed for unleveraged borrow more: ${userBorrowed}`)
     return [type, impl, [userCollateral, debt]] as const
@@ -59,7 +58,7 @@ export function getBorrowMoreImplementationArgs(
       userBorrowed,
       dDebt: debt,
       debt,
-      ...parseMutationRoute(routeId, +(slippage ?? 0), market.coinDecimals),
+      ...parseMutationRoute(routeId, slippage ?? '0', impl),
     }
     return [type, impl, [routerArgs]] as const
   }

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-query.helpers.ts
@@ -47,7 +47,8 @@ export function getBorrowMoreImplementationArgs(
     slippage?: BorrowMoreQuery['slippage']
   },
 ) {
-  const [type, impl] = getBorrowMoreImplementation(marketId, leverageEnabled)
+  const market = getLlamaMarket(marketId)
+  const [type, impl] = getBorrowMoreImplementation(market, leverageEnabled)
   if (type === 'unleveraged') {
     if (+userBorrowed) throw new Error(`Invalid userBorrowed for unleveraged borrow more: ${userBorrowed}`)
     return [type, impl, [userCollateral, debt]] as const
@@ -58,7 +59,7 @@ export function getBorrowMoreImplementationArgs(
       userBorrowed,
       dDebt: debt,
       debt,
-      ...parseMutationRoute(routeId, +(slippage ?? 0)),
+      ...parseMutationRoute(routeId, +(slippage ?? 0), market.coinDecimals),
     }
     return [type, impl, [routerArgs]] as const
   }

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
@@ -1,4 +1,3 @@
-import { getLlamaMarket } from '@/llamalend/llama.utils'
 import { createLoanExpectedCollateralQueryKey } from '@/llamalend/queries/create-loan/create-loan-expected-collateral.query'
 import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/create-loan-query.helpers'
 import type { IChainId, TGas } from '@curvefi/llamalend-api/lib/interfaces'
@@ -88,8 +87,7 @@ const {
     slippage,
     routeId,
   }: CreateLoanEstimateGasQuery): Promise<TGas> => {
-    const market = getLlamaMarket(marketId)
-    const [type, impl] = getCreateLoanImplementation(market, leverageEnabled)
+    const [type, impl] = getCreateLoanImplementation(marketId, leverageEnabled)
     switch (type) {
       case 'zapV2':
         return await impl.estimateGas.createLoan({
@@ -97,7 +95,7 @@ const {
           userBorrowed,
           debt,
           range,
-          ...parseMutationRoute(routeId, slippage, market.coinDecimals),
+          ...parseMutationRoute(routeId, slippage, impl),
         })
       case 'V1':
       case 'V2':

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
@@ -1,3 +1,4 @@
+import { getLlamaMarket } from '@/llamalend/llama.utils'
 import { createLoanExpectedCollateralQueryKey } from '@/llamalend/queries/create-loan/create-loan-expected-collateral.query'
 import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/create-loan-query.helpers'
 import type { IChainId, TGas } from '@curvefi/llamalend-api/lib/interfaces'
@@ -87,7 +88,8 @@ const {
     slippage,
     routeId,
   }: CreateLoanEstimateGasQuery): Promise<TGas> => {
-    const [type, impl] = getCreateLoanImplementation(marketId, leverageEnabled)
+    const market = getLlamaMarket(marketId)
+    const [type, impl] = getCreateLoanImplementation(market, leverageEnabled)
     switch (type) {
       case 'zapV2':
         return await impl.estimateGas.createLoan({
@@ -95,7 +97,7 @@ const {
           userBorrowed,
           debt,
           range,
-          ...parseMutationRoute(routeId, slippage),
+          ...parseMutationRoute(routeId, slippage, market.coinDecimals),
         })
       case 'V1':
       case 'V2':

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-query.helpers.ts
@@ -1,4 +1,5 @@
 import { getLlamaMarket, hasV2Leverage, hasZapV2 } from '@/llamalend/llama.utils'
+import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 
 /**
@@ -13,7 +14,7 @@ import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
  * For non-leveraged operations:
  * - 'unleveraged' using `market` directly
  */
-export function getCreateLoanImplementation(marketId: string, leverageEnabled: boolean) {
+export function getCreateLoanImplementation(marketId: string | LlamaMarketTemplate, leverageEnabled: boolean) {
   const market = getLlamaMarket(marketId)
   return market instanceof LendMarketTemplate
     ? leverageEnabled

--- a/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
@@ -51,7 +51,7 @@ export function getRepayImplementation(
             stateCollateral,
             userCollateral,
             userBorrowed,
-            ...((routeMeta as RouteMutationMeta) ?? parseMutationRoute(routeId, +(slippage ?? 0))),
+            ...((routeMeta as RouteMutationMeta) ?? parseMutationRoute(routeId, +(slippage ?? 0), market.coinDecimals)),
           },
         ],
       ] as const

--- a/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
@@ -43,7 +43,8 @@ export function getRepayImplementation(
     if (!hasUserCollateral && !hasStateCollateral)
       return ['unleveragedLend', market.loan, [{ debt: userBorrowed }]] as const
     if (hasZapV2(market)) {
-      const route = routeMeta ?? parseMutationRoute(routeId, slippage ?? '0', market.leverageZapV2)
+      const route =
+        (routeMeta as RouteMutationMeta) ?? parseMutationRoute(routeId, slippage ?? '0', market.leverageZapV2)
       return ['zapV2', market.leverageZapV2, [{ stateCollateral, userCollateral, userBorrowed, ...route }]] as const
     }
     if (hasLeverage(market)) return ['V1', market.leverage, [stateCollateral, userCollateral, userBorrowed]] as const

--- a/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
@@ -42,19 +42,10 @@ export function getRepayImplementation(
   } else {
     if (!hasUserCollateral && !hasStateCollateral)
       return ['unleveragedLend', market.loan, [{ debt: userBorrowed }]] as const
-    if (hasZapV2(market))
-      return [
-        'zapV2',
-        market.leverageZapV2,
-        [
-          {
-            stateCollateral,
-            userCollateral,
-            userBorrowed,
-            ...((routeMeta as RouteMutationMeta) ?? parseMutationRoute(routeId, +(slippage ?? 0), market.coinDecimals)),
-          },
-        ],
-      ] as const
+    if (hasZapV2(market)) {
+      const route = routeMeta ?? parseMutationRoute(routeId, slippage ?? '0', market.leverageZapV2)
+      return ['zapV2', market.leverageZapV2, [{ stateCollateral, userCollateral, userBorrowed, ...route }]] as const
+    }
     if (hasLeverage(market)) return ['V1', market.leverage, [stateCollateral, userCollateral, userBorrowed]] as const
   }
   throw new Error(

--- a/apps/main/src/llamalend/queries/validation/repay.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/repay.validation.ts
@@ -39,16 +39,23 @@ const validateRepayHasValue = (
   stateCollateral: Decimal | null | undefined,
   userCollateral: Decimal | null | undefined,
   userBorrowed: Decimal | null | undefined,
-) =>
-  test(
-    stateCollateral ? 'stateCollateral' : userCollateral ? 'userCollateral' : 'userBorrowed',
-    'Enter an amount to repay',
-    () => {
-      enforce(stateCollateral ?? userCollateral ?? userBorrowed)
-        .isDecimal()
-        .greaterThan(0)
-    },
-  )
+) => {
+  const activeField = stateCollateral
+    ? ('stateCollateral' as const)
+    : userCollateral
+      ? ('userCollateral' as const)
+      : ('userBorrowed' as const)
+  const validate = (field: typeof activeField, value: Decimal | null | undefined) => {
+    skipWhen(activeField !== field, () => {
+      test(field, 'Enter an amount to repay', () => {
+        enforce(value).isDecimal().greaterThan(0)
+      })
+    })
+  }
+  validate('stateCollateral', stateCollateral)
+  validate('userCollateral', userCollateral)
+  validate('userBorrowed', userBorrowed)
+}
 
 const validateRepayFieldsForMarket = (
   marketId: LlamaMarketTemplate | string | null | undefined,

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { formatUnits } from 'viem'
 import type { GetExpectedFn } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Address } from '@primitives/address.utils'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
@@ -25,10 +26,14 @@ export const parseRoute = (routeId: string | undefined): RouteMeta => {
  * Like parseRoute, but also computes minRecv from outAmount and slippage.
  * minRecv = outAmount * (100 - slippage) / 100
  */
-export const parseMutationRoute = (routeId: string | undefined, slippage: Amount): RouteMutationMeta => {
+export const parseMutationRoute = (
+  routeId: string | undefined,
+  slippage: Amount,
+  [, collateralDecimals]: number[],
+): RouteMutationMeta => {
   const route = parseRoute(routeId)
-  const minReceive = BigNumber(route.quote.outAmount).times(BigNumber(100).minus(slippage)).div(100).toString()
-  return { ...route, minRecv: minReceive }
+  const minReceive = BigInt(BigNumber(route.quote.outAmount).times(BigNumber(100).minus(slippage)).div(100).toFixed(0))
+  return { ...route, minRecv: formatUnits(minReceive, collateralDecimals) }
 }
 
 /**

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -1,8 +1,7 @@
-import BigNumber from 'bignumber.js'
-import { formatUnits } from 'viem'
 import type { GetExpectedFn } from '@curvefi/llamalend-api/lib/interfaces'
+import { ILeverageZapV2 } from '@curvefi/llamalend-api/lib/lendMarkets/interfaces/leverageZapV2'
 import type { Address } from '@primitives/address.utils'
-import type { Amount, Decimal } from '@primitives/decimal.utils'
+import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
 import { fetchApiRoutes, getRouteById } from './router-api.query'
 import type { RouteMeta, RouteMutationMeta, RoutesQuery } from './router-api.types'
@@ -28,12 +27,11 @@ export const parseRoute = (routeId: string | undefined): RouteMeta => {
  */
 export const parseMutationRoute = (
   routeId: string | undefined,
-  slippage: Amount,
-  [, collateralDecimals]: number[],
+  slippage: Decimal,
+  zapv2: ILeverageZapV2,
 ): RouteMutationMeta => {
   const route = parseRoute(routeId)
-  const minReceive = BigInt(BigNumber(route.quote.outAmount).times(BigNumber(100).minus(slippage)).div(100).toFixed(0))
-  return { ...route, minRecv: formatUnits(minReceive, collateralDecimals) }
+  return { ...route, minRecv: zapv2.calcMinRecv(route.quote.outAmount, Number(slippage)) }
 }
 
 /**


### PR DESCRIPTION
- maxReceive on llamalend.js zapv2 was expecting formatted values, not values in wei
- use `calcMinRecv` helper
- fix order of vest validation on repay form