### PR TITLE
feat: support disabling of sticky headers in datatable

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataRow.tsx
@@ -26,17 +26,19 @@ const onCellClick = (target: EventTarget, url: string, routerNavigate: (href: st
 export type DataRowProps<T extends TableItem> = {
   table: Table<T>
   row: Row<T>
-  isLast: boolean
   expandedPanel?: ExpandedPanel<T>
+  isLastRow: boolean
+  shouldStickLastRowToTop?: boolean
   shouldStickFirstColumn?: boolean
   verticalAlign?: 'top' | 'center' | 'bottom'
 }
 
 export const DataRow = <T extends TableItem>({
   table,
-  isLast,
   row,
   expandedPanel,
+  isLastRow,
+  shouldStickLastRowToTop,
   shouldStickFirstColumn,
   verticalAlign = 'center',
 }: DataRowProps<T>) => {
@@ -50,6 +52,7 @@ export const DataRow = <T extends TableItem>({
     [url, push, hasUrl],
   )
   const visibleCells = row.getVisibleCells()
+  const shouldApplyStickyLastRow = isLastRow && shouldStickLastRowToTop
   return (
     <>
       <InvertOnHover hoverColor={t => t.design.Table.Row.Hover} hoverRef={{ current: element }} disabled={isMobile}>
@@ -70,7 +73,7 @@ export const DataRow = <T extends TableItem>({
                   backgroundColor: t => t.design.Table.Row.Hover,
                 },
               },
-              ...(isLast && {
+              ...(shouldApplyStickyLastRow && {
                 // to avoid the sticky header showing without any rows, show the last row on top of it
                 position: 'sticky',
                 zIndex: t => t.zIndex.tableStickyLastRow,
@@ -78,7 +81,7 @@ export const DataRow = <T extends TableItem>({
                 backgroundColor: t => t.design.Table.Row.Default,
               }),
             }),
-            [isLast, hasUrl, verticalAlign],
+            [shouldApplyStickyLastRow, hasUrl, verticalAlign],
           )}
           ref={setElement}
           data-testid={element && `data-table-row-${row.id}`}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -92,7 +92,7 @@ export const DataTable = <T extends TableItem>({
   disableStickyHeader?: boolean
   hideHeader?: boolean
   footerRow?: ReactNode
-} & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
+} & Omit<DataRowProps<T>, 'row' | 'isLastRow' | 'shouldStickLastRowToTop'>) => {
   const { table } = rowProps
   const { rows } = table.getRowModel()
   const { isLimited, isLoading: isLoadingViewAll, onShowAll } = useTableRowLimit(rowLimit, rows.length)
@@ -117,6 +117,7 @@ export const DataTable = <T extends TableItem>({
     }),
     marginBlock: Sizing.sm,
   })
+  const shouldStickLastRowToTop = !disableStickyHeader && !hideHeader
   const showFooter = showPagination || showViewAllButton || footerRow
 
   return (
@@ -155,7 +156,8 @@ export const DataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={!disableStickyHeader && !hideHeader && index === visibleRows.length - 1}
+                isLastRow={index === visibleRows.length - 1}
+                shouldStickLastRowToTop={shouldStickLastRowToTop}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -78,6 +78,7 @@ export const DataTable = <T extends TableItem>({
   viewAllLabel,
   shouldStickFirstColumn = false,
   hideHeader = false,
+  stickyHeader = true,
   footerRow,
   ...rowProps
 }: {
@@ -89,6 +90,7 @@ export const DataTable = <T extends TableItem>({
   rowLimit?: number
   viewAllLabel?: string
   hideHeader?: boolean
+  stickyHeader?: boolean
   footerRow?: ReactNode
 } & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
   const { table } = rowProps
@@ -108,9 +110,11 @@ export const DataTable = <T extends TableItem>({
   useResetPageOnResultChange(table)
   useScrollToTopOnPageChange(table, containerRef)
   const tableHeaderSx = (t: Theme) => ({
-    position: 'sticky',
-    top: maxHeight ? 0 : top,
-    zIndex: t.zIndex.tableHeader,
+    ...(stickyHeader && {
+      position: 'sticky',
+      top: maxHeight ? 0 : top,
+      zIndex: t.zIndex.tableHeader,
+    }),
     marginBlock: Sizing.sm,
   })
   const showFooter = showPagination || showViewAllButton || footerRow
@@ -151,7 +155,7 @@ export const DataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={index === visibleRows.length - 1}
+                isLast={stickyHeader && !hideHeader && index === visibleRows.length - 1}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -76,9 +76,9 @@ export const DataTable = <T extends TableItem>({
   maxHeight,
   rowLimit,
   viewAllLabel,
+  disableStickyHeader,
   shouldStickFirstColumn = false,
   hideHeader = false,
-  stickyHeader = true,
   footerRow,
   ...rowProps
 }: {
@@ -89,8 +89,8 @@ export const DataTable = <T extends TableItem>({
   maxHeight?: `${number}rem` // also sets overflowY to 'auto'
   rowLimit?: number
   viewAllLabel?: string
+  disableStickyHeader?: boolean
   hideHeader?: boolean
-  stickyHeader?: boolean
   footerRow?: ReactNode
 } & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
   const { table } = rowProps
@@ -110,7 +110,7 @@ export const DataTable = <T extends TableItem>({
   useResetPageOnResultChange(table)
   useScrollToTopOnPageChange(table, containerRef)
   const tableHeaderSx = (t: Theme) => ({
-    ...(stickyHeader && {
+    ...(!disableStickyHeader && {
       position: 'sticky',
       top: maxHeight ? 0 : top,
       zIndex: t.zIndex.tableHeader,
@@ -155,7 +155,7 @@ export const DataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={stickyHeader && !hideHeader && index === visibleRows.length - 1}
+                isLast={!disableStickyHeader && !hideHeader && index === visibleRows.length - 1}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
@@ -92,7 +92,7 @@ export const LegacyDataTable = <T extends TableItem>({
   disableStickyHeader?: boolean
   hideHeader?: boolean
   footerRow?: ReactNode
-} & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
+} & Omit<DataRowProps<T>, 'row' | 'isLastRow' | 'shouldStickLastRowToTop'>) => {
   const { table } = rowProps
   const { rows } = table.getRowModel()
   const { isLimited, isLoading: isLoadingViewAll, onShowAll } = useTableRowLimit(rowLimit, rows.length)
@@ -118,6 +118,7 @@ export const LegacyDataTable = <T extends TableItem>({
     backgroundColor: t.design.Table.Header.Fill,
     marginBlock: Sizing.sm,
   })
+  const shouldStickLastRowToTop = !disableStickyHeader && !hideHeader
   const showFooter = showPagination || showViewAllButton || footerRow
 
   return (
@@ -157,7 +158,8 @@ export const LegacyDataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={!disableStickyHeader && !hideHeader && index === visibleRows.length - 1}
+                isLastRow={index === visibleRows.length - 1}
+                shouldStickLastRowToTop={shouldStickLastRowToTop}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
@@ -76,9 +76,9 @@ export const LegacyDataTable = <T extends TableItem>({
   maxHeight,
   rowLimit,
   viewAllLabel,
+  disableStickyHeader,
   shouldStickFirstColumn = false,
   hideHeader = false,
-  stickyHeader = true,
   footerRow,
   ...rowProps
 }: {
@@ -89,8 +89,8 @@ export const LegacyDataTable = <T extends TableItem>({
   maxHeight?: `${number}rem` // also sets overflowY to 'auto'
   rowLimit?: number
   viewAllLabel?: string
+  disableStickyHeader?: boolean
   hideHeader?: boolean
-  stickyHeader?: boolean
   footerRow?: ReactNode
 } & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
   const { table } = rowProps
@@ -110,7 +110,7 @@ export const LegacyDataTable = <T extends TableItem>({
   useResetPageOnResultChange(table)
   useScrollToTopOnPageChange(table, containerRef)
   const tableHeaderSx = (t: Theme) => ({
-    ...(stickyHeader && {
+    ...(!disableStickyHeader && {
       position: 'sticky',
       top: maxHeight ? 0 : top,
       zIndex: t.zIndex.tableHeader,
@@ -157,7 +157,7 @@ export const LegacyDataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={stickyHeader && !hideHeader && index === visibleRows.length - 1}
+                isLast={!disableStickyHeader && !hideHeader && index === visibleRows.length - 1}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
@@ -78,6 +78,7 @@ export const LegacyDataTable = <T extends TableItem>({
   viewAllLabel,
   shouldStickFirstColumn = false,
   hideHeader = false,
+  stickyHeader = true,
   footerRow,
   ...rowProps
 }: {
@@ -89,6 +90,7 @@ export const LegacyDataTable = <T extends TableItem>({
   rowLimit?: number
   viewAllLabel?: string
   hideHeader?: boolean
+  stickyHeader?: boolean
   footerRow?: ReactNode
 } & Omit<DataRowProps<T>, 'row' | 'isLast'>) => {
   const { table } = rowProps
@@ -108,9 +110,11 @@ export const LegacyDataTable = <T extends TableItem>({
   useResetPageOnResultChange(table)
   useScrollToTopOnPageChange(table, containerRef)
   const tableHeaderSx = (t: Theme) => ({
-    position: 'sticky',
-    top: maxHeight ? 0 : top,
-    zIndex: t.zIndex.tableHeader,
+    ...(stickyHeader && {
+      position: 'sticky',
+      top: maxHeight ? 0 : top,
+      zIndex: t.zIndex.tableHeader,
+    }),
     backgroundColor: t.design.Table.Header.Fill,
     marginBlock: Sizing.sm,
   })
@@ -153,7 +157,7 @@ export const LegacyDataTable = <T extends TableItem>({
               <DataRow<T>
                 key={row.id}
                 row={row}
-                isLast={index === visibleRows.length - 1}
+                isLast={stickyHeader && !hideHeader && index === visibleRows.length - 1}
                 shouldStickFirstColumn={shouldStickFirstColumn}
                 {...rowProps}
               />


### PR DESCRIPTION
I ran into the issue where the datatable's sticky headers are causing issues wrt the top & max height when used inside a card and not as a main part of the scrollable page. This PR adds a prop that allows us to optionally disable it.

Inside card with sticky headers by default:
<img width="767" height="276" alt="image" src="https://github.com/user-attachments/assets/728ab15d-8b21-411f-9a07-ef6c70004c08" />

Inside a card with `stickyHeader={false}`:
<img width="754" height="271" alt="image" src="https://github.com/user-attachments/assets/291f3bf5-1358-4166-b315-08a1ef0f7e3b" />
