### PR TITLE
fix: flaky typecheck & e2e

### DIFF
--- a/apps/main/src/dex/features/pool-list/columns/column.definitions.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.definitions.ts
@@ -1,7 +1,8 @@
 import { sumBy } from 'lodash'
 import { createColumnHelper } from '@tanstack/react-table'
-import type { ColumnDef, Row } from '@tanstack/table-core'
+import type { Row } from '@tanstack/table-core'
 import { t } from '@ui-kit/lib/i18n'
+import type { ColumnDefinition } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { boolFilterFn, inListFilterFn, multiFilterFn, rangeFilterFn } from '@ui-kit/shared/ui/DataTable/filters'
 import { PoolTitleCell } from '../cells/PoolTitleCell/PoolTitleCell'
 import { RewardsBaseCell } from '../cells/RewardsBaseCell'
@@ -26,8 +27,7 @@ const headers = {
   [PoolColumnId.Tvl]: t`TVL`,
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type PoolColumn = ColumnDef<PoolListItem, any>
+type PoolColumn = ColumnDefinition<PoolListItem>
 
 /** Sorts pool rows by a numeric reward value, placing rows with no value last. */
 const sortByReward =

--- a/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
+++ b/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react'
 import { NET_SUPPLY_RATE_TITLE } from '@/llamalend/constants'
-import { ColumnDef, type ColumnMeta, createColumnHelper, FilterFnOption } from '@tanstack/react-table'
+import { type ColumnMeta, createColumnHelper, FilterFnOption } from '@tanstack/react-table'
 import { type DeepKeys } from '@tanstack/table-core'
 import { t } from '@ui-kit/lib/i18n'
+import type { ColumnDefinition } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { boolFilterFn, listNotEmptyFilterFn, multiFilterFn, rangeFilterFn } from '@ui-kit/shared/ui/DataTable/filters'
 import { MarketRateType } from '@ui-kit/types/market'
 import { AVERAGE_CATEGORIES } from '@ui-kit/utils'
@@ -65,8 +66,7 @@ const hidden = (field: DeepKeys<LlamaMarket>, id: LlamaMarketColumnId, filterFn:
     meta: { hidden: true },
   })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type LlamaColumn = ColumnDef<LlamaMarket, any>
+type LlamaColumn = ColumnDefinition<LlamaMarket>
 
 /** Columns for the lending markets table. */
 export const LLAMA_MARKET_COLUMNS = [

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -2,7 +2,7 @@ import { capitalize, groupBy } from 'lodash'
 import type { Address } from 'viem'
 import { paginate } from '@curvefi/prices-api/paginate'
 import { addQueryString, FetchError } from '@primitives/fetch.utils'
-import { formatPercent } from '@ui-kit/utils'
+import { formatPercent, isCypress } from '@ui-kit/utils'
 import type { RewardsAction } from '@external-rewards'
 import type { CampaignRewards } from './types'
 
@@ -96,7 +96,7 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] 
  * API is also available in the browser for testing and experimenting at https://api.merkl.xyz/docs
  */
 export const fetchMerklRewards = async (params: object) => {
-  if (window.location.hostname === 'localhost') return {} // todo: ask merkl to add localhost to allowed CORS headers
+  if (window.location.hostname === 'localhost' && !isCypress) return {} // todo: ask merkl to add localhost to allowed CORS headers
   const fetchPage = async (page: number, items: number) => {
     const url = `https://api.merkl.xyz/v4/opportunities${addQueryString({
       ...params,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
@@ -4,6 +4,7 @@ import type { SxProps } from '@mui/system'
 import type { PartialRecord } from '@primitives/objects.utils'
 import {
   type Column,
+  type ColumnDef,
   getCoreRowModel,
   getExpandedRowModel,
   getFilteredRowModel,
@@ -21,6 +22,13 @@ export const DesktopOnlyHoverClass = 'desktop-only-on-hover'
 
 /** css class to make elements clickable in a row and ignore the row click */
 export const ClickableInRowClass = 'clickable-in-row'
+
+/**
+ * We use `satisfies` when declaring columns, but when we want to receive that definition using ColumnDef<T, unknown>,
+ * the type does not get widened, so we need to explicitly define the ColumnDefinition type as ColumnDef<T, any>.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ColumnDefinition<T> = ColumnDef<T, any>
 
 /** Required fields for the data in the table. */
 export type TableItem = { url?: string | null }

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/hooks/useVisibilitySettings.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/hooks/useVisibilitySettings.tsx
@@ -1,8 +1,8 @@
 import { isEqual } from 'lodash'
 import { useCallback, useMemo } from 'react'
-import { ColumnDef } from '@tanstack/react-table'
 import { useTableColumnVisibility } from '@ui-kit/hooks/useLocalStorage'
 import type { MigrationOptions } from '@ui-kit/hooks/useStoredState'
+import type { ColumnDefinition } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import type { VisibilityGroup } from '../visibility.types'
 
 /**
@@ -41,7 +41,7 @@ export const useVisibilitySettings = <TData, TVariant extends string, ColumnIds 
   tableTitle: string,
   groups: Record<TVariant, VisibilityGroup<ColumnIds>[]>,
   variant: TVariant,
-  columns: ColumnDef<TData, unknown>[],
+  columns: ColumnDefinition<TData>[],
   migration: MigrationOptions<Record<TVariant, VisibilityGroup<ColumnIds>[]>>,
 ) => {
   /** current visibility settings in grouped format */

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -48,15 +48,16 @@ testCases.forEach(([width, height, breakpoint]) => {
     })
 
     it(`should allow filtering by rewards`, { scrollBehavior: false }, () => {
-      if (breakpoint !== 'mobile') cy.viewport(oneMobileViewport()[0], height) // todo: filter by rewards currently only visible on mobile
+      if (breakpoint !== 'mobile') cy.viewport(oneMobileViewport()[0], height)
+      const mobile = 'mobile' // todo: filter by rewards currently only visible on mobile
       cy.get(`[data-testid^="data-table-row"]`).should('have.length.at.least', 1)
-      withFilterChips(breakpoint, () => {
+      withFilterChips(mobile, () => {
         cy.get(`[data-testid="chip-rewards"]`).click()
         return cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
       })
-      expandFirstRowOnMobile(breakpoint)
+      expandFirstRowOnMobile(mobile)
       cy.get(`[data-testid="rewards-icons"]`).should('be.visible')
-      withFilterChips(breakpoint, () => {
+      withFilterChips(mobile, () => {
         cy.get(`[data-testid="chip-rewards"]`).click()
         return cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
       })

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -22,6 +22,7 @@ import {
 import { mockMintMarkets, mockMintSnapshots } from '@cy/support/helpers/minting-mocks'
 import { mockTokenPrices } from '@cy/support/helpers/tokens'
 import {
+  API_LOAD_TIMEOUT,
   assertInViewport,
   assertNotInViewport,
   LOAD_TIMEOUT,
@@ -339,7 +340,7 @@ function visitAndWait(
 ) {
   cy.viewport(width, height)
   cy.visit(path, { ...LOAD_TIMEOUT, ...options })
-  cy.get('[data-testid="data-table"]', LOAD_TIMEOUT).should('be.visible')
+  cy.get('[data-testid="data-table"]', API_LOAD_TIMEOUT).should('be.visible')
 }
 
 function enableGraphColumn() {

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -48,18 +48,16 @@ testCases.forEach(([width, height, breakpoint]) => {
 
     it(`should allow filtering by rewards`, { scrollBehavior: false }, () => {
       cy.get(`[data-testid^="data-table-row"]`).should('have.length.at.least', 1)
-      if (breakpoint === 'mobile') {
-        withFilterChips(breakpoint, () => {
-          cy.get(`[data-testid="chip-rewards"]`).click()
-          return cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
-        })
-        expandFirstRowOnMobile(breakpoint)
-        cy.get(`[data-testid="rewards-icons"]`).should('be.visible')
-        withFilterChips(breakpoint, () => {
-          cy.get(`[data-testid="chip-rewards"]`).click()
-          return cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
-        })
-      }
+      withFilterChips(breakpoint, () => {
+        cy.get(`[data-testid="chip-rewards"]`).click()
+        return cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
+      })
+      expandFirstRowOnMobile(breakpoint)
+      cy.get(`[data-testid="rewards-icons"]`).should('be.visible')
+      withFilterChips(breakpoint, () => {
+        cy.get(`[data-testid="chip-rewards"]`).click()
+        return cy.get(`[data-testid^="data-table-row"]`).should('have.length.above', 1)
+      })
     })
 
     it('should have sticky headers', () => {

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -26,6 +26,7 @@ import {
   assertNotInViewport,
   LOAD_TIMEOUT,
   oneDesktopViewport,
+  oneMobileViewport,
   oneViewport,
   RETRY_IN_CI,
 } from '@cy/support/ui'
@@ -47,6 +48,7 @@ testCases.forEach(([width, height, breakpoint]) => {
     })
 
     it(`should allow filtering by rewards`, { scrollBehavior: false }, () => {
+      if (breakpoint !== 'mobile') cy.viewport(oneMobileViewport()[0], height) // todo: filter by rewards currently only visible on mobile
       cy.get(`[data-testid^="data-table-row"]`).should('have.length.at.least', 1)
       withFilterChips(breakpoint, () => {
         cy.get(`[data-testid="chip-rewards"]`).click()
@@ -223,11 +225,7 @@ testCases.forEach(([width, height, breakpoint]) => {
     // todo: filter by chain
 
     it(`should allow filtering by token`, () => {
-      if (breakpoint == 'mobile') {
-        openDrawer(breakpoint, 'filter')
-      } else {
-        cy.get(`[data-testid="btn-open-filters"]`).click()
-      }
+      openFilters(breakpoint)
       checkCoinSelection('collateral')
       checkCoinSelection('borrowed')
     })

--- a/tests/cypress/support/ui.ts
+++ b/tests/cypress/support/ui.ts
@@ -8,7 +8,7 @@ const [MIN_HEIGHT, MAX_HEIGHT] = [600, 1000]
 export const oneDesktopViewport = () =>
   [oneInt(DESKTOP_BREAKPOINT, MAX_WIDTH), oneInt(MIN_HEIGHT, MAX_HEIGHT), 'desktop'] as const
 
-const oneMobileViewport = () =>
+export const oneMobileViewport = () =>
   [oneInt(MIN_WIDTH, TABLET_BREAKPOINT), oneInt(MIN_HEIGHT, MAX_HEIGHT), 'mobile'] as const
 
 const oneTabletViewport = () =>


### PR DESCRIPTION
- typecheck would fail sometimes due to usages of `unknown` in `columnDef` combined with `satisfies`
- rewards test was totally broken, but disabled on desktop/tablet so it seemed flaky. Fixed by enabling Merkl on Cypress