### PR TITLE
feat: derive borrow token symbol instead of hard coding crvusd

### DIFF
--- a/apps/main/src/llamalend/features/market-position-details/BorrowInformation.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/BorrowInformation.tsx
@@ -100,7 +100,7 @@ export const BorrowInformation = ({
         label={t`Total debt`}
         value={totalDebt?.value}
         loading={totalDebt?.loading}
-        valueOptions={{ unit: { symbol: 'crvUSD', position: 'suffix' } }}
+        valueOptions={{ unit: { symbol: collateralValue?.borrow?.symbol ?? '?', position: 'suffix' } }}
         valueTooltip={{
           title: t`Total Debt`,
           body: <TotalDebtTooltipContent />,

--- a/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
@@ -22,8 +22,8 @@ export const CollateralMetricTooltipContent = ({ collateralValue }: CollateralMe
     collateralValue?.collateral?.usdRate,
   )
 
-  const crvUSDValueFormatted = formatMetricValue(collateralValue?.borrow?.value)
-  const crvUSDPercentage = formatPercentage(
+  const borrowValueFormatted = formatMetricValue(collateralValue?.borrow?.value)
+  const borrowPercentage = formatPercentage(
     collateralValue?.borrow?.value,
     collateralValue?.totalValue,
     collateralValue?.borrow?.usdRate,
@@ -37,7 +37,7 @@ export const CollateralMetricTooltipContent = ({ collateralValue }: CollateralMe
   return (
     <TooltipWrapper>
       <TooltipDescription
-        text={t`Collateral value is taken by multiplying tokens in collateral by the oracle price. In soft liquidation, it may include crvUSD due to liquidation protection.`}
+        text={t`Collateral value is taken by multiplying tokens in collateral by the oracle price. In soft liquidation, it may include ${collateralValue?.borrow.symbol} due to liquidation protection.`}
       />
 
       <Stack>
@@ -47,8 +47,8 @@ export const CollateralMetricTooltipContent = ({ collateralValue }: CollateralMe
             {collateralPercentage && ` (${collateralPercentage})`}
           </TooltipItem>
           <TooltipItem title={t`Borrow token`} variant="independent">
-            {`${crvUSDValueFormatted} ${collateralValue?.borrow?.symbol}`}
-            {crvUSDPercentage && ` (${crvUSDPercentage})`}
+            {`${borrowValueFormatted} ${collateralValue?.borrow?.symbol}`}
+            {borrowPercentage && ` (${borrowPercentage})`}
           </TooltipItem>
         </TooltipItems>
       </Stack>

--- a/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
@@ -34,20 +34,23 @@ export const CollateralMetricTooltipContent = ({ collateralValue }: CollateralMe
       ? formatUsd(collateralValue.totalValue, { abbreviate: false })
       : UnavailableNotation
 
+  const collateralTokenSymbol = collateralValue?.collateral?.symbol ?? '?'
+  const borrowTokenSymbol = collateralValue?.borrow?.symbol ?? '?'
+
   return (
     <TooltipWrapper>
       <TooltipDescription
-        text={t`Collateral value is taken by multiplying tokens in collateral by the oracle price. In soft liquidation, it may include ${collateralValue?.borrow.symbol} due to liquidation protection.`}
+        text={t`Collateral value is taken by multiplying tokens in collateral by the oracle price. In soft liquidation, it may include ${borrowTokenSymbol} due to liquidation protection.`}
       />
 
       <Stack>
         <TooltipItems secondary>
           <TooltipItem title={t`Deposit token`} variant="independent">
-            {`${collateralValueFormatted} ${collateralValue?.collateral?.symbol}`}
+            {`${collateralValueFormatted} ${collateralTokenSymbol}`}
             {collateralPercentage && ` (${collateralPercentage})`}
           </TooltipItem>
           <TooltipItem title={t`Borrow token`} variant="independent">
-            {`${borrowValueFormatted} ${collateralValue?.borrow?.symbol}`}
+            {`${borrowValueFormatted} ${borrowTokenSymbol}`}
             {borrowPercentage && ` (${borrowPercentage})`}
           </TooltipItem>
         </TooltipItems>

--- a/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
@@ -50,11 +50,11 @@ export const TotalCollateralTooltip = ({
       <Stack>
         <TooltipItems secondary>
           <TooltipItem title={t`Deposit token`} variant="independent">
-            {`${collateralValueFormatted} ${collateralSymbol}`}
+            {`${collateralValueFormatted} ${collateralSymbol ?? '?'}`}
             {collateralPercentage && ` (${collateralPercentage})`}
           </TooltipItem>
           <TooltipItem title={t`Borrow token`} variant="independent">
-            {`${borrowValueFormatted} ${borrowedSymbol}`}
+            {`${borrowValueFormatted} ${borrowedSymbol ?? '?'}`}
             {borrowPercentage && ` (${borrowPercentage})`}
           </TooltipItem>
         </TooltipItems>

--- a/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
@@ -31,8 +31,8 @@ export const TotalCollateralTooltip = ({
   const collateralValueFormatted = formatMetricValue(totalCollateral)
   const collateralPercentage = formatPercentage(totalCollateral, combinedCollateralUsdValue, collateralUsdRate)
 
-  const crvUSDValueFormatted = formatMetricValue(totalBorrowed)
-  const crvUSDPercentage = formatPercentage(totalBorrowed, combinedCollateralUsdValue, borrowedUsdRate)
+  const borrowValueFormatted = formatMetricValue(totalBorrowed)
+  const borrowPercentage = formatPercentage(totalBorrowed, combinedCollateralUsdValue, borrowedUsdRate)
 
   const totalValueFormatted =
     combinedCollateralUsdValue != null
@@ -54,8 +54,8 @@ export const TotalCollateralTooltip = ({
             {collateralPercentage && ` (${collateralPercentage})`}
           </TooltipItem>
           <TooltipItem title={t`Borrow token`} variant="independent">
-            {`${crvUSDValueFormatted} ${borrowedSymbol}`}
-            {crvUSDPercentage && ` (${crvUSDPercentage})`}
+            {`${borrowValueFormatted} ${borrowedSymbol}`}
+            {borrowPercentage && ` (${borrowPercentage})`}
           </TooltipItem>
         </TooltipItems>
       </Stack>


### PR DESCRIPTION
Changes:
- Derive borrow token symbol from data in places that was still assuming crvUSD would be the borrow token