### PR TITLE
feat: zapV2 in beta mode

### DIFF
--- a/apps/main/src/lend/components/PageLendMarket/ManageLoanTabs.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/ManageLoanTabs.tsx
@@ -14,7 +14,7 @@ import { ImproveHealthForm } from '@/llamalend/features/manage-soft-liquidation/
 import type { BorrowPositionDetailsProps } from '@/llamalend/features/market-position-details'
 import type { UserCollateralEvents } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useManageLoanMuiForm, useManageSoftLiquidation } from '@ui-kit/hooks/useFeatureFlags'
+import { useLoanImplementationKey, useManageLoanMuiForm, useManageSoftLiquidation } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import type { QueryProp, Range } from '@ui-kit/types/util'
 import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
@@ -155,5 +155,6 @@ export const ManageLoanTabs = ({
     : shouldUseManageLoanMuiForm
       ? LendManageNewMenu
       : LendManageLegacyMenu
-  return <FormTabs params={pageProps} menu={menu} shouldWrap={menu === LendManageLegacyMenu} />
+  const key = useLoanImplementationKey()
+  return <FormTabs key={key} params={pageProps} menu={menu} shouldWrap={menu === LendManageLegacyMenu} />
 }

--- a/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
@@ -17,7 +17,7 @@ import type { ManageLoanProps } from '@/loan/components/PageMintMarket/types'
 import { networks } from '@/loan/networks'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useManageLoanMuiForm, useManageSoftLiquidation } from '@ui-kit/hooks/useFeatureFlags'
+import { useLoanImplementationKey, useManageLoanMuiForm, useManageSoftLiquidation } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import type { QueryProp, Range } from '@ui-kit/types/util'
 import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
@@ -168,5 +168,6 @@ export const ManageLoanTabs = ({
     : shouldUseManageLoanMuiForm
       ? MintManageNewMenu
       : MintManageLegacyMenu
-  return <FormTabs params={pageProps} menu={menu} shouldWrap={menu === MintManageLegacyMenu} />
+  const key = useLoanImplementationKey()
+  return <FormTabs key={key} params={pageProps} menu={menu} shouldWrap={menu === MintManageLegacyMenu} />
 }

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -3,8 +3,8 @@
  * These return booleans indicating whether a new experience is enabled.
  */
 
-import { defaultReleaseChannel, ReleaseChannel } from '@ui-kit/utils'
-import { getReleaseChannel, useReleaseChannel } from './useLocalStorage'
+import { ReleaseChannel } from '@ui-kit/utils'
+import { getReleaseChannel, isZapV2Disabled, useDisableZapV2, useReleaseChannel } from './useLocalStorage'
 
 const useBetaChannel = () => useReleaseChannel()[0] === ReleaseChannel.Beta
 const useStableChannel = () => useReleaseChannel()[0] !== ReleaseChannel.Legacy
@@ -12,8 +12,7 @@ const useStableChannel = () => useReleaseChannel()[0] !== ReleaseChannel.Legacy
 /**
  * Alpha channel works like beta for preview/localhost urls, but completely hidden in production.
  * This is used for features actively under development that are known not to be ready.
- *  */
-const isAlpha = () => getReleaseChannel() === ReleaseChannel.Beta && defaultReleaseChannel === ReleaseChannel.Beta
+ **/
 // const useAlphaChannel = () => useBetaChannel() && defaultReleaseChannel === ReleaseChannel.Beta
 
 /** New unified create loan form */
@@ -35,7 +34,12 @@ export const useManageSoftLiquidation = useStableChannel
 export const useAnalyticsApp = useStableChannel
 
 /** New ZapV2 leverage implementation for LlamaLend markets */
-export const isZapV2Enabled = () => isAlpha() && localStorage.getItem('disableZapV2') != 'true'
+export const isZapV2Enabled = () => getReleaseChannel() === ReleaseChannel.Beta && !isZapV2Disabled()
+
+const useZapV2 = () => [useBetaChannel(), !useDisableZapV2()].every(Boolean)
+
+/** gets a key to remount components when ZapV2 is toggled, forcing calls to non-reactive isZapV2Enabled */
+export const useLoanImplementationKey = () => (useZapV2() ? 'zapV2' : '')
 
 /** New LlamaLend v2 implementation */
 export const useLLv2 = useBetaChannel

--- a/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
+++ b/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
@@ -50,6 +50,9 @@ export const useReleaseChannel = () =>
     oldKey: 'beta',
   })
 
+export const useDisableZapV2 = () => useLocalStorage('disableZapV2', false)
+export const isZapV2Disabled = () => getFromLocalStorage<boolean>('disableZapV2') === true
+
 export const useFilterExpanded = (tableTitle: string) =>
   useLocalStorage<boolean>(`filter-expanded-${kebabCase(tableTitle)}`, false)
 
@@ -106,8 +109,6 @@ const useDismissBanner = (bannerKey: string, frequency: keyof typeof Duration.Ba
 }
 
 export const useDismissAaveBanner = () => useDismissBanner('aave-v2-frozen-avalanche-polygon')
-
-export const useDismissFastBridgeBanner = () => useDismissBanner('fast-bridge-paused', 'Daily')
 
 export const useDismissCurveLiteBanner = (chainId: number) => useDismissBanner(`curve-lite-${chainId}`)
 


### PR DESCRIPTION
- enable zapv2 on beta mode
- add a key to loan management tabs so they get remounted