### PR TITLE
feat: show max balance even when errors occur

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -120,7 +120,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           hideBalance
           testId="borrow-debt-input"
           network={network}
-          message={
+          maxMessage={
             <Balance
               inline
               prefix={t`Max borrow:`}

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -129,7 +129,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           testId="borrow-more-input-debt"
           network={network}
           hideBalance
-          message={
+          maxMessage={
             <Balance
               inline
               prefix={t`Max borrow amount:`}

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -70,7 +70,7 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
           network={network}
           positionBalance={{ position: positionCollateral, tooltip: t`Collateral in position` }}
           max={{ ...q(maxRemovable), fieldName: 'maxCollateral' }}
-          message={
+          maxMessage={
             <Balance
               inline
               prefix={t`Max removable:`}

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -173,7 +173,7 @@ export const RepayForm = <ChainId extends IChainId>({
             tokens={tokens}
           />
         }
-        message={
+        maxMessage={
           maxAmountInBorrowTokenError?.message ?? (
             <Balance
               inline

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -34,7 +34,7 @@ export type LoanFormTokenInputProps<
   name: TFieldName
   form: UseFormReturn<TFieldValues> // the form, used to set the value and get errors
   testId: string
-  message?: ReactNode
+  maxMessage?: ReactNode
   /**
    * Optional, displays the position balance instead of the wallet balance.
    */
@@ -70,7 +70,7 @@ export const LoanFormTokenInput = <
   max,
   form,
   testId,
-  message,
+  maxMessage,
   network,
   positionBalance,
   tokenSelector,
@@ -143,11 +143,8 @@ export const LoanFormTokenInput = <
       maxBalance={max && { balance: max.data, chips: 'range', isLoading: max.isLoading }}
       inputBalanceUsd={decimal(usdRate && usdRate * +(value ?? 0))}
     >
-      {errorMessage ? (
-        <HelperMessage message={errorMessage} onNumberClick={onBalance} isError />
-      ) : (
-        message && <HelperMessage onNumberClick={onBalance} message={message} />
-      )}
+      {maxMessage && <HelperMessage onNumberClick={onBalance} message={maxMessage} />}
+      {errorMessage && <HelperMessage message={errorMessage} onNumberClick={onBalance} isError />}
     </LargeTokenInput>
   )
 }


### PR DESCRIPTION
- when the user has set a max balance that is too high, either manually or due to market conditions changing, the max isn't displayed anymore. The user will only see a transaction and/or max balance error. Removing the value completely also doesn't help as you then see the required field error.
- Therefore, I think we should be showing the max balance even when errors are visible