### PR TITLE
feat: release new historical borrow and supply rate charts on market page

### DIFF
--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -12,7 +12,11 @@ import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { getLib } from '@ui-kit/features/connect-wallet'
-import { useNewBandsChart, useMarketHistoricalRatesChart } from '@ui-kit/hooks/useFeatureFlags'
+import {
+  useNewBandsChart,
+  useMarketHistoricalRatesChart,
+  useMarketInterestRatesAndUtilizationChart,
+} from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
@@ -56,8 +60,11 @@ export const MarketInformationComposite = ({
         <>
           {isBorrow && <MarketHistoricalRatesChart market={market} blockchainId={blockchainId} rateMode="borrow" />}
           <MarketHistoricalRatesChart market={market} blockchainId={blockchainId} rateMode="supply" />
-          <MarketRateCurveChart market={market} blockchainId={blockchainId} chainId={rChainId} marketId={rOwmId} />
         </>
+      )}
+
+      {useMarketInterestRatesAndUtilizationChart() && (
+        <MarketRateCurveChart market={market} blockchainId={blockchainId} chainId={rChainId} marketId={rOwmId} />
       )}
 
       {market && (

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -44,5 +44,8 @@ export const isLLv2Enabled = (releaseChannel: ReleaseChannel) => releaseChannel 
 /** New market page layout with forms on the right  */
 export const useRightFormTabsLayout = useStableChannel
 
-/** New market historical rates chart */
-export const useMarketHistoricalRatesChart = useBetaChannel
+/** New market historical borrow and supply rate charts */
+export const useMarketHistoricalRatesChart = useStableChannel
+
+/** New market historical interest rate and utilization chart */
+export const useMarketInterestRatesAndUtilizationChart = useBetaChannel


### PR DESCRIPTION
The interest rate & utilization relationship chart is apparently not ready yet, but the historical borrow and supply rates should be. So the feature flag has been split up such that the util chart remains in beta, but the two other charts will be in stable.

<img width="1068" height="616" alt="image" src="https://github.com/user-attachments/assets/2d587092-1477-43c8-9041-d256d5cdbc66" />
