### PR TITLE
styling: make card padding more consistent and use smaller size for new forms

### DIFF
--- a/apps/main/src/analytics/features/charts/components/EChartsCard.tsx
+++ b/apps/main/src/analytics/features/charts/components/EChartsCard.tsx
@@ -55,23 +55,21 @@ export const EChartsCard = ({
         }
       />
 
-      <CardContent component={Stack} flexGrow={1} {...(!fullscreen && { size: 'small' })}>
-        <Stack gap={Spacing.md} flexGrow={1}>
-          <Box position="relative" {...(fullscreen && { flexGrow: 1 })}>
-            {loading && <CircularProgress sx={{ position: 'absolute', inset: 0, margin: 'auto', zIndex: 2 }} />}
-            <ReactECharts
-              notMerge
-              option={option}
-              style={{
-                height: '100%',
-                ...(!fullscreen && { minHeight: MIN_HEIGHT }),
-                ...(loading && { opacity: 0.5 }),
-              }}
-            />
-          </Box>
+      <CardContent component={Stack} gap={Spacing.md} flexGrow={1} {...(!fullscreen && { size: 'small' })}>
+        <Box position="relative" {...(fullscreen && { flexGrow: 1 })}>
+          {loading && <CircularProgress sx={{ position: 'absolute', inset: 0, margin: 'auto', zIndex: 2 }} />}
+          <ReactECharts
+            notMerge
+            option={option}
+            style={{
+              height: '100%',
+              ...(!fullscreen && { minHeight: MIN_HEIGHT }),
+              ...(loading && { opacity: 0.5 }),
+            }}
+          />
+        </Box>
 
-          {children}
-        </Stack>
+        {children}
       </CardContent>
     </Card>
   </WithWrapper>

--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -63,16 +63,14 @@ export const MarketInformationComposite = ({
       {market && (
         <Card>
           <CardHeader title={t`Advanced Details`} size="small" />
-          <CardContent>
-            <Stack>
-              <AdvancedDetails chainId={rChainId} marketId={rOwmId} market={market} marketType={LlamaMarketType.Lend} />
-              <MarketInfoLayout
-                chainId={rChainId}
-                marketType={LlamaMarketType.Lend}
-                market={market}
-                network={networks[rChainId]}
-              />
-            </Stack>
+          <CardContent component={Stack}>
+            <AdvancedDetails chainId={rChainId} marketId={rOwmId} market={market} marketType={LlamaMarketType.Lend} />
+            <MarketInfoLayout
+              chainId={rChainId}
+              marketType={LlamaMarketType.Lend}
+              market={market}
+              network={networks[rChainId]}
+            />
           </CardContent>
         </Card>
       )}

--- a/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
+++ b/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
@@ -1,7 +1,7 @@
 import { sortBy, uniqBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { CrvUsdPriceTooltip } from '@/llamalend/widgets/tooltips/chart/CrvUsdPriceTooltip'
-import { Stack } from '@mui/material'
+import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
@@ -118,7 +118,7 @@ export const CrvUsdPriceChart = () => {
           />
         }
       />
-      <Stack gap={Spacing.md} sx={{ backgroundColor: (t) => t.design.Layer[1].Fill, padding: Spacing.md }}>
+      <CardContent component={Stack} gap={Spacing.md} size="small">
         <ChartStateWrapper
           height={Height.shortChart}
           isLoading={showLoading}
@@ -143,7 +143,7 @@ export const CrvUsdPriceChart = () => {
           legendSets={legendSets}
           description={t`This chart shows crvUSD's historical peg to $1. For mint market interest rates, the rate is a function of crvUSD's peg. When the price dips below $1, rates increase to incentivize loan repayment and reduce supply; when the price rises above $1, rates decrease to encourage borrowing — restoring balance to the system.`}
         />
-      </Stack>
+      </CardContent>
     </Card>
   )
 }

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -4,7 +4,7 @@ import { type LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
 import { HistoricalRatesTooltip } from '@/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip'
 import type { Chain } from '@curvefi/prices-api'
-import { Stack } from '@mui/material'
+import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
@@ -131,7 +131,7 @@ export const MarketHistoricalRatesChart = ({ market, blockchainId, rateMode }: M
           />
         }
       />
-      <Stack gap={Spacing.md} sx={{ backgroundColor: (t) => t.design.Layer[1].Fill, padding: Spacing.md }}>
+      <CardContent component={Stack} gap={Spacing.md} size="small">
         <ChartStateWrapper
           height={Height.shortChart}
           isLoading={isLoading || !market}
@@ -151,7 +151,7 @@ export const MarketHistoricalRatesChart = ({ market, blockchainId, rateMode }: M
           />
         </ChartStateWrapper>
         <ChartFooter legendSets={legendSets} />
-      </Stack>
+      </CardContent>
     </Card>
   )
 }

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -6,7 +6,7 @@ import { useMarketCapAndAvailable, useRateCurve } from '@/llamalend/queries/mark
 import { RateCurveTooltip } from '@/llamalend/widgets/tooltips/chart/RateCurveTooltip'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
-import { Stack } from '@mui/material'
+import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
@@ -115,7 +115,7 @@ export const MarketRateCurveChart = ({
   return (
     <Card>
       <CardHeader title={t`Interest Rate & Utilization`} size="small" />
-      <Stack gap={Spacing.md} sx={{ backgroundColor: (theme) => theme.design.Layer[1].Fill, padding: Spacing.md }}>
+      <CardContent component={Stack} gap={Spacing.md} size="small">
         <ChartStateWrapper
           height={Height.shortChart}
           isLoading={isLoading || !market}
@@ -140,7 +140,7 @@ export const MarketRateCurveChart = ({
           legendSets={legendSets}
           description={t`This chart illustrates the relationship between utilization and interest rates in this market. It reflects the market’s monetary policy—how rates adjust based on supply and demand dynamics.`}
         />
-      </Stack>
+      </CardContent>
     </Card>
   )
 }

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -54,21 +54,14 @@ export const MarketInformationComposite = ({
       {market && (
         <Card>
           <CardHeader title={t`Advanced Details`} size="small" />
-          <CardContent>
-            <Stack>
-              <AdvancedDetails
-                chainId={chainId}
-                marketId={marketId}
-                market={market}
-                marketType={LlamaMarketType.Mint}
-              />
-              <MarketInfoLayout
-                chainId={chainId}
-                marketType={LlamaMarketType.Mint}
-                market={market}
-                network={networks[chainId]}
-              />
-            </Stack>
+          <CardContent component={Stack}>
+            <AdvancedDetails chainId={chainId} marketId={marketId} market={market} marketType={LlamaMarketType.Mint} />
+            <MarketInfoLayout
+              chainId={chainId}
+              marketType={LlamaMarketType.Mint}
+              market={market}
+              network={networks[chainId]}
+            />
           </CardContent>
         </Card>
       )}

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/index.tsx
@@ -91,56 +91,54 @@ export const Statistics = ({ isChartExpanded, toggleChartExpanded, hideExpandCha
     >
       <Card>
         <CardHeader size="small" title={t`Statistics`} />
-        <CardContent>
-          <Stack gap={Spacing.md}>
-            <StatsStack />
+        <CardContent component={Stack} gap={Spacing.md}>
+          <StatsStack />
 
-            <ChartHeader
-              chartSelections={{
-                selections: chartSelections,
-                activeSelection: selectedStatisticsChart,
-                setActiveSelection: setSelectedStatisticsChart,
-              }}
-              chartOptionVariant="buttons-group"
-              expandChart={hideExpandChart ? undefined : { isExpanded: isChartExpanded, toggleChartExpanded }}
-            />
+          <ChartHeader
+            chartSelections={{
+              selections: chartSelections,
+              activeSelection: selectedStatisticsChart,
+              setActiveSelection: setSelectedStatisticsChart,
+            }}
+            chartOptionVariant="buttons-group"
+            expandChart={hideExpandChart ? undefined : { isExpanded: isChartExpanded, toggleChartExpanded }}
+          />
 
-            {selectedStatisticsChart === 'savingsRate' && (
-              <Stack gap={Spacing.md}>
-                <ChartStateWrapper
-                  height={Height.chart}
-                  isLoading={isScrvUsdYieldLoading}
-                  error={scrvUsdYieldError}
-                  errorMessage={t`Unable to fetch savings rate data.`}
-                >
-                  <RevenueLineChart
-                    height={Height.chart}
-                    data={yieldData ?? EMPTY_YIELD_DATA}
-                    visibleSeries={visibleSeries}
-                  />
-                </ChartStateWrapper>
-                <ChartFooter
-                  legendSets={legendSets}
-                  toggleOptions={timeOptions}
-                  activeToggleOption={revenueChartTimeOption}
-                  onToggleChange={(_, newOption) => setRevenueChartTimeOption(newOption)}
-                />
-              </Stack>
-            )}
-
-            {selectedStatisticsChart === 'distributions' && (
+          {selectedStatisticsChart === 'savingsRate' && (
+            <Stack gap={Spacing.md}>
               <ChartStateWrapper
                 height={Height.chart}
-                isLoading={isRevenueLoading}
-                error={revenueError}
-                errorMessage={t`Unable to fetch distributions data.`}
+                isLoading={isScrvUsdYieldLoading}
+                error={scrvUsdYieldError}
+                errorMessage={t`Unable to fetch savings rate data.`}
               >
-                <RevenueDistributionsBarChart height={Height.chart} data={revenueData ?? null} />
+                <RevenueLineChart
+                  height={Height.chart}
+                  data={yieldData ?? EMPTY_YIELD_DATA}
+                  visibleSeries={visibleSeries}
+                />
               </ChartStateWrapper>
-            )}
+              <ChartFooter
+                legendSets={legendSets}
+                toggleOptions={timeOptions}
+                activeToggleOption={revenueChartTimeOption}
+                onToggleChange={(_, newOption) => setRevenueChartTimeOption(newOption)}
+              />
+            </Stack>
+          )}
 
-            <AdvancedDetails network={networks[Chain.Ethereum]} />
-          </Stack>
+          {selectedStatisticsChart === 'distributions' && (
+            <ChartStateWrapper
+              height={Height.chart}
+              isLoading={isRevenueLoading}
+              error={revenueError}
+              errorMessage={t`Unable to fetch distributions data.`}
+            >
+              <RevenueDistributionsBarChart height={Height.chart} data={revenueData ?? null} />
+            </ChartStateWrapper>
+          )}
+
+          <AdvancedDetails network={networks[Chain.Ethereum]} />
         </CardContent>
       </Card>
     </Stack>

--- a/apps/main/src/loan/components/PageCrvUsdStaking/UserInformation/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/UserInformation/index.tsx
@@ -17,70 +17,68 @@ const { Spacing } = SizesAndSpaces
 
 export const UserInformation = ({ params: { network } }: { params: NetworkUrlParams }) => (
   <Card>
-    <CardContent>
-      <Stack direction="column" gap={Spacing.md}>
-        <Typography alignSelf="center" variant="headingSBold">
-          {t`How to get yield with Savings crvUSD?`}
-        </Typography>
-        <Stack
-          direction="row"
-          gap={Spacing.lg}
-          sx={{
-            flexWrap: {
-              mobile: 'wrap',
-              tablet: 'wrap',
-              desktop: 'nowrap',
-            },
-          }}
-        >
-          <Stack gap={Spacing.sm}>
-            <img src={RCCrvUSDLogoSM} alt="crvUSD logo" width={48} height={48} />
-            <Typography variant="headingXsBold">{t`Get crvUSD`}</Typography>
-            <Typography variant="bodyMRegular">
-              {t`To access the yield of Savings crvUSD (scrvUSD), you need crvUSD.`}{' '}
-              {t`You can acquire it on the open markets or borrow it in the LLAMALEND markets.`}
-            </Typography>
-            <Typography variant="bodyMRegular">
-              {t`We recommend using Curve's`}{' '}
-              <RouterLink href={getInternalUrl('dex', network, DEX_ROUTES.PAGE_SWAP)}>swap</RouterLink>
-              {t`, or alternatively an aggregator like`}{' '}
-              <Link href="https://swap.cow.fi/#/1/swap/WETH/scrvUSD">Cowswap</Link>.
-            </Typography>
-          </Stack>
-
-          <Stack gap={Spacing.sm}>
-            <img src={RCScrvUSDLogoSM} alt="scrvUSD logo" width={48} height={48} />
-            <Typography variant="headingXsBold">{t`Deposit crvUSD and get scrvUSD`}</Typography>
-            <Typography variant="bodyMRegular">
-              {t`By depositing crvUSD in the Curve Savings Vault, you get`}{' '}
-              <Link href="https://docs.curve.finance/user/yield/guides/deposit-scrvusd">scrvUSD</Link>.{' '}
-              {t`This token  represents your share of all the crvUSD deposited in the vault. `}
-            </Typography>
-            <Typography variant="bodyMRegular">
-              {t`scrvUSD is a yield-bearing stablecoin you can use further in DeFi.`}
-            </Typography>
-          </Stack>
-
-          <Stack gap={Spacing.sm}>
-            <YieldGrowth color="inherit" width={48} height={48} />
-            <Typography variant="headingXsBold">{t`Watch your yield grow`}</Typography>
-            <Typography variant="bodyMRegular">
-              {t`Upon deposit, your crvUSD is instantly generating yield and your rewards get `}{' '}
-              <Link href="https://docs.curve.finance/user/yield/scrvusd#how-scrvusd-works-earn-savings-on-your-crvusd">
-                {t`automatically compounded`}
-              </Link>
-              .
-            </Typography>
-            <Typography variant="bodyMRegular">
-              {t`The more crvUSD’s market grows, the more revenue it generates and the more yield get directed to Savings crvUSD and veCRV holders.`}
-            </Typography>
-          </Stack>
+    <CardContent component={Stack} gap={Spacing.md} direction="column">
+      <Typography alignSelf="center" variant="headingSBold">
+        {t`How to get yield with Savings crvUSD?`}
+      </Typography>
+      <Stack
+        direction="row"
+        gap={Spacing.lg}
+        sx={{
+          flexWrap: {
+            mobile: 'wrap',
+            tablet: 'wrap',
+            desktop: 'nowrap',
+          },
+        }}
+      >
+        <Stack gap={Spacing.sm}>
+          <img src={RCCrvUSDLogoSM} alt="crvUSD logo" width={48} height={48} />
+          <Typography variant="headingXsBold">{t`Get crvUSD`}</Typography>
+          <Typography variant="bodyMRegular">
+            {t`To access the yield of Savings crvUSD (scrvUSD), you need crvUSD.`}{' '}
+            {t`You can acquire it on the open markets or borrow it in the LLAMALEND markets.`}
+          </Typography>
+          <Typography variant="bodyMRegular">
+            {t`We recommend using Curve's`}{' '}
+            <RouterLink href={getInternalUrl('dex', network, DEX_ROUTES.PAGE_SWAP)}>swap</RouterLink>
+            {t`, or alternatively an aggregator like`}{' '}
+            <Link href="https://swap.cow.fi/#/1/swap/WETH/scrvUSD">Cowswap</Link>.
+          </Typography>
         </Stack>
 
-        <Box display="flex" justifyContent="center">
-          <ExternalLink href="https://docs.curve.finance/user/curve-tokens/scrvusd" label={t`Learn More`} />
-        </Box>
+        <Stack gap={Spacing.sm}>
+          <img src={RCScrvUSDLogoSM} alt="scrvUSD logo" width={48} height={48} />
+          <Typography variant="headingXsBold">{t`Deposit crvUSD and get scrvUSD`}</Typography>
+          <Typography variant="bodyMRegular">
+            {t`By depositing crvUSD in the Curve Savings Vault, you get`}{' '}
+            <Link href="https://docs.curve.finance/user/yield/guides/deposit-scrvusd">scrvUSD</Link>.{' '}
+            {t`This token  represents your share of all the crvUSD deposited in the vault. `}
+          </Typography>
+          <Typography variant="bodyMRegular">
+            {t`scrvUSD is a yield-bearing stablecoin you can use further in DeFi.`}
+          </Typography>
+        </Stack>
+
+        <Stack gap={Spacing.sm}>
+          <YieldGrowth color="inherit" width={48} height={48} />
+          <Typography variant="headingXsBold">{t`Watch your yield grow`}</Typography>
+          <Typography variant="bodyMRegular">
+            {t`Upon deposit, your crvUSD is instantly generating yield and your rewards get `}{' '}
+            <Link href="https://docs.curve.finance/user/yield/scrvusd#how-scrvusd-works-earn-savings-on-your-crvusd">
+              {t`automatically compounded`}
+            </Link>
+            .
+          </Typography>
+          <Typography variant="bodyMRegular">
+            {t`The more crvUSD’s market grows, the more revenue it generates and the more yield get directed to Savings crvUSD and veCRV holders.`}
+          </Typography>
+        </Stack>
       </Stack>
+
+      <Box display="flex" justifyContent="center">
+        <ExternalLink href="https://docs.curve.finance/user/curve-tokens/scrvusd" label={t`Learn More`} />
+      </Box>
     </CardContent>
   </Card>
 )

--- a/apps/main/src/loan/components/PageCrvUsdStaking/UserPosition/index.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/UserPosition/index.tsx
@@ -37,71 +37,69 @@ export const UserPosition = () => {
   return (
     <Card>
       <CardHeader size="small" title={t`Position Details`} />
-      <CardContent>
-        <Stack gap={Spacing.md}>
-          <Grid container wrap="wrap" columnSpacing={Spacing.lg} rowSpacing={Spacing.md}>
-            <Grid size={6}>
-              <Metric
-                size="large"
-                label={t`Your crvUSD Staked`}
-                value={userScrvUsdBalanceInCrvUsd}
-                valueOptions={{ unit: CRVUSD_OPTIONS }}
-                loading={userBalanceLoading || usdRateLoading || exchangeRateLoading}
-              />
-            </Grid>
-            <Grid size={6}>
-              <Metric
-                size="large"
-                label={t`Your share of the vault`}
-                value={userShareOfTotalScrvUsdSupply}
-                valueOptions={{ unit: 'percentage' }}
-                loading={isStatisticsLoading}
-              />
-            </Grid>
+      <CardContent component={Stack} gap={Spacing.md}>
+        <Grid container wrap="wrap" columnSpacing={Spacing.lg} rowSpacing={Spacing.md}>
+          <Grid size={6}>
+            <Metric
+              size="large"
+              label={t`Your crvUSD Staked`}
+              value={userScrvUsdBalanceInCrvUsd}
+              valueOptions={{ unit: CRVUSD_OPTIONS }}
+              loading={userBalanceLoading || usdRateLoading || exchangeRateLoading}
+            />
+          </Grid>
+          <Grid size={6}>
+            <Metric
+              size="large"
+              label={t`Your share of the vault`}
+              value={userShareOfTotalScrvUsdSupply}
+              valueOptions={{ unit: 'percentage' }}
+              loading={isStatisticsLoading}
+            />
+          </Grid>
+        </Grid>
+
+        <Grid container columnSpacing={Spacing.lg} rowSpacing={Spacing.md} wrap="wrap">
+          <Grid size={3}>
+            <Metric
+              size="small"
+              label={t`30 Days Projection`}
+              value={scrvUsdApy && oneMonthProjectionYield(scrvUsdApy, userScrvUsdBalance)}
+              valueOptions={{ unit: 'dollar' }}
+              loading={isStatisticsLoading || userBalanceLoading}
+              labelTooltip={{
+                title: t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`,
+              }}
+            />
           </Grid>
 
-          <Grid container columnSpacing={Spacing.lg} rowSpacing={Spacing.md} wrap="wrap">
-            <Grid size={3}>
-              <Metric
-                size="small"
-                label={t`30 Days Projection`}
-                value={scrvUsdApy && oneMonthProjectionYield(scrvUsdApy, userScrvUsdBalance)}
-                valueOptions={{ unit: 'dollar' }}
-                loading={isStatisticsLoading || userBalanceLoading}
-                labelTooltip={{
-                  title: t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`,
-                }}
-              />
-            </Grid>
+          <Grid size={3}>
+            <Metric
+              size="small"
+              label={t`1 Year Projection`}
+              value={scrvUsdApy && oneYearProjectionYield(scrvUsdApy, userScrvUsdBalance)}
+              valueOptions={{ unit: 'dollar' }}
+              loading={isStatisticsLoading || userBalanceLoading}
+              labelTooltip={{
+                title: t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`,
+              }}
+            />
+          </Grid>
 
-            <Grid size={3}>
-              <Metric
-                size="small"
-                label={t`1 Year Projection`}
-                value={scrvUsdApy && oneYearProjectionYield(scrvUsdApy, userScrvUsdBalance)}
-                valueOptions={{ unit: 'dollar' }}
-                loading={isStatisticsLoading || userBalanceLoading}
-                labelTooltip={{
-                  title: t`This is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`,
-                }}
-              />
-            </Grid>
-
-            <Grid size={3}>
-              <Metric
-                size="small"
-                label={t`Estimated APY`}
-                value={scrvUsdApy}
-                valueOptions={{ unit: 'percentage' }}
-                loading={isStatisticsLoading}
-                labelTooltip={{
-                  title: t`Annual percentage yield (APY) refers to how much interest is distributed on savings and takes compounded interest into account. 
+          <Grid size={3}>
+            <Metric
+              size="small"
+              label={t`Estimated APY`}
+              value={scrvUsdApy}
+              valueOptions={{ unit: 'percentage' }}
+              loading={isStatisticsLoading}
+              labelTooltip={{
+                title: t`Annual percentage yield (APY) refers to how much interest is distributed on savings and takes compounded interest into account. 
 This value is an indicator based on the historical yield of the crvUSD Savings Vault. It does not guarantee any future yield.`,
-                }}
-              />
-            </Grid>
+              }}
+            />
           </Grid>
-        </Stack>
+        </Grid>
       </CardContent>
     </Card>
   )

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeper.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeper.tsx
@@ -33,26 +33,24 @@ export const PegKeeper = ({ sx, testId = 'pegkeeper', ...pegkeeper }: Props) => 
         rate={rate}
       />
 
-      <CardContent>
-        <Stack gap={Spacing.md}>
-          <PegKeeperMetrics rate={rate} debt={debt} debtCeiling={debtCeiling} poolName={poolName} testId={testId} />
+      <CardContent component={Stack} gap={Spacing.md}>
+        <PegKeeperMetrics rate={rate} debt={debt} debtCeiling={debtCeiling} poolName={poolName} testId={testId} />
 
-          <PegKeeperAdvancedDetails
-            address={address}
-            estCallerProfit={estCallerProfit}
-            poolId={poolId}
-            poolName={poolName}
-            poolAddress={poolAddress}
-            testId={testId}
-          />
+        <PegKeeperAdvancedDetails
+          address={address}
+          estCallerProfit={estCallerProfit}
+          poolId={poolId}
+          poolName={poolName}
+          poolAddress={poolAddress}
+          testId={testId}
+        />
 
-          <PegKeeperRebalanceButton
-            canRebalance={!!estCallerProfit && estCallerProfit !== '0'}
-            isRebalancing={isRebalancing}
-            onRebalance={rebalance}
-            testId={testId}
-          />
-        </Stack>
+        <PegKeeperRebalanceButton
+          canRebalance={!!estCallerProfit && estCallerProfit !== '0'}
+          isRebalancing={isRebalancing}
+          onRebalance={rebalance}
+          testId={testId}
+        />
       </CardContent>
     </Card>
   )

--- a/packages/curve-ui-kit/src/shared/ui/PartnerCard.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/PartnerCard.tsx
@@ -44,58 +44,61 @@ export type Partner = {
 
 export const PartnerCard = ({ name, description, imageId, networks, tags, appUrl, twitterUrl }: Partner) => (
   <Card sx={{ display: 'flex', height: '100%' }}>
-    <CardContent sx={{ display: 'flex', flexGrow: 1, backgroundColor: (t) => t.design.Layer[2].Fill }}>
-      <Stack flexGrow={1} gap={Spacing.md}>
-        <Stack direction="row" gap={Spacing.md}>
-          {imageId && (
-            <Box
-              component="img"
-              src={`${CURVE_ASSETS_URL}/${imageId}`}
-              sx={{ height: IconSize.xxl, width: IconSize.xxl }}
+    <CardContent
+      component={Stack}
+      flexGrow={1}
+      gap={Spacing.md}
+      sx={{ backgroundColor: (t) => t.design.Layer[2].Fill }}
+    >
+      <Stack direction="row" gap={Spacing.md}>
+        {imageId && (
+          <Box
+            component="img"
+            src={`${CURVE_ASSETS_URL}/${imageId}`}
+            sx={{ height: IconSize.xxl, width: IconSize.xxl }}
+          />
+        )}
+        <Stack justifyContent="center">
+          <Typography variant="headingSBold">{name}</Typography>
+
+          {networks && Object.values(networks).some((x) => x) && (
+            <StackedChainIcons
+              blockchainIds={Object.entries(networks)
+                .filter(([, enabled]) => enabled)
+                .map(([networkId]) => networkId)}
             />
           )}
-          <Stack justifyContent="center">
-            <Typography variant="headingSBold">{name}</Typography>
-
-            {networks && Object.values(networks).some((x) => x) && (
-              <StackedChainIcons
-                blockchainIds={Object.entries(networks)
-                  .filter(([, enabled]) => enabled)
-                  .map(([networkId]) => networkId)}
-              />
-            )}
-          </Stack>
         </Stack>
+      </Stack>
 
-        {description && (
-          <Typography flexGrow={1} variant="bodyMRegular">
-            {description}
-          </Typography>
-        )}
+      {description && (
+        <Typography flexGrow={1} variant="bodyMRegular">
+          {description}
+        </Typography>
+      )}
 
-        {/** Could be replaced with icon buttons if somebody's feeling cute */}
-        <Stack direction="row" gap={Spacing.sm} justifyContent="space-between">
-          <Stack direction="row" gap={Spacing.sm} alignItems="center">
-            {appUrl && (
-              <IconButton {...LinkProps} href={appUrl}>
-                <GlobeIcon />
-              </IconButton>
-            )}
-            {twitterUrl && (
-              <IconButton {...LinkProps} href={twitterUrl}>
-                <XIcon />
-              </IconButton>
-            )}
-          </Stack>
-
-          {tags?.length && (
-            <Stack direction="row" gap={Spacing.sm} alignItems="center">
-              {tags.map((tag) => (
-                <Chip key={tag} label={tag} color="highlight" />
-              ))}
-            </Stack>
+      {/** Could be replaced with icon buttons if somebody's feeling cute */}
+      <Stack direction="row" gap={Spacing.sm} justifyContent="space-between">
+        <Stack direction="row" gap={Spacing.sm} alignItems="center">
+          {appUrl && (
+            <IconButton {...LinkProps} href={appUrl}>
+              <GlobeIcon />
+            </IconButton>
+          )}
+          {twitterUrl && (
+            <IconButton {...LinkProps} href={twitterUrl}>
+              <XIcon />
+            </IconButton>
           )}
         </Stack>
+
+        {tags?.length && (
+          <Stack direction="row" gap={Spacing.sm} alignItems="center">
+            {tags.map((tag) => (
+              <Chip key={tag} label={tag} color="highlight" />
+            ))}
+          </Stack>
+        )}
       </Stack>
     </CardContent>
   </Card>

--- a/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
@@ -6,20 +6,27 @@ import { handleBreakpoints } from '../../basic-theme'
 
 const { Spacing } = SizesAndSpaces
 
+const Padding = {
+  xs: Spacing.xs,
+  sm: Spacing.sm,
+  md: Spacing.md,
+  lg: Spacing.lg,
+}
+
 export const defineMuiCardContent = (design: DesignSystem): Components['MuiCardContent'] => ({
   styleOverrides: {
     root: {
       backgroundColor: design.Layer[1].Fill,
-      ...handleBreakpoints({ padding: Spacing.md }),
-      '&:last-child': handleBreakpoints({ paddingBlockEnd: Spacing.md }),
+      ...handleBreakpoints({ padding: Padding.md }),
+      '&:last-child': handleBreakpoints({ paddingBlockEnd: Padding.md }),
     },
   },
   variants: [
     {
       props: { size: 'small' },
       style: {
-        ...handleBreakpoints({ padding: Spacing.sm }),
-        '&:last-child': handleBreakpoints({ paddingBlockEnd: Spacing.sm }),
+        ...handleBreakpoints({ padding: Padding.sm }),
+        '&:last-child': handleBreakpoints({ paddingBlockEnd: Padding.sm }),
       },
     },
   ],

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormContent.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormContent.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
 import Stack from '@mui/material/Stack'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -23,9 +25,11 @@ export const FormContent = ({
   <WithWrapper shouldWrap={footer} Wrapper={Stack} gap={Spacing.sm}>
     <WithWrapper shouldWrap={header} Wrapper={Stack} sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
       {header}
-      <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }} gap={Spacing.md} padding={Spacing.md}>
-        {children}
-      </Stack>
+      <Card>
+        <CardContent component={Stack} size="small" gap={Spacing.md}>
+          {children}
+        </CardContent>
+      </Card>
     </WithWrapper>
     {footer}
   </WithWrapper>

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormSkeleton.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormSkeleton.tsx
@@ -1,14 +1,11 @@
 import Button from '@mui/material/Button'
 import Skeleton from '@mui/material/Skeleton'
-import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { noop } from '@tanstack/react-query'
 import { t } from '@ui-kit/lib/i18n'
 import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { FormContent } from './FormContent'
 import { FormTabs } from './FormTabs'
-
-const { Spacing } = SizesAndSpaces
 
 export const FormSkeleton = () => (
   <FormTabs
@@ -18,7 +15,7 @@ export const FormSkeleton = () => (
         value: 'tab',
         label: <Skeleton width={100} />,
         component: () => (
-          <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }} gap={Spacing.md} padding={Spacing.md}>
+          <FormContent>
             <Skeleton width="100%">
               <LargeTokenInput name="loading" onBalance={noop} message={t`Loading`} />
             </Skeleton>
@@ -26,7 +23,7 @@ export const FormSkeleton = () => (
               <Typography variant="buttonM">{t`Loading form...`}</Typography>
             </Skeleton>
             <Button loading disabled fullWidth />
-          </Stack>
+          </FormContent>
         ),
       },
     ]}


### PR DESCRIPTION
1. Uses card specific paddings from Figma.
2. Make the new forms use `<Card>` and `<CardContent>` such that they use aforementioned configured paddings.
3. As per Figma, the forms should use the smaller sized `<CardContent>`

As a bonus, I've went across most usages of `<CardContent>` and in most cases when there's only a single child, often `<Stack>`, (except when `<Grid>` is being used), we can use the `component` property to reduce nesting.

So as a tip, when reviewing the PR, hide whitespace changes to lessen the diff size.

<img width="469" height="376" alt="image" src="https://github.com/user-attachments/assets/afe0276d-afaa-4f52-8647-ea27a35ee34d" />

The follow 3 chart cards also have been changed to small card content as per Figma
<img width="1076" height="970" alt="image" src="https://github.com/user-attachments/assets/af27befb-75fa-4836-a20b-86f317afdb23" />
