### PR TITLE
feat: disable old deprecate markets

### DIFF
--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketAlert.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { getAddress } from 'viem'
 import { MARKETS_ALERTS } from '@/llamalend/llama-markets.constants'
 import { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { Address } from '@primitives/address.utils'
@@ -10,11 +11,6 @@ export const useMarketAlert = <ChainId extends IChainId>(
   marketType: LlamaMarketType,
 ) =>
   useMemo(
-    () =>
-      controllerAddress &&
-      MARKETS_ALERTS[marketType][rChainId]?.[
-        // we have tests to be sure that all controller addresses of the alerts are lowercase
-        controllerAddress.toLowerCase() as Address
-      ],
+    () => controllerAddress && MARKETS_ALERTS[marketType][rChainId]?.[getAddress(controllerAddress)],
     [rChainId, controllerAddress, marketType],
   )

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -29,7 +29,7 @@ const DEFAULT_ALERT: MarketAlert = {
 
 /**
  * Market alerts keep markets visible while surfacing warnings or disabling new borrow/deposit actions.
- * Addresses must be lowercase. Tests have been added to enforce this.
+ * Addresses must be checksummed. Tests have been added to enforce this.
  */
 export const MARKETS_ALERTS: Record<
   LlamaMarketType,
@@ -39,45 +39,45 @@ export const MARKETS_ALERTS: Record<
   Lend: {
     [Chain.Ethereum]: {
       // one-way-market-30 - sDOLA/crvUSD
-      '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
+      '0xaD444663c6C92B497225c6cE65feE2E7F78BFb86': {
         ...DEFAULT_ALERT,
         message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
       },
       // one-way-market-3 - CRV/crvUSD
-      '0xeda215b7666936ded834f76f3fbc6f323295110a': DEFAULT_ALERT,
+      '0xEdA215b7666936DEd834f76f3fBC6F323295110A': DEFAULT_ALERT,
       // one-way-market-8 - UwU/crvUSD
-      '0x09dbdeb3b301a4753589ac6df8a178c7716ce16b': DEFAULT_ALERT,
+      '0x09dBDEB3b301A4753589Ac6dF8A178C7716ce16B': DEFAULT_ALERT,
     },
     [Chain.Arbitrum]: {
       // one-way-market-7 - FXN/crvUSD
-      '0x7adcc491f0b7f9bc12837b8f5edf0e580d176f1f': {
+      '0x7Adcc491f0B7f9BC12837B8F5Edf0e580d176F1f': {
         alertType: 'danger',
         isBorrowDisabled: true,
         message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
       },
       // one-way-market-47 - iBTC/crvUSD
-      '0x3e293db65c81742e32b74e21a0787d2936beedf7': {
+      '0x3e293dB65c81742e32b74E21A0787d2936beeDf7': {
         ...DEFAULT_ALERT,
         message: t`iBTC is undergoing systematic unwinding. New borrow positions and deposits are disabled.`,
       },
     },
     [Chain.Fraxtal]: {
       // one-way-market-4 - SQUID/crvUSD
-      '0xbf55bb9463bbbb6ad724061910a450939e248ea6': DEFAULT_ALERT,
+      '0xBF55Bb9463bBbB6aD724061910a450939E248eA6': DEFAULT_ALERT,
       // one-way-market-2 - WFRAX/crvUSD
-      '0xf0922934f16dbe5df9f90f729b2023d5e1fc2f15': DEFAULT_ALERT,
+      '0xf0922934f16DbE5Df9f90F729b2023D5e1FC2F15': DEFAULT_ALERT,
     },
     [Chain.Optimism]: {
       // one-way-market-4 - CRV/crvUSD
-      '0x88aa928b906b745009b53a31034701fc377b7c89': DEFAULT_ALERT,
+      '0x88aa928B906b745009B53A31034701Fc377b7C89': DEFAULT_ALERT,
       // one-way-market-3 - OP/crvUSD
-      '0xc5cd9f6a1fb88bed782f475f72ff686ed35b7e8e': DEFAULT_ALERT,
+      '0xC5Cd9f6A1Fb88bed782f475F72fF686ED35b7e8e': DEFAULT_ALERT,
     },
     [Chain.Sonic]: {
       // one-way-market-3 - scETH/crvUSD
-      '0x7547e577b3ddc23c02e10792457f8e51a225692e': DEFAULT_ALERT,
+      '0x7547E577B3DDC23c02E10792457f8e51a225692E': DEFAULT_ALERT,
       // one-way-market-0 - wS/crvUSD
-      '0x5ed490a9b71fa797231d2c5d9be25bf91a953c19': DEFAULT_ALERT,
+      '0x5eD490a9B71fa797231d2c5D9bE25bf91a953C19': DEFAULT_ALERT,
     },
   },
 

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -19,7 +19,18 @@ type MarketAlert = TooltipProps & {
   message?: ReactNode
 }
 
-// Market alerts keep markets visible while surfacing warnings or disabling new borrow/deposit actions.
+const DEFAULT_DEPRECATE: DeprecatedMarketAlert = { message: t`This market is deprecated.` }
+const DEFAULT_ALERT: MarketAlert = {
+  alertType: 'danger',
+  isBorrowDisabled: true,
+  isDepositDisabled: true,
+  message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
+}
+
+/**
+ * Market alerts keep markets visible while surfacing warnings or disabling new borrow/deposit actions.
+ * Addresses must be lowercase. Tests have been added to enforce this.
+ */
 export const MARKETS_ALERTS: Record<
   LlamaMarketType,
   { [chainId: number]: { [controllerAddress: Address]: MarketAlert } }
@@ -29,25 +40,13 @@ export const MARKETS_ALERTS: Record<
     [Chain.Ethereum]: {
       // one-way-market-30 - sDOLA/crvUSD
       '0xad444663c6c92b497225c6ce65fee2e7f78bfb86': {
-        alertType: 'danger',
-        isBorrowDisabled: true,
-        isDepositDisabled: true,
+        ...DEFAULT_ALERT,
         message: t`This market is deprecated after a donation attack. New borrow positions and deposits are disabled.`,
       },
       // one-way-market-3 - CRV/crvUSD
-      '0xeda215b7666936ded834f76f3fbc6f323295110a': {
-        alertType: 'danger',
-        isBorrowDisabled: true,
-        isDepositDisabled: true,
-        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-      },
+      '0xeda215b7666936ded834f76f3fbc6f323295110a': DEFAULT_ALERT,
       // one-way-market-8 - UwU/crvUSD
-      '0x09dbdeb3b301a4753589ac6df8a178c7716ce16b': {
-        alertType: 'danger',
-        isBorrowDisabled: true,
-        isDepositDisabled: true,
-        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-      },
+      '0x09dbdeb3b301a4753589ac6df8a178c7716ce16b': DEFAULT_ALERT,
     },
     [Chain.Arbitrum]: {
       // one-way-market-7 - FXN/crvUSD
@@ -56,22 +55,29 @@ export const MARKETS_ALERTS: Record<
         isBorrowDisabled: true,
         message: t`Due to small liquidity, borrowing or supplying in this market is not advisable.`,
       },
+      // one-way-market-47 - iBTC/crvUSD
+      '0x3e293db65c81742e32b74e21a0787d2936beedf7': {
+        ...DEFAULT_ALERT,
+        message: t`iBTC is undergoing systematic unwinding. New borrow positions and deposits are disabled.`,
+      },
     },
     [Chain.Fraxtal]: {
       // one-way-market-4 - SQUID/crvUSD
-      '0xbf55bb9463bbbb6ad724061910a450939e248ea6': {
-        alertType: 'danger',
-        isBorrowDisabled: true,
-        isDepositDisabled: true,
-        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-      },
+      '0xbf55bb9463bbbb6ad724061910a450939e248ea6': DEFAULT_ALERT,
       // one-way-market-2 - WFRAX/crvUSD
-      '0xf0922934f16dbe5df9f90f729b2023d5e1fc2f15': {
-        alertType: 'danger',
-        isBorrowDisabled: true,
-        isDepositDisabled: true,
-        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
-      },
+      '0xf0922934f16dbe5df9f90f729b2023d5e1fc2f15': DEFAULT_ALERT,
+    },
+    [Chain.Optimism]: {
+      // one-way-market-4 - CRV/crvUSD
+      '0x88aa928b906b745009b53a31034701fc377b7c89': DEFAULT_ALERT,
+      // one-way-market-3 - OP/crvUSD
+      '0xc5cd9f6a1fb88bed782f475f72ff686ed35b7e8e': DEFAULT_ALERT,
+    },
+    [Chain.Sonic]: {
+      // one-way-market-3 - scETH/crvUSD
+      '0x7547e577b3ddc23c02e10792457f8e51a225692e': DEFAULT_ALERT,
+      // one-way-market-0 - wS/crvUSD
+      '0x5ed490a9b71fa797231d2c5d9be25bf91a953c19': DEFAULT_ALERT,
     },
   },
 
@@ -80,7 +86,6 @@ export const MARKETS_ALERTS: Record<
 }
 
 export type DeprecatedMarketAlert = { message: string; url?: string }
-const DEFAULT_DEPRECATE: DeprecatedMarketAlert = { message: t`This market is deprecated.` }
 
 // Deprecated markets are hidden from market list for new users but remain accessible to users with existing positions.
 export const DEPRECATED_LLAMAS: Record<

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -144,6 +144,7 @@ export const DEPRECATED_LLAMAS: Record<
       },
       // UwU-crvUSD
       '0x09dBDEB3b301A4753589Ac6dF8A178C7716ce16B': DEFAULT_DEPRECATE,
+      // UNIT0-crvUSD
       '0xd15d9797c4ECBf1c97c010327602bC51A09Dfb95': DEFAULT_DEPRECATE,
     },
     arbitrum: {

--- a/apps/main/src/llamalend/llama-markets.constants.ts
+++ b/apps/main/src/llamalend/llama-markets.constants.ts
@@ -48,6 +48,13 @@ export const MARKETS_ALERTS: Record<
         isDepositDisabled: true,
         message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
       },
+      // one-way-market-44 - UNIT0/crvUSD
+      '0xd15d9797c4ecbf1c97c010327602bc51a09dfb95': {
+        alertType: 'danger',
+        isBorrowDisabled: true,
+        isDepositDisabled: true,
+        message: t`This market is deprecated. New borrow positions and deposits are disabled.`,
+      },
     },
     [Chain.Arbitrum]: {
       // one-way-market-7 - FXN/crvUSD
@@ -137,6 +144,7 @@ export const DEPRECATED_LLAMAS: Record<
       },
       // UwU-crvUSD
       '0x09dBDEB3b301A4753589Ac6dF8A178C7716ce16B': DEFAULT_DEPRECATE,
+      '0xd15d9797c4ECBf1c97c010327602bC51A09Dfb95': DEFAULT_DEPRECATE,
     },
     arbitrum: {
       // iBTC-crvUSD

--- a/tests/cypress/component/llamalend/market-alerts.cy.tsx
+++ b/tests/cypress/component/llamalend/market-alerts.cy.tsx
@@ -1,4 +1,4 @@
-import { zeroAddress } from 'viem'
+import { zeroAddress, getAddress } from 'viem'
 import { useMarketAlert } from '@/llamalend/features/market-list/hooks/useMarketAlert'
 import { MARKETS_ALERTS } from '@/llamalend/llama-markets.constants'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
@@ -47,13 +47,11 @@ const ALERT_CASES = recordEntries(MARKETS_ALERTS).flatMap(([marketType, marketAl
 )
 
 describe('useMarketAlert', () => {
-  it('keeps every configured market alert key lowercase', () => {
+  it('keeps every configured market alert key checksummed', () => {
     for (const alerts of ALL_MARKET_ALERTS) {
       for (const chainAlerts of Object.values(alerts)) {
         for (const controllerAddress of Object.keys(chainAlerts)) {
-          expect(controllerAddress, `expected ${controllerAddress} to be lowercase`).to.eq(
-            controllerAddress.toLowerCase(),
-          )
+          expect(controllerAddress, `expected address to be checksummed`).to.eq(getAddress(controllerAddress))
         }
       }
     }
@@ -63,7 +61,7 @@ describe('useMarketAlert', () => {
     const alert = oneOf(...ALERT_CASES)
     mountMarketAlert({
       chainId: alert.chainId,
-      controllerAddress: alert.controllerAddress.toUpperCase() as Address,
+      controllerAddress: alert.controllerAddress,
       marketType: alert.marketType,
     })
 

--- a/tests/cypress/component/llamalend/market-deprecations.cy.tsx
+++ b/tests/cypress/component/llamalend/market-deprecations.cy.tsx
@@ -1,6 +1,6 @@
 import { zeroAddress, getAddress } from 'viem'
 import { useMarketAlert } from '@/llamalend/features/market-list/hooks/useMarketAlert'
-import { MARKETS_ALERTS } from '@/llamalend/llama-markets.constants'
+import { DEPRECATED_LLAMAS, MARKETS_ALERTS, NO_LEVERAGE_LEND } from '@/llamalend/llama-markets.constants'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { oneOf, oneValueOf } from '@cy/support/generators'
 import type { Address } from '@primitives/address.utils'
@@ -33,6 +33,7 @@ const mountMarketAlert = ({
 }) => cy.mount(<MarketAlertHookTest chainId={chainId} controllerAddress={controllerAddress} marketType={marketType} />)
 
 const ALL_MARKET_ALERTS = recordValues(MARKETS_ALERTS)
+const ALL_DEPRECATED_LLAMAS = recordValues(DEPRECATED_LLAMAS)
 
 /** Get a list of all alerts for each market type, and chain */
 const ALERT_CASES = recordEntries(MARKETS_ALERTS).flatMap(([marketType, marketAlerts]) =>
@@ -46,7 +47,7 @@ const ALERT_CASES = recordEntries(MARKETS_ALERTS).flatMap(([marketType, marketAl
   ),
 )
 
-describe('useMarketAlert', () => {
+describe('llama market constants', () => {
   it('keeps every configured market alert key checksummed', () => {
     for (const alerts of ALL_MARKET_ALERTS) {
       for (const chainAlerts of Object.values(alerts)) {
@@ -56,7 +57,26 @@ describe('useMarketAlert', () => {
       }
     }
   })
+  it('keeps every deprecated llama address checksummed', () => {
+    for (const deprecatedMarkets of ALL_DEPRECATED_LLAMAS) {
+      for (const chainMarkets of Object.values(deprecatedMarkets)) {
+        for (const controllerAddress of Object.keys(chainMarkets)) {
+          expect(controllerAddress, `expected address to be checksummed`).to.eq(getAddress(controllerAddress))
+        }
+      }
+    }
+  })
 
+  it('keeps every no leverage lend address checksummed', () => {
+    for (const chainMarkets of recordValues(NO_LEVERAGE_LEND)) {
+      for (const controllerAddress of chainMarkets) {
+        expect(controllerAddress, `expected address to be checksummed`).to.eq(getAddress(controllerAddress))
+      }
+    }
+  })
+})
+
+describe('useMarketAlert', () => {
   it(`returns the correct alert for checksummed addresses`, () => {
     const alert = oneOf(...ALERT_CASES)
     mountMarketAlert({


### PR DESCRIPTION
- disable new borrow and deposit to deprecated markets with bad debt
- all addresses in the `llama-markets.constants.ts` are checksummed for consistency
- updated tests to enforce the addresses are checksummed