### PR TITLE
feat: pass selected slippage to estimate gas on dex

### DIFF
--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDeposit.tsx
@@ -93,10 +93,10 @@ export const FormDeposit = ({
   )
 
   const handleApproveClick = useCallback(
-    async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues) => {
+    async (activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string) => {
       const notifyMessage = t`Please approve spending your ${tokensDescription(formValues.amounts)}.`
       const { dismiss } = notify(notifyMessage, 'pending')
-      await fetchStepApprove(activeKey, curve, 'DEPOSIT', poolData.pool, formValues)
+      await fetchStepApprove(activeKey, curve, 'DEPOSIT', poolData.pool, formValues, maxSlippage)
       if (typeof dismiss === 'function') dismiss()
     },
     [fetchStepApprove],
@@ -141,7 +141,7 @@ export const FormDeposit = ({
           status: getStepStatus(isApproved, formStatus.step === 'APPROVAL', isValid),
           type: 'action',
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
-          onClick: async () => handleApproveClick(activeKey, curve, poolData, formValues),
+          onClick: async () => handleApproveClick(activeKey, curve, poolData, formValues, maxSlippage),
         },
         ['DEPOSIT']: {
           key: 'DEPOSIT',

--- a/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
+++ b/apps/main/src/dex/components/PagePool/Deposit/components/FormDepositStake.tsx
@@ -96,10 +96,10 @@ export const FormDepositStake = ({
   )
 
   const handleApproveClick = useCallback(
-    async (activeKey: string, curve: CurveApi, pool: Pool, formValues: FormValues) => {
+    async (activeKey: string, curve: CurveApi, pool: Pool, formValues: FormValues, maxSlippage: string) => {
       const notifyMessage = t`Please approve spending your ${tokensDescription(formValues.amounts)}.`
       const { dismiss } = notify(notifyMessage, 'pending')
-      await fetchStepApprove(activeKey, curve, 'DEPOSIT_STAKE', pool, formValues)
+      await fetchStepApprove(activeKey, curve, 'DEPOSIT_STAKE', pool, formValues, maxSlippage)
       if (typeof dismiss === 'function') dismiss()
     },
     [fetchStepApprove],
@@ -144,7 +144,7 @@ export const FormDepositStake = ({
           status: getStepStatus(isApproved, formStatus.step === 'APPROVAL', isValid),
           type: 'action',
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
-          onClick: () => handleApproveClick(activeKey, curve, poolData.pool, formValues),
+          onClick: () => handleApproveClick(activeKey, curve, poolData.pool, formValues, maxSlippage),
         },
         DEPOSIT_STAKE: {
           key: 'DEPOSIT_STAKE',

--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
@@ -100,10 +100,17 @@ export const FormWithdraw = ({
   )
 
   const handleApproveClick = useCallback(
-    async (activeKey: string, config: Config, curve: CurveApi, pool: Pool, formValues: FormValues) => {
+    async (
+      activeKey: string,
+      config: Config,
+      curve: CurveApi,
+      pool: Pool,
+      formValues: FormValues,
+      maxSlippage: string,
+    ) => {
       const notifyMessage = t`Please approve spending your LP Tokens.`
       const { dismiss } = notify(notifyMessage, 'pending')
-      await fetchStepApprove(activeKey, config, curve, 'WITHDRAW', pool, formValues)
+      await fetchStepApprove(activeKey, config, curve, 'WITHDRAW', pool, formValues, maxSlippage)
       if (typeof dismiss === 'function') dismiss()
     },
     [fetchStepApprove],
@@ -157,7 +164,7 @@ export const FormWithdraw = ({
           status: getStepStatus(isApproved, formStatus.step === 'APPROVAL', isValid),
           type: 'action',
           content: isApproved ? t`Spending Approved` : t`Approve Spending`,
-          onClick: () => handleApproveClick(activeKey, config, curve, poolData.pool, formValues),
+          onClick: () => handleApproveClick(activeKey, config, curve, poolData.pool, formValues, maxSlippage),
         },
         WITHDRAW: {
           key: 'WITHDRAW',

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -57,8 +57,10 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
   const isMdUp = useLayoutStore((state) => state.isMdUp)
   const fetchPoolStats = useStore((state) => state.pools.fetchPoolStats)
   const setPoolIsWrapped = useStore((state) => state.pools.setPoolIsWrapped)
+  const { pool } = poolDataCacheOrApi
 
-  const storeMaxSlippage = useUserProfileStore((state) => state.maxSlippage[chainIdPoolId])
+  const poolMaxSlippage = useUserProfileStore((state) => state.maxSlippage[chainIdPoolId])
+  const poolTypeMaxSlippage = useUserProfileStore((state) => state.maxSlippage[pool.isCrypto ? 'crypto' : 'stable'])
 
   const { data: gaugeManager, isPending: isPendingGaugeManager } = useGaugeManager(
     {
@@ -79,7 +81,6 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
 
   const [seed, setSeed] = useState(DEFAULT_SEED)
 
-  const { pool } = poolDataCacheOrApi
   const { data: network } = useNetworkByChain({ chainId: rChainId })
   const { networkId, isLite, pricesApi } = network
   const { data: pricesApiPoolsMapper } = usePoolsPricesApi({ blockchainId: networkId as Chain })
@@ -108,11 +109,9 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
   const [poolInfoTab, setPoolInfoTab] = useState<DetailInfoTab>('pool')
 
   const maxSlippage = useMemo(() => {
-    if (storeMaxSlippage) return storeMaxSlippage
-    if (!pool) return ''
-
-    return pool.isCrypto ? '0.1' : '0.03'
-  }, [storeMaxSlippage, pool])
+    const poolTypeDefaultMaxSlippage = pool.isCrypto ? '0.1' : '0.03'
+    return poolMaxSlippage || poolTypeMaxSlippage || poolTypeDefaultMaxSlippage
+  }, [pool.isCrypto, poolMaxSlippage, poolTypeMaxSlippage])
 
   usePageVisibleInterval(() => {
     if (curve && poolData) {

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -393,9 +393,9 @@ export const QuickSwap = ({
 
   // maxSlippage
   useEffect(() => {
-    if (isReady) updateFormValues({}, false, cryptoMaxSlippage)
+    if (isReady) updateFormValues({}, false, storeMaxSlippage)
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [cryptoMaxSlippage])
+  }, [storeMaxSlippage])
 
   // pageVisible re-fetch data
   useEffect(() => {

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -394,6 +394,8 @@ export const QuickSwap = ({
   // maxSlippage
   useEffect(() => {
     if (isReady) updateFormValues({}, false, storeMaxSlippage)
+    // Intentionally depend on raw profile slippage values, not storeMaxSlippage.
+    // storeMaxSlippage also changes when route metadata resolves, which can trigger a slippage/activeKey refresh loop.
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [cryptoMaxSlippage, stableMaxSlippage])
 

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -395,7 +395,7 @@ export const QuickSwap = ({
   useEffect(() => {
     if (isReady) updateFormValues({}, false, storeMaxSlippage)
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [storeMaxSlippage])
+  }, [cryptoMaxSlippage, stableMaxSlippage])
 
   // pageVisible re-fetch data
   useEffect(() => {

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -280,15 +280,23 @@ const router = {
     fromAddress: string,
     toAddress: string,
     fromAmount: string,
+    slippageTolerance: string,
     isApprovalCheckOnly?: boolean,
   ) => {
-    log('routerEstGasApproval', fromAddress, toAddress, fromAmount)
+    log('routerEstGasApproval', fromAddress, toAddress, fromAmount, slippageTolerance)
     const resp = { activeKey, isApproved: false, estimatedGas: null as EstimatedGas, error: '' }
     try {
       resp.isApproved = await curve.router.isApproved(fromAddress, fromAmount)
       if (!isApprovalCheckOnly) {
         resp.estimatedGas = resp.isApproved
-          ? await curve.router.estimateGas.swap(fromAddress, toAddress, fromAmount)
+          ? await (
+              curve.router.estimateGas.swap as (
+                inputCoin: string,
+                outputCoin: string,
+                amount: string | number,
+                slippage?: number,
+              ) => Promise<EstimatedGas>
+            )(fromAddress, toAddress, fromAmount, +slippageTolerance)
           : await curve.router.estimateGas.approve(fromAddress, fromAmount)
       }
       void warnIncorrectEstGas(curve.chainId, resp.estimatedGas)
@@ -389,16 +397,17 @@ const poolDeposit = {
     p: Pool,
     isWrapped: boolean,
     amounts: string[],
+    maxSlippage: string,
   ) => {
-    log('depositEstGasApproval', p.name, isWrapped, amounts)
+    log('depositEstGasApproval', p.name, isWrapped, amounts, maxSlippage)
     const resp = { activeKey, isApproved: false, estimatedGas: null as EstimatedGas, error: '' }
     try {
       resp.isApproved = isWrapped ? await p.depositWrappedIsApproved(amounts) : await p.depositIsApproved(amounts)
 
       if (resp.isApproved) {
         resp.estimatedGas = isWrapped
-          ? await p.estimateGas.depositWrapped(amounts)
-          : await p.estimateGas.deposit(amounts)
+          ? await p.estimateGas.depositWrapped(amounts, +maxSlippage)
+          : await p.estimateGas.deposit(amounts, +maxSlippage)
       } else {
         resp.estimatedGas = isWrapped
           ? await p.estimateGas.depositWrappedApprove(amounts)
@@ -480,8 +489,9 @@ const poolDeposit = {
     p: Pool,
     isWrapped: boolean,
     amounts: string[],
+    maxSlippage: string,
   ) => {
-    log('depositAndStakeEstGasApproval', p.name, isWrapped, amounts)
+    log('depositAndStakeEstGasApproval', p.name, isWrapped, amounts, maxSlippage)
     const resp = { activeKey, isApproved: false, estimatedGas: null as EstimatedGas, error: '' }
     try {
       resp.isApproved = isWrapped
@@ -490,8 +500,8 @@ const poolDeposit = {
 
       if (resp.isApproved) {
         resp.estimatedGas = isWrapped
-          ? await p.estimateGas.depositAndStakeWrapped(amounts)
-          : await p.estimateGas.depositAndStake(amounts)
+          ? await p.estimateGas.depositAndStakeWrapped(amounts, +maxSlippage)
+          : await p.estimateGas.depositAndStake(amounts, +maxSlippage)
       } else {
         resp.estimatedGas = isWrapped
           ? await p.estimateGas.depositAndStakeWrappedApprove(amounts)
@@ -782,16 +792,17 @@ const poolWithdraw = {
     p: Pool,
     isWrapped: boolean,
     lpTokenAmount: string,
+    maxSlippage: string,
   ) => {
-    log('withdrawEstGasApproval', p.name, lpTokenAmount)
+    log('withdrawEstGasApproval', p.name, lpTokenAmount, maxSlippage)
     const resp = { activeKey, estimatedGas: null as EstimatedGas, isApproved: false, error: '' }
     try {
       resp.isApproved = await p.withdrawIsApproved(lpTokenAmount)
 
       if (resp.isApproved) {
         resp.estimatedGas = isWrapped
-          ? await p.estimateGas.withdrawWrapped(lpTokenAmount)
-          : await p.estimateGas.withdraw(lpTokenAmount)
+          ? await p.estimateGas.withdrawWrapped(lpTokenAmount, +maxSlippage)
+          : await p.estimateGas.withdraw(lpTokenAmount, +maxSlippage)
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawApprove(lpTokenAmount)
       }
@@ -863,16 +874,17 @@ const poolWithdraw = {
     p: Pool,
     isWrapped: boolean,
     amounts: string[],
+    maxSlippage: string,
   ) => {
-    log('withdrawImbalanceEstGasApproval', p.name, isWrapped, amounts)
+    log('withdrawImbalanceEstGasApproval', p.name, isWrapped, amounts, maxSlippage)
     const resp = { activeKey, estimatedGas: null as EstimatedGas, isApproved: false, error: '' }
     try {
       resp.isApproved = await p.withdrawImbalanceIsApproved(amounts)
 
       if (resp.isApproved) {
         resp.estimatedGas = isWrapped
-          ? await p.estimateGas.withdrawImbalanceWrapped(amounts)
-          : await p.estimateGas.withdrawImbalance(amounts)
+          ? await p.estimateGas.withdrawImbalanceWrapped(amounts, +maxSlippage)
+          : await p.estimateGas.withdrawImbalance(amounts, +maxSlippage)
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawImbalanceApprove(amounts)
       }
@@ -955,15 +967,16 @@ const poolWithdraw = {
     isWrapped: boolean,
     lpTokenAmount: string,
     tokenAddress: string,
+    maxSlippage: string,
   ) => {
-    log('withdrawOneCoinEstGasApproval', p.name, isWrapped, lpTokenAmount, tokenAddress)
+    log('withdrawOneCoinEstGasApproval', p.name, isWrapped, lpTokenAmount, tokenAddress, maxSlippage)
     const resp = { activeKey, estimatedGas: null as EstimatedGas, isApproved: false, error: '' }
     try {
       resp.isApproved = await p.withdrawOneCoinIsApproved(lpTokenAmount)
       if (resp.isApproved) {
         resp.estimatedGas = isWrapped
-          ? await p.estimateGas.withdrawOneCoinWrapped(lpTokenAmount, tokenAddress)
-          : await p.estimateGas.withdrawOneCoin(lpTokenAmount, tokenAddress)
+          ? await p.estimateGas.withdrawOneCoinWrapped(lpTokenAmount, tokenAddress, +maxSlippage)
+          : await p.estimateGas.withdrawOneCoin(lpTokenAmount, tokenAddress, +maxSlippage)
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawOneCoinApprove(lpTokenAmount)
       }

--- a/apps/main/src/dex/store/createPoolDepositSlice.ts
+++ b/apps/main/src/dex/store/createPoolDepositSlice.ts
@@ -86,7 +86,7 @@ export type PoolDepositSlice = {
       chainId: ChainId,
       formType: FormType,
       pool: Pool,
-      maxSlippage?: string,
+      maxSlippage: string,
     ): Promise<FnStepEstGasApprovalResponse>
     fetchStepApprove(
       activeKey: string,
@@ -383,7 +383,7 @@ export const createPoolDepositSlice = (
     },
 
     // steps
-    fetchEstGasApproval: async (activeKey, chainId, formType, pool, maxSlippage = '0') => {
+    fetchEstGasApproval: async (activeKey, chainId, formType, pool, maxSlippage) => {
       const cFormValues = cloneDeep(get()[sliceKey].formValues)
       const { amounts, isWrapped, lpToken } = cFormValues
       const resp =
@@ -584,7 +584,7 @@ export const createPoolDepositSlice = (
           get()[sliceKey].setStateByKey('formStatus', cFormStatus)
 
           // fetch est gas and approval
-          await get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+          await get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool, '')
         }
 
         return resp

--- a/apps/main/src/dex/store/createPoolDepositSlice.ts
+++ b/apps/main/src/dex/store/createPoolDepositSlice.ts
@@ -67,14 +67,35 @@ const sliceKey = 'poolDeposit'
 export type PoolDepositSlice = {
   [sliceKey]: SliceState & {
     fetchExpected(activeKey: string, formType: FormType, pool: Pool, formValues: FormValues): Promise<void>
-    fetchMaxAmount(config: Config, activeKey: string, chainId: ChainId, userAddress: Address, pool: Pool, loadMaxAmount: LoadMaxAmount): Promise<Amount[]>
+    fetchMaxAmount(
+      config: Config,
+      activeKey: string,
+      chainId: ChainId,
+      userAddress: Address,
+      pool: Pool,
+      loadMaxAmount: LoadMaxAmount,
+      maxSlippage: string,
+    ): Promise<Amount[]>
     fetchSeedAmount(poolData: PoolData, formValues: FormValues): Promise<Pick<FormValues, 'amounts' | 'isWrapped'>>
     fetchSlippage(activeKey: string, formType: FormType, pool: Pool, formValues: FormValues, maxSlippage: string): Promise<void>
     setFormValues(formType: FormType, config: Config, curve: CurveApi | null, poolId: string, poolData: PoolData | undefined, formValues: Partial<FormValues>, loadMaxAmount: LoadMaxAmount | null, isSeed: boolean | null, maxSlippage: string): Promise<void>
 
     // steps
-    fetchEstGasApproval(activeKey: string, chainId: ChainId, formType: FormType, pool: Pool): Promise<FnStepEstGasApprovalResponse>
-    fetchStepApprove(activeKey: string, curve: CurveApi, formType: FormType, pool: Pool, formValues: FormValues): Promise<FnStepApproveResponse | undefined>
+    fetchEstGasApproval(
+      activeKey: string,
+      chainId: ChainId,
+      formType: FormType,
+      pool: Pool,
+      maxSlippage?: string,
+    ): Promise<FnStepEstGasApprovalResponse>
+    fetchStepApprove(
+      activeKey: string,
+      curve: CurveApi,
+      formType: FormType,
+      pool: Pool,
+      formValues: FormValues,
+      maxSlippage: string,
+    ): Promise<FnStepApproveResponse | undefined>
     fetchStepDeposit(activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string): Promise<FnStepResponse | undefined>
     fetchStepDepositStake(activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string): Promise<FnStepResponse | undefined>
     fetchStepStakeApprove(activeKey: string, curve: CurveApi, formType: FormType, pool: Pool, formValues: FormValues): Promise<FnStepApproveResponse | undefined>
@@ -124,7 +145,7 @@ export const createPoolDepositSlice = (
         },
       })
     },
-    fetchMaxAmount: async (config, activeKey, chainId, userAddress, pool, { tokenAddress, idx }) => {
+    fetchMaxAmount: async (config, activeKey, chainId, userAddress, pool, { tokenAddress, idx }, maxSlippage) => {
       const cFormValues = cloneDeep(get()[sliceKey].formValues)
       const userBalance = await fetchTokenBalance(config, {
         chainId,
@@ -148,6 +169,7 @@ export const createPoolDepositSlice = (
           pool,
           cFormValues.isWrapped,
           parseAmountsForAPI(cFormValues.amounts),
+          maxSlippage,
         )
         const networks = await fetchNetworks()
         const { basePlusPriority } = await fetchGasInfoAndUpdateLib({ chainId, networks })
@@ -262,6 +284,7 @@ export const createPoolDepositSlice = (
             signerAddress,
             pool,
             loadMaxAmount,
+            maxSlippage,
           )
           activeKey = getActiveKey(pool.id, formType, cFormValues, maxSlippage)
           get()[sliceKey].setStateByKeys({
@@ -332,7 +355,7 @@ export const createPoolDepositSlice = (
                 ...(get()[sliceKey].formEstGas[storedActiveKey] ?? DEFAULT_ESTIMATED_GAS),
                 loading: true,
               })
-              void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+              void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool, maxSlippage)
             }
           }
         }
@@ -353,14 +376,14 @@ export const createPoolDepositSlice = (
               ...(get()[sliceKey].formEstGas[storedActiveKey] ?? DEFAULT_ESTIMATED_GAS),
               loading: true,
             })
-            void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+            void get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool, maxSlippage)
           }
         }
       }
     },
 
     // steps
-    fetchEstGasApproval: async (activeKey, chainId, formType, pool) => {
+    fetchEstGasApproval: async (activeKey, chainId, formType, pool, maxSlippage = '0') => {
       const cFormValues = cloneDeep(get()[sliceKey].formValues)
       const { amounts, isWrapped, lpToken } = cFormValues
       const resp =
@@ -371,6 +394,7 @@ export const createPoolDepositSlice = (
               pool,
               isWrapped,
               parseAmountsForAPI(amounts),
+              maxSlippage,
             )
           : formType === 'DEPOSIT_STAKE'
             ? await curvejsApi.poolDeposit.depositAndStakeEstGasApproval(
@@ -379,6 +403,7 @@ export const createPoolDepositSlice = (
                 pool,
                 isWrapped,
                 parseAmountsForAPI(amounts),
+                maxSlippage,
               )
             : await curvejsApi.poolDeposit.stakeEstGasApproval(activeKey, chainId, pool, lpToken)
 
@@ -399,7 +424,7 @@ export const createPoolDepositSlice = (
       }
       return resp
     },
-    fetchStepApprove: async (activeKey, curve, formType, pool, formValues) => {
+    fetchStepApprove: async (activeKey, curve, formType, pool, formValues, maxSlippage) => {
       const { provider } = useWallet.getState()
       if (!provider) return setMissingProvider(get()[sliceKey])
 
@@ -428,7 +453,7 @@ export const createPoolDepositSlice = (
           get()[sliceKey].setStateByKey('formStatus', cFormStatus)
 
           // fetch est gas and approval
-          await get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool)
+          await get()[sliceKey].fetchEstGasApproval(activeKey, chainId, formType, pool, maxSlippage)
         }
 
         return resp

--- a/apps/main/src/dex/store/createPoolWithdrawSlice.ts
+++ b/apps/main/src/dex/store/createPoolWithdrawSlice.ts
@@ -62,8 +62,24 @@ export type PoolWithdrawSlice = {
     setFormValues(formType: FormType, config: Config, curve: CurveApi | null, poolId: string, poolData: PoolData | undefined, updatedFormValues: Partial<FormValues>, loadMaxAmount: LoadMaxAmount | null, isSeed: boolean | null, maxSlippage: string): Promise<void>
 
     // steps
-    fetchEstGasApproval(activeKey: string, config: Config, curve: CurveApi, formType: FormType, pool: Pool, formValues: FormValues): Promise<FnStepEstGasApprovalResponse | undefined>
-    fetchStepApprove(activeKey: string, config: Config, curve: CurveApi, formType: FormType, pool: Pool, formValues: FormValues): Promise<FnStepApproveResponse | undefined>
+    fetchEstGasApproval(
+      activeKey: string,
+      config: Config,
+      curve: CurveApi,
+      formType: FormType,
+      pool: Pool,
+      formValues: FormValues,
+      maxSlippage: string,
+    ): Promise<FnStepEstGasApprovalResponse | undefined>
+    fetchStepApprove(
+      activeKey: string,
+      config: Config,
+      curve: CurveApi,
+      formType: FormType,
+      pool: Pool,
+      formValues: FormValues,
+      maxSlippage: string,
+    ): Promise<FnStepApproveResponse | undefined>
     fetchStepWithdraw(activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues, maxSlippage: string): Promise<FnStepResponse | undefined>
     fetchStepUnstake(activeKey: string, curve: CurveApi, poolData: PoolData, formValues: FormValues): Promise<FnStepResponse | undefined>
     fetchStepClaim(activeKey: string, curve: CurveApi, poolData: PoolData): Promise<FnStepResponse | undefined>
@@ -149,7 +165,7 @@ export const createPoolWithdrawSlice = (
 
       // get gas
       if (signerAddress) {
-        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues, maxSlippage)
       }
     },
     fetchWithdrawLpToken: async (props) => {
@@ -197,7 +213,7 @@ export const createPoolWithdrawSlice = (
 
         // get gas
         if (signerAddress) {
-          void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues)
+          void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues, maxSlippage)
         }
       }
     },
@@ -288,7 +304,7 @@ export const createPoolWithdrawSlice = (
 
       // get gas
       if (signerAddress) {
-        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues, maxSlippage)
       }
     },
     fetchClaimable: async (activeKey, chainId, pool) => {
@@ -373,14 +389,14 @@ export const createPoolWithdrawSlice = (
           void get()[sliceKey].fetchWithdrawCustom(props)
         }
       } else if (formType === 'UNSTAKE' && !!signerAddress && +cFormValues.stakedLpToken > 0) {
-        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues)
+        void get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, cFormValues, maxSlippage)
       } else if (formType === 'CLAIM') {
         void get()[sliceKey].fetchClaimable(activeKey, chainId, pool)
       }
     },
 
     // steps
-    fetchEstGasApproval: async (activeKey, config, curve, formType, pool, formValues) => {
+    fetchEstGasApproval: async (activeKey, config, curve, formType, pool, formValues, maxSlippage) => {
       const { chainId } = curve
       let resp
       if (formType === 'WITHDRAW') {
@@ -395,6 +411,7 @@ export const createPoolWithdrawSlice = (
                   pool,
                   formValues.isWrapped,
                   formValues.lpToken,
+                  maxSlippage,
                 )
               : formValues.selected === 'imbalance'
                 ? await curvejsApi.poolWithdraw.withdrawImbalanceEstGasApproval(
@@ -403,6 +420,7 @@ export const createPoolWithdrawSlice = (
                     pool,
                     formValues.isWrapped,
                     parseAmountsForAPI(formValues.amounts),
+                    maxSlippage,
                   )
                 : await curvejsApi.poolWithdraw.withdrawOneCoinEstGasApproval(
                     activeKey,
@@ -411,6 +429,7 @@ export const createPoolWithdrawSlice = (
                     formValues.isWrapped,
                     formValues.lpToken,
                     formValues.selectedTokenAddress,
+                    maxSlippage,
                   )
         }
       } else if (formType === 'UNSTAKE') {
@@ -436,7 +455,7 @@ export const createPoolWithdrawSlice = (
       }
       return resp
     },
-    fetchStepApprove: async (activeKey, config, curve, formType, pool, formValues) => {
+    fetchStepApprove: async (activeKey, config, curve, formType, pool, formValues, maxSlippage) => {
       const { provider } = useWallet.getState()
       if (!provider) return setMissingProvider(get()[sliceKey])
 
@@ -471,7 +490,7 @@ export const createPoolWithdrawSlice = (
           get()[sliceKey].setStateByKey('formStatus', cFormStatus)
 
           // fetch est gas and approval
-          await get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, formValues)
+          await get()[sliceKey].fetchEstGasApproval(activeKey, config, curve, formType, pool, formValues, maxSlippage)
         }
 
         return resp

--- a/apps/main/src/dex/store/createQuickSwapSlice.ts
+++ b/apps/main/src/dex/store/createQuickSwapSlice.ts
@@ -40,19 +40,14 @@ const sliceKey = 'quickSwap'
 
 export type QuickSwapSlice = {
   [sliceKey]: SliceState & {
-    fetchMaxAmount(
-      config: Config,
-      curve: CurveApi,
-      searchedParams: SearchedParams,
-      maxSlippage: string | undefined,
-    ): Promise<void>
+    fetchMaxAmount(config: Config, curve: CurveApi, searchedParams: SearchedParams, maxSlippage: string): Promise<void>
     fetchRoutesAndOutput(
       config: Config,
       curve: CurveApi,
       searchedParams: SearchedParams,
       maxSlippage: string,
     ): Promise<void>
-    fetchEstGasApproval(curve: CurveApi, searchedParams: SearchedParams): Promise<void>
+    fetchEstGasApproval(curve: CurveApi, searchedParams: SearchedParams, maxSlippage: string): Promise<void>
     resetFormErrors(): void
     setFormValues(
       config: Config,
@@ -140,7 +135,14 @@ export const createQuickSwapSlice = (
             const poolsMapper = state.pools.poolsMapper[chainId]
             await curvejsApi.router.routesAndOutput(activeKey, curve, poolsMapper, cFormValues, searchedParams)
 
-            const resp = await curvejsApi.router.estGasApproval(activeKey, curve, fromAddress, toAddress, userBalance)
+            const resp = await curvejsApi.router.estGasApproval(
+              activeKey,
+              curve,
+              fromAddress,
+              toAddress,
+              userBalance,
+              maxSlippage,
+            )
 
             if (resp.estimatedGas) {
               cFormValues.fromAmount = getMaxAmountMinusGas(resp.estimatedGas, firstBasePlusPriority, userBalance)
@@ -235,7 +237,7 @@ export const createQuickSwapSlice = (
         }
       }
     },
-    fetchEstGasApproval: async (curve, searchedParams) => {
+    fetchEstGasApproval: async (curve, searchedParams, maxSlippage) => {
       const state = get()
       const sliceState = state[sliceKey]
 
@@ -247,7 +249,14 @@ export const createQuickSwapSlice = (
       if (+fromAmount <= 0 || !signerAddress) return
 
       // api call
-      const resp = await curvejsApi.router.estGasApproval(activeKey, curve, fromAddress, toAddress, fromAmount)
+      const resp = await curvejsApi.router.estGasApproval(
+        activeKey,
+        curve,
+        fromAddress,
+        toAddress,
+        fromAmount,
+        maxSlippage,
+      )
 
       // set estimate gas state
       sliceState.setStateByKey('formEstGas', { [activeKey]: { estimatedGas: resp.estimatedGas, loading: false } })
@@ -343,7 +352,7 @@ export const createQuickSwapSlice = (
 
       // api calls
       await sliceState.fetchRoutesAndOutput(config, curve, searchedParams, maxSlippage)
-      void sliceState.fetchEstGasApproval(curve, searchedParams)
+      void sliceState.fetchEstGasApproval(curve, searchedParams, maxSlippage)
     },
 
     // steps
@@ -382,7 +391,7 @@ export const createQuickSwapSlice = (
 
           // re-fetch est gas, approval, routes and output
           await sliceState.fetchRoutesAndOutput(config, curve, searchedParams, globalMaxSlippage)
-          void sliceState.fetchEstGasApproval(curve, searchedParams)
+          void sliceState.fetchEstGasApproval(curve, searchedParams, globalMaxSlippage)
         }
 
         return resp

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.68.38",
+    "@curvefi/api": "2.68.42",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
     "@types/node": "25.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.68.42",
+    "@curvefi/api": "2.68.43",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",
     "@types/node": "25.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,25 +358,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conventional-changelog/git-client@npm:^2.6.0":
-  version: 2.6.0
-  resolution: "@conventional-changelog/git-client@npm:2.6.0"
-  dependencies:
-    "@simple-libs/child-process-utils": "npm:^1.0.0"
-    "@simple-libs/stream-utils": "npm:^1.2.0"
-    semver: "npm:^7.5.2"
-  peerDependencies:
-    conventional-commits-filter: ^5.0.0
-    conventional-commits-parser: ^6.3.0
-  peerDependenciesMeta:
-    conventional-commits-filter:
-      optional: true
-    conventional-commits-parser:
-      optional: true
-  checksum: 10c0/7f0582858c5a2ecd481e9c3cfd4d87aeecc2ae5894b968a58b692e2a085b80345f069ba33274c77292b64e29af07a98531accb46d7902e93b7c6dce11aee1eb1
-  languageName: node
-  linkType: hard
-
 "@curvefi/api@npm:2.68.43":
   version: 2.68.43
   resolution: "@curvefi/api@npm:2.68.43"

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,19 +358,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:2.68.38":
-  version: 2.68.38
-  resolution: "@curvefi/api@npm:2.68.38"
+"@conventional-changelog/git-client@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@conventional-changelog/git-client@npm:2.6.0"
   dependencies:
-    "@curvefi/ethcall": "npm:^6.0.16"
-    bignumber.js: "npm:^10.0.2"
-    ethers: "npm:^6.16.0"
-    memoizee: "npm:^0.4.17"
-  checksum: 10c0/aa17a98cce4f971c4e1d5be25ea88d16ee8178eb5e8338bad651d51671cfc54f71852f938197538496786db33376d1e49d6760767679d740d04d604c175f4c22
+    "@simple-libs/child-process-utils": "npm:^1.0.0"
+    "@simple-libs/stream-utils": "npm:^1.2.0"
+    semver: "npm:^7.5.2"
+  peerDependencies:
+    conventional-commits-filter: ^5.0.0
+    conventional-commits-parser: ^6.3.0
+  peerDependenciesMeta:
+    conventional-commits-filter:
+      optional: true
+    conventional-commits-parser:
+      optional: true
+  checksum: 10c0/7f0582858c5a2ecd481e9c3cfd4d87aeecc2ae5894b968a58b692e2a085b80345f069ba33274c77292b64e29af07a98531accb46d7902e93b7c6dce11aee1eb1
   languageName: node
   linkType: hard
 
-"@curvefi/ethcall@npm:6.0.16, @curvefi/ethcall@npm:^6.0.16":
+"@curvefi/api@npm:2.68.42":
+  version: 2.68.42
+  resolution: "@curvefi/api@npm:2.68.42"
+  dependencies:
+    "@curvefi/ethcall": "npm:6.0.20"
+    bignumber.js: "npm:^10.0.2"
+    ethers: "npm:^6.16.0"
+    memoizee: "npm:^0.4.17"
+  checksum: 10c0/f9e17769f5836da68be2aa888e218663ba338c10dc77ae0a9f397e5ed15c4690cb9652b5b2c4308589d748a4af04d1b4f0d214588ffbd5553da68d363c22a591
+  languageName: node
+  linkType: hard
+
+"@curvefi/ethcall@npm:6.0.16":
   version: 6.0.16
   resolution: "@curvefi/ethcall@npm:6.0.16"
   dependencies:
@@ -379,6 +398,18 @@ __metadata:
   peerDependencies:
     ethers: ^6.0.0
   checksum: 10c0/3bd41b3d84f0ed0654279a88920ad7ce38507804008fc8caa86fb2763520f594ef62953a260cb07661f6d71afd5467e41249fdda9eb3b71d10623a496679880e
+  languageName: node
+  linkType: hard
+
+"@curvefi/ethcall@npm:6.0.20":
+  version: 6.0.20
+  resolution: "@curvefi/ethcall@npm:6.0.20"
+  dependencies:
+    "@types/node": "npm:^22.12.0"
+    abi-coder: "npm:^5.0.0"
+  peerDependencies:
+    ethers: ^6.0.0
+  checksum: 10c0/59a255ec9b4139cce840c114eae3decbc24319dbf7d41829357d6ab17a87aa8b5f2a34749649e86b961a3b0100e134c874c1e3138909463020876589a769b2b4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,15 +377,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/api@npm:2.68.42":
-  version: 2.68.42
-  resolution: "@curvefi/api@npm:2.68.42"
+"@curvefi/api@npm:2.68.43":
+  version: 2.68.43
+  resolution: "@curvefi/api@npm:2.68.43"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:^10.0.2"
     ethers: "npm:^6.16.0"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/f9e17769f5836da68be2aa888e218663ba338c10dc77ae0a9f397e5ed15c4690cb9652b5b2c4308589d748a4af04d1b4f0d214588ffbd5553da68d363c22a591
+  checksum: 10c0/142e69239c48d53db66ed4aeae4621c1807248c8155f636d155c9a917665a2e2fdaf5f3669e40b372961cd3ec6378c5616de7cfa7744e7871e34dfa4c8341a60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes DEX gas estimates consistently slippage-aware using the exact slippage users selected (used to be hardcoded to 0.1 in curve-js), aligns pool/router slippage sourcing.

Changes:
- Passes selected maxSlippage into gas-estimation calls for router swap, pool deposit/deposit+stake, and withdraw paths.
- Threads maxSlippage through quick-swap/pool deposit/pool withdraw store methods and approve-action call sites.
- Updates pool slippage fallback precedence to: pool-specific setting -> pool-type setting (crypto/stable) -> default.
- Bumps @curvefi/api from to 2.68.43