### PR TITLE
fix: transparent background color disabled ghost button

### DIFF
--- a/packages/curve-ui-kit/src/themes/design/2_theme.ts
+++ b/packages/curve-ui-kit/src/themes/design/2_theme.ts
@@ -170,7 +170,7 @@ export const createLightDesign = (
       },
       Disabled: {
         Label: Text.TextColors.Disabled,
-        Fill: Grays[500],
+        Fill: Transparent,
       },
     },
     Success: {
@@ -635,7 +635,7 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
       },
       Disabled: {
         Label: Blues[700],
-        Fill: Grays[850],
+        Fill: Transparent,
       },
     },
     Success: {
@@ -1061,7 +1061,7 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
       },
       Disabled: {
         Label: Text.TextColors.Disabled,
-        Fill: Grays[500],
+        Fill: Transparent,
       },
     },
     Success: {


### PR DESCRIPTION
- transparent background color for ghost button when disabled. 

Needs to be fixed in the design system on Figma as well I think. Because the color exists on Figma but it's not being used, and has been imported automatically.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="763" height="218" alt="Screenshot 2026-04-16 at 13 58 27" src="https://github.com/user-attachments/assets/f125b95f-9021-409f-a665-1668a83ee783" />
</td>
    <td>
<img width="765" height="214" alt="Screenshot 2026-04-16 at 13 57 54" src="https://github.com/user-attachments/assets/dccc221a-f667-4e4a-be75-27762be100d9" />
</td>
  </tr>
</table>