### PR TITLE
refactor: Llama market deprecations by type

### DIFF
--- a/BLACKLISTS-DEPRECATIONS.md
+++ b/BLACKLISTS-DEPRECATIONS.md
@@ -44,13 +44,13 @@ Examples of deprecation reasons include protocol exploits, vulnerabilities, misc
 
 ### Market Deprecations
 
-**Location:** [`apps/main/src/llamalend/queries/market-list/constants.ts`](apps/main/src/llamalend/queries/market-list/constants.ts)
+**Location:** [`apps/main/src/llamalend/llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)
 
 LlamaLend market deprecations are defined in the `DEPRECATED_LLAMAS` constant. `llama-markets.ts` reads from that constant and maps matching markets to a `deprecatedMessage` field. When set, the market surfaces a deprecation notice to the user. Markets with a deprecation message will be excluded from listings, while still remaining accessible to users with existing positions.
 
 ### Market Alerts
 
-**Location:** [`apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx`](apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx)
+**Location:** [`apps/main/src/llamalend/llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)
 
 LlamaLend also has a separate market alert mechanism for cases where a market should stay visible but new actions should be discouraged or blocked.
 
@@ -63,5 +63,5 @@ These alerts are distinct from `DEPRECATED_LLAMAS`. They can show a banner on th
 | Blacklist   | Pools         | Hidden from front-end                         | [`pools-blacklist.query.ts`](apps/main/src/dex/queries/pools-blacklist.query.ts)              |
 | Blacklist   | Tokens        | Shown as disabled in token selector           | [`blacklist.ts`](packages/curve-ui-kit/src/features/select-token/blacklist.ts)                |
 | Deprecation | Pools         | Warning shown, actions may be disabled        | [`usePoolAlert.tsx`](apps/main/src/dex/hooks/usePoolAlert.tsx)                                |
-| Deprecation | Markets       | Badge/banner shown;                           | [`constants.ts`](apps/main/src/llamalend/queries/market-list/constants.ts)                    |
-| Deprecation | Market alerts | Warning shown, borrow/deposit may be disabled | [`useMarketAlert.tsx`](apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx) |
+| Deprecation | Markets       | Badge/banner shown;                           | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)            |
+| Deprecation | Market alerts | Warning shown, borrow/deposit may be disabled | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)            |

--- a/BLACKLISTS-DEPRECATIONS.md
+++ b/BLACKLISTS-DEPRECATIONS.md
@@ -58,10 +58,10 @@ These alerts are distinct from `DEPRECATED_LLAMAS`. They can show a banner on th
 
 ## Summary
 
-| Mechanism   | Scope         | Effect                                        | Location                                                                                      |
-| ----------- | ------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Blacklist   | Pools         | Hidden from front-end                         | [`pools-blacklist.query.ts`](apps/main/src/dex/queries/pools-blacklist.query.ts)              |
-| Blacklist   | Tokens        | Shown as disabled in token selector           | [`blacklist.ts`](packages/curve-ui-kit/src/features/select-token/blacklist.ts)                |
-| Deprecation | Pools         | Warning shown, actions may be disabled        | [`usePoolAlert.tsx`](apps/main/src/dex/hooks/usePoolAlert.tsx)                                |
-| Deprecation | Markets       | Badge/banner shown;                           | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)            |
-| Deprecation | Market alerts | Warning shown, borrow/deposit may be disabled | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts)            |
+| Mechanism   | Scope         | Effect                                        | Location                                                                           |
+| ----------- | ------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Blacklist   | Pools         | Hidden from front-end                         | [`pools-blacklist.query.ts`](apps/main/src/dex/queries/pools-blacklist.query.ts)   |
+| Blacklist   | Tokens        | Shown as disabled in token selector           | [`blacklist.ts`](packages/curve-ui-kit/src/features/select-token/blacklist.ts)     |
+| Deprecation | Pools         | Warning shown, actions may be disabled        | [`usePoolAlert.tsx`](apps/main/src/dex/hooks/usePoolAlert.tsx)                     |
+| Deprecation | Markets       | Badge/banner shown;                           | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts) |
+| Deprecation | Market alerts | Warning shown, borrow/deposit may be disabled | [`llama-markets.constants.ts`](apps/main/src/llamalend/llama-markets.constants.ts) |

--- a/apps/main/src/bridge/features/bridge/BridgeFormTabs.tsx
+++ b/apps/main/src/bridge/features/bridge/BridgeFormTabs.tsx
@@ -11,7 +11,7 @@ export type BridgeFormParams = {
 
 const BridgeTab = (params: BridgeFormParams) => {
   const bridgeAlert = useBridgeAlert(params.chainId)
-  const bridgeDisabledAlert = bridgeAlert?.isDisableBridge
+  const bridgeDisabledAlert = bridgeAlert?.isBridgeDisabled
     ? { message: bridgeAlert.message, alertType: bridgeAlert.alertType }
     : undefined
 

--- a/apps/main/src/bridge/features/bridge/hooks/useBridgeAlert.tsx
+++ b/apps/main/src/bridge/features/bridge/hooks/useBridgeAlert.tsx
@@ -5,7 +5,7 @@ import { Chain } from '@ui-kit/utils'
 
 export type BridgeAlert = {
   alertType: AlertType
-  isDisableBridge?: boolean // disallow user from bridging
+  isBridgeDisabled?: boolean // disallow user from bridging
   message?: ReactNode
 }
 
@@ -13,7 +13,7 @@ type Alerts = { [chainId: number]: BridgeAlert }
 
 const RSETH_ALERT: BridgeAlert = {
   alertType: 'danger',
-  isDisableBridge: true,
+  isBridgeDisabled: true,
   message: t`FastBridge is temporarily paused as a precaution pending further clarity from a recent third-party incident. No issue has been identified with Curve.`,
 }
 

--- a/apps/main/src/lend/components/PageLendMarket/CreateLoanTabs.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/CreateLoanTabs.tsx
@@ -21,7 +21,7 @@ function CreateLoanTab({ market, rChainId, onPricesUpdated }: CreateLoanProps) {
       chainId={rChainId}
       market={market}
       onPricesUpdated={onPricesUpdated}
-      borrowDisabledAlert={marketAlert?.isDisableBorrow && marketAlert}
+      borrowDisabledAlert={marketAlert?.isBorrowDisabled && marketAlert}
     />
   )
 }

--- a/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultDepositMint/index.tsx
@@ -247,7 +247,7 @@ export const VaultDepositMint = ({ rChainId, rOwmId, isLoaded, api, market, user
       {marketAlert?.message && <AlertBox alertType={marketAlert.alertType}>{marketAlert.message}</AlertBox>}
 
       {/* actions */}
-      {!marketAlert?.isDisableDeposit && (
+      {!marketAlert?.isDepositDisabled && (
         <LoanFormConnect haveSigner={!!signerAddress} loading={!api}>
           {formStatus.error ? <AlertFormError errorKey={formStatus.error} handleBtnClose={() => reset({})} /> : null}
           {txInfoBar}

--- a/apps/main/src/lend/components/PageVault/VaultTabs.tsx
+++ b/apps/main/src/lend/components/PageVault/VaultTabs.tsx
@@ -21,7 +21,7 @@ type VaultProps = PageContentProps<MarketUrlParams>
 
 function DepositTab({ rChainId, market, isLoaded }: VaultProps) {
   const marketAlert = useMarketAlert(rChainId, getControllerAddress(market), LlamaMarketType.Lend)
-  const depositDisabledAlert = marketAlert?.isDisableDeposit
+  const depositDisabledAlert = marketAlert?.isDepositDisabled
     ? { message: marketAlert.message, alertType: marketAlert.alertType }
     : undefined
 

--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
@@ -1,58 +1,8 @@
-import { ReactNode, useMemo } from 'react'
+import { useMemo } from 'react'
+import { MARKETS_ALERTS } from '@/llamalend/llama-markets.constants'
 import { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { Address } from '@primitives/address.utils'
-import { AlertType } from '@ui/AlertBox/types'
-import type { TooltipProps } from '@ui/Tooltip/types'
-import { t } from '@ui-kit/lib/i18n'
-import type { BannerProps } from '@ui-kit/shared/ui/Banner'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { Chain } from '@ui-kit/utils'
-
-export type MarketAlert = TooltipProps & {
-  alertType: AlertType
-  isDisableBorrow?: boolean // disallow user from creating new borrow positions
-  isDisableDeposit?: boolean // disallow user from supply deposit
-  // banner message, related to the market situation
-  banner?: Omit<BannerProps, 'children'> & { title: ReactNode }
-  // action card message, related to action of user
-  message?: ReactNode
-}
-
-export const MARKETS_ALERTS: Record<
-  LlamaMarketType,
-  { [chainId: number]: { [controllerAddress: Address]: MarketAlert } }
-> = {
-  /** LEND MARKET ALERTS */
-  Lend: {
-    [Chain.Ethereum]: {
-      // one-way-market-30 - sDOLA/crvUSD
-      '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
-        alertType: 'danger',
-        isDisableBorrow: true,
-        isDisableDeposit: true,
-        message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
-      },
-      // one-way-market-3 - CRV/crvUSD
-      '0xeda215b7666936ded834f76f3fbc6f323295110a': {
-        alertType: 'danger',
-        isDisableBorrow: true,
-        isDisableDeposit: true,
-        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-      },
-    },
-    [Chain.Arbitrum]: {
-      // one-way-market-7 - FXN/crvUSD
-      '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
-        alertType: 'danger',
-        isDisableDeposit: true,
-        message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
-      },
-    },
-  },
-
-  /** MINT MARKET ALERTS */
-  Mint: {},
-}
 
 export const useMarketAlert = <ChainId extends IChainId>(
   rChainId: ChainId,

--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
@@ -18,36 +18,41 @@ export type MarketAlert = TooltipProps & {
   message?: ReactNode
 }
 
-export type Alerts = { [chainId: number]: { [controllerAddress: Address]: MarketAlert } }
+export const MARKETS_ALERTS: Record<
+  LlamaMarketType,
+  { [chainId: number]: { [controllerAddress: Address]: MarketAlert } }
+> = {
+  /** LEND MARKET ALERTS */
+  Lend: {
+    [Chain.Ethereum]: {
+      // one-way-market-30 - sDOLA/crvUSD
+      '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
+        alertType: 'danger',
+        isDisableBorrow: true,
+        isDisableDeposit: true,
+        message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
+      },
+      // one-way-market-3 - CRV/crvUSD
+      '0xeda215b7666936ded834f76f3fbc6f323295110a': {
+        alertType: 'danger',
+        isDisableBorrow: true,
+        isDisableDeposit: true,
+        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
+      },
+    },
+    [Chain.Arbitrum]: {
+      // one-way-market-7 - FXN/crvUSD
+      '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
+        alertType: 'danger',
+        isDisableDeposit: true,
+        message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
+      },
+    },
+  },
 
-export const LEND_MARKETS_ALERTS: Alerts = {
-  [Chain.Ethereum]: {
-    // one-way-market-30 - sDOLA/crvUSD
-    '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
-      alertType: 'danger',
-      isDisableBorrow: true,
-      isDisableDeposit: true,
-      message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
-    },
-    // one-way-market-3 - CRV/crvUSD
-    '0xeda215b7666936ded834f76f3fbc6f323295110a': {
-      alertType: 'danger',
-      isDisableBorrow: true,
-      isDisableDeposit: true,
-      message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-    },
-  },
-  [Chain.Arbitrum]: {
-    // one-way-market-7 - FXN/crvUSD
-    '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
-      alertType: 'danger',
-      isDisableDeposit: true,
-      message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
-    },
-  },
+  /** MINT MARKET ALERTS */
+  Mint: {},
 }
-
-export const MINT_MARKETS_ALERTS: Alerts = {}
 
 export const useMarketAlert = <ChainId extends IChainId>(
   rChainId: ChainId,
@@ -57,7 +62,7 @@ export const useMarketAlert = <ChainId extends IChainId>(
   useMemo(
     () =>
       controllerAddress &&
-      (marketType === LlamaMarketType.Lend ? LEND_MARKETS_ALERTS : MINT_MARKETS_ALERTS)[rChainId]?.[
+      MARKETS_ALERTS[marketType][rChainId]?.[
         // we have tests to be sure that all controller addresses of the alerts are lowercase
         controllerAddress.toLowerCase() as Address
       ],

--- a/apps/main/src/llamalend/hooks/useDeprecatedMarket.ts
+++ b/apps/main/src/llamalend/hooks/useDeprecatedMarket.ts
@@ -3,20 +3,23 @@ import { isAddressEqual } from 'viem'
 import { DEPRECATED_LLAMAS } from '@/llamalend/llama-markets.constants'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 
 export const useDeprecatedMarket = ({
   blockchainId,
   controllerAddress,
+  marketType,
 }: {
   blockchainId: Chain | undefined
   controllerAddress: Address | undefined
+  marketType: LlamaMarketType
 }) =>
   useMemo(() => {
     if (!blockchainId || !controllerAddress) return null
 
     return (
-      Object.entries(DEPRECATED_LLAMAS[blockchainId] ?? {}).find(([address]) =>
+      Object.entries(DEPRECATED_LLAMAS[marketType][blockchainId] ?? {}).find(([address]) =>
         isAddressEqual(address as Address, controllerAddress),
       )?.[1] ?? null
     )
-  }, [blockchainId, controllerAddress])
+  }, [blockchainId, controllerAddress, marketType])

--- a/apps/main/src/llamalend/hooks/useDeprecatedMarket.ts
+++ b/apps/main/src/llamalend/hooks/useDeprecatedMarket.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { isAddressEqual } from 'viem'
-import { DEPRECATED_LLAMAS } from '@/llamalend/queries/market-list/constants'
+import { DEPRECATED_LLAMAS } from '@/llamalend/llama-markets.constants'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -60,117 +60,129 @@ export type DeprecatedMarketAlert = { message: string; url?: string }
 const DEFAULT_DEPRECATE: DeprecatedMarketAlert = { message: t`This market is deprecated.` }
 
 // Deprecated markets are hidden from market list for new users but remain accessible to users with existing positions.
-export const DEPRECATED_LLAMAS: PartialRecord<ApiChain, Record<Address, DeprecatedMarketAlert>> = {
-  ethereum: {
-    // sfrxETH v1 mint market
-    '0x8472A9A7632b173c8Cf3a86D3afec50c35548e76': {
-      message: t`Please note this market is being phased out. We recommend migrating to the sfrxETH v2 market which uses an updated oracle.`,
+export const DEPRECATED_LLAMAS: Record<
+  LlamaMarketType,
+  PartialRecord<ApiChain, Record<Address, DeprecatedMarketAlert>>
+> = {
+  /** DEPRECATED LEND MARKET */
+  Lend: {
+    ethereum: {
+      // swBTC-crvUSD
+      '0x276B8C8873079eEACCF4Dd241De14be92D733b45': {
+        message: t`This market is empty (it's never been used) and the oracle cannot be trusted.`,
+      },
+      // wstUSR-crvUSD
+      '0x89707721927d7aaeeee513797A8d6cBbD0e08f41': DEFAULT_DEPRECATE,
+      // sDOLA-crvUSD 2024-07-17
+      '0xCf3DF6C1B4A6b38496661B31170de9508b867C8E': DEFAULT_DEPRECATE,
+      // sDOLA-crvUSD
+      '0xaD444663c6C92B497225c6cE65feE2E7F78BFb86': {
+        message: t`This market is deprecated after donation attack.`,
+      },
+      // crvUSD-WETH old
+      '0xa5D9137d2A1Ee912469d911A8E74B6c77503bac8': DEFAULT_DEPRECATE,
+      // crvUSD-tBTC old
+      '0xe438658874b0acf4D81c24172E137F0eE00621b8': DEFAULT_DEPRECATE,
+      // USD0USD0++-crvUSD old
+      '0xDC8b1Caf2e10dE76fb67E82C2485E7d4fA098C53': DEFAULT_DEPRECATE,
+      // ynETH-crvUSD
+      '0xdC5D5EE1223D4C8b7eAc8e876793f2171e7e8dEb': DEFAULT_DEPRECATE,
+      // crvUSD-ynETH
+      '0x757C61d89bD0406BfcBB68178BBfaE79ECa46c0f': DEFAULT_DEPRECATE,
+      // LBTC-crvUSD
+      '0xC28C2FD809FC1795f90de1C9dA2131434A77721d': DEFAULT_DEPRECATE,
+      // sUSDf-crvUSD
+      '0xD961B0Da2B0Fb04439c96B552777720B5FC551A0': DEFAULT_DEPRECATE,
+      // yvUSDC-1-crvUSD
+      '0xB62B9272679d7A495d7e9698d8663F217224408a': DEFAULT_DEPRECATE,
+      // yvUSDS-1-crvUSD
+      '0xE786af7faef857C8D850d648723Eec0A27cd8581': DEFAULT_DEPRECATE,
+      // yvWETH-1-crvUSD
+      '0x5bfEE37053d711F49A0aCf5afEd6496fA68dCE32': DEFAULT_DEPRECATE,
+      // zkBTC-crvUSD
+      '0xbe0f8c48776c0433B2b778AE9c076C21683ebe7B': DEFAULT_DEPRECATE,
+      // zkBTC-crvUSD (2)
+      '0xbCc9AcD2E7934bb8B5d734416737694AcDD9E25a': DEFAULT_DEPRECATE,
+      // sdeUSD-crvUSD
+      '0xFA4f65B3Dc477738ce8618e9145E1f0Ad9E29034': DEFAULT_DEPRECATE,
+      // ezETH-crvUSD
+      '0x3c1350aa6FaFF17c87Bde2015BBb45100D37dAD3': DEFAULT_DEPRECATE,
+      // CRV-crvUSD
+      '0xEdA215b7666936DEd834f76f3fBC6F323295110A': {
+        message: t`This market is deprecated, read the governance post to learn more.`,
+        url: 'https://gov.curve.finance/t/crv-long-llamalend-market-next-steps/11045',
+      },
     },
-    // swBTC-crvUSD lend market
-    '0x276B8C8873079eEACCF4Dd241De14be92D733b45': {
-      message: t`This market is empty (it's never been used) and the oracle cannot be trusted.`,
+    arbitrum: {
+      // iBTC-crvUSD
+      '0x3e293dB65c81742e32b74E21A0787d2936beeDf7': { message: t`iBTC is undergoing systematic unwinding` },
+      // EYWA-crvUSD
+      '0x7a5A1c91dAF5A41942F90b3f8a9c4d3526294c16': DEFAULT_DEPRECATE,
+      // FXN-crvUSD
+      '0x7Adcc491f0B7f9BC12837B8F5Edf0e580d176F1f': DEFAULT_DEPRECATE,
+      // FXN-crvUSD
+      '0xAe659CE8f2f23649E09e92D164244AA127A7a2c7': DEFAULT_DEPRECATE,
+      // CRV-crvUSD
+      '0xF4e35f69D0BeE1AFC26EE73f12Fa7fA220F16F40': DEFAULT_DEPRECATE,
+      // IBTC-crvUSD
+      '0x991Bf50A34972227e681127D9127a1Dc54f67a3b': DEFAULT_DEPRECATE,
+      // tBTC-crvUSD
+      '0x4153532Eb32D57a1a08cD024c66E79635aFC8e3a': DEFAULT_DEPRECATE,
+      // stXAI-crvUSD
+      '0x5A2b666E6f36CB0a17CF03c9feb421855Ca9751D': DEFAULT_DEPRECATE,
+      // stXAI-crvUSD
+      '0x6c1cD25cC6320f992EDE07F6a6e93810e8855bc2': DEFAULT_DEPRECATE,
+      // WBTC-crvUSD old
+      '0x28c20590de7539C316191F413686dcF794d8898E': DEFAULT_DEPRECATE,
+      // gmUSDC-crvUSD
+      '0x4064Ed6Ae070F126F56c47c8a8CdD6B924668b5D': DEFAULT_DEPRECATE,
+      // gmUSDC-crvUSD
+      '0x5014AB37Fca7201baDEc3C0d0f28Dc7899cdC7D5': DEFAULT_DEPRECATE,
+      // stXAI-crvUSD
+      '0x398e6dd92Df9F792D0107668871e6F49ebdfE028': DEFAULT_DEPRECATE,
+      // ARB-crvUSD old
+      '0x76709bC0dA299Ab0234EEC51385E900922AE98f5': DEFAULT_DEPRECATE,
     },
-    //wstUSR-crvUSD lend market
-    '0x89707721927d7aaeeee513797A8d6cBbD0e08f41': DEFAULT_DEPRECATE,
-    // LBTC-crvUSD v1 mint market
-    '0x8aca5A776a878Ea1F8967e70a23b8563008f58Ef': DEFAULT_DEPRECATE,
-    // sDOLA-crvUSD 2024-07-17 lend market
-    '0xCf3DF6C1B4A6b38496661B31170de9508b867C8E': DEFAULT_DEPRECATE,
-    // sDOLA-crvUSD
-    '0xaD444663c6C92B497225c6cE65feE2E7F78BFb86': {
-      message: t`This market is deprecated after donation attack.`,
+    sonic: {
+      // sTS-crvUSD
+      '0xB8C93fb97884Ea07c2Eb0eA741f78D10e8C5aF9F': DEFAULT_DEPRECATE,
+      // scETH-crvUSD
+      '0x7547E577B3DDC23c02E10792457f8e51a225692E': DEFAULT_DEPRECATE,
+      // wS-crvUSD
+      '0x5eD490a9B71fa797231d2c5D9bE25bf91a953C19': DEFAULT_DEPRECATE,
+      // scUSD-crvUSD
+      '0xbb7A0C558Fd34234Dc1608f4CD0a334E0075D73a': DEFAULT_DEPRECATE,
+      // wOS-crvUSD
+      '0xDC06056e208aB92bF173FF6DD662F1018ea0E483': DEFAULT_DEPRECATE,
     },
-    // crvUSD-WETH old lend market
-    '0xa5D9137d2A1Ee912469d911A8E74B6c77503bac8': DEFAULT_DEPRECATE,
-    //crvUSD-tBTC old lend market
-    '0xe438658874b0acf4D81c24172E137F0eE00621b8': DEFAULT_DEPRECATE,
-    // USD0USD0++-crvUSD old lend market
-    '0xDC8b1Caf2e10dE76fb67E82C2485E7d4fA098C53': DEFAULT_DEPRECATE,
-    // ynETH-crvUSD lend market
-    '0xdC5D5EE1223D4C8b7eAc8e876793f2171e7e8dEb': DEFAULT_DEPRECATE,
-    // crvUSD-ynETH lend market
-    '0x757C61d89bD0406BfcBB68178BBfaE79ECa46c0f': DEFAULT_DEPRECATE,
-    // LBTC-crvUSD lend market
-    '0xC28C2FD809FC1795f90de1C9dA2131434A77721d': DEFAULT_DEPRECATE,
-    // sUSDf-crvUSD lend market
-    '0xD961B0Da2B0Fb04439c96B552777720B5FC551A0': DEFAULT_DEPRECATE,
-    // yvUSDC-1-crvUSD lend market
-    '0xB62B9272679d7A495d7e9698d8663F217224408a': DEFAULT_DEPRECATE,
-    // yvUSDS-1-crvUSD lend market
-    '0xE786af7faef857C8D850d648723Eec0A27cd8581': DEFAULT_DEPRECATE,
-    // yvWETH-1-crvUSD lend market
-    '0x5bfEE37053d711F49A0aCf5afEd6496fA68dCE32': DEFAULT_DEPRECATE,
-    // zkBTC-crvUSD lend market
-    '0xbe0f8c48776c0433B2b778AE9c076C21683ebe7B': DEFAULT_DEPRECATE,
-    // zkBTC-crvUSD (2) lend market
-    '0xbCc9AcD2E7934bb8B5d734416737694AcDD9E25a': DEFAULT_DEPRECATE,
-    // sdeUSD-crvUSD lend market
-    '0xFA4f65B3Dc477738ce8618e9145E1f0Ad9E29034': DEFAULT_DEPRECATE,
-    // ezETH-crvUSD lend market
-    '0x3c1350aa6FaFF17c87Bde2015BBb45100D37dAD3': DEFAULT_DEPRECATE,
-    // CRV-crvUSD lend market
-    '0xEdA215b7666936DEd834f76f3fBC6F323295110A': {
-      message: t`This market is deprecated, read the governance post to learn more.`,
-      url: 'https://gov.curve.finance/t/crv-long-llamalend-market-next-steps/11045',
+    optimism: {
+      // WBTC-crvUSD
+      '0x09cEd8b3392bED73B0358e39AaEC0A6e9b0e76DF': DEFAULT_DEPRECATE,
+      // CRV-crvUSD
+      '0x88aa928B906b745009B53A31034701Fc377b7C89': DEFAULT_DEPRECATE,
+      // wstETH-crvUSD
+      '0x6CE5B539367A29d48038A9F3108E6e0f226b83ed': DEFAULT_DEPRECATE,
+      // OP-crvUSD
+      '0xC5Cd9f6A1Fb88bed782f475F72fF686ED35b7e8e': DEFAULT_DEPRECATE,
+      // WETH-crvUSD
+      '0x9dba46e6a06FBf24CA11f8912B44338fe1b28Ea9': DEFAULT_DEPRECATE,
+    },
+    fraxtal: {
+      // CRV-crvUSD
+      '0x99d5b47D431f1963940F72ffa6F25bC0B9849CbF': DEFAULT_DEPRECATE,
     },
   },
-  arbitrum: {
-    // iBTC-crvUSD lend market
-    '0x3e293dB65c81742e32b74E21A0787d2936beeDf7': { message: t`iBTC is undergoing systematic unwinding` },
-    // EYWA-crvUSD lend market
-    '0x7a5A1c91dAF5A41942F90b3f8a9c4d3526294c16': DEFAULT_DEPRECATE,
-    // FXN-crvUSD lend market
-    '0x7Adcc491f0B7f9BC12837B8F5Edf0e580d176F1f': DEFAULT_DEPRECATE,
-    // FXN-crvUSD lend market
-    '0xAe659CE8f2f23649E09e92D164244AA127A7a2c7': DEFAULT_DEPRECATE,
-    // CRV-crvUSD lend market
-    '0xF4e35f69D0BeE1AFC26EE73f12Fa7fA220F16F40': DEFAULT_DEPRECATE,
-    // IBTC-crvUSD lend market
-    '0x991Bf50A34972227e681127D9127a1Dc54f67a3b': DEFAULT_DEPRECATE,
-    // tBTC-crvUSD lend market
-    '0x4153532Eb32D57a1a08cD024c66E79635aFC8e3a': DEFAULT_DEPRECATE,
-    // stXAI-crvUSD lend market
-    '0x5A2b666E6f36CB0a17CF03c9feb421855Ca9751D': DEFAULT_DEPRECATE,
-    // stXAI-crvUSD lend market
-    '0x6c1cD25cC6320f992EDE07F6a6e93810e8855bc2': DEFAULT_DEPRECATE,
-    // WBTC-crvUSD old lend market
-    '0x28c20590de7539C316191F413686dcF794d8898E': DEFAULT_DEPRECATE,
-    // gmUSDC-crvUSD lend market
-    '0x4064Ed6Ae070F126F56c47c8a8CdD6B924668b5D': DEFAULT_DEPRECATE,
-    // gmUSDC-crvUSD lend market
-    '0x5014AB37Fca7201baDEc3C0d0f28Dc7899cdC7D5': DEFAULT_DEPRECATE,
-    // stXAI-crvUSD lend market
-    '0x398e6dd92Df9F792D0107668871e6F49ebdfE028': DEFAULT_DEPRECATE,
-    // ARB-crvUSD old lend market
-    '0x76709bC0dA299Ab0234EEC51385E900922AE98f5': DEFAULT_DEPRECATE,
-  },
-  sonic: {
-    // sTS-crvUSD lend market
-    '0xB8C93fb97884Ea07c2Eb0eA741f78D10e8C5aF9F': DEFAULT_DEPRECATE,
-    // scETH-crvUSD lend market
-    '0x7547E577B3DDC23c02E10792457f8e51a225692E': DEFAULT_DEPRECATE,
-    // wS-crvUSD lend market
-    '0x5eD490a9B71fa797231d2c5D9bE25bf91a953C19': DEFAULT_DEPRECATE,
-    // scUSD-crvUSD lend market
-    '0xbb7A0C558Fd34234Dc1608f4CD0a334E0075D73a': DEFAULT_DEPRECATE,
-    // wOS-crvUSD lend market
-    '0xDC06056e208aB92bF173FF6DD662F1018ea0E483': DEFAULT_DEPRECATE,
-  },
-  optimism: {
-    // WBTC-crvUSD lend market
-    '0x09cEd8b3392bED73B0358e39AaEC0A6e9b0e76DF': DEFAULT_DEPRECATE,
-    // CRV-crvUSD lend market
-    '0x88aa928B906b745009B53A31034701Fc377b7C89': DEFAULT_DEPRECATE,
-    // wstETH-crvUSD lend market
-    '0x6CE5B539367A29d48038A9F3108E6e0f226b83ed': DEFAULT_DEPRECATE,
-    // OP-crvUSD lend market
-    '0xC5Cd9f6A1Fb88bed782f475F72fF686ED35b7e8e': DEFAULT_DEPRECATE,
-    // WETH-crvUSD lend market
-    '0x9dba46e6a06FBf24CA11f8912B44338fe1b28Ea9': DEFAULT_DEPRECATE,
-  },
-  fraxtal: {
-    // CRV-crvUSD
-    '0x99d5b47D431f1963940F72ffa6F25bC0B9849CbF': DEFAULT_DEPRECATE,
+
+  /** DEPRECATED MINT MARKET */
+  Mint: {
+    ethereum: {
+      // sfrxETH v1
+      '0x8472A9A7632b173c8Cf3a86D3afec50c35548e76': {
+        message: t`Please note this market is being phased out. We recommend migrating to the sfrxETH v2 market which uses an updated oracle.`,
+      },
+      // LBTC-crvUSD v1
+      '0x8aca5A776a878Ea1F8967e70a23b8563008f58Ef': DEFAULT_DEPRECATE,
+    },
   },
 }
 

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -11,8 +11,8 @@ import { Chain } from '@ui-kit/utils'
 
 type MarketAlert = TooltipProps & {
   alertType: AlertType
-  isDisableBorrow?: boolean // disallow user from creating new borrow positions
-  isDisableDeposit?: boolean // disallow user from supply deposit
+  isBorrowDisabled?: boolean // disallow user from creating new borrow positions
+  isDepositDisabled?: boolean // disallow user from supply deposit
   // banner message, related to the market situation
   banner?: Omit<BannerProps, 'children'> & { title: ReactNode }
   // action card message, related to action of user
@@ -30,15 +30,15 @@ export const MARKETS_ALERTS: Record<
       // one-way-market-30 - sDOLA/crvUSD
       '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
         alertType: 'danger',
-        isDisableBorrow: true,
-        isDisableDeposit: true,
+        isBorrowDisabled: true,
+        isDepositDisabled: true,
         message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
       },
       // one-way-market-3 - CRV/crvUSD
       '0xeda215b7666936ded834f76f3fbc6f323295110a': {
         alertType: 'danger',
-        isDisableBorrow: true,
-        isDisableDeposit: true,
+        isBorrowDisabled: true,
+        isDepositDisabled: true,
         message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
       },
     },
@@ -46,7 +46,7 @@ export const MARKETS_ALERTS: Record<
       // one-way-market-7 - FXN/crvUSD
       '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
         alertType: 'danger',
-        isDisableDeposit: true,
+        isBorrowDisabled: true,
         message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
       },
     },

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -1,13 +1,66 @@
-import { type Chain } from '@curvefi/prices-api'
+import { ReactNode } from 'react'
+import { type Chain as ApiChain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { type PartialRecord } from '@primitives/objects.utils'
+import { AlertType } from '@ui/AlertBox/types'
+import type { TooltipProps } from '@ui/Tooltip/types'
 import { t } from '@ui-kit/lib/i18n'
+import type { BannerProps } from '@ui-kit/shared/ui/Banner'
+import { LlamaMarketType } from '@ui-kit/types/market'
+import { Chain } from '@ui-kit/utils'
 
-export type DeprecatedMarket = { message: string; url?: string }
+type MarketAlert = TooltipProps & {
+  alertType: AlertType
+  isDisableBorrow?: boolean // disallow user from creating new borrow positions
+  isDisableDeposit?: boolean // disallow user from supply deposit
+  // banner message, related to the market situation
+  banner?: Omit<BannerProps, 'children'> & { title: ReactNode }
+  // action card message, related to action of user
+  message?: ReactNode
+}
 
-const DEFAULT_DEPRECATE: DeprecatedMarket = { message: t`This market is deprecated.` }
+// Market alerts keep markets visible while surfacing warnings or disabling new borrow/deposit actions.
+export const MARKETS_ALERTS: Record<
+  LlamaMarketType,
+  { [chainId: number]: { [controllerAddress: Address]: MarketAlert } }
+> = {
+  /** LEND MARKET ALERTS */
+  Lend: {
+    [Chain.Ethereum]: {
+      // one-way-market-30 - sDOLA/crvUSD
+      '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
+        alertType: 'danger',
+        isDisableBorrow: true,
+        isDisableDeposit: true,
+        message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
+      },
+      // one-way-market-3 - CRV/crvUSD
+      '0xeda215b7666936ded834f76f3fbc6f323295110a': {
+        alertType: 'danger',
+        isDisableBorrow: true,
+        isDisableDeposit: true,
+        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
+      },
+    },
+    [Chain.Arbitrum]: {
+      // one-way-market-7 - FXN/crvUSD
+      '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
+        alertType: 'danger',
+        isDisableDeposit: true,
+        message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
+      },
+    },
+  },
 
-export const DEPRECATED_LLAMAS: PartialRecord<Chain, Record<Address, DeprecatedMarket>> = {
+  /** MINT MARKET ALERTS */
+  Mint: {},
+}
+
+export type DeprecatedMarketAlert = { message: string; url?: string }
+const DEFAULT_DEPRECATE: DeprecatedMarketAlert = { message: t`This market is deprecated.` }
+
+// Deprecated markets are hidden from market list for new users but remain accessible to users with existing positions.
+export const DEPRECATED_LLAMAS: PartialRecord<ApiChain, Record<Address, DeprecatedMarketAlert>> = {
   ethereum: {
     // sfrxETH v1 mint market
     '0x8472A9A7632b173c8Cf3a86D3afec50c35548e76': {
@@ -145,7 +198,7 @@ export const DEPRECATED_LLAMAS: PartialRecord<Chain, Record<Address, DeprecatedM
  *   .map((market) => [market.id, market.addresses.controller])
  * ```
  */
-export const NO_LEVERAGE_LEND: PartialRecord<Chain, Address[]> = {
+export const NO_LEVERAGE_LEND: PartialRecord<ApiChain, Address[]> = {
   ethereum: [
     '0x1E0165DbD2019441aB7927C018701f3138114D71',
     '0xaade9230AA9161880E13a38C83400d3D1995267b',

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -17,7 +17,7 @@ import { combineQueriesMeta, PartialQueryResult } from '@ui-kit/lib'
 import { CRVUSD_ROUTES, getInternalUrl, LEND_ROUTES } from '@ui-kit/shared/routes'
 import { type ExtraIncentive, LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import { useMappedQuery } from '@ui-kit/types/util'
-import { DEPRECATED_LLAMAS, NO_LEVERAGE_LEND } from './constants'
+import { DEPRECATED_LLAMAS, NO_LEVERAGE_LEND } from '../../llama-markets.constants'
 import { getFavoriteMarketOptions } from './favorite-markets'
 import {
   getLendingVaultsOptions,

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -115,6 +115,7 @@ const convertLendingVault = (
   userBorrows: Set<Address>,
   userSupplied: Set<Address>,
 ): LlamaMarket => {
+  const marketType = LlamaMarketType.Lend
   const hasBorrowed = userBorrows.has(controller)
   const hasSupplied = userSupplied.has(vault)
   const totalExtraRewardApy =
@@ -177,9 +178,9 @@ const convertLendingVault = (
           }))
         : [],
     },
-    type: LlamaMarketType.Lend,
+    type: marketType,
     url: getInternalUrl('lend', chain, `${LEND_ROUTES.PAGE_MARKETS}/${controller}`),
-    deprecatedMessage: DEPRECATED_LLAMAS[chain]?.[controller]?.message ?? null,
+    deprecatedMessage: DEPRECATED_LLAMAS[marketType][chain]?.[controller]?.message ?? null,
     isFavorite: favoriteMarkets.has(vault),
     rewards: [...(campaigns[vault.toLowerCase()] ?? []), ...(campaigns[controller.toLowerCase()] ?? [])],
     leverage: NO_LEVERAGE_LEND[chain]?.includes(controller) ? null : leverage,
@@ -223,6 +224,7 @@ const convertMintMarket = (
   userMintMarkets: Set<Address>,
   collateralIndex: number, // index in the list of markets with the same collateral token, used to create a unique name
 ): LlamaMarket => {
+  const marketType = LlamaMarketType.Mint
   const hasBorrow = userMintMarkets.has(address)
   const [collateralSymbol, collateralAddress] = getCollateral(collateralToken)
   const name = collateralIndex > 1 ? `${collateralSymbol}${collateralIndex}` : collateralSymbol
@@ -271,8 +273,8 @@ const convertMintMarket = (
       borrowTotalApr: computeTotalRate(borrowApr, collateralToken.rebasingYieldApr ?? 0),
       incentives: [],
     },
-    type: LlamaMarketType.Mint,
-    deprecatedMessage: DEPRECATED_LLAMAS[chain]?.[address]?.message ?? null,
+    type: marketType,
+    deprecatedMessage: DEPRECATED_LLAMAS[marketType][chain]?.[address]?.message ?? null,
     url: getInternalUrl('crvusd', chain, `${CRVUSD_ROUTES.PAGE_MARKETS}/${name}`),
     isFavorite: favoriteMarkets.has(llamma),
     rewards: [...(campaigns[address.toLowerCase()] ?? []), ...(campaigns[llamma.toLowerCase()] ?? [])],

--- a/apps/main/src/llamalend/widgets/banners/DeprecatedMarketBanner.tsx
+++ b/apps/main/src/llamalend/widgets/banners/DeprecatedMarketBanner.tsx
@@ -1,8 +1,8 @@
-import { DeprecatedMarket } from '@/llamalend/queries/market-list/constants'
+import { DeprecatedMarketAlert } from '@/llamalend/llama-markets.constants'
 import { t } from '@ui-kit/lib/i18n'
 import { Banner } from '@ui-kit/shared/ui/Banner'
 
-export const DeprecatedMarketBanner = ({ message, url }: DeprecatedMarket) => (
+export const DeprecatedMarketBanner = ({ message, url }: DeprecatedMarketAlert) => (
   <Banner severity="warning" subtitle={message} learnMoreUrl={url}>
     {t`This market is deprecated`}
   </Banner>

--- a/apps/main/src/llamalend/widgets/banners/MarketBanners.tsx
+++ b/apps/main/src/llamalend/widgets/banners/MarketBanners.tsx
@@ -29,7 +29,7 @@ export const MarketBanners = <ChainId extends IChainId>({
   const controllerAddress = getControllerAddress(market)
   const marketType = market instanceof LendMarketTemplate ? LlamaMarketType.Lend : LlamaMarketType.Mint
   const marketAlert = useMarketAlert(chainId, controllerAddress, marketType)
-  const deprecatedMarket = useDeprecatedMarket({ blockchainId, controllerAddress })
+  const deprecatedMarket = useDeprecatedMarket({ blockchainId, controllerAddress, marketType })
   const { data: solvencyMarket } = useSolvencyMarket({ type: marketType, blockchainId, controllerAddress })
   return (
     <>

--- a/tests/cypress/component/llamalend/market-alerts.cy.tsx
+++ b/tests/cypress/component/llamalend/market-alerts.cy.tsx
@@ -1,5 +1,6 @@
 import { zeroAddress } from 'viem'
-import { useMarketAlert, MARKETS_ALERTS } from '@/llamalend/features/market-list/hooks/useMarketAlert'
+import { useMarketAlert } from '@/llamalend/features/market-list/hooks/useMarketAlert'
+import { MARKETS_ALERTS } from '@/llamalend/llama-markets.constants'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { oneOf, oneValueOf } from '@cy/support/generators'
 import type { Address } from '@primitives/address.utils'

--- a/tests/cypress/component/llamalend/market-alerts.cy.tsx
+++ b/tests/cypress/component/llamalend/market-alerts.cy.tsx
@@ -1,12 +1,9 @@
 import { zeroAddress } from 'viem'
-import {
-  useMarketAlert,
-  LEND_MARKETS_ALERTS,
-  MINT_MARKETS_ALERTS,
-} from '@/llamalend/features/market-list/hooks/useMarketAlert'
+import { useMarketAlert, MARKETS_ALERTS } from '@/llamalend/features/market-list/hooks/useMarketAlert'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { oneOf } from '@cy/support/generators'
+import { oneOf, oneValueOf } from '@cy/support/generators'
 import type { Address } from '@primitives/address.utils'
+import { recordEntries, recordValues } from '@primitives/objects.utils'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { Chain } from '@ui-kit/utils'
 
@@ -34,14 +31,18 @@ const mountMarketAlert = ({
   marketType: LlamaMarketType
 }) => cy.mount(<MarketAlertHookTest chainId={chainId} controllerAddress={controllerAddress} marketType={marketType} />)
 
-const ALL_MARKET_ALERTS = [LEND_MARKETS_ALERTS, MINT_MARKETS_ALERTS] as const
+const ALL_MARKET_ALERTS = recordValues(MARKETS_ALERTS)
 
-const LEND_ALERT_CASES = Object.entries(LEND_MARKETS_ALERTS).flatMap(([chainId, chainAlerts]) =>
-  Object.entries(chainAlerts).map(([controllerAddress, alert]) => ({
-    chainId: Number(chainId) as IChainId,
-    controllerAddress: controllerAddress as Address,
-    alertType: alert.alertType,
-  })),
+/** Get a list of all alerts for each market type, and chain */
+const ALERT_CASES = recordEntries(MARKETS_ALERTS).flatMap(([marketType, marketAlerts]) =>
+  recordEntries(marketAlerts).flatMap(([chainId, chainAlerts]) =>
+    recordEntries(chainAlerts).map(([controllerAddress, alert]) => ({
+      marketType,
+      chainId: Number(chainId) as IChainId,
+      controllerAddress,
+      alertType: alert.alertType,
+    })),
+  ),
 )
 
 describe('useMarketAlert', () => {
@@ -57,12 +58,12 @@ describe('useMarketAlert', () => {
     }
   })
 
-  it(`returns the correct alert for lend checksummed addresses`, () => {
-    const alert = oneOf(...LEND_ALERT_CASES)
+  it(`returns the correct alert for checksummed addresses`, () => {
+    const alert = oneOf(...ALERT_CASES)
     mountMarketAlert({
       chainId: alert.chainId,
       controllerAddress: alert.controllerAddress.toUpperCase() as Address,
-      marketType: LlamaMarketType.Lend,
+      marketType: alert.marketType,
     })
 
     cy.get('[data-testid="market-alert-state"]').should('have.text', alert.alertType)
@@ -72,7 +73,7 @@ describe('useMarketAlert', () => {
     mountMarketAlert({
       chainId: Chain.Avalanche as IChainId,
       controllerAddress: zeroAddress,
-      marketType: LlamaMarketType.Lend,
+      marketType: oneValueOf(LlamaMarketType),
     })
 
     cy.get('[data-testid="market-alert-state"]').should('have.text', 'missing')


### PR DESCRIPTION
- moved market alerts and deprecated markets in a shared `llama-markets.constants.ts` file
- refactor LlamaLend deprecated markets divided by Lend and Mint type

next: https://github.com/curvefi/curve-frontend/pull/2397