### PR TITLE
feat: append on-chain borrow and supply rates to historical charts

### DIFF
--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -36,8 +36,22 @@ export const MarketInformationComposite = ({ pageProps, type, previewPrices }: M
     <Stack gap={PAGE_SPACING}>
       {isBorrow && <ChartAndActivityComp rChainId={rChainId} rOwmId={rOwmId} api={api} previewPrices={previewPrices} />}
 
-      {isBorrow && <MarketHistoricalRatesChart market={market} blockchainId={blockchainId} rateMode="borrow" />}
-      <MarketHistoricalRatesChart market={market} blockchainId={blockchainId} rateMode="supply" />
+      {isBorrow && (
+        <MarketHistoricalRatesChart
+          market={market}
+          blockchainId={blockchainId}
+          chainId={rChainId}
+          marketId={rOwmId}
+          rateMode="borrow"
+        />
+      )}
+      <MarketHistoricalRatesChart
+        market={market}
+        blockchainId={blockchainId}
+        chainId={rChainId}
+        marketId={rOwmId}
+        rateMode="supply"
+      />
 
       {useMarketInterestRatesAndUtilizationChart() && (
         <MarketRateCurveChart market={market} blockchainId={blockchainId} chainId={rChainId} marketId={rOwmId} />

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -9,6 +9,7 @@ import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
+import { notFalsy } from '@primitives/objects.utils'
 import { formatDate } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { timeOptions, type TimeOption } from '@ui-kit/lib/model/query/time-option-validation'
@@ -81,13 +82,13 @@ export const MarketHistoricalRatesChart = ({
   const chartData = useMemo<RateChartPoint[]>(() => {
     const onChainRate = rateMode === 'borrow' ? marketRates?.borrowApr : marketRates?.lendApy
     const sorted = sortBy(
-      [
+      notFalsy(
         ...snapshots.map(snapshot => ({
           timestamp: snapshot.timestamp,
           rate: Number(rateMode === 'borrow' ? snapshot.borrowApr : 'lendApy' in snapshot ? snapshot.lendApy * 100 : 0),
         })),
-        ...(onChainRate == null ? [] : [{ timestamp: Date.now(), rate: Number(onChainRate) }]),
-      ],
+        onChainRate != null && { timestamp: Date.now(), rate: Number(onChainRate) },
+      ),
       item => item.timestamp,
     )
 

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -2,6 +2,7 @@ import { sortBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { type LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
+import { useMarketRates } from '@/llamalend/queries/market'
 import { HistoricalRatesTooltip } from '@/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip'
 import type { Chain } from '@curvefi/prices-api'
 import { CardContent, Stack } from '@mui/material'
@@ -39,6 +40,8 @@ type RateSeriesKey = 'rate' | 'movingAverage' | 'totalAverage'
 type MarketHistoricalRatesChartProps = {
   market: LlamaMarketTemplate | undefined | null
   blockchainId: Chain | undefined
+  chainId: number
+  marketId: string
   rateMode: RateMode
 }
 
@@ -54,7 +57,13 @@ const SUPPLY_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash: string }[
   { key: 'totalAverage', label: t`Average APY`, dash: '4 4' },
 ]
 
-export const MarketHistoricalRatesChart = ({ market, blockchainId, rateMode }: MarketHistoricalRatesChartProps) => {
+export const MarketHistoricalRatesChart = ({
+  market,
+  blockchainId,
+  chainId,
+  marketId,
+  rateMode,
+}: MarketHistoricalRatesChartProps) => {
   const [timeOption, setTimeOption] = useState<TimeOption>('1M')
   const activeSeriesConfig = rateMode === 'borrow' ? BORROW_SERIES_CONFIG : SUPPLY_SERIES_CONFIG
   const [visibleSeries, setVisibleSeries] = useState<RateSeriesKey[]>(activeSeriesConfig.map(({ key }) => key))
@@ -67,14 +76,19 @@ export const MarketHistoricalRatesChart = ({ market, blockchainId, rateMode }: M
     isLoading,
     error,
   } = useLlamaSnapshot(market, blockchainId, Boolean(market && blockchainId), { kind: 'timeRange', timeOption })
+  const { data: marketRates } = useMarketRates({ chainId, marketId }, Boolean(market))
 
   const chartData = useMemo<RateChartPoint[]>(() => {
+    const onChainRate = rateMode === 'borrow' ? marketRates?.borrowApr : marketRates?.lendApy
     const sorted = sortBy(
-      snapshots.map(snapshot => ({
-        // timestamp is typed as Date but may be a string after JSON serialization (e.g. React Query cache)
-        timestamp: new Date(snapshot.timestamp).getTime(),
-        rate: Number(rateMode === 'borrow' ? snapshot.borrowApr : 'lendApy' in snapshot ? snapshot.lendApy * 100 : 0),
-      })),
+      [
+        ...snapshots.map(snapshot => ({
+          // timestamp is typed as Date but may be a string after JSON serialization (e.g. React Query cache)
+          timestamp: new Date(snapshot.timestamp).getTime(),
+          rate: Number(rateMode === 'borrow' ? snapshot.borrowApr : 'lendApy' in snapshot ? snapshot.lendApy * 100 : 0),
+        })),
+        ...(onChainRate == null ? [] : [{ timestamp: Date.now(), rate: Number(onChainRate) }]),
+      ],
       item => item.timestamp,
     )
 
@@ -83,7 +97,7 @@ export const MarketHistoricalRatesChart = ({ market, blockchainId, rateMode }: M
       d => d.rate,
       d => d.timestamp,
     )
-  }, [snapshots, rateMode])
+  }, [snapshots, rateMode, marketRates])
 
   const seriesColors: Record<RateSeriesKey, string> = useMemo(
     () => ({ rate: Color.Primary[500], movingAverage: Color.Secondary[500], totalAverage: Color.Tertiary[400] }),

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -83,8 +83,7 @@ export const MarketHistoricalRatesChart = ({
     const sorted = sortBy(
       [
         ...snapshots.map(snapshot => ({
-          // timestamp is typed as Date but may be a string after JSON serialization (e.g. React Query cache)
-          timestamp: new Date(snapshot.timestamp).getTime(),
+          timestamp: snapshot.timestamp,
           rate: Number(rateMode === 'borrow' ? snapshot.borrowApr : 'lendApy' in snapshot ? snapshot.lendApy * 100 : 0),
         })),
         ...(onChainRate == null ? [] : [{ timestamp: Date.now(), rate: Number(onChainRate) }]),

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -30,7 +30,13 @@ export const MarketInformationComposite = ({
 }: MarketInformationCompProps) => (
   <Stack gap={PAGE_SPACING}>
     <ChartAndActivityComp chainId={chainId} marketId={marketId} market={market} previewPrices={previewPrices} />
-    <MarketHistoricalRatesChart market={market} blockchainId={BlockchainIds[Chain.Ethereum]} rateMode="borrow" />
+    <MarketHistoricalRatesChart
+      market={market}
+      blockchainId={BlockchainIds[Chain.Ethereum]}
+      chainId={chainId}
+      marketId={marketId}
+      rateMode="borrow"
+    />
     <CrvUsdPriceChart />
 
     <Card size="small">


### PR DESCRIPTION
Changes:
- Adds on-chain borrow/supply rate as last datapoints in historical rate charts