### PR TITLE
chore: bump curvefi/api to 2.69.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.69.0",
+    "@curvefi/api": "2.69.1",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
     "@types/node": "25.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.68.38",
+    "@curvefi/api": "2.69.0",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
     "@types/node": "25.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,15 +358,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:2.69.0":
-  version: 2.69.0
-  resolution: "@curvefi/api@npm:2.69.0"
+"@curvefi/api@npm:2.69.1":
+  version: 2.69.1
+  resolution: "@curvefi/api@npm:2.69.1"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:^10.0.2"
     ethers: "npm:^6.16.0"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/9bee1a7dda1d090f0c8a8ae0ca787b1a3301ffe1f9bf02afa64a3581dc3919b223e3fd81523078d52219a0b7356478633da0e7b0f2c5aa0d88339e8024d9857e
+  checksum: 10c0/7d409aa71735e16e2f5254b13bdb2948ed9859a0748b3f1b546f736644776e554fd7ce50afb9f0752e6c4a53b494106b378328a01bb64960b335a5c80b472786
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,19 +358,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:2.68.38":
-  version: 2.68.38
-  resolution: "@curvefi/api@npm:2.68.38"
+"@curvefi/api@npm:2.69.0":
+  version: 2.69.0
+  resolution: "@curvefi/api@npm:2.69.0"
   dependencies:
-    "@curvefi/ethcall": "npm:^6.0.16"
+    "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:^10.0.2"
     ethers: "npm:^6.16.0"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/aa17a98cce4f971c4e1d5be25ea88d16ee8178eb5e8338bad651d51671cfc54f71852f938197538496786db33376d1e49d6760767679d740d04d604c175f4c22
+  checksum: 10c0/9bee1a7dda1d090f0c8a8ae0ca787b1a3301ffe1f9bf02afa64a3581dc3919b223e3fd81523078d52219a0b7356478633da0e7b0f2c5aa0d88339e8024d9857e
   languageName: node
   linkType: hard
 
-"@curvefi/ethcall@npm:6.0.16, @curvefi/ethcall@npm:^6.0.16":
+"@curvefi/ethcall@npm:6.0.16":
   version: 6.0.16
   resolution: "@curvefi/ethcall@npm:6.0.16"
   dependencies:
@@ -379,6 +379,18 @@ __metadata:
   peerDependencies:
     ethers: ^6.0.0
   checksum: 10c0/3bd41b3d84f0ed0654279a88920ad7ce38507804008fc8caa86fb2763520f594ef62953a260cb07661f6d71afd5467e41249fdda9eb3b71d10623a496679880e
+  languageName: node
+  linkType: hard
+
+"@curvefi/ethcall@npm:6.0.20":
+  version: 6.0.20
+  resolution: "@curvefi/ethcall@npm:6.0.20"
+  dependencies:
+    "@types/node": "npm:^22.12.0"
+    abi-coder: "npm:^5.0.0"
+  peerDependencies:
+    ethers: ^6.0.0
+  checksum: 10c0/59a255ec9b4139cce840c114eae3decbc24319dbf7d41829357d6ab17a87aa8b5f2a34749649e86b961a3b0100e134c874c1e3138909463020876589a769b2b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes:
- Bumps curve-js to 2.69.1 https://github.com/curvefi/curve-js/pull/540/