### PR TITLE
fix: always use usd rates for percentages in currency reserves if available

### DIFF
--- a/apps/main/src/dex/store/createPoolsSlice.ts
+++ b/apps/main/src/dex/store/createPoolsSlice.ts
@@ -235,19 +235,16 @@ export const createPoolsSlice = (set: StoreApi<State>['setState'], get: StoreApi
         crTokens.push(crToken)
       }
 
-      // update percentShareInPool
-      crTokens.map((cr: CurrencyReservesToken) => {
+      for (const cr of crTokens) {
         if (isEmpty) {
           cr.percentShareInPool = '0'
-        } else if (poolData.pool.isCrypto && isNaN(cr.usdRate)) {
-          cr.percentShareInPool = 'NaN'
-        } else if (poolData.pool.isCrypto) {
+          // Only use USD balances for currency reserves if all tokens have a usd balance (and pool isn't empty)
+        } else if (crTokens.every((cr) => cr.balanceUsd > 0)) {
           cr.percentShareInPool = ((cr.balanceUsd / totalUsd) * 100).toFixed(2)
         } else {
           cr.percentShareInPool = ((cr.balance / total) * 100).toFixed(2)
         }
-        return cr
-      })
+      }
 
       const result: CurrencyReserves = {
         poolId: pool.id,


### PR DESCRIPTION
Turns out the USD rates for currency reserve percentages were only used if the pool was a crypto pool, but I think we should always use the USD rates if they're available, even if it's a stable pool (so that depegs are also more accurately presented?)

PS: I tried to refactor using queries and prices API, but the tech debt makes it impossible (due to how pool data is not querified yet).

**New**
<img width="668" height="263" alt="image" src="https://github.com/user-attachments/assets/e5ff02c4-8848-447b-a074-07f12e1e4cc0" />

**Old**
<img width="661" height="271" alt="image" src="https://github.com/user-attachments/assets/74b42660-db43-4093-a320-48611d3e907a" />
