### PR TITLE
fix: disable solvency market for mint markets

### DIFF
--- a/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
+++ b/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
@@ -17,7 +17,8 @@ type BadDebtParams = {
  * Returns solvency and insolvency data for a single market.
  */
 export const useSolvencyMarket = ({ type, blockchainId, controllerAddress }: BadDebtParams) => {
-  const enabled = !!blockchainId && !!controllerAddress
+  // solvency is only relevant for lending markets; if mint markets have bad debt that's a protocol problem, not a user problem
+  const enabled = !!blockchainId && !!controllerAddress && type === LlamaMarketType.Lend
   const badDebtMarkets = useBadDebtMarkets({ type }, enabled)
   const llamaMarketQuery = useLlamaMarket({ blockchainId, controllerAddress })
   const market = llamaMarketQuery?.data


### PR DESCRIPTION
Shows no solvency banner for mint markets by disabling the `useBadDebtMarkets` query if the market type isn't a lending market.

**Not showing for WEETH mint market**
<img width="448" height="130" alt="image" src="https://github.com/user-attachments/assets/d0b66637-453f-48dc-8ff7-718c9aae8d24" />

**Still showing for (deprecated) CRV lending market**
<img width="1065" height="130" alt="image" src="https://github.com/user-attachments/assets/c6c42524-95f1-43d1-aea8-e1ea6669d374" />

