### PR TITLE
feat: use skeletons for advanced details on market pages

### DIFF
--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -67,20 +67,18 @@ export const MarketInformationComposite = ({
         <MarketRateCurveChart market={market} blockchainId={blockchainId} chainId={rChainId} marketId={rOwmId} />
       )}
 
-      {market && (
-        <Card>
-          <CardHeader title={t`Advanced Details`} size="small" />
-          <CardContent component={Stack}>
-            <AdvancedDetails chainId={rChainId} marketId={rOwmId} market={market} marketType={LlamaMarketType.Lend} />
-            <MarketInfoLayout
-              chainId={rChainId}
-              marketType={LlamaMarketType.Lend}
-              market={market}
-              network={networks[rChainId]}
-            />
-          </CardContent>
-        </Card>
-      )}
+      <Card>
+        <CardHeader title={t`Advanced Details`} size="small" />
+        <CardContent component={Stack}>
+          <AdvancedDetails chainId={rChainId} marketId={rOwmId} market={market} marketType={LlamaMarketType.Lend} />
+          <MarketInfoLayout
+            chainId={rChainId}
+            marketType={LlamaMarketType.Lend}
+            market={market}
+            network={networks[rChainId]}
+          />
+        </CardContent>
+      </Card>
     </Stack>
   )
 }

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
@@ -13,6 +13,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { AddressActionInfo } from '@ui-kit/shared/ui/AddressActionInfo'
 import { TokenIcon, type TokenIconProps } from '@ui-kit/shared/ui/TokenIcon'
+import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { Spacing } = SizesAndSpaces
@@ -40,7 +41,11 @@ const TokenLabel = ({ blockchainId, address, label }: TokenIconProps & { label: 
 
 export const MarketContractsSection = ({ chainId, market, network }: MarketContractsProps) => {
   const { collateralToken, borrowToken } = market ? getTokens(market) : {}
-  const { data: oracleAddress } = useMarketOracleAddress({ chainId, marketId: market?.id })
+  const { data: oracleAddress, isLoading: oracleAddressIsLoading } = useMarketOracleAddress({
+    chainId,
+    marketId: market?.id,
+  })
+  const loading = !network || !market || oracleAddressIsLoading
 
   const tokenItems: ContractItem[] = market
     ? [
@@ -99,11 +104,13 @@ export const MarketContractsSection = ({ chainId, market, network }: MarketContr
     <Stack gap={Spacing.md}>
       <Stack gap={Spacing.sm}>
         <CardHeader title={t`Contracts`} size="small" data-inline />
-        <Stack>
-          {tokenItems.map(({ key, label, address }) => (
-            <AddressActionInfo key={key} network={network} title={label} address={address} />
-          ))}
-        </Stack>
+        <WithSkeleton loading={loading} variant="rectangular" height={'4lh'} width="100%">
+          <Stack>
+            {tokenItems.map(({ key, label, address }) => (
+              <AddressActionInfo key={key} network={network} title={label} address={address} />
+            ))}
+          </Stack>
+        </WithSkeleton>
       </Stack>
 
       <Stack>

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
@@ -21,40 +21,42 @@ export const MarketLoanParameters = ({ chainId, marketId }: { chainId: IChainId;
     error: errorParameters,
   } = useMarketParameters({ chainId, marketId })
 
+  const loading = !marketId || isLoadingParameters
+
   return (
     <>
       <ActionInfo
         label={t`AMM swap fee`}
         value={formatPercent(parameters?.fee)}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Admin fee`}
         value={formatPercent(parameters?.admin_fee)}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Band width factor`}
         value={formatNumber(parameters?.A ?? 0, { abbreviate: false, useGrouping: false })}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Loan discount`}
         value={formatPercent(parameters?.loan_discount)}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Liquidation discount`}
         value={formatPercent(parameters?.liquidation_discount)}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
 
@@ -62,7 +64,7 @@ export const MarketLoanParameters = ({ chainId, marketId }: { chainId: IChainId;
         label={t`Max LTV`}
         value={formatPercent(getMaxLTV(parameters?.A ?? 0, parameters?.loan_discount))}
         valueTooltip={t`Max possible loan at N=4`}
-        loading={isLoadingParameters}
+        loading={loading}
         error={errorParameters}
       />
     </>

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketParameterRows.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketParameterRows.tsx
@@ -35,21 +35,21 @@ export const MarketPricesRows = ({ chainId, marketId, enablePricePerShare }: Mar
         label={t`Base price`}
         value={formatNumber(basePrice)}
         valueTooltip={basePrice != null ? formatNumber(basePrice, { decimals: 5 }) : undefined}
-        loading={isLoadingBasePrice}
+        loading={isLoadingBasePrice || !marketId}
         error={errorBasePrice}
       />
       <ActionInfo
         label={t`Oracle price`}
         value={formatNumber(oraclePrice)}
         valueTooltip={oraclePrice != null ? formatNumber(oraclePrice, { decimals: 5 }) : undefined}
-        loading={isLoadingOraclePrice}
+        loading={isLoadingOraclePrice || !marketId}
         error={errorOraclePrice}
       />
       {enablePricePerShare && (
         <ActionInfo
           label={t`Price per share`}
           value={formatNumber(pricePerShare, { decimals: 5 })}
-          loading={isLoadingPricePerShare}
+          loading={isLoadingPricePerShare || !marketId}
           error={errorPricePerShare}
         />
       )}

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -51,20 +51,23 @@ export const MarketInformationComposite = ({
           <CrvUsdPriceChart />
         </>
       )}
-      {market && (
-        <Card>
-          <CardHeader title={t`Advanced Details`} size="small" />
-          <CardContent component={Stack}>
-            <AdvancedDetails chainId={chainId} marketId={marketId} market={market} marketType={LlamaMarketType.Mint} />
-            <MarketInfoLayout
-              chainId={chainId}
-              marketType={LlamaMarketType.Mint}
-              market={market}
-              network={networks[chainId]}
-            />
-          </CardContent>
-        </Card>
-      )}
+      <Card>
+        <CardHeader title={t`Advanced Details`} size="small" />
+        <CardContent component={Stack}>
+          <AdvancedDetails
+            chainId={chainId}
+            marketId={marketId}
+            market={market || undefined}
+            marketType={LlamaMarketType.Mint}
+          />
+          <MarketInfoLayout
+            chainId={chainId}
+            marketType={LlamaMarketType.Mint}
+            market={market || undefined}
+            network={networks[chainId]}
+          />
+        </CardContent>
+      </Card>
     </Stack>
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/WithSkeleton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/WithSkeleton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { default as Skeleton, SkeletonProps } from '@mui/material/Skeleton'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 


### PR DESCRIPTION
Unrelated, but `loan` and `lend` deduplication wen.

Btw, the contacts section is highly dynamic, so I just picked a height of ~4 lines for the rectangular skeleton based on vibes; looked good to me.

<img width="1081" height="495" alt="image" src="https://github.com/user-attachments/assets/51f6c5f4-0905-4a6d-88c9-2afcd5c6e77d" />
