### PR TITLE
chore: split check supply chain step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,24 @@ env:
 permissions:
   contents: read
 jobs:
+  check-supply-chain:
+    name: Check supply chain
+    timeout-minutes: 6
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # needed to diff yarn.lock against the base branch commit
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Restore cache
+        uses: ./.github/actions/restore-cache
+      - run: yarn set version stable
+      - run: yarn install --immutable
+      - run: yarn check-supply-chain
+
   lint:
     name: Lint, format & typecheck
     timeout-minutes: 6
@@ -221,24 +239,6 @@ jobs:
           name: dev-server-log-${{ matrix.browser }}-${{ matrix.count }}
           if-no-files-found: error
           path: e2e-*.log
-
-  check-supply-chain:
-    name: Check supply chain
-    timeout-minutes: 6
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # needed to diff yarn.lock against the base branch commit
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: yarn
-      - name: Restore cache
-        uses: ./.github/actions/restore-cache
-      - run: yarn set version stable
-      - run: yarn install --immutable
-      - run: yarn check-supply-chain
 
   notify:
     name: Notify Slack

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # needed to diff yarn.lock against the base branch commit
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -31,7 +29,6 @@ jobs:
         if: always()
       - run: yarn typecheck
         if: always()
-      - run: yarn check-supply-chain
 
   test:
     name: Unit tests
@@ -224,6 +221,24 @@ jobs:
           name: dev-server-log-${{ matrix.browser }}-${{ matrix.count }}
           if-no-files-found: error
           path: e2e-*.log
+
+  check-supply-chain:
+    name: Check supply chain
+    timeout-minutes: 6
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # needed to diff yarn.lock against the base branch commit
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Restore cache
+        uses: ./.github/actions/restore-cache
+      - run: yarn set version stable
+      - run: yarn install --immutable
+      - run: yarn check-supply-chain
 
   notify:
     name: Notify Slack


### PR DESCRIPTION
- put the dependency check in a separate job so we can separately include it in the required checks (or not)