### PR TITLE
fix: double slider clamping

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
@@ -127,7 +127,7 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
   const [internalValue, setInternalValue, cancelDebounce] = useDebounce<T>({
     initialValue: value,
     debounceMs,
-    callback: useCallback(nextValue => onChange(clampDecimal(nextValue, min, max)), [onChange, min, max]),
+    callback: onChange,
   })
 
   /** The current display values for slider and inputs */


### PR DESCRIPTION
- the NumericTextField already handles the clamping. By clamping twice, the internal state gets out-of-date.
- setRange would be called with the already clamped value, resetting the maxDebt even if there is no range change.
- without a range change, queries would not get triggered, so the max debt was never loaded