### PR TITLE
styling: shorten low crv emissions aprs to just < 0.01%

### DIFF
--- a/apps/main/src/dex/components/PoolRewardsCrv.tsx
+++ b/apps/main/src/dex/components/PoolRewardsCrv.tsx
@@ -29,6 +29,7 @@ export const PoolRewardsCrv = ({
     } else if (rewardsApy?.crv && (rewardsApy?.crv[0] !== 0 || rewardsApy?.crv[1] !== 0)) {
       const [base, boosted] = rewardsApy.crv
       if (!base && !boosted) return null
+      if (base < 0.01) return '< 0.01% CRV' // Anything less is basically not worth the time
       const formattedBase = formatNumber(base, FORMAT_OPTIONS.PERCENT)
 
       if (boosted) {


### PR DESCRIPTION
This component is still using the old school number formatter, so I just opted for this quick custom behavior instead of adjusting fornatting. There's another ticket for coming up with categories and such.

Opted comparing base value rather than boosted, because otherwise we'd still end up with stuff like `0.0000004% -> 0.1%`

<img width="240" height="1067" alt="image" src="https://github.com/user-attachments/assets/81a811ed-3da4-4601-963b-fb5c10563306" />
