### PR TITLE
fix: slider labels positions

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LiquidationRangeSlider.tsx
@@ -1,13 +1,10 @@
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
-import Grid from '@mui/material/Grid'
+import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { t } from '@ui-kit/lib/i18n'
 import { SliderInput } from '@ui-kit/shared/ui/SliderInput'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { decimal } from '@ui-kit/utils'
 import { PRESET_RANGES } from '../../../constants'
-
-const { Spacing } = SizesAndSpaces
 
 export const LiquidationRangeSlider = ({
   setRange,
@@ -24,29 +21,24 @@ export const LiquidationRangeSlider = ({
   const minValue = liqRanges?.[0]?.n ?? market?.minBands ?? PRESET_RANGES.MaxLtv
   const maxValue = liqRanges?.[liqRanges.length - 1]?.n ?? market?.maxBands ?? PRESET_RANGES.Safe
   return (
-    <Grid container columnSpacing={Spacing.sm}>
-      <Grid container size={8}>
-        <Grid size={12} container>
-          <Grid size={6}>
-            <Typography variant="bodyXsRegular" color="textSecondary">{t`Max LTV`}</Typography>
-          </Grid>
-          <Grid size={6} sx={{ textAlign: 'right' }}>
-            <Typography variant="bodyXsRegular" color="textSecondary">{t`Conservative`}</Typography>
-          </Grid>
-        </Grid>
-      </Grid>
-      <Grid size={12}>
-        <SliderInput
-          name="range"
-          onChange={val => setRange(parseInt(val))}
-          aria-label={t`Bands`}
-          value={decimal(range) ?? `${minValue}`}
-          min={minValue}
-          max={maxValue}
-          sliderProps={{ 'data-rail-background': 'safe' }}
-          inputProps={{ adornment: 'bands' }}
-        />
-      </Grid>
-    </Grid>
+    <SliderInput
+      name="range"
+      onChange={val => setRange(parseInt(val))}
+      aria-label={t`Bands`}
+      value={decimal(range) ?? `${minValue}`}
+      min={minValue}
+      max={maxValue}
+      sliderProps={{ 'data-rail-background': 'safe' }}
+      inputProps={{ adornment: 'bands' }}
+      sliderLabel={
+        <Stack direction="row" justifyContent="space-between">
+          {[t`Max LTV`, t`Conservative`].map(l => (
+            <Typography key={l} variant="bodyXsRegular" color="textSecondary">
+              {l}
+            </Typography>
+          ))}
+        </Stack>
+      }
+    />
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
@@ -239,7 +239,7 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
   )
 
   const renderSlider = (
-    <Stack width="100%">
+    <Stack flexGrow={1}>
       {sliderLabel}
       <Slider
         size={size}
@@ -261,7 +261,12 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
   )
 
   return (
-    <Stack direction={layoutDirection} alignItems="end" columnGap={Spacing.sm} rowGap={Spacing.xs}>
+    <Stack
+      direction={layoutDirection}
+      alignItems={layoutDirection === 'row' ? 'end' : 'stretch'}
+      columnGap={Spacing.sm}
+      rowGap={Spacing.xs}
+    >
       {layoutDirection === 'row' ? (
         <>
           {isRange && renderInput(currentFirst, 0)}
@@ -277,7 +282,7 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
             justifyContent={isRange ? 'space-between' : 'flex-end'}
             columnGap={Spacing.sm}
             rowGap={Spacing.xs}
-            width="100%"
+            flexGrow={1}
           >
             {isRange && renderInput(currentFirst, 0)}
             {renderInput(currentSecond, 1)}

--- a/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/SliderInput.tsx
@@ -1,5 +1,5 @@
 import { sortBy } from 'lodash'
-import { useCallback, useMemo } from 'react'
+import { ReactNode, useCallback, useMemo } from 'react'
 import { TextFieldProps } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -31,6 +31,8 @@ export type SliderInputProps<T extends Decimal | DecimalRangeValue> = {
   max?: number
   /** Step increment for the slider */
   step?: number
+  /** Optional label placed on top of the slider */
+  sliderLabel?: ReactNode
   /** Propagated to both inputs and slider */
   disabled?: boolean
   /** The debounce time in milliseconds for the slider and inputs */
@@ -91,6 +93,7 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
   onChange,
   min = 0,
   max = Infinity,
+  sliderLabel,
   step,
   disabled,
   sliderProps,
@@ -236,26 +239,29 @@ export const SliderInput = <T extends Decimal | DecimalRangeValue>({
   )
 
   const renderSlider = (
-    <Slider
-      size={size}
-      value={sliderValue}
-      onChange={handleSliderChange}
-      onChangeCommitted={(event, newValue) => {
-        handleSliderCommit(event, newValue)
-        sliderOnChangeCommitted?.(event, newValue)
-      }}
-      min={sliderMinValue}
-      max={sliderMaxValue}
-      step={sliderStepValue}
-      disabled={disabled}
-      scale={mapFromSliderValue}
-      data-testid={`slider-${name}`}
-      {...restSliderProps}
-    />
+    <Stack width="100%">
+      {sliderLabel}
+      <Slider
+        size={size}
+        value={sliderValue}
+        onChange={handleSliderChange}
+        onChangeCommitted={(event, newValue) => {
+          handleSliderCommit(event, newValue)
+          sliderOnChangeCommitted?.(event, newValue)
+        }}
+        min={sliderMinValue}
+        max={sliderMaxValue}
+        step={sliderStepValue}
+        disabled={disabled}
+        scale={mapFromSliderValue}
+        data-testid={`slider-${name}`}
+        {...restSliderProps}
+      />
+    </Stack>
   )
 
   return (
-    <Stack direction={layoutDirection} alignItems="center" columnGap={Spacing.sm} rowGap={Spacing.xs} width="100%">
+    <Stack direction={layoutDirection} alignItems="end" columnGap={Spacing.sm} rowGap={Spacing.xs}>
       {layoutDirection === 'row' ? (
         <>
           {isRange && renderInput(currentFirst, 0)}

--- a/packages/curve-ui-kit/src/shared/ui/stories/SliderInput.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/SliderInput.stories.tsx
@@ -82,7 +82,7 @@ const meta: Meta<typeof SliderInputComponent> = {
       description: 'Callback triggered when the value changes.',
     },
     sliderLabel: {
-      control: false,
+      control: 'text',
       description: 'Label of the slider',
     },
   },

--- a/packages/curve-ui-kit/src/shared/ui/stories/SliderInput.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/stories/SliderInput.stories.tsx
@@ -81,12 +81,22 @@ const meta: Meta<typeof SliderInputComponent> = {
       control: false,
       description: 'Callback triggered when the value changes.',
     },
+    sliderLabel: {
+      control: false,
+      description: 'Label of the slider',
+    },
   },
 }
 
 type Story = StoryObj<typeof SliderInput>
 
 export const Default: Story = {}
+
+export const WithLabel: Story = {
+  args: {
+    sliderLabel: 'Bands',
+  },
+}
 
 export const ColumnLayout: Story = {
   args: {


### PR DESCRIPTION
In order to fix it properly I added a sliderProp to the SliderInput component, so the labels will always take the slider's width instead of using a Grid or a constant width 

- fix slider's labels position

<table>
  <tr>
    <th>Before</th>
    <td>
<img width="458" height="56" alt="Screenshot 2026-05-11 at 20 47 53" src="https://github.com/user-attachments/assets/ab0ed585-95de-4956-979c-add33bc3de33" />
</td>
  </tr>
  <tr>
    <th>After</th>
    <td>
<img width="460" height="53" alt="Screenshot 2026-05-11 at 20 48 01" src="https://github.com/user-attachments/assets/48ef60fe-0481-4d91-b839-149a7ff8a42d" />
</td>
  </tr>
</table>
