### PR TITLE
fix: repay price impact query

### DIFF
--- a/apps/main/src/llamalend/queries/repay/repay-gas-estimate.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-gas-estimate.query.ts
@@ -59,7 +59,7 @@ const { useQuery: useRepayLoanEstimateGas, invalidate: invalidateRepayLoanEstima
       case 'V2':
         return await impl.estimateGas.repay(...args, +slippage)
       case 'deleverage':
-        throw new Error('estimateGas.repay is not supported for deleverage repay')
+        return await impl.estimateGas.repay(...args, +slippage)
       case 'unleveragedLend':
         return await impl.estimateGas.repay(...args)
       case 'unleveragedMint':

--- a/apps/main/src/llamalend/queries/repay/repay-health.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-health.query.ts
@@ -61,7 +61,7 @@ export const { getQueryOptions: getRepayHealthOptions, invalidate: invalidateRep
       case 'V2':
         return (await impl.repayHealth(stateCollateral, userCollateral, userBorrowed, isHealthFull)) as Decimal
       case 'deleverage':
-        return (await impl.repayHealth(userCollateral, isHealthFull)) as Decimal
+        return (await impl.repayHealth(stateCollateral, isHealthFull)) as Decimal
       case 'unleveragedMint':
         return (await impl.repayHealth(userBorrowed, isHealthFull)) as Decimal
       case 'unleveragedLend':

--- a/apps/main/src/llamalend/queries/repay/repay-price-impact.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-price-impact.query.ts
@@ -59,7 +59,7 @@ export const { useQuery: useRepayPriceImpact, invalidate: invalidateRepayPriceIm
       case 'V2':
         return decimal(await impl.repayPriceImpact(stateCollateral, userCollateral)) ?? null
       case 'deleverage':
-        return decimal(await impl.priceImpact(userCollateral)) ?? null
+        return decimal(await impl.priceImpact(stateCollateral)) ?? null
       case 'unleveragedLend':
       case 'unleveragedMint':
         return '0' // there is no price impact, user repays debt directly


### PR DESCRIPTION
- fixed repay queries for `deleverage` as we were using `userCollateral` instead of `stateCollateral` when repaying from position