### PR TITLE
e2e: prefetch mint markets

### DIFF
--- a/apps/main/src/lend/queries/lend-market-names.query.ts
+++ b/apps/main/src/lend/queries/lend-market-names.query.ts
@@ -10,7 +10,7 @@ const V2 = 'v2' as const
 
 const v2chains = [Chain.Optimism]
 
-export const { useQuery: useLendMarketNames, prefetchQuery: prefetchMarkets } = queryFactory({
+export const { useQuery: useLendMarketNames, prefetchQuery: prefetchLendMarkets } = queryFactory({
   queryKey: ({ chainId, enableLLv2 }: ChainParams & { enableLLv2: boolean }) =>
     [...rootKeys.chain({ chainId }), 'lendMarkets.getMarketList', { enableLLv2 }] as const,
   queryFn: async ({ chainId, enableLLv2 }: ChainQuery & { enableLLv2: boolean }): Promise<string[]> => {

--- a/apps/main/src/lend/store/createAppSlice.ts
+++ b/apps/main/src/lend/store/createAppSlice.ts
@@ -9,7 +9,7 @@ import { isLLv2Enabled } from '@ui-kit/hooks/useFeatureFlags'
 import { log } from '@ui-kit/lib/logging'
 import { ReleaseChannel } from '@ui-kit/utils'
 import { formatTimeDiff } from '@ui-kit/utils/time.utils'
-import { prefetchMarkets } from '../queries/lend-market-names.query'
+import { prefetchLendMarkets } from '../queries/lend-market-names.query'
 
 export type SliceKey = keyof State | ''
 export type StateKey = string
@@ -52,7 +52,7 @@ export const createAppSlice = (set: StoreApi<State>['setState'], get: StoreApi<S
     }
 
     // unfortunately, we cannot use markets from the cache as that leaves curve-lending-js in an inconsistent state
-    await prefetchMarkets({ chainId: api.chainId, enableLLv2: isLLv2Enabled(releaseChannel) })
+    await prefetchLendMarkets({ chainId: api.chainId, enableLLv2: isLLv2Enabled(releaseChannel) })
 
     log(`Hydrated Lend - Complete in ${formatTimeDiff(start)}`)
   },

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -21,12 +21,14 @@ import { LlamaMarketType } from '@ui-kit/types/market'
 import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
 import { SOLVENCY_THRESHOLDS } from './llama-markets.constants'
 
+export const isLendMarketId = (id: string) => id.startsWith('one-way')
+
 /**
  * Gets a Llama market (either a mint or lend market) by its ID.
  * Throws an error if no market is found with the given ID.
  */
 export const getLlamaMarket = (id: string | LlamaMarketTemplate, lib = requireLib('llamaApi')): LlamaMarketTemplate =>
-  typeof id === 'string' ? (id.startsWith('one-way') ? lib.getLendMarket(id) : lib.getMintMarket(id)) : id
+  typeof id === 'string' ? (isLendMarketId(id) ? lib.getLendMarket(id) : lib.getMintMarket(id)) : id
 
 /**
  * Helper to retrieve the llama market after initialization, avoiding crashing the components using it.

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -21,14 +21,12 @@ import { LlamaMarketType } from '@ui-kit/types/market'
 import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
 import { SOLVENCY_THRESHOLDS } from './llama-markets.constants'
 
-export const isLendMarketId = (id: string) => id.startsWith('one-way')
-
 /**
  * Gets a Llama market (either a mint or lend market) by its ID.
  * Throws an error if no market is found with the given ID.
  */
 export const getLlamaMarket = (id: string | LlamaMarketTemplate, lib = requireLib('llamaApi')): LlamaMarketTemplate =>
-  typeof id === 'string' ? (isLendMarketId(id) ? lib.getLendMarket(id) : lib.getMintMarket(id)) : id
+  typeof id === 'string' ? (id.startsWith('one-way') ? lib.getLendMarket(id) : lib.getMintMarket(id)) : id
 
 /**
  * Helper to retrieve the llama market after initialization, avoiding crashing the components using it.

--- a/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
@@ -23,7 +23,17 @@ const testCases = objectKeys(LOAN_TEST_MARKETS).map(type =>
 
 describe('Collateral forms', () => {
   testCases.forEach(
-    ({ borrow, chainId, collateral, collateralAddress, controllerAddress, collateralDecimals, id, label }) =>
+    ({
+      borrow,
+      chainId,
+      collateral,
+      collateralAddress,
+      controllerAddress,
+      collateralDecimals,
+      id,
+      label,
+      marketType,
+    }) =>
       describe(label, () => {
         skipTestsAfterFailure() // the remove collateral test needs the collateral to be added first
 
@@ -50,6 +60,7 @@ describe('Collateral forms', () => {
             marketId={id}
             userAddress={address}
             onPricesUpdated={onPricesUpdated}
+            marketType={marketType}
           />
         )
 

--- a/tests/cypress/component/llamalend/loan.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/loan.rpc.cy.tsx
@@ -39,7 +39,7 @@ import { LlamaMarketType } from '@ui-kit/types/market'
 import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 import { waitFor } from '@ui-kit/utils/time.utils'
 
-const testCases = recordValues(LlamaMarketType).map(marketType => ({ marketType, ...oneLoanTestMarket(marketType) }))
+const testCases = recordValues(LlamaMarketType).map(marketType => oneLoanTestMarket(marketType))
 
 /**
  * The lend markets have a memoize() around the userState function that we cannot control from the outside.
@@ -116,6 +116,7 @@ testCases.forEach(
           marketId={id}
           userAddress={address}
           onPricesUpdated={onPricesUpdated}
+          marketType={marketType}
         />
       )
 

--- a/tests/cypress/component/llamalend/manage-soft-liq.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/manage-soft-liq.rpc.cy.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useMemo } from 'react'
-import { prefetchMarkets } from '@/lend/queries/lend-market-names.query'
+import { prefetchLendMarkets } from '@/lend/queries/lend-market-names.query'
 import { ClosePositionForm } from '@/llamalend/features/manage-soft-liquidation/ui/tabs/ClosePositionForm'
 import { ImproveHealthForm } from '@/llamalend/features/manage-soft-liquidation/ui/tabs/ImproveHealthForm'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
@@ -49,7 +49,7 @@ describe('Manage soft liquidation', () => {
         app="llamalend"
         network={network}
         onChainUnavailable={console.error}
-        hydrate={{ llamalend: () => prefetchMarkets({ chainId, enableLLv2: true }) }}
+        hydrate={{ llamalend: () => prefetchLendMarkets({ chainId, enableLLv2: true }) }}
       >
         {children}
       </CurveProvider>

--- a/tests/cypress/component/llamalend/supply.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/supply.rpc.cy.tsx
@@ -44,6 +44,7 @@ import {
 import { createVirtualTestnet } from '@cy/support/helpers/tenderly'
 import { skipTestsAfterFailure } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
+import { LlamaMarketType } from '@ui-kit/types/market'
 
 const testCases = [oneOf(...SUPPLY_TEST_MARKETS)]
 
@@ -83,6 +84,7 @@ testCases.forEach(
           chainId={chainId}
           marketId={id}
           userAddress={address}
+          marketType={LlamaMarketType.Lend}
         />
       )
 

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { prefetchMarkets } from '@/lend/queries/lend-market-names.query'
+import { prefetchLendMarkets } from '@/lend/queries/lend-market-names.query'
 import { CreateLoanForm } from '@/llamalend/features/borrow/components/CreateLoanForm'
 import { AddCollateralForm } from '@/llamalend/features/manage-loan/components/AddCollateralForm'
 import { BorrowMoreForm } from '@/llamalend/features/manage-loan/components/BorrowMoreForm'
@@ -14,6 +14,7 @@ import { UnstakeForm } from '@/llamalend/features/supply/components/UnstakeForm'
 import { WithdrawForm } from '@/llamalend/features/supply/components/WithdrawForm'
 import { getLlamaMarket } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
+import { prefetchMintMarkets } from '@/loan/entities/mint-markets.query'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import { fakeCollateralEvents } from '@cy/support/helpers/llamalend/mock-loan-test-data'
@@ -26,6 +27,7 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { useCurve } from '@ui-kit/features/connect-wallet/lib/CurveContext'
 import { CurveProvider } from '@ui-kit/features/connect-wallet/lib/CurveProvider'
 import type { UserMarketQuery } from '@ui-kit/lib/model'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ, type Range } from '@ui-kit/types/util'
 
 // todo: soft liquidation should be detected not forced by passing a tab. However, that detection is in the separate apps for now.
@@ -84,15 +86,24 @@ function LlammalendTest({ tab, onPricesUpdated, type, ...props }: LlammalendTest
   )
 }
 
-export type LlammalendTestCaseProps = LlammalendTestProps & TenderlyWagmiConfigFromVNet
+export type LlammalendTestCaseProps = LlammalendTestProps &
+  TenderlyWagmiConfigFromVNet & { marketType: LlamaMarketType }
 
-export const LlammalendTestCase = ({ vnet, privateKey, chainId, ...props }: LlammalendTestCaseProps) => (
+export const LlammalendTestCase = ({ vnet, privateKey, chainId, marketType, ...props }: LlammalendTestCaseProps) => (
   <ComponentTestWrapper config={createTenderlyWagmiConfigFromVNet({ vnet, privateKey })} autoConnect>
     <CurveProvider
       app="llamalend"
       network={llamaNetworks[chainId]}
       onChainUnavailable={console.error}
-      hydrate={useMemo(() => ({ llamalend: () => prefetchMarkets({ chainId, enableLLv2: true }) }), [chainId])}
+      hydrate={useMemo(
+        () => ({
+          llamalend: {
+            [LlamaMarketType.Lend]: () => prefetchLendMarkets({ chainId, enableLLv2: true }),
+            [LlamaMarketType.Mint]: () => prefetchMintMarkets({ chainId }),
+          }[marketType],
+        }),
+        [chainId, marketType],
+      )}
     >
       <Box sx={{ maxWidth: 520 }}>
         <LlammalendTest {...props} chainId={chainId} />

--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -87,9 +87,12 @@ export const LOAN_TEST_MARKETS = {
 type TestLlamaMarket = (typeof LOAN_TEST_MARKETS)[LlamaMarketType][number]
 
 export const oneLoanTestMarket = (
-  type: LlamaMarketType = oneValueOf(LlamaMarketType),
+  marketType: LlamaMarketType = oneValueOf(LlamaMarketType),
   filter?: (market: TestLlamaMarket) => boolean,
-) => oneOf(...(filter ? LOAN_TEST_MARKETS[type].filter(filter) : LOAN_TEST_MARKETS[type]))
+) => ({
+  marketType,
+  ...oneOf(...(filter ? LOAN_TEST_MARKETS[marketType].filter(filter) : LOAN_TEST_MARKETS[marketType])),
+})
 
 /**
  * Check all loan detail values are loaded and valid.


### PR DESCRIPTION
- pass `marketType` to `LlammalendTestCase` so it can call `prefetchMintMarkets` when applicable ([rpc test run](https://github.com/curvefi/curve-frontend/actions/runs/25795661091/job/75772201878))
- rename `prefetchLendMarkets`