### PR TITLE
chore: component tests freezing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,9 @@ jobs:
       fail-fast: false
       matrix:
         browser: [ chrome, firefox, electron ]
-        count: [ 1 ]
+        count: [ 1, 2, 3, 4 ]
     name: Cypress component tests in ${{ matrix.browser }} ${{ matrix.count }}
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +81,7 @@ jobs:
             tee ../cypress-component-${{ matrix.browser }}-${{ matrix.count }}.log \
               >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
         working-directory: tests
+        timeout-minutes: 8
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [ chrome, firefox, electron ]
-        count: [ 1, 2, 3, 4 ]
+        count: [ 1 ]
     name: Cypress component tests in ${{ matrix.browser }} ${{ matrix.count }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
             tee ../cypress-component-${{ matrix.browser }}-${{ matrix.count }}.log \
               >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
         working-directory: tests
-        timeout-minutes: 8
+        timeout-minutes: 8 # lower timeout than the whole job, so we can get screenshots on timeout
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
@@ -120,6 +120,7 @@ jobs:
           yarn run cy:run:rpc --browser electron 2>&1 | \
             tee ../rpc-cypress.log >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
         working-directory: tests
+        timeout-minutes: 8 # lower timeout than the whole job, so we can get screenshots on timeout
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
@@ -153,7 +154,7 @@ jobs:
           - browser: chrome
             count: 2
     name: Cypress e2e tests in ${{ matrix.browser }} ${{ matrix.count }}
-    timeout-minutes: 25
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -187,6 +188,7 @@ jobs:
           yarn run cy:run:e2e --browser ${{ matrix.browser }} 2>&1 | \
             tee ../e2e-cypress-${{ matrix.browser }}-${{ matrix.count }}.log \
               >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
+        timeout-minutes: 15 # lower timeout than the whole job, so we can get screenshots on timeout
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -13,7 +13,7 @@ import { getUserMarketCollateralEvents as getLendUserMarketCollateralEvents } fr
 import { type Address, Hex } from '@primitives/address.utils'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
 import { notFalsy, objectKeys } from '@primitives/objects.utils'
-import { requireLib, type Wallet } from '@ui-kit/features/connect-wallet'
+import { getLib, requireLib, type Wallet } from '@ui-kit/features/connect-wallet'
 import { isZapV2Enabled } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
@@ -24,6 +24,16 @@ import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
  */
 export const getLlamaMarket = (id: string | LlamaMarketTemplate, lib = requireLib('llamaApi')): LlamaMarketTemplate =>
   typeof id === 'string' ? (id.startsWith('one-way') ? lib.getLendMarket(id) : lib.getMintMarket(id)) : id
+
+/**
+ * Helper to retrieve the llama market after initialization, avoiding crashing the components using it.
+ * We use this helper during query validation since we cannot crash the validation suite outside `test()`
+ */
+export const tryGetLlamaMarket = (marketId: LlamaMarketTemplate | string | null | undefined) => {
+  if (typeof marketId === 'object') return marketId
+  const lib = getLib('llamaApi') // retrieve lib separately to avoid crashing the whole app when uninitialized
+  return marketId && lib && getLlamaMarket(marketId, lib)
+}
 
 export const isLendV2Market = (market: LlamaMarketTemplate) =>
   market instanceof LendMarketTemplate && market.version === 'v2'

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-query.helpers.ts
@@ -1,4 +1,5 @@
 import { getLlamaMarket, hasV2Leverage, hasZapV2 } from '@/llamalend/llama.utils'
+import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 
 /**
@@ -13,7 +14,7 @@ import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
  * For non-leveraged operations:
  * - 'unleveraged' using `market` directly
  */
-export function getCreateLoanImplementation(marketId: string, leverageEnabled: boolean) {
+export function getCreateLoanImplementation(marketId: string | LlamaMarketTemplate, leverageEnabled: boolean) {
   const market = getLlamaMarket(marketId)
   return market instanceof LendMarketTemplate
     ? leverageEnabled

--- a/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
@@ -1,6 +1,6 @@
 import { enforce, skipWhen, test } from 'vest'
 import { PRESET_RANGES } from '@/llamalend/constants'
-import { getLlamaMarket, hasLeverage, hasLeverageValue } from '@/llamalend/llama.utils'
+import { getLlamaMarket, hasLeverage, hasLeverageValue, tryGetLlamaMarket } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import type { Decimal } from '@primitives/decimal.utils'
 
@@ -77,7 +77,8 @@ export const validateLeverageSupported = (
   marketId: LlamaMarketTemplate | string | null | undefined,
   { required }: { required: boolean },
 ) => {
-  skipWhen(!required || !marketId, () => {
+  const market = tryGetLlamaMarket(marketId)
+  skipWhen(!required || !market, () => {
     test('marketId', 'Market does not support leverage', () => {
       const market = getLlamaMarket(marketId!)
       enforce(hasLeverage(market)).isTruthy()
@@ -86,10 +87,10 @@ export const validateLeverageSupported = (
 }
 
 export const validateLeverageValuesSupported = (marketId: string | null | undefined) => {
-  skipWhen(!marketId, () => {
+  const market = tryGetLlamaMarket(marketId)
+  skipWhen(!market, () => {
     test('marketId', 'Market does not support leverage values', () => {
-      const market = getLlamaMarket(marketId!)
-      enforce(hasLeverageValue(market)).isTruthy()
+      enforce(market && hasLeverageValue(market)).isTruthy()
     })
   })
 }

--- a/apps/main/src/llamalend/queries/validation/borrow-more.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow-more.validation.ts
@@ -1,5 +1,5 @@
 import { skipWhen } from 'vest'
-import { isRouterRequired } from '@/llamalend/llama.utils'
+import { isRouterRequired, tryGetLlamaMarket } from '@/llamalend/llama.utils'
 import { getBorrowMoreImplementation } from '@/llamalend/queries/borrow-more/borrow-more-query.helpers'
 import {
   validateDebt,
@@ -55,10 +55,10 @@ const validateBorrowMoreFieldsForMarket = ({
   routeId: string | null | undefined
   debt: Decimal | null | undefined
 }) => {
-  skipWhen(!marketId, () => {
-    if (!marketId) return
-    const [type] = getBorrowMoreImplementation(marketId, leverageEnabled)
-    validateRoute(routeId, !!(debt && leverageEnabled && isRouterRequired(type)))
+  const market = tryGetLlamaMarket(marketId)
+  skipWhen(!market, () => {
+    const [type] = market ? getBorrowMoreImplementation(market, leverageEnabled) : []
+    validateRoute(routeId, !!(debt && leverageEnabled && type && isRouterRequired(type)))
   })
 }
 

--- a/apps/main/src/llamalend/queries/validation/borrow.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow.validation.ts
@@ -1,5 +1,5 @@
 import { group, skipWhen } from 'vest'
-import { isRouterRequired } from '@/llamalend/llama.utils'
+import { isRouterRequired, tryGetLlamaMarket } from '@/llamalend/llama.utils'
 import {
   validateDebt,
   validateLeverageEnabled,
@@ -80,11 +80,11 @@ export const createLoanQueryValidationSuite = ({
       ignoreMaxCollateral,
     })
     const { marketId, leverageEnabled, routeId } = params
-    skipWhen(!marketId, () => {
-      if (!marketId) return
-      const [type] = getCreateLoanImplementation(marketId, !!leverageEnabled)
+    const market = tryGetLlamaMarket(marketId)
+    skipWhen(!market, () => {
+      const [type] = market ? getCreateLoanImplementation(market, !!leverageEnabled) : []
       // if we don't need debt we cannot need a route, as we need a route to calculate max debt
-      const routeRequired = debtRequired && !!leverageEnabled && isRouterRequired(type)
+      const routeRequired = !!type && debtRequired && !!leverageEnabled && isRouterRequired(type)
       validateRoute(routeId, routeRequired)
     })
   })

--- a/apps/main/src/llamalend/queries/validation/borrow.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow.validation.ts
@@ -84,7 +84,6 @@ export const createLoanQueryValidationSuite = ({
     skipWhen(!market, () => {
       const [type] = market ? getCreateLoanImplementation(market, !!leverageEnabled) : []
       // if we don't need debt we cannot need a route, as we need a route to calculate max debt
-      const routeRequired = !!type && debtRequired && !!leverageEnabled && isRouterRequired(type)
-      validateRoute(routeId, routeRequired)
+      validateRoute(routeId, !!(type && debtRequired && leverageEnabled && isRouterRequired(type)))
     })
   })

--- a/apps/main/src/llamalend/queries/validation/repay.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/repay.validation.ts
@@ -1,5 +1,5 @@
 import { enforce, skipWhen, test } from 'vest'
-import { isRouterRequired } from '@/llamalend/llama.utils'
+import { isRouterRequired, tryGetLlamaMarket } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { getRepayImplementationType } from '@/llamalend/queries/repay/repay-query.helpers'
 import {
@@ -57,16 +57,18 @@ const validateRepayFieldsForMarket = (
   userBorrowed: Decimal | null | undefined,
   routeId: string | null | undefined,
 ) => {
-  skipWhen(!marketId, () => {
-    if (!marketId) return // somehow, skipWhen doesn't stop execution of the inner function
+  const market = tryGetLlamaMarket(marketId)
+  skipWhen(!market, () => {
     // Get the implementation to validate fields according to market capabilities. Default to 0 just like the queries
-    const type = getRepayImplementationType(marketId, {
-      stateCollateral: stateCollateral ?? '0',
-      userCollateral: userCollateral ?? '0',
-      userBorrowed: userBorrowed ?? '0',
-    })
-    const swapRequired = !!stateCollateral || !!userCollateral || !!routeId
-    validateRoute(routeId, swapRequired && isRouterRequired(type))
+    const type =
+      market &&
+      getRepayImplementationType(market, {
+        stateCollateral: stateCollateral ?? '0',
+        userCollateral: userCollateral ?? '0',
+        userBorrowed: userBorrowed ?? '0',
+      })
+    const swapRequired = stateCollateral || userCollateral || routeId
+    validateRoute(routeId, !!(type && swapRequired && isRouterRequired(type)))
   })
 }
 

--- a/apps/main/src/llamalend/queries/validation/supply.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/supply.validation.ts
@@ -1,5 +1,5 @@
 import { enforce, skipWhen, test } from 'vest'
-import { getLlamaMarket, hasGauge, hasVault } from '@/llamalend/llama.utils'
+import { getLlamaMarket, hasGauge, hasVault, tryGetLlamaMarket } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -68,10 +68,8 @@ export type SharesToAssetsParams<ChainId = number> = FieldsOf<SharesToAssetsQuer
  * Accepts either a market ID string or a LlamaMarketTemplate instance.
  * @throws Error if the market does not have a vault (only LendMarkets have vaults)
  */
-export function requireVault(marketId: string): LendMarketTemplate
-export function requireVault(market: LlamaMarketTemplate): LendMarketTemplate
-export function requireVault(marketOrId: string | LlamaMarketTemplate): LendMarketTemplate {
-  const market = typeof marketOrId === 'string' ? getLlamaMarket(marketOrId) : marketOrId
+export function requireVault(marketId: string | LlamaMarketTemplate): LendMarketTemplate {
+  const market = getLlamaMarket(marketId)
   assert(hasVault(market), 'Market does not have a vault')
   return market as LendMarketTemplate
 }
@@ -83,19 +81,19 @@ export function requireGauge(marketId: string): LendMarketTemplate {
 }
 
 export const validateHasVault = (marketId: string | null | undefined) => {
-  skipWhen(!marketId, () => {
+  const market = tryGetLlamaMarket(marketId!)
+  skipWhen(!market, () => {
     test('marketId', 'Market does not have a vault', () => {
-      const market = getLlamaMarket(marketId!)
-      enforce(hasVault(market)).isTruthy()
+      enforce(market && hasVault(market)).isTruthy()
     })
   })
 }
 
 const validateHasGauge = (marketId: string | null | undefined) => {
-  skipWhen(!marketId, () => {
+  const market = tryGetLlamaMarket(marketId!)
+  skipWhen(!market, () => {
     test('marketId', 'Market does not have a gauge', () => {
-      const market = getLlamaMarket(marketId!)
-      enforce(hasGauge(market)).isTruthy()
+      enforce(market && hasGauge(market)).isTruthy()
     })
   })
 }

--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -16,7 +16,6 @@ import {
 } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createBorrowMoreScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
 import { mockMintSnapshots } from '@cy/support/helpers/minting-mocks'
-import { range } from '@primitives/objects.utils'
 import { constQ } from '@ui-kit/types/util'
 import { Chain } from '@ui-kit/utils'
 
@@ -49,65 +48,63 @@ const testCases = [
   },
 ]
 
-range(10).forEach((index) => {
-  describe('BorrowMoreForm (mocked)' + ` ${index + 1}`, () => {
-    beforeEach(() => mockMintSnapshots({ limit: 1 }))
+describe('BorrowMoreForm (mocked)', () => {
+  beforeEach(() => mockMintSnapshots({ limit: 1 }))
 
-    afterEach(() => resetLlamaTestContext())
+  afterEach(() => resetLlamaTestContext())
 
-    testCases.forEach(({ approved, title, withCollateral, buttonText }) => {
-      it(title, () => {
-        const userCollateral = withCollateral ? oneDecimal(0.01, 0.5, 3) : undefined
-        const { borrow, expected, expectedCurrentDebt, expectedFutureDebt, llamaApi, market, stubs } =
-          createBorrowMoreScenario({ chainId, approved, collateral: userCollateral })
-        const onPricesUpdated = cy.spy().as('onPricesUpdated')
+  testCases.forEach(({ approved, title, withCollateral, buttonText }) => {
+    it(title, () => {
+      const userCollateral = withCollateral ? oneDecimal(0.01, 0.5, 3) : undefined
+      const { borrow, expected, expectedCurrentDebt, expectedFutureDebt, llamaApi, market, stubs } =
+        createBorrowMoreScenario({ chainId, approved, collateral: userCollateral })
+      const onPricesUpdated = cy.spy().as('onPricesUpdated')
 
-        setLlamaApi(llamaApi)
-        setGasInfo({ chainId, networks: llamaNetworks })
+      setLlamaApi(llamaApi)
+      setGasInfo({ chainId, networks: llamaNetworks })
 
-        cy.mount(
-          <MockLoanTestWrapper llamaApi={llamaApi}>
-            <BorrowMoreForm
-              market={market}
-              networks={llamaNetworks}
-              chainId={chainId}
-              onPricesUpdated={onPricesUpdated}
-              enabled
-              collateralEvents={constQ(fakeCollateralEvents)}
-            />
-          </MockLoanTestWrapper>,
-        )
+      cy.mount(
+        <MockLoanTestWrapper llamaApi={llamaApi}>
+          <BorrowMoreForm
+            market={market}
+            networks={llamaNetworks}
+            chainId={chainId}
+            onPricesUpdated={onPricesUpdated}
+            enabled
+            collateralEvents={constQ(fakeCollateralEvents)}
+          />
+        </MockLoanTestWrapper>,
+      )
 
-        writeBorrowMoreForm({ debt: borrow, userCollateral })
-        checkBorrowMoreDetailsLoaded({
-          expectedCurrentDebt,
-          expectedFutureDebt,
-          leverageEnabled: false,
-        })
-        cy.get('[data-testid="borrow-more-submit-button"]').should('have.text', buttonText)
+      writeBorrowMoreForm({ debt: borrow, userCollateral })
+      checkBorrowMoreDetailsLoaded({
+        expectedCurrentDebt,
+        expectedFutureDebt,
+        leverageEnabled: false,
+      })
+      cy.get('[data-testid="borrow-more-submit-button"]').should('have.text', buttonText)
 
-        cy.then(() => {
-          expect(stubs.parameters).to.have.been.calledWithExactly()
-          expect(stubs.borrowMoreHealth).to.have.been.calledWithExactly(...expected.health)
-          expect(stubs.borrowMoreMaxRecv).to.have.been.calledWithExactly(...expected.maxRecv)
-          expect(stubs.borrowMoreIsApproved).to.have.been.calledWithExactly(...expected.isApproved)
-          if (approved) {
-            expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
-            expect(stubs.estimateGasBorrowMoreApprove).to.not.have.been.called
-          } else {
-            expect(stubs.estimateGasBorrowMoreApprove).to.have.been.calledWithExactly(...expected.estimateGasApprove)
-          }
-        })
+      cy.then(() => {
+        expect(stubs.parameters).to.have.been.calledWithExactly()
+        expect(stubs.borrowMoreHealth).to.have.been.calledWithExactly(...expected.health)
+        expect(stubs.borrowMoreMaxRecv).to.have.been.calledWithExactly(...expected.maxRecv)
+        expect(stubs.borrowMoreIsApproved).to.have.been.calledWithExactly(...expected.isApproved)
+        if (approved) {
+          expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
+          expect(stubs.estimateGasBorrowMoreApprove).to.not.have.been.called
+        } else {
+          expect(stubs.estimateGasBorrowMoreApprove).to.have.been.calledWithExactly(...expected.estimateGasApprove)
+        }
+      })
 
-        submitBorrowMoreForm().then(() => {
-          expect(stubs.borrowMore).to.have.been.calledWithExactly(...expected.submit)
-          if (approved) {
-            expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
-            expect(stubs.borrowMoreApprove).to.not.have.been.called
-          } else {
-            expect(stubs.borrowMoreApprove).to.have.been.calledWithExactly(...expected.approve)
-          }
-        })
+      submitBorrowMoreForm().then(() => {
+        expect(stubs.borrowMore).to.have.been.calledWithExactly(...expected.submit)
+        if (approved) {
+          expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
+          expect(stubs.borrowMoreApprove).to.not.have.been.called
+        } else {
+          expect(stubs.borrowMoreApprove).to.have.been.calledWithExactly(...expected.approve)
+        }
       })
     })
   })

--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -16,6 +16,7 @@ import {
 } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createBorrowMoreScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
 import { mockMintSnapshots } from '@cy/support/helpers/minting-mocks'
+import { range } from '@primitives/objects.utils'
 import { constQ } from '@ui-kit/types/util'
 import { Chain } from '@ui-kit/utils'
 
@@ -48,63 +49,65 @@ const testCases = [
   },
 ]
 
-describe('BorrowMoreForm (mocked)', () => {
-  beforeEach(() => mockMintSnapshots({ limit: 1 }))
+range(10).forEach((index) => {
+  describe('BorrowMoreForm (mocked)' + ` ${index + 1}`, () => {
+    beforeEach(() => mockMintSnapshots({ limit: 1 }))
 
-  afterEach(() => resetLlamaTestContext())
+    afterEach(() => resetLlamaTestContext())
 
-  testCases.forEach(({ approved, title, withCollateral, buttonText }) => {
-    it(title, () => {
-      const userCollateral = withCollateral ? oneDecimal(0.01, 0.5, 3) : undefined
-      const { borrow, expected, expectedCurrentDebt, expectedFutureDebt, llamaApi, market, stubs } =
-        createBorrowMoreScenario({ chainId, approved, collateral: userCollateral })
-      const onPricesUpdated = cy.spy().as('onPricesUpdated')
+    testCases.forEach(({ approved, title, withCollateral, buttonText }) => {
+      it(title, () => {
+        const userCollateral = withCollateral ? oneDecimal(0.01, 0.5, 3) : undefined
+        const { borrow, expected, expectedCurrentDebt, expectedFutureDebt, llamaApi, market, stubs } =
+          createBorrowMoreScenario({ chainId, approved, collateral: userCollateral })
+        const onPricesUpdated = cy.spy().as('onPricesUpdated')
 
-      setLlamaApi(llamaApi)
-      setGasInfo({ chainId, networks: llamaNetworks })
+        setLlamaApi(llamaApi)
+        setGasInfo({ chainId, networks: llamaNetworks })
 
-      cy.mount(
-        <MockLoanTestWrapper llamaApi={llamaApi}>
-          <BorrowMoreForm
-            market={market}
-            networks={llamaNetworks}
-            chainId={chainId}
-            onPricesUpdated={onPricesUpdated}
-            enabled
-            collateralEvents={constQ(fakeCollateralEvents)}
-          />
-        </MockLoanTestWrapper>,
-      )
+        cy.mount(
+          <MockLoanTestWrapper llamaApi={llamaApi}>
+            <BorrowMoreForm
+              market={market}
+              networks={llamaNetworks}
+              chainId={chainId}
+              onPricesUpdated={onPricesUpdated}
+              enabled
+              collateralEvents={constQ(fakeCollateralEvents)}
+            />
+          </MockLoanTestWrapper>,
+        )
 
-      writeBorrowMoreForm({ debt: borrow, userCollateral })
-      checkBorrowMoreDetailsLoaded({
-        expectedCurrentDebt,
-        expectedFutureDebt,
-        leverageEnabled: false,
-      })
-      cy.get('[data-testid="borrow-more-submit-button"]').should('have.text', buttonText)
+        writeBorrowMoreForm({ debt: borrow, userCollateral })
+        checkBorrowMoreDetailsLoaded({
+          expectedCurrentDebt,
+          expectedFutureDebt,
+          leverageEnabled: false,
+        })
+        cy.get('[data-testid="borrow-more-submit-button"]').should('have.text', buttonText)
 
-      cy.then(() => {
-        expect(stubs.parameters).to.have.been.calledWithExactly()
-        expect(stubs.borrowMoreHealth).to.have.been.calledWithExactly(...expected.health)
-        expect(stubs.borrowMoreMaxRecv).to.have.been.calledWithExactly(...expected.maxRecv)
-        expect(stubs.borrowMoreIsApproved).to.have.been.calledWithExactly(...expected.isApproved)
-        if (approved) {
-          expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
-          expect(stubs.estimateGasBorrowMoreApprove).to.not.have.been.called
-        } else {
-          expect(stubs.estimateGasBorrowMoreApprove).to.have.been.calledWithExactly(...expected.estimateGasApprove)
-        }
-      })
+        cy.then(() => {
+          expect(stubs.parameters).to.have.been.calledWithExactly()
+          expect(stubs.borrowMoreHealth).to.have.been.calledWithExactly(...expected.health)
+          expect(stubs.borrowMoreMaxRecv).to.have.been.calledWithExactly(...expected.maxRecv)
+          expect(stubs.borrowMoreIsApproved).to.have.been.calledWithExactly(...expected.isApproved)
+          if (approved) {
+            expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
+            expect(stubs.estimateGasBorrowMoreApprove).to.not.have.been.called
+          } else {
+            expect(stubs.estimateGasBorrowMoreApprove).to.have.been.calledWithExactly(...expected.estimateGasApprove)
+          }
+        })
 
-      submitBorrowMoreForm().then(() => {
-        expect(stubs.borrowMore).to.have.been.calledWithExactly(...expected.submit)
-        if (approved) {
-          expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
-          expect(stubs.borrowMoreApprove).to.not.have.been.called
-        } else {
-          expect(stubs.borrowMoreApprove).to.have.been.calledWithExactly(...expected.approve)
-        }
+        submitBorrowMoreForm().then(() => {
+          expect(stubs.borrowMore).to.have.been.calledWithExactly(...expected.submit)
+          if (approved) {
+            expect(stubs.estimateGasBorrowMore).to.have.been.calledWithExactly(...expected.estimateGas)
+            expect(stubs.borrowMoreApprove).to.not.have.been.called
+          } else {
+            expect(stubs.borrowMoreApprove).to.have.been.calledWithExactly(...expected.approve)
+          }
+        })
       })
     })
   })


### PR DESCRIPTION
- avoid exceptions when calling the validation suite (exceptions are only allowed inside `test()`)
- the exception would crash the whole app when the api was not set (caused by `resetLlamaTestContext` in tests)
- add a timeout to all cypress tests step so we can get screenshots in case of timeout

<img width="1747" height="1106" alt="Screenshot From 2026-04-15 10-22-10" src="https://github.com/user-attachments/assets/88baed0a-b330-45d5-bbb5-4b09920e2e69" />
