### PR TITLE
chore: stop hiding a single row

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -93,7 +93,7 @@ export const DataTable = <T extends TableItem>({
 } & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
   const { table } = rowProps
   const { rows } = table.getRowModel()
-  const { isLimited, isLoading: isLoadingViewAll, handleShowAll } = useTableRowLimit(rowLimit)
+  const { isLimited, isLoading: isLoadingViewAll, onShowAll } = useTableRowLimit(rowLimit, rows.length)
   // When number of rows are limited, show only rowLimit rows
   const visibleRows = isLimited && rowLimit ? rows.slice(0, rowLimit) : rows
   const showViewAllButton = isLimited && rows.length > rowLimit!
@@ -165,7 +165,7 @@ export const DataTable = <T extends TableItem>({
             {footerRow && <TableRow>{footerRow}</TableRow>}
             {showViewAllButton && (
               <TableRow>
-                <TableViewAllCell colSpan={columnCount} onClick={handleShowAll} isLoading={isLoadingViewAll}>
+                <TableViewAllCell colSpan={columnCount} onClick={onShowAll} isLoading={isLoadingViewAll}>
                   {viewAllLabel || t`View all`}
                 </TableViewAllCell>
               </TableRow>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/useTableRowLimit.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/useTableRowLimit.ts
@@ -1,31 +1,19 @@
-import { useState, useTransition } from 'react'
+import { useCallback, useState, useTransition } from 'react'
 
 /**
  * Hook to manage table row limiting functionality.
- * When a rowLimit is provided, the table will initially show only that many rows
- * with a "show all" button. Once clicked, all rows are shown with pagination enabled.
+ * When a rowLimit is provided, the table will initially show only that many rows with a "show all" button.
+ * Except when we have exactly rowLimit+1 rows, there is no point in hiding a single row.
+ * Once clicked, all rows are shown with pagination enabled.
  */
-export function useTableRowLimit(rowLimit?: number) {
-  const [showAllRows, setShowAllRows] = useState(false)
-  const [isPending, startTransition] = useTransition()
+export function useTableRowLimit(rowLimit: number | undefined, totalRows: number) {
+  const [isShowingAllRows, setShowAll] = useState(false)
+  const [isLoading, startTransition] = useTransition()
 
-  const isLimited = rowLimit != null && !showAllRows
+  const isLimited = rowLimit != null && !isShowingAllRows && totalRows > rowLimit + 1 // don't hide a single row, saves little space
 
-  const handleShowAll = () => {
-    // when toggling the show all rows, we want to use a transition to avoid blocking the UI
-    startTransition(() => {
-      setShowAllRows(true)
-    })
-  }
+  // when toggling the show all rows, use a transition to avoid blocking the UI
+  const onShowAll = useCallback(() => startTransition(() => setShowAll(true)), [startTransition])
 
-  const reset = () => {
-    setShowAllRows(false)
-  }
-
-  return {
-    isLimited,
-    isLoading: isPending,
-    handleShowAll,
-    reset,
-  }
+  return { isLimited, isLoading, onShowAll }
 }


### PR DESCRIPTION
- currently, when users have exactly 4 positions, they see 3 and a show all button to display the last one.
- that extra click does not save any space, so I think it makes sense to add one row of tolerance