### PR TITLE
refactor: only show solvency in advanced details on lend markets

### DIFF
--- a/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
@@ -96,7 +96,7 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
           ...TooltipOptions,
         }}
       />
-      {solvency && (
+      {solvency && marketType === LlamaMarketType.Lend && (
         <Metric
           size="medium"
           label={t`Solvency`}


### PR DESCRIPTION
Changes:
- Only show `Solvency` metric in lend markets in market advanced details