### PR TITLE
chore: lend market page performance

### DIFF
--- a/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
@@ -16,11 +16,13 @@ import { getControllerAddress } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { PageHeader } from '@/llamalend/widgets/page-header'
-import { isPricesApiChain, type Chain } from '@curvefi/prices-api'
+import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
+import { type Chain, isPricesApiChain } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
-import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
+import { ConnectWalletPrompt, type LlamaApi, useCurve } from '@ui-kit/features/connect-wallet'
 import { useLayoutStore } from '@ui-kit/features/layout'
 import { useParams } from '@ui-kit/hooks/router'
+import { useLoanSlices } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { REFRESH_INTERVAL } from '@ui-kit/lib/model'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -29,22 +31,60 @@ import type { Range } from '@ui-kit/types/util'
 import { DetailPageLayout } from '@ui-kit/widgets/DetailPageLayout/DetailPageLayout'
 import { CampaignRewardsBanner } from '../CampaignRewardsBanner'
 
-export const LendMarketPage = () => {
-  const { isHydrated } = useCurve()
-  const params = useParams<MarketUrlParams>()
-  const { rMarket, rChainId: chainId } = parseMarketParams(params)
-
-  const { data: market, isSuccess } = useOneWayMarket(chainId, rMarket)
-  const { llamaApi: api = null, provider } = useCurve()
-
+function useLegacyFetching({
+  api,
+  market,
+  loanExists,
+}: {
+  api: LlamaApi | null
+  market: LendMarketTemplate | undefined
+  loanExists: boolean | undefined
+}) {
+  const enabled = useLoanSlices()
+  const userActiveKey = helpers.getUserActiveKey(api, market!)
   const isPageVisible = useLayoutStore(state => state.isPageVisible)
   const fetchAllMarketDetails = useStore(state => state.markets.fetchAll)
   const fetchUserMarketBalances = useStore(state => state.user.fetchUserMarketBalances)
   const fetchAllUserMarketDetails = useStore(state => state.user.fetchAll)
   const setMarketsStateKey = useStore(state => state.markets.setStateByKey)
+  useEffect(() => {
+    // delay fetch rest after form details are fetched first
+    const timer = setTimeout(async () => {
+      if (!api || !market || !isPageVisible || !enabled) return
+      await fetchAllMarketDetails(api, market, true)
+      if (api.signerAddress) {
+        await fetchUserMarketBalances(api, market, true)
+        if (loanExists) {
+          void fetchAllUserMarketDetails(api, market, true)
+        }
+      }
+    }, REFRESH_INTERVAL['3s'])
+    return () => clearTimeout(timer)
+  }, [
+    enabled,
+    api,
+    fetchAllMarketDetails,
+    fetchUserMarketBalances,
+    fetchAllUserMarketDetails,
+    isPageVisible,
+    market,
+    loanExists,
+  ])
+
+  useEffect(() => {
+    if (market && loanExists && enabled) setMarketsStateKey('marketDetailsView', 'user')
+  }, [loanExists, setMarketsStateKey, enabled, market])
+  return userActiveKey
+}
+
+export const LendMarketPage = () => {
+  const { isHydrated } = useCurve()
+  const params = useParams<MarketUrlParams>()
+  const { rMarket, rChainId: chainId } = parseMarketParams(params)
+  const { data: market, isSuccess } = useOneWayMarket(chainId, rMarket)
+  const { llamaApi: api = null, provider } = useCurve()
 
   const marketId = market?.id ?? '' // todo: use market?.id directly everywhere since we pass the market too!
-  const userActiveKey = helpers.getUserActiveKey(api, market!)
   const { address: userAddress } = useConnection()
   useLendPageTitle(market?.collateral_token?.symbol ?? rMarket, t`Lend`)
 
@@ -55,7 +95,6 @@ export const LendMarketPage = () => {
     userAddress,
   })
 
-  const [isLoaded, setLoaded] = useState(false)
   const [previewPrices, onPricesUpdated] = useState<Range<Decimal> | undefined>(undefined)
   const controllerAddress = getControllerAddress(market)
   const borrowPositionDetails = useBorrowPositionDetails({
@@ -74,45 +113,15 @@ export const LendMarketPage = () => {
     network,
   })
 
-  useEffect(() => {
-    // delay fetch rest after form details are fetched first
-    const timer = setTimeout(async () => {
-      if (!api || !market || !isPageVisible) return
-      await fetchAllMarketDetails(api, market, true)
-      if (api.signerAddress) {
-        await fetchUserMarketBalances(api, market, true)
-        if (loanExists) {
-          void fetchAllUserMarketDetails(api, market, true)
-        }
-      }
-    }, REFRESH_INTERVAL['3s'])
-    return () => clearTimeout(timer)
-  }, [
-    api,
-    fetchAllMarketDetails,
-    fetchUserMarketBalances,
-    fetchAllUserMarketDetails,
-    isPageVisible,
-    market,
-    loanExists,
-  ])
-
-  useEffect(() => {
-    if (api && market && isPageVisible) {
-      if (loanExists) setMarketsStateKey('marketDetailsView', 'user')
-      setLoaded(true)
-    }
-  }, [api, isPageVisible, loanExists, market, setMarketsStateKey])
-
   const pageProps = {
     params,
     rChainId: chainId,
     rOwmId: marketId,
     userAddress,
-    isLoaded,
+    isLoaded: !!market,
     api,
     market,
-    userActiveKey,
+    userActiveKey: useLegacyFetching({ api, market, loanExists }),
     onPricesUpdated,
   }
 
@@ -121,11 +130,10 @@ export const LendMarketPage = () => {
   ) : provider ? (
     <DetailPageLayout
       formTabs={
-        chainId &&
-        marketId &&
+        market &&
         !isLoanExistsLoading &&
         (loanExists ? (
-          <ManageLoanTabs collateralEvents={collateralEvents} position={borrowPositionDetails} {...pageProps} />
+          <ManageLoanTabs {...pageProps} collateralEvents={collateralEvents} position={borrowPositionDetails} />
         ) : (
           <CreateLoanTabs {...pageProps} params={params} />
         ))

--- a/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
@@ -4,6 +4,7 @@ import { RemoveCollateralForm } from '@/llamalend/features/manage-loan/component
 import { RepayForm } from '@/llamalend/features/manage-loan/components/RepayForm'
 import { ClosePositionForm } from '@/llamalend/features/manage-soft-liquidation/ui/tabs/ClosePositionForm'
 import { ImproveHealthForm } from '@/llamalend/features/manage-soft-liquidation/ui/tabs/ImproveHealthForm'
+import type { BorrowPositionDetailsProps } from '@/llamalend/features/market-position-details'
 import type { UserCollateralEvents } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
 import { hasDeleverage } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
@@ -158,10 +159,12 @@ const MintManageSoftLiquidationMenu = [
 ] satisfies FormTab<MintManageLoanProps>[]
 
 export const ManageLoanTabs = ({
-  isInSoftLiquidation,
+  position: {
+    liquidationAlert: { softLiquidation, hardLiquidation },
+  },
   ...pageProps
-}: MintManageLoanProps & { isInSoftLiquidation: boolean }) => {
-  const shouldUseSoftLiquidation = useManageSoftLiquidation() && isInSoftLiquidation
+}: MintManageLoanProps & { position: BorrowPositionDetailsProps }) => {
+  const shouldUseSoftLiquidation = useManageSoftLiquidation() && (softLiquidation || hardLiquidation)
   const shouldUseManageLoanMuiForm = useManageLoanMuiForm()
   const menu = shouldUseSoftLiquidation
     ? MintManageSoftLiquidationMenu

--- a/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
@@ -10,7 +10,6 @@ import { MarketInformationComposite } from '@/loan/components/MarketInformationC
 import { CreateLoanTabs } from '@/loan/components/PageMintMarket/CreateLoanTabs'
 import { ManageLoanTabs } from '@/loan/components/PageMintMarket/ManageLoanTabs'
 import { useMintMarket } from '@/loan/entities/mint-markets'
-import { useUserLoanDetails } from '@/loan/hooks/useUserLoanDetails'
 import { networks } from '@/loan/networks'
 import { useStore } from '@/loan/store/useStore'
 import { type CollateralUrlParams } from '@/loan/types/loan.types'
@@ -40,10 +39,13 @@ export const MintMarketPage = () => {
   const market = useMintMarket({ chainId: rChainId, marketId: rCollateralId })
   const marketId = market?.id ?? ''
 
-  const { data: loanExists } = useLoanExists({ chainId: rChainId, marketId, userAddress: address })
+  const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists({
+    chainId: rChainId,
+    marketId,
+    userAddress: address,
+  })
   const fetchLoanDetails = useStore(state => state.loans.fetchLoanDetails)
 
-  const loanStatus = useUserLoanDetails(market?.id ?? '')?.userStatus?.colorKey ?? ''
   const network = networks[rChainId]
   const controllerAddress = getControllerAddress(market)
   const borrowPositionDetails = useBorrowPositionDetails({
@@ -83,7 +85,7 @@ export const MintMarketPage = () => {
     }
   }, REFRESH_INTERVAL['1m'])
 
-  const formProps = {
+  const pageProps = {
     curve,
     isReady: !!curve?.signerAddress && !!market,
     market: market ?? null,
@@ -92,21 +94,17 @@ export const MintMarketPage = () => {
     onPricesUpdated: setPreviewPrices,
   }
 
-  const isLoading = !loaded || (loanExists && !loanStatus)
   return isHydrated && !market ? (
     <ErrorPage title="404" subtitle={t`Market Not Found`} continueUrl={getCollateralListPathname(params)} />
   ) : provider ? (
     <DetailPageLayout
       formTabs={
-        !isLoading &&
+        loaded &&
+        !isLoanExistsLoading &&
         (loanExists ? (
-          <ManageLoanTabs
-            {...formProps}
-            collateralEvents={collateralEvents}
-            isInSoftLiquidation={loanStatus !== 'healthy'}
-          />
+          <ManageLoanTabs {...pageProps} collateralEvents={collateralEvents} position={borrowPositionDetails} />
         ) : (
-          <CreateLoanTabs {...formProps} />
+          <CreateLoanTabs {...pageProps} />
         ))
       }
       header={

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -96,6 +96,7 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] 
  * API is also available in the browser for testing and experimenting at https://api.merkl.xyz/docs
  */
 export const fetchMerklRewards = async (params: object) => {
+  if (window.location.hostname === 'localhost') return {} // todo: ask merkl to add localhost to allowed CORS headers
   const fetchPage = async (page: number, items: number) => {
     const url = `https://api.merkl.xyz/v4/opportunities${addQueryString({
       ...params,

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveContext.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveContext.tsx
@@ -1,10 +1,8 @@
 import { BrowserProvider } from 'ethers'
-import { createContext, useContext, useEffect, useMemo } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { useConnection, useConnectorClient } from 'wagmi'
-import type { Address } from '@primitives/address.utils'
 import type { NetworkDef } from '@ui/utils'
 import { setUser } from '@ui-kit/features/sentry'
-import { useDebouncedValue } from '@ui-kit/hooks/useDebounce'
 import type { Provider } from '@ui-kit/lib/ethers'
 import { ConnectState, type CurveApi, type LlamaApi, type Wallet } from './types'
 
@@ -22,35 +20,31 @@ type CurveContextValue = {
   provider?: Provider
   network?: NetworkDef
   isHydrated: boolean
-  isReconnecting: boolean
+  isInitialized: boolean
 }
 
 export const CurveContext = createContext<CurveContextValue>({
   connectState: LOADING,
   isHydrated: false,
-  isReconnecting: true,
+  isInitialized: false,
 })
 
 /**
- * Detects if the wallet is in the process of reconnecting.
- * - `isReconnecting` is set when switching pages
- * - `isConnecting` is set when the wallet gets flipped from connecting to connected when loading,
- *   especially without any wallet plugin
- * Therefore, we use a very cumbersome condition to detect if we are reconnecting, and also need some debouncing 😭
+ * Blocks app init until wagmi settles the initial wallet state.
+ * `useConnection()` and `useConnectorClient()` can resolve at different times, so once initialized, we keep returning true.
  */
-function useWagmiIsReconnecting(address?: Address) {
+function useWagmiIsInitialized(hasWallet: boolean) {
   const { isReconnecting, isConnected, isConnecting } = useConnection()
-  const isConnectingDebounced = useDebouncedValue(isConnecting, { defaultValue: true })
-  return !address && (isConnectingDebounced || isReconnecting || isConnected)
+  const [wasInitialized, setWasInitialized] = useState(false)
+
+  const isInitialized = !isConnecting && !isReconnecting && (!isConnected || hasWallet)
+  useEffect(() => setWasInitialized(wasInitialized => isInitialized || wasInitialized), [isInitialized])
+  return isInitialized || wasInitialized // note: use || since `isInitialized` is set one render before `wasInitialized`
 }
 
 /**
- * Separate hook to get the wallet and provider from wagmi.
- * This is moved here so that it's only used once in the context provider.
- *
- * Note: When using private key accounts in Cypress tests, wagmi doesn't automatically
- * expose these accounts through eth_accounts RPC calls. This creates an incompatibility
- * with ethers BrowserProvider, which relies on eth_accounts to determine the signer address.
+ * Reads the wagmi client once for the context provider.
+ * Note: Cypress private key accounts may not expose `eth_accounts`, which BrowserProvider expects.
  */
 export function useWagmiWallet() {
   const { data: client } = useConnectorClient()
@@ -63,7 +57,7 @@ export function useWagmiWallet() {
   )
   useEffect(() => setUser({ address, chainId }), [address, chainId])
   return {
-    isReconnecting: useWagmiIsReconnecting(address),
+    isInitialized: useWagmiIsInitialized(!!address && !!request),
     wallet,
     provider: useMemo(() => wallet && new BrowserProvider(wallet.provider), [wallet]),
   }

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveProvider.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/CurveProvider.tsx
@@ -41,18 +41,18 @@ export const CurveProvider = <App extends AppName>({
   const [connectState, setConnectState] = useState<ConnectState>(LOADING)
   const walletChainId = useChainId()
   const switchChain = useSwitchChain()
-  const { wallet, provider, isReconnecting } = useWagmiWallet()
+  const { wallet, provider, isInitialized } = useWagmiWallet()
+
   const isFocused = useIsDocumentFocused()
   const libKey = AppLibs[app]
   const config = useConfig()
   const [releaseChannel] = useReleaseChannel()
-
   useEffect(() => {
     /**
      * Checks the wallet chain if the network changes or the wallet is connected to a different chain.
      * Separate from the heavier `initApp` because `isFocused` changes often.
      */
-    if (isReconnecting) return // wait for wagmi to auto-reconnect
+    if (!isInitialized) return // wait for wagmi to auto-reconnect
     if (!network) return onChainUnavailable(walletChainId) // will redirect to the wallet's chain if supported
     if (network.chainId == walletChainId) return // all good
     if (isFocused) {
@@ -62,10 +62,10 @@ export const CurveProvider = <App extends AppName>({
         setConnectState(FAILURE)
       })
     }
-  }, [isFocused, isReconnecting, walletChainId, network, onChainUnavailable, switchChain, wallet])
+  }, [isFocused, isInitialized, walletChainId, network, onChainUnavailable, switchChain, wallet])
 
   useEffect(() => {
-    if (isReconnecting) return // wait for wagmi to auto-reconnect
+    if (!isInitialized) return // wait for wagmi to auto-reconnect
     const abort = new AbortController()
     const signal = abort.signal
 
@@ -118,7 +118,7 @@ export const CurveProvider = <App extends AppName>({
     }
     void initLib()
     return () => abort.abort()
-  }, [app, config, hydrate, isReconnecting, libKey, network, wallet, walletChainId, releaseChannel])
+  }, [app, config, hydrate, isInitialized, libKey, network, wallet, walletChainId, releaseChannel])
 
   // the following statements are skipping the render cycle, only update the libs when connectState changes too!
   const curveApi = globalLibs.getMatching('curveApi', wallet, network?.chainId)
@@ -131,7 +131,7 @@ export const CurveProvider = <App extends AppName>({
         connectState,
         network,
         isHydrated,
-        isReconnecting,
+        isInitialized,
         ...(wallet && { wallet }),
         ...(provider && { provider }),
         ...(curveApi && { curveApi }),

--- a/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletPrompt.tsx
+++ b/packages/curve-ui-kit/src/features/connect-wallet/ui/ConnectWalletPrompt.tsx
@@ -11,9 +11,9 @@ import { useWallet } from '../lib/useWallet'
 const { Spacing, MaxWidth } = SizesAndSpaces
 
 export const ConnectWalletPrompt = ({ description, testId }: { description: string; testId?: string }) => {
-  const { isReconnecting, connectState } = useCurve()
+  const { isInitialized, connectState } = useCurve()
   const { connect } = useWallet()
-  const isConnecting = isLoading(connectState) || isReconnecting
+  const isConnecting = isLoading(connectState) || !isInitialized
   return (
     <Stack alignItems="center" marginBlock={Spacing.lg} data-testid={testId}>
       <Stack

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -41,3 +41,6 @@ export const useMarketInterestRatesAndUtilizationChart = useStableChannel
 
 /** New market list and search layout */
 export const useNewMarketListLayout = useBetaChannel
+
+export const useLoanSlices = () =>
+  ![useManageSoftLiquidation(), useManageLoanMuiForm(), useLendingMuiForm()].every(Boolean)

--- a/packages/curve-ui-kit/src/utils/useTraceProps.ts
+++ b/packages/curve-ui-kit/src/utils/useTraceProps.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from 'react'
 
+const start = new Date().getTime()
+const showTimeDiff = () => (new Date().getTime() - start).toLocaleString() + 'ms'
+
 export function useTraceProps<T extends Record<string, unknown>>(name: string, props: T) {
   const propsRef = useRef<T>(props)
   useEffect(() => {
@@ -11,15 +14,15 @@ export function useTraceProps<T extends Record<string, unknown>>(name: string, p
     )
     if (Object.keys(changedProps).length) {
       console.info(
-        `useTraceProps ${name} ${new Date().toISOString()}: Changed props`,
+        `useTraceProps ${name} ${showTimeDiff()}: Changed props`,
         Object.entries(changedProps).map(([key, [prev, curr]]) => `${key}: ${toString(prev)} -> ${toString(curr)}`),
       )
     }
     propsRef.current = props
   }, [props, name])
   useEffect(() => {
-    console.info(`useTraceProps ${name} ${new Date().toISOString()}: Mounted`, { ...propsRef.current })
-    return () => console.warn(`useTraceProps ${name} ${new Date().toISOString()}: Unmounted`, { ...propsRef.current })
+    console.info(`useTraceProps ${name} ${showTimeDiff()}: Mounted`, { ...propsRef.current })
+    return () => console.warn(`useTraceProps ${name} ${showTimeDiff()}: Unmounted`, { ...propsRef.current })
   }, [name])
 }
 

--- a/tests/cypress/support/helpers/llamalend/MockLoanTestWrapper.tsx
+++ b/tests/cypress/support/helpers/llamalend/MockLoanTestWrapper.tsx
@@ -27,7 +27,7 @@ export const MockLoanTestWrapper = ({ children, llamaApi }: MockLoanTestWrapperP
       value={{
         connectState: ConnectState.SUCCESS,
         isHydrated: true,
-        isReconnecting: false,
+        isInitialized: true,
         llamaApi: llamaApi as never,
         wallet: { provider: { request: async () => undefined }, address: TEST_ADDRESS },
         provider: {} as never, // Intentionally unused here; gas info is seeded via setGasInfo() in test context.


### PR DESCRIPTION
- stop running slice fetching in stable mode (this is not included in the stats below)
- do not reinitialize the library if wagmi flips back to reconnecting (improves a few hundred ms)
- most improvements are in https://github.com/curvefi/curve-llamalend.js/pull/96

currently (commit [e135fe7](https://github.com/curvefi/curve-frontend/pull/2477/commits/e135fe7786e0816e2fa925710b297e8e9c15354a)+[17a3a16](https://github.com/curvefi/curve-llamalend.js/pull/96/changes/17a3a160e12c75c60528d0adf5fda155f1c4d75a)), the cold reload of a lend market on the ethereum network is:
- ~300ms until wagmi is called (unchanged)
- ~1600ms for wagmi connection (was 1800ms)
- ~900ms for llamalend.js init (was 7500ms)
- ~2200ms for fetchMarkets (was 2700ms)
- page load 5s (was 12s)

Note these times are not yet visible in the preview env since llamalend isn't updated
