### PR TITLE
fix: use curve router for borrow max receive

### DIFF
--- a/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
@@ -2,7 +2,6 @@ import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/cre
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
-import { RouteProviders } from '@primitives/router.utils'
 import { getExpectedFn } from '@ui-kit/entities/router-api'
 import { type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys } from '@ui-kit/lib/model'
@@ -86,7 +85,7 @@ export const {
             userCollateral,
             userBorrowed,
             range,
-            getExpected: getExpectedFn({ chainId, router: RouteProviders, userAddress, slippage }),
+            getExpected: getExpectedFn({ chainId, userAddress, slippage }),
           }),
         )
       }


### PR DESCRIPTION
- #2493 updated the code so the curve router is used for max receive calculation on the borrow more and repay forms, but  the create loan form was still using all the routers (and odos is just too slow rn)