### PR TITLE
fix: dao primary-400 color change regressions

### DIFF
--- a/apps/main/src/dao/components/Charts/LineChartComponent.tsx
+++ b/apps/main/src/dao/components/Charts/LineChartComponent.tsx
@@ -60,12 +60,12 @@ export const LineChartComponent = ({ data, height = 400 }: Props) => {
         <Line
           type="monotone"
           dataKey="gauge_relative_weight"
-          stroke="var(--primary-400)"
+          stroke="var(--link-400)"
           strokeWidth={2}
           activeDot={{ r: 4 }}
           dot={{
             r: 3,
-            fill: 'var(--primary-400)',
+            fill: 'var(--link-400)',
             stroke: 'var(--chart-purple)',
             strokeWidth: 2,
           }}

--- a/apps/main/src/dao/components/PaginatedTable/TableHeader.tsx
+++ b/apps/main/src/dao/components/PaginatedTable/TableHeader.tsx
@@ -63,7 +63,6 @@ const TableTitle = styled.p`
   display: flex;
   align-items: center;
   padding: var(--spacing-3) var(--spacing-3) var(--spacing-2);
-  /* border-bottom: 1px solid var(--gray-500a20); */
 `
 
 const TableTitleButton = styled(Button)`

--- a/apps/main/src/dao/components/SmallLabel/index.tsx
+++ b/apps/main/src/dao/components/SmallLabel/index.tsx
@@ -35,7 +35,7 @@ const BoxedData = styled.span<{ isKilled?: boolean; isNetwork?: boolean }>`
   ${({ isNetwork }) =>
     isNetwork &&
     `
-      color: var(--primary-400);
-      border: 1px solid var(--primary-400);
+      color: var(--link-400);
+      border: 1px solid var(--link-400);
     `}
 `

--- a/packages/ui/src/styles/theme-chad.css
+++ b/packages/ui/src/styles/theme-chad.css
@@ -109,6 +109,8 @@ body.theme-chad {
   --input_button--hover--color: var(--text-600);
 
   /* Link */
+  --link--hover--color: var(--link-400);
+  --link--underline--hover-color: var(--link-400);
   --link_box--color: var(--text-600);
   --link_box-alternate--background-color: var(--primary-600);
 

--- a/packages/ui/src/styles/theme-default.css
+++ b/packages/ui/src/styles/theme-default.css
@@ -130,17 +130,17 @@ body.theme-default {
   --button_filled-hover-contrast--background-color: var(--primary-300);
   --button_outlined--color: var(--text-400);
   --button_outlined--border-color: var(--border-400);
-  --button_outlined--hover--color: var(--primary-400);
+  --button_outlined--hover--color: var(--link-400);
   --button_outlined--hover--background-color: var(--primary-400a10);
-  --button_outlined_darkbg--hover--color: var(--primary-400);
+  --button_outlined_darkbg--hover--color: var(--link-400);
   --button_outlined_darkbg--hover--background-color: var(--primary-400a10);
-  --button_icon--hover--color: var(--primary-400);
+  --button_icon--hover--color: var(--link-400);
   --button_icon--hover--background-color: var(--primary-400a10);
-  --button_text--color: var(--primary-400);
+  --button_text--color: var(--link-400);
   --button-text-contrast--color: var(--primary-700);
-  --button_text--hover--color: var(--primary-400);
-  --button_text_darkbg--hover--color: var(--primary-400);
-  --button_text_darkbg--color: var(--primary-400);
+  --button_text--hover--color: var(--link-400);
+  --button_text_darkbg--hover--color: var(--link-400);
+  --button_text_darkbg--color: var(--link-400);
   --box_action--button--text-transform: capitalize;
 
   /*  Health Mode  */


### PR DESCRIPTION
`primary-400` that was used in some places in the dao components was at some point changed to a very light violet color that was almost invisible against light background. The DAO page is in need of updating to implement our new theme and components but this PR just fixes the pressing issues so users can get legibility back 

Changes:
- Changes places that used `primary-400` to use `link-400` instead in DAO components