### PR TITLE
fix: circular import breaking rpc tests

### DIFF
--- a/packages/curve-ui-kit/src/lib/api/cache.ts
+++ b/packages/curve-ui-kit/src/lib/api/cache.ts
@@ -1,7 +1,8 @@
 import { type Mutation, MutationCache, QueryCache } from '@tanstack/react-query'
 import { addBreadcrumb, captureError } from '@ui-kit/features/sentry'
 import { logError, logMutation, logSuccess } from '@ui-kit/lib/logging'
-import { QUERY_KEY_IDENTIFIER as USD_RATE_KEY_IDENTIFER } from '../model/entities/token-usd-rate'
+
+export const USD_RATE_KEY_IDENTIFER = 'usdRate' as const
 
 // disable logging for queries that are too verbose
 const disableCacheQueryKeys = new Set<unknown>(['readContracts', USD_RATE_KEY_IDENTIFER])

--- a/packages/curve-ui-kit/src/lib/model/entities/token-usd-rate.ts
+++ b/packages/curve-ui-kit/src/lib/model/entities/token-usd-rate.ts
@@ -8,6 +8,7 @@ import { getLib } from '@ui-kit/features/connect-wallet'
 import type { LibKey } from '@ui-kit/features/connect-wallet/lib/types'
 import { getWagmiConfig } from '@ui-kit/features/connect-wallet/lib/wagmi/wagmi-config'
 import { combineQueriesToObject, createValidationSuite } from '@ui-kit/lib'
+import { USD_RATE_KEY_IDENTIFER } from '@ui-kit/lib/api/cache'
 import {
   NoRetryError,
   queryFactory,
@@ -19,8 +20,6 @@ import {
 import { tokenValidationGroup } from '@ui-kit/lib/model/query/token-validation'
 import { BlockchainIds, Chain, REUSD_ADDRESS, SREUSD_ADDRESS } from '@ui-kit/utils'
 import { readContract } from '@wagmi/core'
-
-export const QUERY_KEY_IDENTIFIER = 'usdRate' as const
 
 const getTestTokenPrice = async (chainId: number, tokenAddress: string): Promise<number | null> => {
   if (chainId === Chain.Optimism) {
@@ -119,7 +118,7 @@ export const {
   fetchQuery: fetchTokenUsdRate,
   getQueryOptions: getTokenUsdRateQueryOptions,
 } = queryFactory({
-  queryKey: (params: TokenParams) => [...rootKeys.token(params), QUERY_KEY_IDENTIFIER] as const,
+  queryKey: (params: TokenParams) => [...rootKeys.token(params), USD_RATE_KEY_IDENTIFER] as const,
   queryFn: async ({ chainId, tokenAddress }: TokenQuery) => await fetchUsdRate(chainId, tokenAddress),
   validationSuite: createValidationSuite(({ chainId, tokenAddress }: TokenParams) => {
     tokenValidationGroup({ chainId, tokenAddress })


### PR DESCRIPTION
- fix error `can't access lexical declaration 'USD_RATE_KEY_IDENTIFER' before initialization` in rpc tests