### PR TITLE
refactor: move chart dash patterns to shared UI constants

### DIFF
--- a/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdPrice.tsx
+++ b/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdPrice.tsx
@@ -39,7 +39,7 @@ export function ChartCrvUsdPrice() {
   const palette = createPalette({ theme })
 
   const legendSets: LegendItem[] = useMemo(
-    () => [{ label: PRICE_LABEL, line: { lineStroke: palette.colors[0], dash: 'none' } }],
+    () => [{ label: PRICE_LABEL, line: { lineStroke: palette.colors[0] } }],
     [palette.colors],
   )
 

--- a/apps/main/src/llamalend/features/bands-chart/markLines.ts
+++ b/apps/main/src/llamalend/features/bands-chart/markLines.ts
@@ -1,3 +1,8 @@
+import {
+  CHART_LINE_DASH_PATTERNS,
+  CHART_REFERENCE_LINE_WIDTH,
+  type ChartLineDashPattern,
+} from '@ui-kit/shared/ui/Chart/chart.utils'
 import { BandsChartPalette, UserBandsPriceRange } from './types'
 
 /**
@@ -6,23 +11,16 @@ import { BandsChartPalette, UserBandsPriceRange } from './types'
  * Includes lineStyle metadata for label styling
  */
 type MarkLine = [{ coord: [number, number] }, { coord: [number, number] }] & {
-  lineStyle: { color: string; type: string; width: number }
+  lineStyle: { color: string; type: ChartLineDashPattern; width: number }
 }
 
 /**
  * Creates a standardized mark line configuration using coord format
  * for proper alignment with custom series rectangles
  */
-const createMarkLine = (
-  xStart: number,
-  xEnd: number,
-  yValue: number,
-  color: string,
-  type = 'dashed',
-  width = 2,
-): MarkLine => {
+const createMarkLine = (xStart: number, xEnd: number, yValue: number, color: string): MarkLine => {
   const line: MarkLine = [{ coord: [xStart, yValue] }, { coord: [xEnd, yValue] }] as MarkLine
-  line.lineStyle = { color, type, width }
+  line.lineStyle = { color, type: CHART_LINE_DASH_PATTERNS.reference, width: CHART_REFERENCE_LINE_WIDTH }
   return line
 }
 

--- a/apps/main/src/llamalend/features/bands-chart/markLines.ts
+++ b/apps/main/src/llamalend/features/bands-chart/markLines.ts
@@ -20,7 +20,7 @@ type MarkLine = [{ coord: [number, number] }, { coord: [number, number] }] & {
  */
 const createMarkLine = (xStart: number, xEnd: number, yValue: number, color: string): MarkLine => {
   const line: MarkLine = [{ coord: [xStart, yValue] }, { coord: [xEnd, yValue] }] as MarkLine
-  line.lineStyle = { color, type: CHART_LINE_DASH_PATTERNS.reference, width: CHART_REFERENCE_LINE_WIDTH }
+  line.lineStyle = { color, type: CHART_LINE_DASH_PATTERNS.regular, width: CHART_REFERENCE_LINE_WIDTH }
   return line
 }
 

--- a/apps/main/src/llamalend/features/bands-chart/markLines.ts
+++ b/apps/main/src/llamalend/features/bands-chart/markLines.ts
@@ -1,6 +1,6 @@
 import {
   CHART_LINE_DASH_PATTERNS,
-  CHART_REFERENCE_LINE_WIDTH,
+  CHART_LINE_WIDTHS,
   type ChartLineDashPattern,
 } from '@ui-kit/shared/ui/Chart/chart.utils'
 import { BandsChartPalette, UserBandsPriceRange } from './types'
@@ -14,13 +14,31 @@ type MarkLine = [{ coord: [number, number] }, { coord: [number, number] }] & {
   lineStyle: { color: string; type: ChartLineDashPattern; width: number }
 }
 
+type MarkLineStyle = MarkLine['lineStyle']
+
+const DEFAULT_MARK_LINE_STYLE = {
+  type: CHART_LINE_DASH_PATTERNS.regular,
+  width: CHART_LINE_WIDTHS.referenceLine,
+} satisfies Omit<MarkLineStyle, 'color'>
+
+const DEFAULT_ORACLE_PRICE_LINE_STYLE = {
+  type: CHART_LINE_DASH_PATTERNS.tight,
+  width: CHART_LINE_WIDTHS.defaultPriceLine,
+} satisfies Omit<MarkLineStyle, 'color'>
+
 /**
  * Creates a standardized mark line configuration using coord format
  * for proper alignment with custom series rectangles
  */
-const createMarkLine = (xStart: number, xEnd: number, yValue: number, color: string): MarkLine => {
+const createMarkLine = (
+  xStart: number,
+  xEnd: number,
+  yValue: number,
+  color: string,
+  style: Omit<MarkLineStyle, 'color'> = DEFAULT_MARK_LINE_STYLE,
+): MarkLine => {
   const line: MarkLine = [{ coord: [xStart, yValue] }, { coord: [xEnd, yValue] }] as MarkLine
-  line.lineStyle = { color, type: CHART_LINE_DASH_PATTERNS.regular, width: CHART_REFERENCE_LINE_WIDTH }
+  line.lineStyle = { color, ...style }
   return line
 }
 
@@ -48,7 +66,7 @@ const createOraclePriceMarkLine = (
   const price = Number(oraclePrice)
   if (!Number.isFinite(price)) return []
 
-  return [createMarkLine(xStart, xEnd, price, palette.oraclePriceLineColor)]
+  return [createMarkLine(xStart, xEnd, price, palette.oraclePriceLineColor, DEFAULT_ORACLE_PRICE_LINE_STYLE)]
 }
 
 export const generateMarkLines = (

--- a/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
+++ b/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
@@ -15,7 +15,9 @@ import {
   ChartFooter,
   type LegendItem,
   addMovingAverages,
+  CHART_LINE_DASH_PATTERNS,
   EChartsLineChart,
+  type ChartLineDashPattern,
   type LineSeriesConfig,
   SelectTimeOption,
 } from '@ui-kit/shared/ui/Chart'
@@ -33,10 +35,10 @@ export type CrvUsdPriceChartPoint = {
 
 type PriceSeriesKey = 'price' | 'movingAverage' | 'totalAverage'
 
-const SERIES_CONFIG: { key: PriceSeriesKey; label: string; dash: string }[] = [
-  { key: 'price', label: t`crvUSD Price`, dash: 'none' },
-  { key: 'movingAverage', label: t`7-day MA Price`, dash: '2 2' },
-  { key: 'totalAverage', label: t`Average Price`, dash: '4 4' },
+const SERIES_CONFIG: { key: PriceSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
+  { key: 'price', label: t`crvUSD Price` },
+  { key: 'movingAverage', label: t`7-day MA Price`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+  { key: 'totalAverage', label: t`Average Price`, dash: CHART_LINE_DASH_PATTERNS.average },
 ]
 
 export const CrvUsdPriceChart = () => {

--- a/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
+++ b/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
@@ -37,8 +37,8 @@ type PriceSeriesKey = 'price' | 'movingAverage' | 'totalAverage'
 
 const SERIES_CONFIG: { key: PriceSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
   { key: 'price', label: t`crvUSD Price` },
-  { key: 'movingAverage', label: t`7-day MA Price`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
-  { key: 'totalAverage', label: t`Average Price`, dash: CHART_LINE_DASH_PATTERNS.average },
+  { key: 'movingAverage', label: t`7-day MA Price`, dash: CHART_LINE_DASH_PATTERNS.tight },
+  { key: 'totalAverage', label: t`Average Price`, dash: CHART_LINE_DASH_PATTERNS.regular },
 ]
 
 export const CrvUsdPriceChart = () => {

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -50,14 +50,14 @@ type MarketHistoricalRatesChartProps = {
 
 const BORROW_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
   { key: 'rate', label: t`Borrow APR` },
-  { key: 'movingAverage', label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
-  { key: 'totalAverage', label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.average },
+  { key: 'movingAverage', label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.tight },
+  { key: 'totalAverage', label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.regular },
 ]
 
 const SUPPLY_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
   { key: 'rate', label: t`Supply APY` },
-  { key: 'movingAverage', label: t`7-day MA APY`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
-  { key: 'totalAverage', label: t`Average APY`, dash: CHART_LINE_DASH_PATTERNS.average },
+  { key: 'movingAverage', label: t`7-day MA APY`, dash: CHART_LINE_DASH_PATTERNS.tight },
+  { key: 'totalAverage', label: t`Average APY`, dash: CHART_LINE_DASH_PATTERNS.regular },
 ]
 
 export const MarketHistoricalRatesChart = ({

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -18,7 +18,9 @@ import {
   ChartFooter,
   type LegendItem,
   addMovingAverages,
+  CHART_LINE_DASH_PATTERNS,
   EChartsLineChart,
+  type ChartLineDashPattern,
   type LineSeriesConfig,
   SelectTimeOption,
 } from '@ui-kit/shared/ui/Chart'
@@ -46,16 +48,16 @@ type MarketHistoricalRatesChartProps = {
   rateMode: RateMode
 }
 
-const BORROW_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash: string }[] = [
-  { key: 'rate', label: t`Borrow APR`, dash: 'none' },
-  { key: 'movingAverage', label: t`7-day MA APR`, dash: '2 2' },
-  { key: 'totalAverage', label: t`Average APR`, dash: '4 4' },
+const BORROW_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
+  { key: 'rate', label: t`Borrow APR` },
+  { key: 'movingAverage', label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+  { key: 'totalAverage', label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.average },
 ]
 
-const SUPPLY_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash: string }[] = [
-  { key: 'rate', label: t`Supply APY`, dash: 'none' },
-  { key: 'movingAverage', label: t`7-day MA APY`, dash: '2 2' },
-  { key: 'totalAverage', label: t`Average APY`, dash: '4 4' },
+const SUPPLY_SERIES_CONFIG: { key: RateSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
+  { key: 'rate', label: t`Supply APY` },
+  { key: 'movingAverage', label: t`7-day MA APY`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+  { key: 'totalAverage', label: t`Average APY`, dash: CHART_LINE_DASH_PATTERNS.average },
 ]
 
 export const MarketHistoricalRatesChart = ({

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -15,7 +15,9 @@ import { t } from '@ui-kit/lib/i18n'
 import {
   ChartFooter,
   ChartStateWrapper,
+  CHART_LINE_DASH_PATTERNS,
   EChartsLineChart,
+  type ChartLineDashPattern,
   type LegendItem,
   type LineSeriesConfig,
 } from '@ui-kit/shared/ui/Chart'
@@ -32,9 +34,9 @@ export type RateCurveChartPoint = {
 
 type RateCurveSeriesKey = keyof Omit<RateCurveChartPoint, 'utilization'>
 
-const SERIES_CONFIG: { key: RateCurveSeriesKey; label: string; dash: string }[] = [
-  { key: 'borrowApr', label: t`Borrow APR`, dash: 'none' },
-  { key: 'supplyApy', label: t`Supply APY`, dash: '8 8' },
+const SERIES_CONFIG: { key: RateCurveSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
+  { key: 'borrowApr', label: t`Borrow APR` },
+  { key: 'supplyApy', label: t`Supply APY`, dash: CHART_LINE_DASH_PATTERNS.alternateSeries },
 ]
 
 export const MarketRateCurveChart = ({
@@ -81,7 +83,7 @@ export const MarketRateCurveChart = ({
           value: currentUtilization,
           label: formatPercent(currentUtilization),
           color: Color.Primary[500],
-          dash: '2 2',
+          dash: CHART_LINE_DASH_PATTERNS.movingAverage,
         },
       ),
     [currentUtilization, Color.Primary],

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -36,7 +36,7 @@ type RateCurveSeriesKey = keyof Omit<RateCurveChartPoint, 'utilization'>
 
 const SERIES_CONFIG: { key: RateCurveSeriesKey; label: string; dash?: ChartLineDashPattern }[] = [
   { key: 'borrowApr', label: t`Borrow APR` },
-  { key: 'supplyApy', label: t`Supply APY`, dash: CHART_LINE_DASH_PATTERNS.alternateSeries },
+  { key: 'supplyApy', label: t`Supply APY`, dash: CHART_LINE_DASH_PATTERNS.wide },
 ]
 
 export const MarketRateCurveChart = ({
@@ -83,7 +83,7 @@ export const MarketRateCurveChart = ({
           value: currentUtilization,
           label: formatPercent(currentUtilization),
           color: Color.Primary[500],
-          dash: CHART_LINE_DASH_PATTERNS.movingAverage,
+          dash: CHART_LINE_DASH_PATTERNS.tight,
         },
       ),
     [currentUtilization, Color.Primary],

--- a/apps/main/src/llamalend/widgets/tooltips/chart/ChartTooltipComponents.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/chart/ChartTooltipComponents.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Paper, Stack, Typography } from '@mui/material'
+import type { ChartLineDashPattern } from '@ui-kit/shared/ui/Chart'
 import { LegendLine } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
@@ -44,7 +45,7 @@ export const ChartTooltipSeriesRow = ({
   label: ReactNode
   value: ReactNode
   lineColor: string
-  dash?: string
+  dash?: ChartLineDashPattern
 }) => (
   <Stack direction="row" justifyContent="space-between" alignItems="center">
     <Stack direction="row" spacing={Spacing.xs} alignItems="center">

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/constants.ts
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/constants.ts
@@ -1,8 +1,9 @@
 import type { YieldKeys } from '@/loan/components/PageCrvUsdStaking/types'
 import { t } from '@ui-kit/lib/i18n'
+import { CHART_LINE_DASH_PATTERNS, type ChartLineDashPattern } from '@ui-kit/shared/ui/Chart'
 
-export const priceLineLabels: Record<YieldKeys, { label: string; dash: string }> = {
-  apyProjected: { label: t`APR`, dash: 'none' },
-  proj_apy_7d_avg: { label: t`7-day MA APR`, dash: '2 2' },
-  proj_apy_total_avg: { label: t`Average APR`, dash: '4 4' },
+export const priceLineLabels: Record<YieldKeys, { label: string; dash?: ChartLineDashPattern }> = {
+  apyProjected: { label: t`APR` },
+  proj_apy_7d_avg: { label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+  proj_apy_total_avg: { label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.average },
 } as const

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/constants.ts
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/constants.ts
@@ -4,6 +4,6 @@ import { CHART_LINE_DASH_PATTERNS, type ChartLineDashPattern } from '@ui-kit/sha
 
 export const priceLineLabels: Record<YieldKeys, { label: string; dash?: ChartLineDashPattern }> = {
   apyProjected: { label: t`APR` },
-  proj_apy_7d_avg: { label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.movingAverage },
-  proj_apy_total_avg: { label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.average },
+  proj_apy_7d_avg: { label: t`7-day MA APR`, dash: CHART_LINE_DASH_PATTERNS.tight },
+  proj_apy_total_avg: { label: t`Average APR`, dash: CHART_LINE_DASH_PATTERNS.regular },
 } as const

--- a/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
+++ b/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
@@ -3,6 +3,7 @@ import { createChart, ColorType, LineStyle, CandlestickSeries, LineSeries } from
 import lodash from 'lodash'
 import { useEffect, useRef, useState, useCallback, useMemo, type RefObject } from 'react'
 import { Box } from '@mui/material'
+import { CHART_REFERENCE_LINE_WIDTH } from '@ui-kit/shared/ui/Chart/chart.utils'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { PRICE_SCALE_MARGINS } from './constants'
 import { createLiquidationRangeSeries } from './custom-series/liquidationRangeSeries'
@@ -526,7 +527,7 @@ export const CandleChart = ({
     if (!chartRef.current || oraclePriceSeriesRef.current) return
 
     oraclePriceSeriesRef.current = chartRef.current.addSeries(LineSeries, {
-      lineWidth: 2 as LineWidth,
+      lineWidth: CHART_REFERENCE_LINE_WIDTH as LineWidth,
       priceLineStyle: LineStyle.Dashed,
       visible: false, // Default visibility, will be updated by separate effect
     })

--- a/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
+++ b/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
@@ -75,6 +75,8 @@ type LiquidationRangeSeriesApi = ISeriesApi<
   LiquidationRangeSeriesOptions
 >
 
+const LIQUIDATION_RANGE_LINE_STYLE: LiquidationRangeSeriesOptions['lineStyle'] = LineStyle.Dashed
+
 type Props = {
   /**
    * If the chart is used on a Llamalend market page we hide the candle series label and label line.
@@ -157,7 +159,7 @@ export const CandleChart = ({
             topLineColor: memoizedColors.rangeLineTop,
             bottomLineColor: memoizedColors.rangeLineBottom,
             lineWidth: 2,
-            lineStyle: LineStyle.Dashed,
+            lineStyle: LIQUIDATION_RANGE_LINE_STYLE,
             showTopLine: false,
             showBottomLine: false,
           },
@@ -174,7 +176,7 @@ export const CandleChart = ({
             topLineColor: memoizedColors.rangeLineFutureTop,
             bottomLineColor: memoizedColors.rangeLineFutureBottom,
             lineWidth: 2,
-            lineStyle: LineStyle.Dashed,
+            lineStyle: LIQUIDATION_RANGE_LINE_STYLE,
             showTopLine: false,
             showBottomLine: false,
           },
@@ -190,7 +192,7 @@ export const CandleChart = ({
           topLineColor: memoizedColors.rangeLineBottom,
           bottomLineColor: memoizedColors.rangeLineBottom,
           lineWidth: 2,
-          lineStyle: LineStyle.Dashed,
+          lineStyle: LIQUIDATION_RANGE_LINE_STYLE,
           showTopLine: true,
           showBottomLine: true,
         },
@@ -423,7 +425,7 @@ export const CandleChart = ({
       if (!chartRef.current) return
       const series = chartRef.current.addCustomSeries(createLiquidationRangeSeries(), {
         lineWidth: 2,
-        lineStyle: LineStyle.LargeDashed,
+        lineStyle: LineStyle.Solid,
       })
       series.applyOptions(getSeriesAppearance('historical').seriesOptions)
       historicalRangeSeriesRefs.current.push(series)

--- a/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
+++ b/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
@@ -3,7 +3,7 @@ import { createChart, ColorType, LineStyle, CandlestickSeries, LineSeries } from
 import lodash from 'lodash'
 import { useEffect, useRef, useState, useCallback, useMemo, type RefObject } from 'react'
 import { Box } from '@mui/material'
-import { CHART_REFERENCE_LINE_WIDTH } from '@ui-kit/shared/ui/Chart/chart.utils'
+import { CHART_LINE_WIDTHS } from '@ui-kit/shared/ui/Chart/chart.utils'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { PRICE_SCALE_MARGINS } from './constants'
 import { createLiquidationRangeSeries } from './custom-series/liquidationRangeSeries'
@@ -530,7 +530,7 @@ export const CandleChart = ({
     if (!chartRef.current || oraclePriceSeriesRef.current) return
 
     oraclePriceSeriesRef.current = chartRef.current.addSeries(LineSeries, {
-      lineWidth: CHART_REFERENCE_LINE_WIDTH as LineWidth,
+      lineWidth: CHART_LINE_WIDTHS.referenceLine as LineWidth,
       priceLineStyle: LineStyle.Dashed,
       visible: false, // Default visibility, will be updated by separate effect
     })

--- a/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
+++ b/packages/curve-ui-kit/src/features/candle-chart/CandleChart.tsx
@@ -273,6 +273,7 @@ export const CandleChart = ({
     if (!chartContainerRef.current) return
 
     chartRef.current = createChart(chartContainerRef.current, {
+      hoveredSeriesOnTop: false,
       timeScale: {
         borderVisible: false,
       },

--- a/packages/curve-ui-kit/src/features/candle-chart/custom-series/liquidationRangeSeries.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/custom-series/liquidationRangeSeries.ts
@@ -12,8 +12,10 @@ import {
   type PriceToCoordinateConverter,
   type Time,
 } from 'lightweight-charts'
+import { CHART_LINE_DASH_PATTERNS } from '@ui-kit/shared/ui/Chart/chart.utils'
 
 type Coordinate = number
+type LiquidationRangeLineStyle = LineStyle.Solid | LineStyle.Dashed
 
 export type LiquidationRangePoint = CustomData<Time> & {
   upper: number
@@ -28,7 +30,7 @@ export type LiquidationRangeSeriesOptions = CustomSeriesOptions & {
   topLineColor: string
   bottomLineColor: string
   lineWidth: number
-  lineStyle: LineStyle
+  lineStyle: LiquidationRangeLineStyle
   showTopLine?: boolean
   showBottomLine?: boolean
 }
@@ -58,6 +60,11 @@ type RendererPayload = {
   data: PaneRendererCustomData<Time, LiquidationRangePoint> | null
   options: LiquidationRangeSeriesOptions
 }
+
+const CANVAS_LINE_DASH_BY_STYLE = {
+  [LineStyle.Solid]: [],
+  [LineStyle.Dashed]: CHART_LINE_DASH_PATTERNS.regular,
+} satisfies Record<LiquidationRangeLineStyle, number[]>
 
 // Tiny factory that keeps payload state outside the renderer object LW charts consumes.
 const createRenderer = () => {
@@ -185,16 +192,7 @@ const drawBoundary = (
   ctx.beginPath()
   ctx.lineWidth = lineWidth
   ctx.strokeStyle = color
-
-  if (lineStyle === LineStyle.Dashed || lineStyle === LineStyle.LargeDashed) {
-    ctx.setLineDash(lineStyle === LineStyle.Dashed ? [4, 4] : [12, 12])
-  } else if (lineStyle === LineStyle.Dotted) {
-    ctx.setLineDash([2, 2])
-  } else if (lineStyle === LineStyle.SparseDotted) {
-    ctx.setLineDash([2, 8])
-  } else {
-    ctx.setLineDash([])
-  }
+  ctx.setLineDash(CANVAS_LINE_DASH_BY_STYLE[lineStyle])
 
   ctx.moveTo(points[0].x, points[0][key])
   points.forEach(point => ctx.lineTo(point.x, point[key]))

--- a/packages/curve-ui-kit/src/features/candle-chart/custom-series/liquidationRangeSeries.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/custom-series/liquidationRangeSeries.ts
@@ -187,9 +187,9 @@ const drawBoundary = (
   ctx.strokeStyle = color
 
   if (lineStyle === LineStyle.Dashed || lineStyle === LineStyle.LargeDashed) {
-    ctx.setLineDash(lineStyle === LineStyle.Dashed ? [6, 6] : [12, 6])
+    ctx.setLineDash(lineStyle === LineStyle.Dashed ? [4, 4] : [12, 12])
   } else if (lineStyle === LineStyle.Dotted) {
-    ctx.setLineDash([2, 4])
+    ctx.setLineDash([2, 2])
   } else if (lineStyle === LineStyle.SparseDotted) {
     ctx.setLineDash([2, 8])
   } else {

--- a/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartLegendToggles.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartLegendToggles.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 import { useTheme } from '@mui/material/styles'
 import { notFalsy } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
+import { CHART_LINE_DASH_PATTERNS } from '@ui-kit/shared/ui/Chart/chart.utils'
 import type { LegendItem } from '@ui-kit/shared/ui/Chart/LegendSet'
 
 type UseChartLegendTogglesOptions = {
@@ -35,13 +36,13 @@ export const useChartLegendToggles = ({
       notFalsy(
         {
           label: t`Oracle Price`,
-          line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+          line: { lineStroke: theme.palette.primary.main },
           toggled: oraclePriceVisible,
           onToggle: llammaEndpoint ? undefined : toggleOraclePriceVisible,
         },
         hasLiquidationRange && {
           label: t`Liquidation threshold`,
-          line: { lineStroke: theme.design.Chart.Candles.Negative, dash: '4 4' },
+          line: { lineStroke: theme.design.Chart.Candles.Negative, dash: CHART_LINE_DASH_PATTERNS.average },
           toggled: liqRangeCurrentVisible,
           onToggle: toggleLiqRangeCurrentVisible,
         },

--- a/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartLegendToggles.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartLegendToggles.ts
@@ -42,7 +42,7 @@ export const useChartLegendToggles = ({
         },
         hasLiquidationRange && {
           label: t`Liquidation threshold`,
-          line: { lineStroke: theme.design.Chart.Candles.Negative, dash: CHART_LINE_DASH_PATTERNS.average },
+          line: { lineStroke: theme.design.Chart.Candles.Negative, dash: CHART_LINE_DASH_PATTERNS.regular },
           toggled: liqRangeCurrentVisible,
           onToggle: toggleLiqRangeCurrentVisible,
         },

--- a/packages/curve-ui-kit/src/shared/ui/Chart/EChartsLineChart.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/EChartsLineChart.tsx
@@ -1,6 +1,7 @@
 import ReactECharts, { type EChartsOption } from 'echarts-for-react'
 import { useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useTheme } from '@mui/material/styles'
+import type { ChartLineDashPattern } from '@ui-kit/shared/ui/Chart/chart.utils'
 import { useEChartsTooltip } from '@ui-kit/shared/ui/Chart/hooks/useEChartsTooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
@@ -10,7 +11,7 @@ export type LineSeriesConfig<TSeriesKey extends string> = {
   key: TSeriesKey
   label: string
   color: string
-  dash?: string
+  dash?: ChartLineDashPattern
   strokeWidth?: number
 }
 
@@ -19,7 +20,7 @@ type EChartsLineChartTooltipContext<TData, TSeriesKey extends string> = {
   visibleSeries: LineSeriesConfig<TSeriesKey>[]
 }
 
-type EChartsLineMarkLine = { value: number; label?: string; color: string; dash?: string }
+type EChartsLineMarkLine = { value: number; label?: string; color: string; dash?: ChartLineDashPattern }
 
 /** Derive y-axis bounds from all visible series so toggling legend items adjusts the range */
 const getYAxisBounds = <TData extends Record<string, unknown>, TSeriesKey extends string>(
@@ -34,14 +35,6 @@ const getYAxisBounds = <TData extends Record<string, unknown>, TSeriesKey extend
   const max = Math.max(...values)
   const padding = min === max ? 1 : (max - min) * paddingRatio
   return { yMin: min - padding, yMax: max + padding }
-}
-
-const parseDashType = (dash?: string): 'solid' | number[] => {
-  const segments = dash
-    ?.split(' ')
-    .map(segment => Number(segment))
-    .filter(segment => Number.isFinite(segment) && segment > 0)
-  return segments?.length ? segments : 'solid'
 }
 
 export const EChartsLineChart = <
@@ -190,7 +183,7 @@ export const EChartsLineChart = <
         lineStyle: {
           color: line.color,
           width: line.strokeWidth ?? 2,
-          type: parseDashType(line.dash),
+          ...(line.dash && { type: line.dash }),
         },
         ...(index === 0 &&
           markLines?.length && {
@@ -219,7 +212,7 @@ export const EChartsLineChart = <
                   ...((markLine.color || markLine.dash) && {
                     lineStyle: {
                       ...(markLine.color && { color: markLine.color }),
-                      ...(markLine.dash && { type: parseDashType(markLine.dash) }),
+                      ...(markLine.dash && { type: markLine.dash }),
                     },
                   }),
                 })),

--- a/packages/curve-ui-kit/src/shared/ui/Chart/LegendSet.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/LegendSet.tsx
@@ -1,6 +1,7 @@
 import ButtonBase from '@mui/material/ButtonBase'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import type { ChartLineDashPattern } from '@ui-kit/shared/ui/Chart/chart.utils'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { Transition, Duration } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -9,9 +10,17 @@ const { Spacing } = SizesAndSpaces
 
 const TransitionFunction = `${Transition} ${Duration.Delay}ms`
 
-export const LegendLine = ({ color, dash, opacity = 1 }: { color: string; dash?: string; opacity?: number }) => (
+export const LegendLine = ({
+  color,
+  dash,
+  opacity = 1,
+}: {
+  color: string
+  dash?: ChartLineDashPattern
+  opacity?: number
+}) => (
   <svg width="20" height="2" style={{ opacity, transition: `opacity ${TransitionFunction}` }}>
-    <line x1="0" y1="1" x2="20" y2="1" stroke={color} strokeWidth={2} strokeDasharray={dash} />
+    <line x1="0" y1="1" x2="20" y2="1" stroke={color} strokeWidth={2} strokeDasharray={dash?.join(' ')} />
   </svg>
 )
 
@@ -25,7 +34,7 @@ export type LegendItem = {
   label: string
   line?: {
     lineStroke: string
-    dash: string
+    dash?: ChartLineDashPattern
   }
   box?: {
     outlineStroke?: string

--- a/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
@@ -2,6 +2,18 @@ import { meanBy } from 'lodash'
 import { movingAverage } from '@primitives/array.utils'
 import { TIME_FRAMES } from '@ui-kit/lib/model/time'
 
+export type ChartLineDashPattern = number[]
+
+export const CHART_LINE_DASH_PATTERNS = {
+  movingAverage: [2, 2],
+  compact: [4, 2],
+  average: [4, 4],
+  alternateSeries: [8, 8],
+  reference: [8, 4],
+} satisfies Record<string, ChartLineDashPattern>
+
+export const CHART_REFERENCE_LINE_WIDTH = 2
+
 export function addMovingAverages<T>(
   data: T[],
   getValue: (item: T) => number,

--- a/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
@@ -5,6 +5,7 @@ import { TIME_FRAMES } from '@ui-kit/lib/model/time'
 export type ChartLineDashPattern = number[]
 
 export const CHART_LINE_DASH_PATTERNS = {
+  /** Matches lightweight-charts LineStyle.Dashed with the default 1px price line width. */
   tight: [2, 2],
   short: [4, 2],
   /** Matches lightweight-charts LineStyle.Dashed with the chart line width assumption of 2px.  */
@@ -12,7 +13,10 @@ export const CHART_LINE_DASH_PATTERNS = {
   wide: [8, 8],
 } satisfies Record<string, ChartLineDashPattern>
 
-export const CHART_REFERENCE_LINE_WIDTH = 2
+export const CHART_LINE_WIDTHS = {
+  defaultPriceLine: 1,
+  referenceLine: 2,
+} as const
 
 export function addMovingAverages<T>(
   data: T[],

--- a/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
@@ -5,11 +5,11 @@ import { TIME_FRAMES } from '@ui-kit/lib/model/time'
 export type ChartLineDashPattern = number[]
 
 export const CHART_LINE_DASH_PATTERNS = {
-  movingAverage: [2, 2],
-  compact: [4, 2],
-  average: [4, 4],
-  alternateSeries: [8, 8],
-  reference: [8, 4],
+  tight: [2, 2],
+  short: [4, 2],
+  /** Matches lightweight-charts LineStyle.Dashed with the chart line width assumption of 2px.  */
+  regular: [4, 4],
+  wide: [8, 8],
 } satisfies Record<string, ChartLineDashPattern>
 
 export const CHART_REFERENCE_LINE_WIDTH = 2

--- a/packages/curve-ui-kit/src/shared/ui/stories/ChartFooter.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/ChartFooter.stories.tsx
@@ -4,6 +4,7 @@ import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { t } from '@ui-kit/lib/i18n'
+import { CHART_LINE_DASH_PATTERNS } from '@ui-kit/shared/ui/Chart'
 import { ChartFooter } from '@ui-kit/shared/ui/Chart/ChartFooter'
 import type { LegendItem } from '@ui-kit/shared/ui/Chart/LegendSet'
 
@@ -46,7 +47,7 @@ const BasicLegendsWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
     },
     {
       label: t`Conversion zone`,
@@ -97,7 +98,7 @@ const InteractiveLegendsWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
       toggled: visibility.oraclePrice,
       onToggle: toggleVisibility,
     },
@@ -141,7 +142,7 @@ const WithSoftLiquidationWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
     },
     {
       label: t`Conversion zone`,
@@ -184,7 +185,7 @@ const WithToggleButtonsWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
     },
     {
       label: t`Conversion zone`,
@@ -244,7 +245,7 @@ const FullFeaturedWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
       toggled: visibility.oraclePrice,
       onToggle: toggleVisibility,
     },
@@ -291,9 +292,12 @@ const LineLegendsWrapper = () => {
   const theme = useTheme()
 
   const legendSets: LegendItem[] = [
-    { label: 'Line 1', line: { lineStroke: theme.design.Chart.Lines[1], dash: 'none' } },
-    { label: 'Line 2', line: { lineStroke: theme.design.Chart.Lines[2], dash: '4 2' } },
-    { label: 'Line 3', line: { lineStroke: theme.design.Chart.Lines[3], dash: '2 2' } },
+    { label: 'Line 1', line: { lineStroke: theme.design.Chart.Lines[1] } },
+    { label: 'Line 2', line: { lineStroke: theme.design.Chart.Lines[2], dash: CHART_LINE_DASH_PATTERNS.compact } },
+    {
+      label: 'Line 3',
+      line: { lineStroke: theme.design.Chart.Lines[3], dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+    },
   ]
 
   return (
@@ -369,7 +373,7 @@ const NarrowContainerWrapper = () => {
   const legendSets: LegendItem[] = [
     {
       label: t`Oracle Price`,
-      line: { lineStroke: theme.palette.primary.main, dash: 'none' },
+      line: { lineStroke: theme.palette.primary.main },
     },
     {
       label: t`Conversion zone`,

--- a/packages/curve-ui-kit/src/shared/ui/stories/ChartFooter.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/ChartFooter.stories.tsx
@@ -293,10 +293,10 @@ const LineLegendsWrapper = () => {
 
   const legendSets: LegendItem[] = [
     { label: 'Line 1', line: { lineStroke: theme.design.Chart.Lines[1] } },
-    { label: 'Line 2', line: { lineStroke: theme.design.Chart.Lines[2], dash: CHART_LINE_DASH_PATTERNS.compact } },
+    { label: 'Line 2', line: { lineStroke: theme.design.Chart.Lines[2], dash: CHART_LINE_DASH_PATTERNS.short } },
     {
       label: 'Line 3',
-      line: { lineStroke: theme.design.Chart.Lines[3], dash: CHART_LINE_DASH_PATTERNS.movingAverage },
+      line: { lineStroke: theme.design.Chart.Lines[3], dash: CHART_LINE_DASH_PATTERNS.tight },
     },
   ]
 


### PR DESCRIPTION
Dash patterns were getting scattered across the different chart implementations and defined over and over again. This PR gathers them in a constant.

Changes:
- Gather all dash implementations in shared constant in the [`Chart`](https://github.com/curvefi/curve-frontend/blob/3d319806b1f93af0d71a355c8786cc518ca774a6/packages/curve-ui-kit/src/shared/ui/Chart) directory
- Match bands-chart markLine dash patterns with lightweight-charts dash patterns (lightweight-charts doesn't allow custom patterns)
- Toggle `hoveredSeriesOnTop` to `false` in candle-chart, introduced in lightweight-charts 5.2.0 (was screwing up series order on hover)