### PR TITLE
fix: hide leverage fields for deleveraging

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
@@ -34,11 +34,11 @@ const remainingDebt = (debt: Decimal, repayAmount: Decimal) => {
 function useRepayRemainingDebt(
   {
     params,
-    swapRequired,
+    showLeverage,
     prevDebt,
   }: {
     params: RepayParams
-    swapRequired: boolean
+    showLeverage: boolean
     prevDebt: Query<Decimal | null>
   },
   { isFull, userBorrowed }: Pick<RepayFormData, 'userBorrowed' | 'isFull'>,
@@ -48,7 +48,7 @@ function useRepayRemainingDebt(
   const prev = prevDebt.data
   const debt: QueryProp<Decimal | null> = isFull
     ? constQ('0')
-    : swapRequired
+    : showLeverage
       ? {
           data: prev && expectedBorrowedQuery.data && remainingDebt(prev, expectedBorrowedQuery.data.totalBorrowed),
           ...combineQueryState(prevDebt, expectedBorrowedQuery),
@@ -88,8 +88,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   tokens: { collateralToken, borrowToken },
   networks,
   onSlippageChange,
-  hasLeverage,
-  swapRequired,
+  showLeverage,
   routes,
   form,
   prices,
@@ -101,8 +100,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
   networks: NetworkDict<ChainId>
   onSlippageChange: (newSlippage: Decimal) => void
-  hasLeverage: boolean | undefined
-  swapRequired: boolean
+  showLeverage: boolean
   routes: MarketRoutes | undefined
   form: UseFormReturn<RepayFormData>
   prices?: QueryProp<Range<Decimal> | null>
@@ -112,7 +110,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   const prevLoanState = usePrevLoanState({ params, collateralToken, borrowToken, prevPrices }, isOpen)
   const { prevCollateral, prevDebt } = prevLoanState
   const { debt, debtDelta } = useRepayRemainingDebt(
-    { params, swapRequired, prevDebt },
+    { params, showLeverage, prevDebt },
     { isFull, userBorrowed },
     isOpen,
   )
@@ -149,9 +147,10 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
         isOpen && isFull,
       )}
       {...useLeverageInfoFields({
-        leverageEnabled: swapRequired, // in llamalend.js we need to use the leverage implementations to do any swap
+        // we need to use the leverage implementations to do any swap. deleverage implementation cannot show the expected values
+        leverageEnabled: showLeverage,
         leverageValue: useRepayFutureLeverage(params, isOpen),
-        prevLeverageValue: useUserCurrentLeverage(params, isOpen && !!hasLeverage),
+        prevLeverageValue: useUserCurrentLeverage(params, isOpen),
         prevCollateral,
         leverageTotalCollateral: mapQuery(prevCollateral, prev =>
           isFull ? decimal(0) : decimal(new BigNumber(prev).minus(stateCollateral ?? '0')),

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -4,7 +4,7 @@ import { RepayTokenList, type RepayTokenListProps } from '@/llamalend/features/m
 import { RepayTokenOption, useRepayTokens } from '@/llamalend/features/manage-loan/hooks/useRepayTokens'
 import { AlertRepayDebtToIncreaseHealth } from '@/llamalend/features/manage-soft-liquidation/ui/alerts/AlertRepayDebtToIncreaseHealth'
 import type { UserCollateralEvents } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
-import { hasLeverage } from '@/llamalend/llama.utils'
+import { hasLeverageValue } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { useRepayPrices } from '@/llamalend/queries/repay/repay-prices.query'
 import { useUserPrices } from '@/llamalend/queries/user'
@@ -99,7 +99,7 @@ export const RepayForm = <ChainId extends IChainId>({
   const selectedField = token?.field ?? 'userBorrowed'
   const selectedToken = selectedField == 'userBorrowed' ? borrowToken : collateralToken
   const fromPosition = isFull.data === false && selectedField === 'stateCollateral'
-  const swapRequired = selectedToken !== borrowToken
+  const showLeverage = selectedToken !== borrowToken && !!market && hasLeverageValue(market)
 
   // The max repay amount in the helper message should always be denominated in terms of the borrow token.
   const { data: maxAmountInBorrowToken } = useTokenAmountConversion({
@@ -139,8 +139,7 @@ export const RepayForm = <ChainId extends IChainId>({
           tokens={{ collateralToken, borrowToken }}
           networks={networks}
           onSlippageChange={value => updateForm(form, { slippage: value })}
-          hasLeverage={market && hasLeverage(market)}
-          swapRequired={swapRequired}
+          showLeverage={showLeverage}
           routes={routes}
           prices={q(useRepayPrices(params, !isInSoftLiquidation))} // when in soft liquidation, the prices do not change
           prevPrices={q(useUserPrices(params))}

--- a/apps/main/src/llamalend/features/manage-loan/hooks/useRepayTokens.ts
+++ b/apps/main/src/llamalend/features/manage-loan/hooks/useRepayTokens.ts
@@ -64,8 +64,8 @@ export const useRepayTokens = ({
 }) => {
   const [token, onToken] = useState<RepayTokenOption | undefined>()
   const tokens = useMemo(() => getRepayTokenOptions({ market, networkId }), [market, networkId])
-  const leverageEnabled = collateralEvents.data && isPositionLeveraged(collateralEvents.data?.originalLeverage)
-  const field = leverageEnabled === true ? 'stateCollateral' : leverageEnabled === false ? 'userBorrowed' : undefined
+  const isLeveraged = collateralEvents.data && isPositionLeveraged(collateralEvents.data?.originalLeverage)
+  const field = isLeveraged === true ? 'stateCollateral' : isLeveraged === false ? 'userBorrowed' : undefined
   const defaultToken = tokens.find(t => t.field === field)
   useEffect(() => {
     // override the user's choice when we get to know they have a (non)-leveraged position

--- a/apps/main/src/llamalend/queries/repay/repay-future-leverage.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-future-leverage.query.ts
@@ -60,5 +60,5 @@ export const { useQuery: useRepayFutureLeverage, invalidate: invalidateRepayFutu
     }
   },
   category: 'llamalend.repay',
-  validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false }),
+  validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false, requireLeverageValue: true }),
 })

--- a/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
@@ -86,9 +86,12 @@ export const validateLeverageSupported = (
   })
 }
 
-export const validateLeverageValuesSupported = (marketId: string | null | undefined) => {
+export const validateLeverageValuesSupported = (
+  marketId: LlamaMarketTemplate | string | null | undefined,
+  required = true,
+) => {
   const market = tryGetLlamaMarket(marketId)
-  skipWhen(!market, () => {
+  skipWhen(!market || !required, () => {
     test('marketId', 'Market does not support leverage values', () => {
       enforce(market && hasLeverageValue(market)).isTruthy()
     })

--- a/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/borrow-fields.validation.ts
@@ -123,9 +123,9 @@ export const validateMaxBorrowed = (
       enforce(maxBorrowed).isDecimal()
     })
   })
-  skipWhen(userBorrowed == null || maxBorrowed == null, () => {
+  skipWhen(maxBorrowed == null, () => {
     test('userBorrowed', `The maximum ${label} is ${maxBorrowed}`, () => {
-      enforce(userBorrowed).lessThanOrEquals(maxBorrowed)
+      enforce(userBorrowed ?? '0').lessThanOrEquals(maxBorrowed)
     })
   })
 }

--- a/apps/main/src/llamalend/queries/validation/repay.validation.ts
+++ b/apps/main/src/llamalend/queries/validation/repay.validation.ts
@@ -5,6 +5,7 @@ import { getRepayImplementationType } from '@/llamalend/queries/repay/repay-quer
 import {
   validateIsFull,
   validateLeverageSupported,
+  validateLeverageValuesSupported,
   validateMaxBorrowed,
   validateMaxCollateral,
   validateMaxStateCollateral,
@@ -88,13 +89,14 @@ const repayValidationGroup = (
     maxRequired = validateMax,
   }: { leverageRequired: boolean; validateMax: boolean; maxRequired?: boolean },
 ) => {
+  const market = tryGetLlamaMarket(marketId)
   validateRepayCollateralField('userCollateral', userCollateral)
   validateRepayCollateralField('stateCollateral', stateCollateral)
   validateRepayBorrowedField(userBorrowed)
   validateRepayHasValue(stateCollateral, userCollateral, userBorrowed)
-  validateRepayFieldsForMarket(marketId, stateCollateral, userCollateral, userBorrowed, routeId)
+  validateRepayFieldsForMarket(market, stateCollateral, userCollateral, userBorrowed, routeId)
   validateSlippage({ slippage })
-  validateLeverageSupported(marketId, { required: leverageRequired })
+  validateLeverageSupported(market, { required: leverageRequired })
   validateIsFull(isFull)
 
   skipWhen(!validateMax, () => {
@@ -107,13 +109,17 @@ const repayValidationGroup = (
 export const repayValidationSuite = ({
   leverageRequired,
   validateMax,
+  requireLeverageValue = leverageRequired,
 }: {
   leverageRequired: boolean
   validateMax: boolean
+  requireLeverageValue?: boolean
 }) =>
   createValidationSuite(({ chainId, marketId, userAddress, ...params }: RepayParams) => {
+    const market = tryGetLlamaMarket(marketId)
     userMarketValidationSuite({ chainId, marketId, userAddress })
-    repayValidationGroup(marketId, params, { leverageRequired, validateMax })
+    repayValidationGroup(market, params, { leverageRequired, validateMax })
+    validateLeverageValuesSupported(market, requireLeverageValue)
   })
 
 export const repayFormValidationSuite = (market: LlamaMarketTemplate | undefined) =>


### PR DESCRIPTION
- introduce a new conditional in the repay forms to decide whether to show leverage or not
- instead of only checking which token is being used, we also need to check if the implementation supports displaying leverage at all
- fixes the repay validation when switching between fields