### PR TITLE
fix: isDirty boolean from react-hook-form

### DIFF
--- a/packages/curve-ui-kit/src/utils/react-form.utils.ts
+++ b/packages/curve-ui-kit/src/utils/react-form.utils.ts
@@ -62,7 +62,8 @@ export const filterFormErrors = <TFieldValues extends FieldValues>(formState: Fo
     ...recordEntries(formState.errors)
       .filter(
         ([field, error]) =>
-          (field in formState.touchedFields || (field === 'root' && formState.isDirty)) && error?.message,
+          (field in formState.touchedFields || (field === 'root' && Object.keys(formState.touchedFields).length > 0)) &&
+          error?.message,
       )
       .map(([field, error]) => [field, error!.message!] as const),
   )


### PR DESCRIPTION
- isDirty is true even for automated form updates e.g. for max fields, so use touchedFields instead.