### PR TITLE
[codex] increase llamalend advanced details metric size

### DIFF
--- a/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
@@ -61,7 +61,7 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
   return (
     <Box display="grid" gap={Spacing.lg} gridTemplateColumns={{ mobile: 'repeat(2, 1fr)', tablet: 'repeat(4, 1fr)' }}>
       <Metric
-        size="small"
+        size="medium"
         label={t`Utilization`}
         value={utilization}
         loading={availableLiquidity?.loading}
@@ -74,7 +74,7 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
         }}
       />
       <Metric
-        size="small"
+        size="medium"
         label={t`Total collateral`}
         value={collateral?.combinedCollateralUsdValue}
         loading={collateral?.loading}
@@ -97,7 +97,7 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
         }}
       />
       <Metric
-        size="small"
+        size="medium"
         label={t`Solvency`}
         value={solvency?.value}
         loading={solvency?.loading}
@@ -110,7 +110,7 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
       />
       {maxLeverage && (
         <Metric
-          size="small"
+          size="medium"
           label={t`Max leverage`}
           value={maxLeverage?.value == null ? undefined : +maxLeverage.value}
           loading={maxLeverage?.loading}


### PR DESCRIPTION
## Summary
- Increase the Advanced Details metrics on Llamalend market pages from small to medium.
- Keep using the shared Metric component without changing its implementation.

## Validation
- yarn eslint apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
- yarn workspace main typecheck runs, but currently fails on existing broad MUI/theme augmentation errors outside this change.