### PR TITLE
fix: only show collateral and borrowed legends in the chart footer if there are userBands/a user position

### DIFF
--- a/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
+++ b/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
@@ -80,11 +80,12 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
   }, [])
 
   const showBands = newBandsChartEnabled && bands && isBandsVisible
+  const hasUserBands = !!bands?.userBandsBalances?.length
   const collateralSymbol = bands?.collateralToken?.symbol
   const borrowSymbol = bands?.borrowToken?.symbol
   const chartFooterLegendSets = useMemo(
     () =>
-      showBands
+      showBands && hasUserBands
         ? notFalsy<LegendItem>(
             ...chart.legendSets,
             collateralSymbol && { label: collateralSymbol, box: { fill: bandsPalette.userCollateralShareColor } },
@@ -93,6 +94,7 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
         : chart.legendSets,
     [
       showBands,
+      hasUserBands,
       chart.legendSets,
       collateralSymbol,
       borrowSymbol,


### PR DESCRIPTION
Changes:
- Only show `collateral token` and `borrowed token` chart footer legends if there is a user position (they indicate shares of a user band)

<img width="1033" height="553" alt="SCR-20260427-mudc" src="https://github.com/user-attachments/assets/9cf6a010-66af-4f61-aea3-11c1d25438a2" />