### PR TITLE
fix: repay form validation

### DIFF
--- a/apps/main/src/llamalend/queries/repay/repay-health.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-health.query.ts
@@ -1,3 +1,4 @@
+import { repayExpectedBorrowedQueryKey } from '@/llamalend/queries/repay/repay-expected-borrowed.query'
 import type { RepayHealthParams, RepayHealthQuery } from '@/llamalend/queries/validation/repay.types'
 import { repayValidationSuite } from '@/llamalend/queries/validation/repay.validation'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -64,4 +65,5 @@ export const {
   },
   category: 'llamalend.repay',
   validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: true }),
+  dependencies: (params) => [repayExpectedBorrowedQueryKey(params)],
 })

--- a/apps/main/src/llamalend/queries/validation/repay.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/repay.validation.ts
@@ -40,21 +40,11 @@ const validateRepayHasValue = (
   userCollateral: Decimal | null | undefined,
   userBorrowed: Decimal | null | undefined,
 ) => {
-  const activeField = stateCollateral
-    ? ('stateCollateral' as const)
-    : userCollateral
-      ? ('userCollateral' as const)
-      : ('userBorrowed' as const)
-  const validate = (field: typeof activeField, value: Decimal | null | undefined) => {
-    skipWhen(activeField !== field, () => {
-      test(field, 'Enter an amount to repay', () => {
-        enforce(value).isDecimal().greaterThan(0)
-      })
-    })
-  }
-  validate('stateCollateral', stateCollateral)
-  validate('userCollateral', userCollateral)
-  validate('userBorrowed', userBorrowed)
+  test('root', 'Enter an amount to repay', () => {
+    enforce(stateCollateral ?? userCollateral ?? userBorrowed)
+      .isDecimal()
+      .greaterThan(0)
+  })
 }
 
 const validateRepayFieldsForMarket = (


### PR DESCRIPTION
- instead of validating the fields one-by-one we need to use root validation
  - vest will not revalidate fields if they didn't change, so if users only filled in stateCollateral for example, the userBorrowed validation will be stuck to 'userBorrowed: enter an amount to repay'
- root is the correct way to verify behavior when multiple fields are interdependent