### PR TITLE
feat: improve create loan risk clarity

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -20,6 +20,7 @@ import { FormAlerts, HighPriceImpactAlert } from '@ui-kit/widgets/DetailPageLayo
 import { useCreateLoanForm } from '../hooks/useCreateLoanForm'
 import { AdvancedCreateLoanOptions } from './AdvancedCreateLoanOptions'
 import { CreateLoanInfoList } from './CreateLoanInfoList'
+import { HighLiquidationRiskAlert } from './HighLiquidationRiskAlert'
 import { LeverageInput } from './LeverageInput'
 import { LoanPresetSelector } from './LoanPresetSelector'
 
@@ -62,6 +63,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
     values,
     leverage,
     priceImpact,
+    isHighLiquidationRisk,
   } = useCreateLoanForm({ market, network, preset, onPricesUpdated, disabled: !!borrowDisabledAlert })
 
   const toggleLeverage = useCallback(
@@ -138,6 +140,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
       </LoanPresetSelector>
 
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(maxLeverage)} />
+      <HighLiquidationRiskAlert isHighLiquidationRisk={isHighLiquidationRisk} />
 
       {borrowDisabledAlert ? (
         <AlertDisableForm>{borrowDisabledAlert.message}</AlertDisableForm>

--- a/apps/main/src/llamalend/features/borrow/components/HighLiquidationRiskAlert.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/HighLiquidationRiskAlert.tsx
@@ -1,0 +1,26 @@
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import { t } from '@ui-kit/lib/i18n'
+import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
+import type { QueryProp } from '@ui-kit/types/util'
+
+export const HighLiquidationRiskAlert = ({
+  isHighLiquidationRisk: { data, isLoading, error },
+}: {
+  isHighLiquidationRisk: QueryProp<boolean | null>
+}) =>
+  error ? (
+    <Alert severity="error" data-testid="high-liquidation-risk-error">
+      <AlertTitle>{t`Cannot determine liquidation risk`}</AlertTitle>
+      {error.message}
+    </Alert>
+  ) : (
+    data && (
+      <WithSkeleton loading={isLoading}>
+        <Alert severity="warning" data-testid="high-liquidation-risk-alert" variant="outlined">
+          <AlertTitle>{t`High liquidation risk`}</AlertTitle>
+          {t`This borrow amount places your liquidation range close to the current price, increasing liquidation risk.`}
+        </Alert>
+      </WithSkeleton>
+    )
+  )

--- a/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
@@ -11,7 +11,7 @@ import { PRESET_RANGES, LoanPreset } from '../../../constants'
 
 const PRESETS = {
   [LoanPreset.Safe]: {
-    title: t`Conservative`,
+    title: t`Default`,
     description:
       t`Sets up your Llamalend loan to offer the maximum safety by spreading your liquidity across more bands. ` +
       `This does not fully protect you from liquidation, but could give you more time to repay or close your loan in case of sudden price movements.`,

--- a/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
@@ -9,24 +9,14 @@ import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { PRESET_RANGES, LoanPreset } from '../../../constants'
 
-const PRESETS = {
-  [LoanPreset.Safe]: {
-    title: t`Default`,
-    description:
-      t`Sets up your Llamalend loan to offer the maximum safety by spreading your liquidity across more bands. ` +
-      `This does not fully protect you from liquidation, but could give you more time to repay or close your loan in case of sudden price movements.`,
-  },
-  [LoanPreset.MaxLtv]: {
-    title: t`Max LTV`,
-    description:
-      t`Sets up your Llamalend loan to offer the maximum LTV (highest loan to value ratio) against your collateral. ` +
-      `This implies higher risks.`,
-  },
-  [LoanPreset.Custom]: {
-    title: t`Custom`,
-    description: t`Setup your loan as you like it.`,
-  },
+const PRESETS_DESCRIPTIONS = {
+  [LoanPreset.Safe]: t`Default`,
+  [LoanPreset.MaxLtv]: t`Max LTV`,
+  [LoanPreset.Custom]: t`Custom`,
 }
+
+const PRESET_TOOLTIP_TITLE = t`Liquidation protection setup`
+const PRESET_TOOLTIP_BODY = t`Liquidation protection setup enables you to set the depth of the liquidation range for your position and determines how gradually your position moves through soft liquidation. Wider protection gives your position more room to react to price moves. Narrower protection allows higher LTV, but increases liquidation risk.`
 
 const { Spacing } = SizesAndSpaces
 
@@ -60,10 +50,10 @@ export const LoanPresetSelector = ({
       >
         {Object.values(LoanPreset).map(p => (
           <Tooltip
-            title={PRESETS[p].title}
+            title={PRESET_TOOLTIP_TITLE}
             body={
               <TooltipWrapper>
-                <TooltipDescription text={PRESETS[p].description} />
+                <TooltipDescription text={PRESET_TOOLTIP_BODY} />
               </TooltipWrapper>
             }
             key={p}
@@ -74,7 +64,7 @@ export const LoanPresetSelector = ({
               data-testid={`loan-preset-${p}`}
               sx={{ flex: 1, whiteSpace: 'nowrap' }}
             >
-              {PRESETS[p].title}
+              {PRESETS_DESCRIPTIONS[p]}
             </ToggleButton>
           </Tooltip>
         ))}

--- a/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
@@ -26,6 +26,7 @@ import { useCreateLoanIsApproved } from '../../../queries/create-loan/create-loa
 import { invalidateOrRefetchCreateLoanRouteQueries } from '../../../queries/create-loan/create-loan-route-invalidation'
 import { createLoanQueryValidationSuite } from '../../../queries/validation/borrow.validation'
 import { type CreateLoanForm } from '../types'
+import { useIsHighLiquidationRisk } from './useIsHighLiquidationRisk'
 import { useMaxTokenValues } from './useMaxTokenValues'
 
 // to crete a loan we need the debt/maxDebt, but we skip the market validation as that's given separately to the mutation
@@ -117,6 +118,7 @@ export function useCreateLoanForm<ChainId extends LlamaChainId>({
   useCallbackSync(useCreateLoanPrices(params), onPricesUpdated)
 
   const priceImpact = q(useCreateLoanPriceImpact(params, values.leverageEnabled))
+  const isHighLiquidationRisk = q(useIsHighLiquidationRisk(params))
 
   const isPending = formState.isSubmitting || isCreating
   const isDisabled =
@@ -139,6 +141,7 @@ export function useCreateLoanForm<ChainId extends LlamaChainId>({
     },
     isApproved: useCreateLoanIsApproved(params),
     priceImpact,
+    isHighLiquidationRisk,
     formErrors: useFormErrors(formState),
     routes: useMarketRoutes({
       chainId,

--- a/apps/main/src/llamalend/features/borrow/hooks/useIsHighLiquidationRisk.ts
+++ b/apps/main/src/llamalend/features/borrow/hooks/useIsHighLiquidationRisk.ts
@@ -1,0 +1,25 @@
+import { useCreateLoanPrices } from '@/llamalend/queries/create-loan/create-loan-prices.query'
+import { useMarketOraclePrice } from '@/llamalend/queries/market'
+import { combineQueryState } from '@ui-kit/lib'
+import { decimalDiv, decimalGreaterThan } from '@ui-kit/utils'
+import type { CreateLoanFormQueryParams } from '../types'
+
+/**
+ * When the upper end of the liquidation range is this percentage of the oracle price,
+ * it means the user is very close to entering soft-liquidation right from the start.
+ * @example: Oracle price is $10 and the soft-liquidation starts at $9.5
+ */
+const RANGE_PROXIMITY = '0.95'
+
+export const useIsHighLiquidationRisk = (params: CreateLoanFormQueryParams) => {
+  const oraclePrice = useMarketOraclePrice(params)
+  const prices = useCreateLoanPrices(params)
+
+  return {
+    data:
+      oraclePrice.data &&
+      prices.data?.[1] &&
+      decimalGreaterThan(decimalDiv(prices.data?.[1], oraclePrice.data), RANGE_PROXIMITY),
+    ...combineQueryState(oraclePrice, prices),
+  }
+}


### PR DESCRIPTION
1. Rename 'Conservative' preset (old 'Safe') to 'Default'.
2. Give every preset button the same (new) tooltip.
3. Show a 'high liquidation risk' alert when the loan's liquidation range is within 5% of the oracle price.

I didn't add the optional check that only shows the alert if the borrow usage is >75% of the max borrow to reduce noise. Can add it later if it's really noisy, I'd rather make it less strict at the start than not strict enough.

I tried to figure out how to add a test for this but I can't see the forest from the trees, and neither can Claude. No matter what I enter in the borrow amount, it doesn't seem to have an effect on the liquidation range. So I just tested manuallyon the WBTC market as in the screenshot below.

<img width="472" height="733" alt="image" src="https://github.com/user-attachments/assets/e2ed7104-fa43-41d5-be2d-47b49c841568" />
