### PR TITLE
refactor: market list layout (part 1)

### DIFF
--- a/apps/main/src/llamalend/features/market-list/LendingMarketsFilters.tsx
+++ b/apps/main/src/llamalend/features/market-list/LendingMarketsFilters.tsx
@@ -2,6 +2,7 @@ import { keyBy, type Dictionary } from 'lodash'
 import { useMemo } from 'react'
 import Chip from '@mui/material/Chip'
 import Grid from '@mui/material/Grid'
+import { useNewMarketListLayout } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import type { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { parseListFilter } from '@ui-kit/shared/ui/DataTable/filters'
@@ -68,6 +69,7 @@ export const LendingMarketsFilters = ({
       container
       spacing={Spacing.sm}
       paddingBlockStart={Spacing.sm}
+      {...(useNewMarketListLayout() && { paddingBlockEnd: Spacing.sm })}
       paddingInline={{ mobile: 0, tablet: Spacing.md.tablet, desktop: Spacing.md.desktop }}
     >
       <TableFilterColumn size={TABLE_FILTER_COLUMN_SIZE} title={t`Collateral Tokens`}>

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box'
 import type { Address } from '@primitives/address.utils'
 import { useWallet } from '@ui-kit/features/connect-wallet'
 import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
-import { useLLv2 } from '@ui-kit/hooks/useFeatureFlags'
+import { useLLv2, useNewMarketListLayout } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -18,6 +18,7 @@ import { useLlamaMarkets } from '../../queries/market-list/llama-markets'
 import { invalidateAllUserMintMarkets, invalidateMintMarkets } from '../../queries/market-list/mint-markets'
 import { LendTableFooter } from './LendTableFooter'
 import { LlamaMarketsTable } from './LlamaMarketsTable'
+import { NewLlamaMarketsTable } from './NewLlamaMarketsTable'
 import { UserPositionsTable } from './UserPositionsTable'
 
 const { Spacing } = SizesAndSpaces
@@ -82,7 +83,11 @@ export const LlamaMarketsList = () => {
         </Box>
       )}
 
-      <LlamaMarketsTable onReload={onReload} result={data} isError={isError} loading={loading} />
+      {useNewMarketListLayout() ? (
+        <NewLlamaMarketsTable onReload={onReload} result={data} isError={isError} loading={loading} />
+      ) : (
+        <LlamaMarketsTable onReload={onReload} result={data} isError={isError} loading={loading} />
+      )}
     </ListPageWrapper>
   )
 }

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
@@ -6,11 +6,11 @@ import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
 import { getHiddenCount, getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
+import { NewDataTable } from '@ui-kit/shared/ui/DataTable/NewDataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
-import { TableFilters } from '@ui-kit/shared/ui/DataTable/TableFilters'
-import { TableFiltersTitles } from '@ui-kit/shared/ui/DataTable/TableFiltersTitles'
+import { NewTableFilters } from '@ui-kit/shared/ui/DataTable/NewTableFilters'
+import { NewTableFiltersHeader } from '@ui-kit/shared/ui/DataTable/NewTableFiltersHeader'
 import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
 import { LlamaChainFilterChips } from './chips/LlamaChainFilterChips'
 import { LlamaListChips } from './chips/LlamaListChips'
@@ -65,7 +65,7 @@ export const LlamaMarketsTable = ({
   })
 
   return (
-    <DataTable
+    <NewDataTable
       table={table}
       emptyState={
         <EmptyStateRow table={table}>
@@ -84,7 +84,7 @@ export const LlamaMarketsTable = ({
       shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       loading={loading}
     >
-      <TableFilters<LlamaMarketColumnId>
+      <NewTableFilters<LlamaMarketColumnId>
         filterExpandedKey={LOCAL_STORAGE_KEY}
         loading={loading}
         onReload={onReload}
@@ -94,7 +94,7 @@ export const LlamaMarketsTable = ({
         disableSearchAutoFocus
         searchText={globalFilter}
         onSearch={setGlobalFilter}
-        leftChildren={<TableFiltersTitles title={t`Markets`} subtitle={t`Find your next opportunity`} />}
+        header={<NewTableFiltersHeader title={t`Markets`} subtitle={t`Find your next opportunity`} />}
         collapsible={<LendingMarketsFilters data={data} {...filterProps} />}
         chips={
           <>
@@ -111,6 +111,6 @@ export const LlamaMarketsTable = ({
           </>
         }
       />
-    </DataTable>
+    </NewDataTable>
   )
 }

--- a/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
@@ -5,15 +5,16 @@ import { ExpandedState } from '@tanstack/react-table'
 import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
+import { ReloadIcon } from '@ui-kit/shared/icons/ReloadIcon'
 import { getHiddenCount, getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
 import { NewDataTable } from '@ui-kit/shared/ui/DataTable/NewDataTable'
+import { NewTableButton } from '@ui-kit/shared/ui/DataTable/NewTableButton'
 import { NewTableFilters } from '@ui-kit/shared/ui/DataTable/NewTableFilters'
 import { NewTableFiltersHeader } from '@ui-kit/shared/ui/DataTable/NewTableFiltersHeader'
 import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
-import { LlamaChainFilterChips } from './chips/LlamaChainFilterChips'
-import { LlamaListChips } from './chips/LlamaListChips'
+import { NewLlamaListChips } from './chips/NewLlamaListChips'
 import { DEFAULT_SORT } from './columns'
 import { LLAMA_MARKET_COLUMNS } from './columns'
 import { LlamaMarketColumnId } from './columns'
@@ -86,29 +87,28 @@ export const NewLlamaMarketsTable = ({
     >
       <NewTableFilters<LlamaMarketColumnId>
         filterExpandedKey={LOCAL_STORAGE_KEY}
-        loading={loading}
-        onReload={onReload}
         visibilityGroups={columnSettings}
         toggleVisibility={toggleVisibility}
-        hasSearchBar
         disableSearchAutoFocus
         searchText={globalFilter}
         onSearch={setGlobalFilter}
-        header={<NewTableFiltersHeader title={t`Markets`} />}
+        header={
+          <NewTableFiltersHeader
+            title={t`Markets`}
+            rightChildren={<NewTableButton onClick={onReload} icon={ReloadIcon} rotateIcon={loading} />}
+          />
+        }
         collapsible={<LendingMarketsFilters data={data} {...filterProps} />}
         chips={
-          <>
-            <LlamaChainFilterChips data={data} {...filterProps} />
-            <LlamaListChips
-              hiddenCount={getHiddenCount(table)}
-              resetFilters={resetFilters}
-              hasFavorites={hasFavorites}
-              onSortingChange={onSortingChange}
-              sortField={sortField}
-              data={data}
-              {...filterProps}
-            />
-          </>
+          <NewLlamaListChips
+            hiddenCount={getHiddenCount(table)}
+            resetFilters={resetFilters}
+            hasFavorites={hasFavorites}
+            onSortingChange={onSortingChange}
+            sortField={sortField}
+            data={data}
+            {...filterProps}
+          />
         }
       />
     </NewDataTable>

--- a/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
@@ -6,11 +6,11 @@ import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
 import { getHiddenCount, getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
-import { TableFilters } from '@ui-kit/shared/ui/DataTable/TableFilters'
-import { TableFiltersTitles } from '@ui-kit/shared/ui/DataTable/TableFiltersTitles'
+import { NewDataTable } from '@ui-kit/shared/ui/DataTable/NewDataTable'
+import { NewTableFilters } from '@ui-kit/shared/ui/DataTable/NewTableFilters'
+import { NewTableFiltersHeader } from '@ui-kit/shared/ui/DataTable/NewTableFiltersHeader'
 import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
 import { LlamaChainFilterChips } from './chips/LlamaChainFilterChips'
 import { LlamaListChips } from './chips/LlamaListChips'
@@ -26,7 +26,7 @@ const LOCAL_STORAGE_KEY = 'Llamalend Markets'
 
 const pagination = { pageIndex: 0, pageSize: 200 }
 
-export const LlamaMarketsTable = ({
+export const NewLlamaMarketsTable = ({
   onReload,
   result,
   isError,
@@ -65,7 +65,7 @@ export const LlamaMarketsTable = ({
   })
 
   return (
-    <DataTable
+    <NewDataTable
       table={table}
       emptyState={
         <EmptyStateRow table={table}>
@@ -84,7 +84,7 @@ export const LlamaMarketsTable = ({
       shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       loading={loading}
     >
-      <TableFilters<LlamaMarketColumnId>
+      <NewTableFilters<LlamaMarketColumnId>
         filterExpandedKey={LOCAL_STORAGE_KEY}
         loading={loading}
         onReload={onReload}
@@ -94,7 +94,7 @@ export const LlamaMarketsTable = ({
         disableSearchAutoFocus
         searchText={globalFilter}
         onSearch={setGlobalFilter}
-        leftChildren={<TableFiltersTitles title={t`Markets`} subtitle={t`Find your next opportunity`} />}
+        header={<NewTableFiltersHeader title={t`Markets`} />}
         collapsible={<LendingMarketsFilters data={data} {...filterProps} />}
         chips={
           <>
@@ -111,6 +111,6 @@ export const LlamaMarketsTable = ({
           </>
         }
       />
-    </DataTable>
+    </NewDataTable>
   )
 }

--- a/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/NewLlamaMarketsTable.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from 'react'
 import type { LlamaMarketsResult } from '@/llamalend/queries/market-list/llama-markets'
 import Button from '@mui/material/Button'
 import { ExpandedState } from '@tanstack/react-table'
-import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
+import { useIsMobile, useIsTablet } from '@ui-kit/hooks/useBreakpoints'
+import { useFilterExpanded } from '@ui-kit/hooks/useLocalStorage'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
 import { ReloadIcon } from '@ui-kit/shared/icons/ReloadIcon'
@@ -14,10 +15,12 @@ import { NewTableButton } from '@ui-kit/shared/ui/DataTable/NewTableButton'
 import { NewTableFilters } from '@ui-kit/shared/ui/DataTable/NewTableFilters'
 import { NewTableFiltersHeader } from '@ui-kit/shared/ui/DataTable/NewTableFiltersHeader'
 import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
+import { NewFilterChip } from './chips/NewFilterChip'
 import { NewLlamaListChips } from './chips/NewLlamaListChips'
 import { DEFAULT_SORT } from './columns'
 import { LLAMA_MARKET_COLUMNS } from './columns'
 import { LlamaMarketColumnId } from './columns'
+import { NewMarketSortDrawer } from './drawers/NewMarketSortDrawer'
 import { useLlamaGlobalFilterFn } from './filters/llamaGlobalFilter'
 import { useLlamaTableVisibility } from './hooks/useLlamaTableVisibility'
 import { LendingMarketsFilters } from './LendingMarketsFilters'
@@ -40,6 +43,8 @@ export const NewLlamaMarketsTable = ({
 }) => {
   const { markets, userHasPositions, hasFavorites } = result ?? {}
   const data = useMemo(() => markets ?? [], [markets])
+  const [filterExpanded, setFilterExpanded] = useFilterExpanded(LOCAL_STORAGE_KEY)
+  const isMobile = useIsMobile()
 
   const { globalFilter, setGlobalFilter, columnFilters, columnFiltersById, setColumnFilter, resetFilters } = useFilters(
     { columns: LlamaMarketColumnId },
@@ -87,6 +92,7 @@ export const NewLlamaMarketsTable = ({
     >
       <NewTableFilters<LlamaMarketColumnId>
         filterExpandedKey={LOCAL_STORAGE_KEY}
+        filterExpanded={filterExpanded}
         visibilityGroups={columnSettings}
         toggleVisibility={toggleVisibility}
         disableSearchAutoFocus
@@ -99,17 +105,19 @@ export const NewLlamaMarketsTable = ({
           />
         }
         collapsible={<LendingMarketsFilters data={data} {...filterProps} />}
-        chips={
-          <NewLlamaListChips
+        filterChip={
+          <NewFilterChip
+            filterExpanded={filterExpanded}
+            setFilterExpanded={setFilterExpanded}
             hiddenCount={getHiddenCount(table)}
             resetFilters={resetFilters}
             hasFavorites={hasFavorites}
-            onSortingChange={onSortingChange}
-            sortField={sortField}
             data={data}
             {...filterProps}
           />
         }
+        sortChip={isMobile && <NewMarketSortDrawer onSortingChange={onSortingChange} sortField={sortField} />}
+        chips={<NewLlamaListChips hasFavorites={hasFavorites} {...filterProps} />}
       />
     </NewDataTable>
   )

--- a/apps/main/src/llamalend/features/market-list/chips/NewFilterChip.tsx
+++ b/apps/main/src/llamalend/features/market-list/chips/NewFilterChip.tsx
@@ -1,0 +1,53 @@
+import { Dispatch, ReactNode, SetStateAction } from 'react'
+import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
+import { t } from '@ui-kit/lib/i18n'
+import { FilterIcon } from '@ui-kit/shared/icons/FilterIcon'
+import { GridChip } from '@ui-kit/shared/ui/DataTable/chips/GridChip'
+import type { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { MarketRateType } from '@ui-kit/types/market'
+import { LlamaMarketColumnId } from '../columns'
+import { NewMarketListFilterDrawer } from '../drawers/NewMarketListFilterDrawer'
+
+type Props = {
+  filterExpanded: boolean
+  setFilterExpanded: Dispatch<SetStateAction<boolean>>
+  hiddenCount: number
+  resetFilters: () => void
+  children?: ReactNode
+  hasFavorites?: boolean
+  data: LlamaMarket[]
+  userPositionsTab?: MarketRateType
+} & FilterProps<LlamaMarketColumnId>
+
+export const NewFilterChip = ({
+  filterExpanded,
+  setFilterExpanded,
+  hiddenCount,
+  resetFilters,
+  hasFavorites,
+  data,
+  userPositionsTab,
+  ...filterProps
+}: Props) => {
+  const isMobile = useIsMobile()
+  return isMobile ? (
+    <NewMarketListFilterDrawer
+      hasFavorites={hasFavorites}
+      data={data}
+      hiddenCount={hiddenCount}
+      resetFilters={resetFilters}
+      userPositionsTab={userPositionsTab}
+      {...filterProps}
+    />
+  ) : (
+    <GridChip
+      label={t`Filters`}
+      selectableChipSize="large"
+      selected={filterExpanded}
+      icon={<FilterIcon />}
+      toggle={() => setFilterExpanded((prev) => !prev)}
+      data-testid="btn-expand-filters"
+    />
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/chips/NewLlamaListChips.tsx
+++ b/apps/main/src/llamalend/features/market-list/chips/NewLlamaListChips.tsx
@@ -1,0 +1,76 @@
+import { type ReactNode } from 'react'
+import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
+import Grid from '@mui/material/Grid'
+import { OnChangeFn, SortingState } from '@tanstack/react-table'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
+import { t } from '@ui-kit/lib/i18n'
+import { HeartIcon } from '@ui-kit/shared/icons/HeartIcon'
+import { GridChip } from '@ui-kit/shared/ui/DataTable/chips/GridChip'
+import type { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { MarketRateType } from '@ui-kit/types/market'
+import { LlamaMarketColumnId } from '../columns'
+import { MarketListFilterDrawer } from '../drawers/MarketListFilterDrawer'
+import { MarketSortDrawer } from '../drawers/MarketSortDrawer'
+import { useToggleFilter } from '../hooks/useToggleFilter'
+
+const { Spacing } = SizesAndSpaces
+
+type LlamaListChipsProps = {
+  hiddenCount: number
+  resetFilters: () => void
+  children?: ReactNode
+  hasFavorites?: boolean
+  onSortingChange: OnChangeFn<SortingState>
+  sortField: LlamaMarketColumnId
+  data: LlamaMarket[]
+  userPositionsTab?: MarketRateType
+} & FilterProps<LlamaMarketColumnId>
+
+export const NewLlamaListChips = ({
+  hiddenCount,
+  resetFilters,
+  hasFavorites,
+  onSortingChange,
+  sortField,
+  data,
+  userPositionsTab,
+  ...filterProps
+}: LlamaListChipsProps) => {
+  const isMobile = useIsMobile()
+  const hasPopularFilters = userPositionsTab === MarketRateType.Borrow || !userPositionsTab
+  const [favorites, toggleFavorites] = useToggleFilter(LlamaMarketColumnId.IsFavorite, filterProps)
+  return (
+    <Grid container spacing={Spacing.sm} size={{ mobile: 12, tablet: 'auto' }}>
+      {isMobile ? (
+        <Grid container columnSpacing={Spacing.sm} size={12}>
+          <Grid size={6}>
+            {onSortingChange && sortField && (
+              <MarketSortDrawer onSortingChange={onSortingChange} sortField={sortField} />
+            )}
+          </Grid>
+          <Grid size={6}>
+            <MarketListFilterDrawer
+              hasFavorites={hasFavorites}
+              data={data}
+              hiddenCount={hiddenCount}
+              resetFilters={resetFilters}
+              userPositionsTab={userPositionsTab}
+              {...filterProps}
+            />
+          </Grid>
+        </Grid>
+      ) : (
+        <GridChip
+          label={t`Favorites`}
+          selected={favorites}
+          toggle={toggleFavorites}
+          onDelete={toggleFavorites}
+          icon={<HeartIcon />}
+          data-testid="chip-favorites"
+          disabled={hasPopularFilters}
+        />
+      )}
+    </Grid>
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/chips/NewLlamaListChips.tsx
+++ b/apps/main/src/llamalend/features/market-list/chips/NewLlamaListChips.tsx
@@ -1,76 +1,31 @@
-import { type ReactNode } from 'react'
-import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import Grid from '@mui/material/Grid'
-import { OnChangeFn, SortingState } from '@tanstack/react-table'
-import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
 import { HeartIcon } from '@ui-kit/shared/icons/HeartIcon'
 import { GridChip } from '@ui-kit/shared/ui/DataTable/chips/GridChip'
 import type { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { MarketRateType } from '@ui-kit/types/market'
 import { LlamaMarketColumnId } from '../columns'
-import { MarketListFilterDrawer } from '../drawers/MarketListFilterDrawer'
-import { MarketSortDrawer } from '../drawers/MarketSortDrawer'
 import { useToggleFilter } from '../hooks/useToggleFilter'
 
 const { Spacing } = SizesAndSpaces
 
 type LlamaListChipsProps = {
-  hiddenCount: number
-  resetFilters: () => void
-  children?: ReactNode
-  hasFavorites?: boolean
-  onSortingChange: OnChangeFn<SortingState>
-  sortField: LlamaMarketColumnId
-  data: LlamaMarket[]
-  userPositionsTab?: MarketRateType
+  hasFavorites: boolean | undefined
 } & FilterProps<LlamaMarketColumnId>
 
-export const NewLlamaListChips = ({
-  hiddenCount,
-  resetFilters,
-  hasFavorites,
-  onSortingChange,
-  sortField,
-  data,
-  userPositionsTab,
-  ...filterProps
-}: LlamaListChipsProps) => {
-  const isMobile = useIsMobile()
-  const hasPopularFilters = userPositionsTab === MarketRateType.Borrow || !userPositionsTab
+export const NewLlamaListChips = ({ hasFavorites, ...filterProps }: LlamaListChipsProps) => {
   const [favorites, toggleFavorites] = useToggleFilter(LlamaMarketColumnId.IsFavorite, filterProps)
   return (
     <Grid container spacing={Spacing.sm} size={{ mobile: 12, tablet: 'auto' }}>
-      {isMobile ? (
-        <Grid container columnSpacing={Spacing.sm} size={12}>
-          <Grid size={6}>
-            {onSortingChange && sortField && (
-              <MarketSortDrawer onSortingChange={onSortingChange} sortField={sortField} />
-            )}
-          </Grid>
-          <Grid size={6}>
-            <MarketListFilterDrawer
-              hasFavorites={hasFavorites}
-              data={data}
-              hiddenCount={hiddenCount}
-              resetFilters={resetFilters}
-              userPositionsTab={userPositionsTab}
-              {...filterProps}
-            />
-          </Grid>
-        </Grid>
-      ) : (
-        <GridChip
-          label={t`Favorites`}
-          selected={favorites}
-          toggle={toggleFavorites}
-          onDelete={toggleFavorites}
-          icon={<HeartIcon />}
-          data-testid="chip-favorites"
-          disabled={hasPopularFilters}
-        />
-      )}
+      <GridChip
+        label={t`Favorites`}
+        selected={favorites}
+        toggle={toggleFavorites}
+        onDelete={toggleFavorites}
+        icon={<HeartIcon />}
+        data-testid="chip-favorites"
+        disabled={!hasFavorites}
+      />
     </Grid>
   )
 }

--- a/apps/main/src/llamalend/features/market-list/drawers/NewMarketListFilterDrawer.tsx
+++ b/apps/main/src/llamalend/features/market-list/drawers/NewMarketListFilterDrawer.tsx
@@ -1,0 +1,69 @@
+import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
+import { Grid } from '@mui/material'
+import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { t } from '@ui-kit/lib/i18n'
+import { FilterIcon } from '@ui-kit/shared/icons/FilterIcon'
+import { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { HiddenCountResetButton } from '@ui-kit/shared/ui/DataTable/HiddenCountResetButton'
+import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
+import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
+import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { MarketRateType } from '@ui-kit/types/market'
+import { LlamaListMarketChips } from '../chips/LlamaListMarketChips'
+import { LlamaListUserChips } from '../chips/LlamaListUserChips'
+import type { LlamaMarketColumnId } from '../columns'
+import { LendingMarketsFilters } from '../LendingMarketsFilters'
+
+const { Spacing } = SizesAndSpaces
+
+type Props = {
+  hasFavorites: boolean | undefined
+  data: LlamaMarket[]
+  hiddenCount: number
+  resetFilters: () => void
+  userPositionsTab?: MarketRateType
+} & FilterProps<LlamaMarketColumnId>
+
+export const NewMarketListFilterDrawer = ({
+  hasFavorites,
+  data,
+  hiddenCount,
+  resetFilters,
+  userPositionsTab,
+  ...filterProps
+}: Props) => {
+  const [open, , closeDrawer, toggleDrawer] = useSwitch(false)
+  const hasPopularFilters = userPositionsTab === MarketRateType.Borrow || !userPositionsTab
+  const showUserChips = !userPositionsTab
+  return (
+    <SwipeableDrawer
+      paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }}
+      button={
+        <SelectableChip
+          size="large"
+          selected={open}
+          icon={<FilterIcon />}
+          toggle={toggleDrawer}
+          data-testid="btn-drawer-filter-lamalend-markets"
+        />
+      }
+      open={open}
+      setOpen={closeDrawer}
+    >
+      <DrawerHeader title={t`Filters`}>
+        <HiddenCountResetButton hiddenCount={hiddenCount} resetFilters={resetFilters} />
+      </DrawerHeader>
+      <DrawerItems data-testid="drawer-filter-menu-lamalend-markets">
+        {hasPopularFilters && <DrawerHeader title={t`Popular Filters`} />}
+        <Grid container spacing={Spacing.sm}>
+          {hasPopularFilters && <LlamaListMarketChips {...filterProps} />}
+          {showUserChips && <LlamaListUserChips hasFavorites={hasFavorites} {...filterProps} />}
+        </Grid>
+        <DrawerHeader title={t`Extras Filters`} />
+        <LendingMarketsFilters {...filterProps} data={data} />
+      </DrawerItems>
+    </SwipeableDrawer>
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/drawers/NewMarketSortDrawer.tsx
+++ b/apps/main/src/llamalend/features/market-list/drawers/NewMarketSortDrawer.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback, useMemo, useRef } from 'react'
+import { MenuItem } from '@mui/material'
+import Typography from '@mui/material/Typography'
+import { OnChangeFn, SortingState } from '@tanstack/react-table'
+import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { t } from '@ui-kit/lib/i18n'
+import { CaretSortIcon } from '@ui-kit/shared/icons/CaretSort'
+import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
+import { InvertOnHover } from '@ui-kit/shared/ui/InvertOnHover'
+import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
+import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
+import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { LlamaMarketColumnId } from '../columns'
+import { useLlamaMarketSortOptions } from '../hooks/useLlamaMarketSortOptions'
+
+const { Spacing, ButtonSize } = SizesAndSpaces
+
+type Props = {
+  onSortingChange: OnChangeFn<SortingState>
+  sortField: LlamaMarketColumnId
+}
+
+export const NewMarketSortDrawer = ({ onSortingChange, sortField }: Props) => {
+  const [open, , closeDrawer, toggleDrawer] = useSwitch(false)
+  const sortOptions = useLlamaMarketSortOptions()
+  const menuRef = useRef<HTMLLIElement | null>(null)
+
+  const selectedOption = useMemo(() => sortOptions.find((option) => option.id === sortField), [sortOptions, sortField])
+
+  const handleSort = useCallback(
+    (id: LlamaMarketColumnId) => {
+      onSortingChange([{ id, desc: true }])
+      closeDrawer()
+    },
+    [onSortingChange, closeDrawer],
+  )
+
+  return (
+    <SwipeableDrawer
+      paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }}
+      button={
+        <SelectableChip
+          size="large"
+          selected={open}
+          icon={<CaretSortIcon />}
+          toggle={toggleDrawer}
+          data-testid="btn-drawer-sort-lamalend-markets"
+        />
+      }
+      open={open}
+      setOpen={closeDrawer}
+    >
+      <DrawerHeader title={t`Sort by`} />
+      <DrawerItems data-testid="drawer-sort-menu-lamalend-markets">
+        {sortOptions.map(({ id, label }) => (
+          <InvertOnHover hoverRef={menuRef} key={id}>
+            <MenuItem
+              ref={menuRef}
+              value={id}
+              className={selectedOption?.id === id ? 'Mui-selected' : ''}
+              onClick={() => handleSort(id)}
+              sx={{ justifyContent: 'space-between', minHeight: ButtonSize.sm }}
+            >
+              <Typography component="span" variant="bodyMBold">
+                {label}
+              </Typography>
+              {selectedOption?.id === id && <CheckIcon sx={{ marginLeft: Spacing.sm }} />}
+            </MenuItem>
+          </InvertOnHover>
+        ))}
+      </DrawerItems>
+    </SwipeableDrawer>
+  )
+}

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -46,3 +46,6 @@ export const useRightFormTabsLayout = useStableChannel
 
 /** New market historical rates chart */
 export const useMarketHistoricalRatesChart = useBetaChannel
+
+/** New market list and search layout */
+export const useNewMarketListLayout = useBetaChannel

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.d.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.d.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import '@tanstack/table-core'
+import type { RowData } from '@tanstack/table-core'
+import type { TypographyVariantKey } from '@ui-kit/themes/typography'
+import type { TooltipProps } from '../Tooltip'
+
+/**
+ * Extend the tanstack ColumnMeta interface to add our custom properties
+ */
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    type?: 'numeric' // aligns cell content to the right
+    hidden?: boolean // todo: get rid of this property, use column visibility, it breaks e.g. column.getIsLastColumn()
+    variant?: TypographyVariantKey
+    tooltip?: Omit<TooltipProps, 'children'>
+  }
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.tsx
@@ -15,8 +15,8 @@ import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { type TableItem, type TanstackTable } from './data-table.utils'
 import { DataRow, type DataRowProps } from './DataRow'
-import { FilterRow } from './FilterRow'
 import { HeaderCell } from './HeaderCell'
+import { NewFilterRow } from './NewFilterRow'
 import { SkeletonRows } from './SkeletonRows'
 import { TableViewAllCell } from './TableViewAllCell'
 import { useTableRowLimit } from './useTableRowLimit'
@@ -111,7 +111,6 @@ export const NewDataTable = <T extends TableItem>({
     position: 'sticky',
     top: maxHeight ? 0 : top,
     zIndex: t.zIndex.tableHeader,
-    backgroundColor: t.design.Table.Header.Fill,
     marginBlock: Sizing['sm'],
   })
   const showFooter = showPagination || showViewAllButton || footerRow
@@ -120,14 +119,13 @@ export const NewDataTable = <T extends TableItem>({
     <WithWrapper Wrapper={Box} shouldWrap={maxHeight} sx={{ maxHeight, overflowY: 'auto' }} ref={containerRef}>
       <Table
         sx={{
-          backgroundColor: (t) => t.design.Layer[1].Fill,
           borderCollapse: 'separate' /* Don't collapse to avoid funky stuff with the sticky header */,
         }}
         data-testid={!loading && 'data-table'}
       >
         {!hideHeader && (
           <TableHead sx={tableHeaderSx} data-testid="data-table-head">
-            {children && <FilterRow table={table}>{children}</FilterRow>}
+            {children && <NewFilterRow table={table}>{children}</NewFilterRow>}
 
             {headerGroups.map((headerGroup) => (
               <TableRow key={headerGroup.id} sx={{ height: Sizing['xxl'] }}>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewDataTable.tsx
@@ -1,0 +1,185 @@
+/// <reference types="./DataTable.d.ts" />
+import { type ReactNode, type RefObject, useEffect, useEffectEvent, useMemo, useRef } from 'react'
+import Box from '@mui/material/Box'
+import { Theme } from '@mui/material/styles'
+import Table from '@mui/material/Table'
+import TableBody from '@mui/material/TableBody'
+import TableCell from '@mui/material/TableCell'
+import TableFooter from '@mui/material/TableFooter'
+import TableHead from '@mui/material/TableHead'
+import TableRow from '@mui/material/TableRow'
+import { useLayoutStore } from '@ui-kit/features/layout'
+import { t } from '@ui-kit/lib/i18n'
+import { TablePagination } from '@ui-kit/shared/ui/DataTable/TablePagination'
+import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { type TableItem, type TanstackTable } from './data-table.utils'
+import { DataRow, type DataRowProps } from './DataRow'
+import { FilterRow } from './FilterRow'
+import { HeaderCell } from './HeaderCell'
+import { SkeletonRows } from './SkeletonRows'
+import { TableViewAllCell } from './TableViewAllCell'
+import { useTableRowLimit } from './useTableRowLimit'
+
+/**
+ * Scrolls to the top of the window whenever the column filters change.
+ */
+function useScrollToTopOnFilterChange<T extends TableItem>(table: TanstackTable<T>) {
+  const { columnFilters } = table.getState()
+  useEffect(() => {
+    if (columnFilters.length) {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [columnFilters])
+}
+
+/**
+ * Scrolls to the top of the table container whenever the page changes with manual pagination.
+ */
+function useScrollToTopOnPageChange<T extends TableItem>(
+  table: TanstackTable<T>,
+  containerRef: RefObject<HTMLElement | null>,
+) {
+  const { pageIndex } = table.getState().pagination
+  useEffect(() => {
+    containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [pageIndex, containerRef])
+}
+
+/**
+ * Resets the table pagination to the first page whenever the number of filtered results changes.
+ * Skipped for manual pagination since data changes on every page change.
+ */
+function useResetPageOnResultChange<T extends TableItem>(table: TanstackTable<T>) {
+  const isManualPagination = table.options.manualPagination
+  const resultCount = table.getFilteredRowModel().rows.length
+  const onPaginationChangeEvent = useEffectEvent(table.setPagination)
+  const lastResultCount = useRef<number>(resultCount)
+  useEffect(() => {
+    // Skip for manual pagination - data is expected to change on page change
+    if (isManualPagination) return
+    // Reset to first page, but only if result amount wasn't 0 (links must keep working while data might still be loading)
+    if (lastResultCount.current && resultCount) onPaginationChangeEvent((prev) => ({ ...prev, pageIndex: 0 }))
+    lastResultCount.current = resultCount
+  }, [resultCount, isManualPagination])
+}
+
+const { Sizing } = SizesAndSpaces
+
+/**
+ * DataTable component to render the table with headers and rows.
+ */
+export const NewDataTable = <T extends TableItem>({
+  emptyState,
+  children,
+  loading,
+  maxHeight,
+  rowLimit,
+  viewAllLabel,
+  shouldStickFirstColumn = false,
+  hideHeader = false,
+  footerRow,
+  ...rowProps
+}: {
+  table: TanstackTable<T>
+  emptyState: ReactNode
+  children?: ReactNode // passed to <FilterRow />
+  loading: boolean
+  maxHeight?: `${number}rem` // also sets overflowY to 'auto'
+  rowLimit?: number
+  viewAllLabel?: string
+  hideHeader?: boolean
+  footerRow?: ReactNode
+} & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
+  const { table } = rowProps
+  const { rows } = table.getRowModel()
+  const { isLimited, isLoading: isLoadingViewAll, onShowAll } = useTableRowLimit(rowLimit, rows.length)
+  // When number of rows are limited, show only rowLimit rows
+  const visibleRows = isLimited && rowLimit ? rows.slice(0, rowLimit) : rows
+  const showViewAllButton = isLimited && rows.length > rowLimit!
+  // pagination should bw shown if no rows limit and if needed
+  const showPagination = !isLimited && table.getPageCount() > 1
+
+  const headerGroups = table.getHeaderGroups()
+  const columnCount = useMemo(() => headerGroups.reduce((acc, group) => acc + group.headers.length, 0), [headerGroups])
+  const top = useLayoutStore((state) => state.navHeight)
+  const containerRef = useRef<HTMLDivElement>(null)
+  useScrollToTopOnFilterChange(table)
+  useResetPageOnResultChange(table)
+  useScrollToTopOnPageChange(table, containerRef)
+  const tableHeaderSx = (t: Theme) => ({
+    position: 'sticky',
+    top: maxHeight ? 0 : top,
+    zIndex: t.zIndex.tableHeader,
+    backgroundColor: t.design.Table.Header.Fill,
+    marginBlock: Sizing['sm'],
+  })
+  const showFooter = showPagination || showViewAllButton || footerRow
+
+  return (
+    <WithWrapper Wrapper={Box} shouldWrap={maxHeight} sx={{ maxHeight, overflowY: 'auto' }} ref={containerRef}>
+      <Table
+        sx={{
+          backgroundColor: (t) => t.design.Layer[1].Fill,
+          borderCollapse: 'separate' /* Don't collapse to avoid funky stuff with the sticky header */,
+        }}
+        data-testid={!loading && 'data-table'}
+      >
+        {!hideHeader && (
+          <TableHead sx={tableHeaderSx} data-testid="data-table-head">
+            {children && <FilterRow table={table}>{children}</FilterRow>}
+
+            {headerGroups.map((headerGroup) => (
+              <TableRow key={headerGroup.id} sx={{ height: Sizing['xxl'] }}>
+                {headerGroup.headers.map((header, index) => (
+                  <HeaderCell
+                    key={header.id}
+                    header={header}
+                    isSticky={!index && shouldStickFirstColumn}
+                    width={`calc(100% / ${columnCount})`}
+                  />
+                ))}
+              </TableRow>
+            ))}
+          </TableHead>
+        )}
+        <TableBody>
+          {loading ? (
+            <SkeletonRows table={table} shouldStickFirstColumn={shouldStickFirstColumn} />
+          ) : rows.length === 0 ? (
+            emptyState
+          ) : (
+            visibleRows.map((row, index) => (
+              <DataRow<T>
+                key={row.id}
+                row={row}
+                isLast={index === visibleRows.length - 1}
+                shouldStickFirstColumn={shouldStickFirstColumn}
+                {...rowProps}
+              />
+            ))
+          )}
+        </TableBody>
+        {showFooter && (
+          <TableFooter>
+            {footerRow && <TableRow>{footerRow}</TableRow>}
+            {showViewAllButton && (
+              <TableRow>
+                <TableViewAllCell colSpan={columnCount} onClick={onShowAll} isLoading={isLoadingViewAll}>
+                  {viewAllLabel || t`View all`}
+                </TableViewAllCell>
+              </TableRow>
+            )}
+            {showPagination && (
+              <TableRow>
+                <TableCell colSpan={columnCount}>
+                  <TablePagination table={table} />
+                </TableCell>
+              </TableRow>
+            )}
+          </TableFooter>
+        )}
+      </Table>
+    </WithWrapper>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewFilterRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewFilterRow.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react'
+import TableCell from '@mui/material/TableCell'
+import TableRow from '@mui/material/TableRow'
+import type { TableItem, TanstackTable } from './data-table.utils'
+
+export const NewFilterRow = <T extends TableItem>({
+  table,
+  children,
+}: {
+  children: ReactNode
+  table: TanstackTable<T>
+}) => (
+  <TableRow>
+    <TableCell
+      colSpan={table.getHeaderGroups().reduce((count, { headers }) => count + headers.length, 0)}
+      sx={{ padding: 0, borderBottomWidth: 0 }}
+      data-testid="table-filters"
+    >
+      {children}
+    </TableCell>
+  </TableRow>
+)

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableButton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableButton.tsx
@@ -1,0 +1,47 @@
+import { forwardRef } from 'react'
+import IconButton from '@mui/material/IconButton'
+import SvgIcon from '@mui/material/SvgIcon'
+import { LoadingAnimation, TransitionFunction } from '@ui-kit/themes/design/0_primitives'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { IconSize } = SizesAndSpaces
+
+/**
+ * A button for controlling the DataTable.
+ */
+export const NewTableButton = forwardRef<
+  HTMLButtonElement,
+  {
+    onClick: () => void
+    rotateIcon?: boolean
+    testId?: string
+    icon: typeof SvgIcon
+    active?: boolean
+  }
+>(({ active, icon: Icon, rotateIcon, testId, ...rest }, ref) => (
+  <IconButton
+    ref={ref}
+    size="small"
+    data-testid={testId}
+    sx={(t) => ({
+      /** The IconButton component is being used in the codebase as a Button component (with only the icon) or as a Chip component (like here)
+       * These are represented by two different components in Figma, therefore we should properly handle both variants from mui-icon-button.ts.
+       * TODO: refactor the IconButton's style from mui-icon-button.ts */
+      transition: `color ${TransitionFunction}`,
+      color: active || rotateIcon ? t.design.Button.Ghost.Hover.Label : t.design.Button.Ghost.Default.Label,
+      '&:hover': {
+        color: t.design.Button.Ghost.Hover.Label,
+      },
+      '&:disabled': {
+        color: t.design.Button.Ghost.Disabled.Label,
+      },
+      '& svg': {
+        width: IconSize.md,
+        height: IconSize.md,
+      },
+    })}
+    {...rest}
+  >
+    <Icon {...(rotateIcon && { sx: LoadingAnimation })} />
+  </IconButton>
+))

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
@@ -6,12 +6,13 @@ import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { useDebounce } from '@ui-kit/hooks/useDebounce'
 import { useFilterExpanded } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { t } from '@ui-kit/lib/i18n'
+import { GearIcon } from '@ui-kit/shared/icons/GearIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { FilterIcon } from '../../icons/FilterIcon'
-import { GearIcon } from '../../icons/GearIcon'
-import { ReloadIcon } from '../../icons/ReloadIcon'
-import { TableButton } from './TableButton'
-import { TableSearchField } from './TableSearchField'
+import { GridChip } from './chips/GridChip'
+import { NewTableButton } from './NewTableButton'
+import { NewTableSearchField } from './NewTableSearchField'
 import { TableVisibilitySettingsPopover } from './TableVisibilitySettingsPopover'
 import type { VisibilityGroup } from './visibility.types'
 
@@ -23,11 +24,8 @@ const { Spacing } = SizesAndSpaces
 export const NewTableFilters = <ColumnIds extends string>({
   header,
   filterExpandedKey,
-  loading,
-  onReload,
   visibilityGroups,
   toggleVisibility,
-  hasSearchBar,
   collapsible,
   chips,
   searchText,
@@ -36,11 +34,8 @@ export const NewTableFilters = <ColumnIds extends string>({
 }: {
   header: ReactNode
   filterExpandedKey: string
-  loading: boolean
-  onReload?: () => void
   visibilityGroups: VisibilityGroup<ColumnIds>[]
   toggleVisibility?: (columns: string[]) => void
-  hasSearchBar?: boolean
   collapsible?: ReactNode // filters that may be collapsed
   chips?: ReactNode // buttons that are part of the collapsible (on mobile) or always visible (on larger screens)
   searchText: string // text to search for, only used for mobile
@@ -52,54 +47,42 @@ export const NewTableFilters = <ColumnIds extends string>({
   const settingsRef = useRef<HTMLButtonElement>(null)
   // search is here because we remove the table title when searching on mobile
   const isMobile = useIsMobile()
-  const [isSearchExpanded, , , toggleSearchExpanded] = useSwitch(!isMobile)
   const [searchValue, setSearchValue] = useDebounce({ initialValue: searchText, callback: onSearch })
   const isCollapsible = collapsible || (isMobile && chips)
-  const isExpandedOrValue = Boolean(isSearchExpanded || searchValue)
 
   return (
-    <Stack paddingBlockEnd={{ mobile: Spacing.sm.tablet }}>
+    <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
       {header}
-      <Grid container spacing={Spacing.sm} paddingInline={Spacing.md} justifyContent="space-between">
-        <Grid
-          size={{ mobile: isExpandedOrValue ? 12 : 'auto', tablet: 6 }}
-          display="flex"
-          justifyContent="flex-end"
-          gap={Spacing.xs}
-          flexWrap="wrap"
-        >
-          {hasSearchBar && (
-            <TableSearchField
-              value={searchValue}
-              onChange={setSearchValue}
-              testId={filterExpandedKey}
-              {...(isMobile && { toggleExpanded: toggleSearchExpanded })}
-              isExpanded={isExpandedOrValue}
-              disableAutoFocus={disableSearchAutoFocus}
-            />
-          )}
-          {!isMobile && toggleVisibility && (
-            <TableButton
+      <Grid container spacing={Spacing.lg} justifyContent="space-between" alignItems="center">
+        <Grid size={{ mobile: 12, tablet: 7 }} padding={Spacing.sm} display="flex">
+          <GridChip
+            label={t`Filters`}
+            selectableChipSize="large"
+            selected={filterExpanded}
+            icon={<FilterIcon />}
+            toggle={() => setFilterExpanded((prev) => !prev)}
+            data-testid="btn-expand-filters"
+          />
+
+          <NewTableSearchField
+            value={searchValue}
+            onChange={setSearchValue}
+            testId={filterExpandedKey}
+            disableAutoFocus={disableSearchAutoFocus}
+          />
+        </Grid>
+        {!isMobile && (
+          <Grid container size="grow" spacing={Spacing.sm} justifyContent="flex-end">
+            {chips}
+            <NewTableButton
               ref={settingsRef}
               onClick={openVisibilitySettings}
               icon={GearIcon}
               testId="btn-visibility-settings"
               active={visibilitySettingsOpen}
             />
-          )}
-          {isCollapsible && !isMobile && (
-            <TableButton
-              onClick={() => setFilterExpanded((prev) => !prev)}
-              active={filterExpanded}
-              icon={FilterIcon}
-              testId="btn-expand-filters"
-            />
-          )}
-          {onReload && !isMobile && <TableButton onClick={onReload} icon={ReloadIcon} rotateIcon={loading} />}
-        </Grid>
-        <Grid container size={12} spacing={Spacing.sm} justifyContent="space-between">
-          {chips}
-        </Grid>
+          </Grid>
+        )}
       </Grid>
       {isCollapsible && !isMobile && <Collapse in={filterExpanded}>{collapsible}</Collapse>}
 

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
@@ -1,0 +1,124 @@
+import { ReactNode, useRef } from 'react'
+import Collapse from '@mui/material/Collapse'
+import Fade from '@mui/material/Fade'
+import Grid from '@mui/material/Grid'
+import Stack from '@mui/material/Stack'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
+import { useDebounce } from '@ui-kit/hooks/useDebounce'
+import { useFilterExpanded } from '@ui-kit/hooks/useLocalStorage'
+import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { Duration } from '@ui-kit/themes/design/0_primitives'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { FilterIcon } from '../../icons/FilterIcon'
+import { GearIcon } from '../../icons/GearIcon'
+import { ReloadIcon } from '../../icons/ReloadIcon'
+import { TableButton } from './TableButton'
+import { TableSearchField } from './TableSearchField'
+import { TableVisibilitySettingsPopover } from './TableVisibilitySettingsPopover'
+import type { VisibilityGroup } from './visibility.types'
+
+const { Spacing } = SizesAndSpaces
+
+/**
+ * A component that wraps a table and provides a title, subtitle, and filter controls.
+ */
+export const NewTableFilters = <ColumnIds extends string>({
+  leftChildren,
+  filterExpandedKey,
+  loading,
+  onReload,
+  visibilityGroups,
+  toggleVisibility,
+  hasSearchBar,
+  collapsible,
+  chips,
+  searchText,
+  disableSearchAutoFocus,
+  onSearch,
+}: {
+  leftChildren: ReactNode
+  filterExpandedKey: string
+  loading: boolean
+  onReload?: () => void
+  visibilityGroups: VisibilityGroup<ColumnIds>[]
+  toggleVisibility?: (columns: string[]) => void
+  hasSearchBar?: boolean
+  collapsible?: ReactNode // filters that may be collapsed
+  chips?: ReactNode // buttons that are part of the collapsible (on mobile) or always visible (on larger screens)
+  searchText: string // text to search for, only used for mobile
+  disableSearchAutoFocus?: boolean
+  onSearch: (value: string) => void
+}) => {
+  const [filterExpanded, setFilterExpanded] = useFilterExpanded(filterExpandedKey)
+  const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch()
+  const settingsRef = useRef<HTMLButtonElement>(null)
+  // search is here because we remove the table title when searching on mobile
+  const isMobile = useIsMobile()
+  const [isSearchExpanded, , , toggleSearchExpanded] = useSwitch(!isMobile)
+  const [searchValue, setSearchValue] = useDebounce({ initialValue: searchText, callback: onSearch })
+  const isCollapsible = collapsible || (isMobile && chips)
+  const isExpandedOrValue = Boolean(isSearchExpanded || searchValue)
+  const hideTitle = hasSearchBar && isExpandedOrValue && isMobile
+
+  return (
+    <Stack paddingBlockEnd={{ mobile: Spacing.sm.tablet }} paddingBlockStart={{ mobile: Spacing.md.tablet }}>
+      <Grid container spacing={Spacing.sm} paddingInline={Spacing.md} justifyContent="space-between">
+        <Fade in={!hideTitle} timeout={Duration.Transition} mountOnEnter unmountOnExit>
+          <Grid size={{ mobile: 'grow', tablet: 6 }} sx={{ position: hideTitle ? 'absolute' : 'relative' }}>
+            {leftChildren}
+          </Grid>
+        </Fade>
+        <Grid
+          size={{ mobile: isExpandedOrValue ? 12 : 'auto', tablet: 6 }}
+          display="flex"
+          justifyContent="flex-end"
+          gap={Spacing.xs}
+          flexWrap="wrap"
+        >
+          {hasSearchBar && (
+            <TableSearchField
+              value={searchValue}
+              onChange={setSearchValue}
+              testId={filterExpandedKey}
+              {...(isMobile && { toggleExpanded: toggleSearchExpanded })}
+              isExpanded={isExpandedOrValue}
+              disableAutoFocus={disableSearchAutoFocus}
+            />
+          )}
+          {!isMobile && toggleVisibility && (
+            <TableButton
+              ref={settingsRef}
+              onClick={openVisibilitySettings}
+              icon={GearIcon}
+              testId="btn-visibility-settings"
+              active={visibilitySettingsOpen}
+            />
+          )}
+          {isCollapsible && !isMobile && (
+            <TableButton
+              onClick={() => setFilterExpanded((prev) => !prev)}
+              active={filterExpanded}
+              icon={FilterIcon}
+              testId="btn-expand-filters"
+            />
+          )}
+          {onReload && !isMobile && <TableButton onClick={onReload} icon={ReloadIcon} rotateIcon={loading} />}
+        </Grid>
+        <Grid container size={12} spacing={Spacing.sm} justifyContent="space-between">
+          {chips}
+        </Grid>
+      </Grid>
+      {isCollapsible && !isMobile && <Collapse in={filterExpanded}>{collapsible}</Collapse>}
+
+      {visibilitySettingsOpen != null && toggleVisibility && (
+        <TableVisibilitySettingsPopover<ColumnIds>
+          anchorRef={settingsRef}
+          visibilityGroups={visibilityGroups}
+          toggleVisibility={toggleVisibility}
+          open={visibilitySettingsOpen}
+          onClose={closeVisibilitySettings}
+        />
+      )}
+    </Stack>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
@@ -1,13 +1,11 @@
 import { ReactNode, useRef } from 'react'
 import Collapse from '@mui/material/Collapse'
-import Fade from '@mui/material/Fade'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { useDebounce } from '@ui-kit/hooks/useDebounce'
 import { useFilterExpanded } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
-import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { FilterIcon } from '../../icons/FilterIcon'
 import { GearIcon } from '../../icons/GearIcon'
@@ -23,7 +21,7 @@ const { Spacing } = SizesAndSpaces
  * A component that wraps a table and provides a title, subtitle, and filter controls.
  */
 export const NewTableFilters = <ColumnIds extends string>({
-  leftChildren,
+  header,
   filterExpandedKey,
   loading,
   onReload,
@@ -36,7 +34,7 @@ export const NewTableFilters = <ColumnIds extends string>({
   disableSearchAutoFocus,
   onSearch,
 }: {
-  leftChildren: ReactNode
+  header: ReactNode
   filterExpandedKey: string
   loading: boolean
   onReload?: () => void
@@ -58,16 +56,11 @@ export const NewTableFilters = <ColumnIds extends string>({
   const [searchValue, setSearchValue] = useDebounce({ initialValue: searchText, callback: onSearch })
   const isCollapsible = collapsible || (isMobile && chips)
   const isExpandedOrValue = Boolean(isSearchExpanded || searchValue)
-  const hideTitle = hasSearchBar && isExpandedOrValue && isMobile
 
   return (
-    <Stack paddingBlockEnd={{ mobile: Spacing.sm.tablet }} paddingBlockStart={{ mobile: Spacing.md.tablet }}>
+    <Stack paddingBlockEnd={{ mobile: Spacing.sm.tablet }}>
+      {header}
       <Grid container spacing={Spacing.sm} paddingInline={Spacing.md} justifyContent="space-between">
-        <Fade in={!hideTitle} timeout={Duration.Transition} mountOnEnter unmountOnExit>
-          <Grid size={{ mobile: 'grow', tablet: 6 }} sx={{ position: hideTitle ? 'absolute' : 'relative' }}>
-            {leftChildren}
-          </Grid>
-        </Fade>
         <Grid
           size={{ mobile: isExpandedOrValue ? 12 : 'auto', tablet: 6 }}
           display="flex"

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useRef } from 'react'
+import Box from '@mui/material/Box'
 import Collapse from '@mui/material/Collapse'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
@@ -55,15 +56,25 @@ export const NewTableFilters = <ColumnIds extends string>({
     <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
       {header}
       <Grid container spacing={Spacing.lg} padding={Spacing.sm} justifyContent="space-between" alignItems="center">
-        <Grid size={{ mobile: 12, tablet: 7 }} display="flex">
-          {filterChip}
-          <NewTableSearchField
-            value={searchValue}
-            onChange={setSearchValue}
-            testId={filterExpandedKey}
-            disableAutoFocus={disableSearchAutoFocus}
-          />
-          {sortChip}
+        <Grid
+          size={{ mobile: 12, tablet: 7 }}
+          sx={{
+            display: 'flex',
+            // overlap adjacent component to avoid duplicate border width
+            '& > .tableControl + .tableControl': { ml: '-1px' },
+          }}
+        >
+          {/* Box wrapper needed for applying style */}
+          {filterChip && <Box className="tableControl">{filterChip}</Box>}
+          <Box className="tableControl" sx={{ flex: 1, minWidth: 0 }}>
+            <NewTableSearchField
+              value={searchValue}
+              onChange={setSearchValue}
+              testId={filterExpandedKey}
+              disableAutoFocus={disableSearchAutoFocus}
+            />
+          </Box>
+          {sortChip && <Box className="tableControl">{sortChip}</Box>}
         </Grid>
         {!isMobile && (
           <Grid container size="grow" spacing="none" justifyContent="flex-end">

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFilters.tsx
@@ -4,13 +4,9 @@ import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { useDebounce } from '@ui-kit/hooks/useDebounce'
-import { useFilterExpanded } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
-import { t } from '@ui-kit/lib/i18n'
 import { GearIcon } from '@ui-kit/shared/icons/GearIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { FilterIcon } from '../../icons/FilterIcon'
-import { GridChip } from './chips/GridChip'
 import { NewTableButton } from './NewTableButton'
 import { NewTableSearchField } from './NewTableSearchField'
 import { TableVisibilitySettingsPopover } from './TableVisibilitySettingsPopover'
@@ -24,25 +20,30 @@ const { Spacing } = SizesAndSpaces
 export const NewTableFilters = <ColumnIds extends string>({
   header,
   filterExpandedKey,
+  filterExpanded,
   visibilityGroups,
   toggleVisibility,
   collapsible,
   chips,
+  filterChip,
+  sortChip,
   searchText,
   disableSearchAutoFocus,
   onSearch,
 }: {
   header: ReactNode
   filterExpandedKey: string
+  filterExpanded: boolean
   visibilityGroups: VisibilityGroup<ColumnIds>[]
   toggleVisibility?: (columns: string[]) => void
   collapsible?: ReactNode // filters that may be collapsed
   chips?: ReactNode // buttons that are part of the collapsible (on mobile) or always visible (on larger screens)
+  filterChip?: ReactNode // buttons responsible for filtering
+  sortChip?: ReactNode // buttons responsible for sorting
   searchText: string // text to search for, only used for mobile
   disableSearchAutoFocus?: boolean
   onSearch: (value: string) => void
 }) => {
-  const [filterExpanded, setFilterExpanded] = useFilterExpanded(filterExpandedKey)
   const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch()
   const settingsRef = useRef<HTMLButtonElement>(null)
   // search is here because we remove the table title when searching on mobile
@@ -53,26 +54,19 @@ export const NewTableFilters = <ColumnIds extends string>({
   return (
     <Stack sx={{ backgroundColor: (t) => t.design.Layer[1].Fill }}>
       {header}
-      <Grid container spacing={Spacing.lg} justifyContent="space-between" alignItems="center">
-        <Grid size={{ mobile: 12, tablet: 7 }} padding={Spacing.sm} display="flex">
-          <GridChip
-            label={t`Filters`}
-            selectableChipSize="large"
-            selected={filterExpanded}
-            icon={<FilterIcon />}
-            toggle={() => setFilterExpanded((prev) => !prev)}
-            data-testid="btn-expand-filters"
-          />
-
+      <Grid container spacing={Spacing.lg} padding={Spacing.sm} justifyContent="space-between" alignItems="center">
+        <Grid size={{ mobile: 12, tablet: 7 }} display="flex">
+          {filterChip}
           <NewTableSearchField
             value={searchValue}
             onChange={setSearchValue}
             testId={filterExpandedKey}
             disableAutoFocus={disableSearchAutoFocus}
           />
+          {sortChip}
         </Grid>
         {!isMobile && (
-          <Grid container size="grow" spacing={Spacing.sm} justifyContent="flex-end">
+          <Grid container size="grow" spacing="none" justifyContent="flex-end">
             {chips}
             <NewTableButton
               ref={settingsRef}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
@@ -1,0 +1,13 @@
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+export const NewTableFiltersHeader = ({ title, subtitle }: { title: string; subtitle?: string }) => (
+  <Stack height="100%" justifyContent="end">
+    <Typography variant="headingSBold">{title}</Typography>
+    {subtitle && (
+      <Typography variant="bodySRegular" color="textSecondary">
+        {subtitle}
+      </Typography>
+    )}
+  </Stack>
+)

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
@@ -1,13 +1,20 @@
+import { ReactNode } from 'react'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
-export const NewTableFiltersHeader = ({ title, subtitle }: { title: string; subtitle?: string }) => (
-  <Stack height="100%" justifyContent="end">
+const { Spacing } = SizesAndSpaces
+
+export const NewTableFiltersHeader = ({ title, rightChildren }: { title: string; rightChildren?: ReactNode }) => (
+  <Stack
+    direction="row"
+    justifyContent="space-between"
+    // background needed because table head has a dfault color, and transparent is not possible because table head is sticky
+    sx={{ backgroundColor: (t) => t.design.Layer.App.Background }}
+    // cannot use Stack + gap because the background color need to be this one and not the default
+    paddingBlockEnd={Spacing.xs}
+  >
     <Typography variant="headingSBold">{title}</Typography>
-    {subtitle && (
-      <Typography variant="bodySRegular" color="textSecondary">
-        {subtitle}
-      </Typography>
-    )}
+    {rightChildren}
   </Stack>
 )

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableFiltersHeader.tsx
@@ -9,6 +9,7 @@ export const NewTableFiltersHeader = ({ title, rightChildren }: { title: string;
   <Stack
     direction="row"
     justifyContent="space-between"
+    alignItems="end"
     // background needed because table head has a dfault color, and transparent is not possible because table head is sticky
     sx={{ backgroundColor: (t) => t.design.Layer.App.Background }}
     // cannot use Stack + gap because the background color need to be this one and not the default

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableSearchField.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/NewTableSearchField.tsx
@@ -1,0 +1,21 @@
+import { notFalsy } from '@primitives/objects.utils'
+import { SearchField } from '@ui-kit/shared/ui/SearchField'
+
+type Props = {
+  value: string
+  placeholder?: string
+  onChange: (value: string) => void
+  testId?: string
+  disableAutoFocus?: boolean
+}
+
+export const NewTableSearchField = ({ value, onChange, testId, disableAutoFocus }: Props) => (
+  <SearchField
+    placeholder="Search"
+    value={value}
+    onSearch={onChange}
+    data-testid={notFalsy('table-text-search', testId).join('-')}
+    size="small"
+    disableAutoFocus={disableAutoFocus}
+  />
+)

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -1,13 +1,12 @@
-import lodash, { max, sum } from 'lodash'
+import { max, sum } from 'lodash'
 import { LlamaMarketColumnId } from '@/llamalend/features/market-list/columns/columns.enum'
 import type { GetMarketsResponse } from '@curvefi/prices-api/llamalend'
-import { oneOf, shuffle, type TokenType } from '@cy/support/generators'
+import { oneOf, type TokenType } from '@cy/support/generators'
 import {
   closeDrawer,
   closeSlider,
   expandFilters,
   expandFirstRowOnMobile,
-  firstRow,
   openDrawer,
   withFilterChips,
 } from '@cy/support/helpers/data-table.helpers'
@@ -25,14 +24,13 @@ import { mockTokenPrices } from '@cy/support/helpers/tokens'
 import {
   assertInViewport,
   assertNotInViewport,
-  type Breakpoint,
   LOAD_TIMEOUT,
   oneDesktopViewport,
   oneViewport,
   RETRY_IN_CI,
 } from '@cy/support/ui'
 import { range, recordValues, repeat } from '@primitives/objects.utils'
-import { MarketRateType } from '@ui-kit/types/market'
+import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 
 const wstEthMarket = '0x100dAa78fC509Db39Ef7D04DE0c1ABD299f4C6CE' as const
 const sfrxEthMarket = '0x8472A9A7632b173c8Cf3a86D3afec50c35548e76' as const
@@ -45,21 +43,23 @@ testCases.forEach(([width, height, breakpoint]) => {
 
     beforeEach(() => {
       vaultData = setupMocks()
-      visitAndWait([width, height, breakpoint])
+      visitAndWait([width, height])
     })
 
     it(`should allow filtering by rewards`, { scrollBehavior: false }, () => {
       cy.get(`[data-testid^="data-table-row"]`).should('have.length.at.least', 1)
-      withFilterChips(breakpoint, () => {
-        cy.get(`[data-testid="chip-rewards"]`).click()
-        return cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
-      })
-      expandFirstRowOnMobile(breakpoint)
-      cy.get(`[data-testid="rewards-icons"]`).should('be.visible')
-      withFilterChips(breakpoint, () => {
-        cy.get(`[data-testid="chip-rewards"]`).click()
-        return cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
-      })
+      if (breakpoint === 'mobile') {
+        withFilterChips(breakpoint, () => {
+          cy.get(`[data-testid="chip-rewards"]`).click()
+          return cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
+        })
+        expandFirstRowOnMobile(breakpoint)
+        cy.get(`[data-testid="rewards-icons"]`).should('be.visible')
+        withFilterChips(breakpoint, () => {
+          cy.get(`[data-testid="chip-rewards"]`).click()
+          return cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
+        })
+      }
     })
 
     it('should have sticky headers', () => {
@@ -70,12 +70,9 @@ testCases.forEach(([width, height, breakpoint]) => {
 
       // filter height changes because text wraps depending on the width
       const filterHeight = {
-        // the height of the header changes depending on how often the description text wraps
-        mobile: [176, 144, 134],
-        // on tablet, we expect 3 rows until 900px, then 2 rows
-        tablet: [144, 112, 104],
-        // on desktop, we expect 2 rows always
-        desktop: [104],
+        mobile: [90],
+        tablet: [100],
+        desktop: [100],
       }[breakpoint]
       cy.get('[data-testid="table-filters"]').invoke('outerHeight').should('be.oneOf', filterHeight)
       cy.get('[data-testid^="data-table-row"]').eq(10).invoke('outerHeight').should('equal', 65)
@@ -87,11 +84,11 @@ testCases.forEach(([width, height, breakpoint]) => {
         .first()
         .find(`[data-testid="market-link-${HighTVLAddress}"]`)
         .should('exist')
-      withFilterChips(breakpoint, () => {
-        cy.get(`[data-testid="chip-lend"]`).click()
-        return cy.get(`[data-testid="pool-type-mint"]`).should('not.exist')
-      })
       if (breakpoint == 'mobile') {
+        withFilterChips(breakpoint, () => {
+          cy.get(`[data-testid="chip-lend"]`).click()
+          return cy.get(`[data-testid="pool-type-mint"]`).should('not.exist')
+        })
         cy.get(`[data-testid="data-table-cell-tvl"]`).first().contains('$')
         openDrawer(breakpoint, 'sort')
         cy.get('[data-testid="drawer-sort-menu-lamalend-markets"]').contains('Utilization', LOAD_TIMEOUT)
@@ -116,10 +113,7 @@ testCases.forEach(([width, height, breakpoint]) => {
     it('should show charts on ' + [breakpoint, [width, height].join('x')].join('/'), () => {
       const vaultCount = sum(recordValues(vaultData).map((d) => d.data.length))
 
-      withFilterChips(breakpoint, () => {
-        cy.get(`[data-testid="chip-lend"]`).click()
-        return cy.get(`[data-testid="pool-type-mint"]`).should('not.exist')
-      })
+      filterByMarketType([width, height])
       if (breakpoint == 'mobile') {
         expandFirstRowOnMobile(breakpoint)
       } else {
@@ -149,13 +143,7 @@ testCases.forEach(([width, height, breakpoint]) => {
     })
 
     it('should find markets by text', () => {
-      // only on mobile is the search not auto-expanded
-      if (breakpoint === 'mobile') {
-        cy.get('[data-testid="btn-expand-search-Llamalend Markets"]').click({ waitForAnimations: true })
-        cy.get("[data-testid^='table-text-search-'] input").should('be.focused') // element is focused when animation completes
-      } else {
-        cy.get("[data-testid^='table-text-search-'] input").click()
-      }
+      cy.get("[data-testid^='table-text-search-'] input").click()
       cy.get("[data-testid='table-text-search-Llamalend Markets'] input").type('wstETH crvUSD')
       cy.url().should('include', 'search=wstETH+crvUSD')
       cy.scrollTo(0, 0)
@@ -228,21 +216,7 @@ testCases.forEach(([width, height, breakpoint]) => {
         cy.url().should('include', `${columnId}=`)
       })
     })
-
-    it('should allow filtering by chain', () => {
-      const chains = Object.keys(vaultData)
-      const chain = oneOf(...chains)
-      cy.get(`[data-testid="chip-chain-${chain}"]`).click()
-      cy.url().should('include', `chain=${chain}`)
-
-      cy.get(`[data-testid="data-table-cell-assets"]:first [data-testid="chain-icon-${chain}"]`).should('be.visible')
-
-      const otherChain = oneOf(...chains.filter((c) => c !== chain))
-      cy.get(`[data-testid="chip-chain-${otherChain}"]`).click()
-      ;[chain, otherChain].forEach((c) => cy.get(`[data-testid="chain-icon-${c}"]`).should('be.visible'))
-      cy.url().should('include', chain)
-      cy.url().should('include', otherChain)
-    })
+    // todo: filter by chain
 
     it(`should allow filtering by token`, () => {
       if (breakpoint == 'mobile') {
@@ -266,26 +240,9 @@ testCases.forEach(([width, height, breakpoint]) => {
       cy.get(`[data-testid="favorite-icon"]:visible`).should('not.exist')
       cy.get(`[data-testid="favorite-icon-filled"]:visible`).click()
       cy.get(`[data-testid="table-empty-row"]`).should('exist')
-      withFilterChips(breakpoint, () => cy.get(`[data-testid="reset-filter"]`).click())
-      cy.url().should('not.include', 'isFavorite=')
-      cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
     })
 
-    it(`should allow filtering by market type`, () =>
-      withFilterChips(breakpoint, () =>
-        cy.get(`[data-testid^="data-table-row"]`).then(({ length }) => {
-          const [type, otherType] = shuffle('Mint', 'Lend')
-          cy.get(`[data-testid="chip-${type.toLowerCase()}"]`).click()
-          cy.url().should('include', `type=${type}`)
-          cy.get(`[data-testid^="pool-type-"]`).each(($el) =>
-            expect($el.attr('data-testid')).equals(`pool-type-${type.toLowerCase()}`),
-          )
-          cy.get(`[data-testid^="data-table-row"]`).should('have.length.below', length)
-          cy.get(`[data-testid="chip-${otherType.toLowerCase()}"]`).click()
-          cy.url().should('include', `type=${type},${otherType}`)
-          cy.get(`[data-testid^="data-table-row"]`).should('have.length', length)
-        }),
-      ))
+    // todo: test reset fiter button yet to be implemented
 
     it(`should copy the market address`, RETRY_IN_CI, () => {
       expandFirstRowOnMobile(breakpoint)
@@ -301,13 +258,10 @@ testCases.forEach(([width, height, breakpoint]) => {
 
     it(`should navigate to market details`, () => {
       const [type, urlRegex] = oneOf(
-        ['mint', /\/crvusd\/\w+\/markets\/[\w-]+\/?$/],
-        ['lend', /\/lend\/\w+\/markets\/.+\/?$/],
+        [LlamaMarketType.Mint, /\/crvusd\/\w+\/markets\/[\w-]+\/?$/],
+        [LlamaMarketType.Lend, /\/lend\/\w+\/markets\/.+\/?$/],
       )
-      withFilterChips(breakpoint, () => {
-        cy.get(`[data-testid="chip-${type}"]`).click()
-        return firstRow().contains(lodash.capitalize(type))
-      })
+      filterByMarketType([width, height], type)
       cy.get(`[data-testid^="market-link-"]`).first().click()
       if (breakpoint === 'mobile') {
         cy.get(`[data-testid^="llama-market-go-to-market"]:visible`).click()
@@ -375,9 +329,13 @@ testCases.forEach(([width, height, breakpoint]) => {
   })
 })
 
-function visitAndWait([width, height]: [number, number, Breakpoint], options?: Partial<Cypress.VisitOptions>) {
+function visitAndWait(
+  [width, height]: [number, number],
+  path = '/llamalend/ethereum/markets/',
+  options?: Partial<Cypress.VisitOptions>,
+) {
   cy.viewport(width, height)
-  cy.visit('/llamalend/ethereum/markets/', { ...LOAD_TIMEOUT, ...options })
+  cy.visit(path, { ...LOAD_TIMEOUT, ...options })
   cy.get('[data-testid="data-table"]', LOAD_TIMEOUT).should('be.visible')
 }
 
@@ -416,3 +374,12 @@ const getMaxTvl = (vaultData: Record<Chain, GetMarketsResponse>) =>
       ),
     ),
   ) ?? 0
+
+// no more chips to filter by market type for the new table
+const filterByMarketType = (size: [number, number], marketType: LlamaMarketType = LlamaMarketType.Lend) => {
+  visitAndWait(size, `/llamalend/ethereum/markets?type=${marketType}`)
+  cy.url().should('include', `type=${marketType}`)
+  cy.get(
+    `[data-testid="pool-type-${(marketType === LlamaMarketType.Lend ? LlamaMarketType.Mint : LlamaMarketType.Lend).toLowerCase()}"]`,
+  ).should('not.exist')
+}


### PR DESCRIPTION
As part of improving the search and filtering experience in the market list, this work will be delivered in multiple steps. This PR represents the first step and focuses on moving the existing components to their final structure. Subsequent PRs will introduce the new filters within a popover, along with additional refinements to fully match the updated design. You will notice that during this transition, chain chips will be temporarily unavailable (Beta only).

While refactoring the market table, and keeping the current implementation intact for stable and legacy channels, I chose to duplicate the relevant components rather than introduce multiple `if`, as the number of changes is significant.

The new components follow the same naming as the originals, with a New prefix (e.g., `DataTable` → `NewDataTable`). When the refactor is complete across the user position table and the pool list table as well, the original components will be removed and the new ones will be renamed.

Next PR: [refactor Chip component](https://github.com/curvefi/curve-frontend/pull/2411)

<img width="1505" height="447" alt="Screenshot 2026-04-24 at 17 03 08" src="https://github.com/user-attachments/assets/5f3f4220-0f6d-4d10-b8b7-636ee35773a3" />
