### PR TITLE
fix: undefined market in rpc test

### DIFF
--- a/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
@@ -17,7 +17,9 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { objectKeys } from '@primitives/objects.utils'
 import { formatNumber } from '@ui-kit/utils'
 
-const testCases = objectKeys(LOAN_TEST_MARKETS).map(type => oneLoanTestMarket(type, market => !market.hasLeverage))
+const testCases = objectKeys(LOAN_TEST_MARKETS).map(type =>
+  oneLoanTestMarket(type, market => !market.hasLeverageManagement),
+)
 
 describe('Collateral forms', () => {
   testCases.forEach(


### PR DESCRIPTION
- Fixes [undefined market in rpc tests](https://github.com/curvefi/curve-frontend/actions/runs/25378962374)
- There are no test mint markets that support no leverage at all.
- In #2338 we fixed that by introducing a new flag for loan management which is what we are looking for here.