### PR TITLE
feat: share chart price formatting across charts

### DIFF
--- a/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
+++ b/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
@@ -1,6 +1,7 @@
 import { TooltipItem, TooltipItems, TooltipWrapper } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import { Box, Stack, Typography } from '@mui/material'
 import { t } from '@ui-kit/lib/i18n'
+import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { LegendBox } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber, formatPercent, formatUsd } from '@ui-kit/utils'
@@ -24,6 +25,8 @@ const formatAbbreviatedNumber = (value: number | undefined): string =>
   typeof value === 'number' ? `${formatNumber(value, { abbreviate: true })}` : '?'
 
 const formatUsdValue = (value: number | undefined): string => (typeof value === 'number' ? formatUsd(value) : '?')
+const formatBandPrice = (value: number): string =>
+  formatChartAxisNumber(value, { unit: 'dollar', abbreviateFrom: false })
 
 export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipContentProps) => {
   const palette = useBandsChartPalette()
@@ -77,7 +80,7 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
             <TooltipItems secondary>
               <TooltipItem title={t`Band range`} sx={{ marginBottom: Spacing.sm }}>
                 {typeof data.p_down === 'number' && typeof data.p_up === 'number'
-                  ? `${formatNumber(data.p_down, { unit: 'dollar', abbreviate: false, highPrecision: true, minimumSignificantDigits: 4, maximumSignificantDigits: 4 })} - ${formatNumber(data.p_up, { unit: 'dollar', abbreviate: false, highPrecision: true, minimumSignificantDigits: 4, maximumSignificantDigits: 4 })}`
+                  ? `${formatBandPrice(data.p_down)} - ${formatBandPrice(data.p_up)}`
                   : '?'}
               </TooltipItem>
               <TooltipItem

--- a/apps/main/src/llamalend/features/bands-chart/bands-chart.utils.ts
+++ b/apps/main/src/llamalend/features/bands-chart/bands-chart.utils.ts
@@ -1,14 +1,4 @@
-import { formatNumber } from '@ui-kit/utils'
 import { BandsChartToken } from './types'
 
 export const getBandsChartToken = (address: string | undefined, symbol?: string): BandsChartToken =>
   address && symbol ? { address, symbol } : undefined
-
-/** matches candle-chart formatting but with simpler decimal management, maximumSignificantDigits does the same job but works in the bands-chart context */
-export const formatNumberWithOptions = (value: number) =>
-  formatNumber(value, {
-    // only abbreviating above 10000 to avoid 4013 becoming 4.013k etc
-    abbreviate: value >= 10000,
-    maximumSignificantDigits: 4,
-    useGrouping: false,
-  })

--- a/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
+++ b/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
@@ -1,7 +1,7 @@
 import type { EChartsOption } from 'echarts-for-react'
 import { sum, zip } from 'lodash'
+import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
-import { formatNumberWithOptions } from './bands-chart.utils'
 import { generateMarkLines } from './markLines'
 import { ChartDataPoint, BandsChartPalette, DerivedChartData, UserBandsPriceRange } from './types'
 
@@ -189,7 +189,7 @@ export const getChartOptions = (
         showMaxLabel: false,
         // label margin matches the lightweight-charts time scale margin used by the adjacent candle chart
         margin: 10,
-        formatter: (value: number) => formatNumberWithOptions(value),
+        formatter: (value: number) => formatChartAxisNumber(value),
       },
       splitLine: {
         show: true,

--- a/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
+++ b/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
@@ -17,12 +17,12 @@ import {
   addMovingAverages,
   CHART_LINE_DASH_PATTERNS,
   EChartsLineChart,
+  formatChartAxisNumber,
   type ChartLineDashPattern,
   type LineSeriesConfig,
   SelectTimeOption,
 } from '@ui-kit/shared/ui/Chart'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatNumber } from '@ui-kit/utils'
 
 const { Spacing, Height } = SizesAndSpaces
 
@@ -119,9 +119,7 @@ export const CrvUsdPriceChart = () => {
             series={series}
             visibleSeries={visibleSeries}
             xTickFormatter={(value: CrvUsdPriceChartPoint['timestamp'] | number | string) => formatDate(value)}
-            yTickFormatter={value =>
-              formatNumber(+value, { unit: 'dollar', abbreviate: false, decimals: 4, minimumFractionDigits: 4 })
-            }
+            yTickFormatter={value => formatChartAxisNumber(+value, { unit: 'dollar' })}
             yPaddingRatio={0.25}
             renderTooltip={CrvUsdPriceTooltip}
           />

--- a/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/chart.utils.ts
@@ -1,8 +1,12 @@
 import { meanBy } from 'lodash'
 import { movingAverage } from '@primitives/array.utils'
 import { TIME_FRAMES } from '@ui-kit/lib/model/time'
+import { formatNumber, type NumberFormatOptions } from '@ui-kit/utils/number'
 
 export type ChartLineDashPattern = number[]
+
+export const DEFAULT_CHART_SIGNIFICANT_DIGITS = 5
+const DEFAULT_CHART_ABBREVIATE_FROM = 10000
 
 export const CHART_LINE_DASH_PATTERNS = {
   /** Matches lightweight-charts LineStyle.Dashed with the default 1px price line width. */
@@ -17,6 +21,46 @@ export const CHART_LINE_WIDTHS = {
   defaultPriceLine: 1,
   referenceLine: 2,
 } as const
+
+/**
+ * Formats numeric chart labels with a compact significant-digit default.
+ *
+ * This is intentionally a thin preset over `formatNumber`: chart axes should use significant digits rather than fixed
+ * decimals, abbreviate only from 10k so values like `4013` stay literal, and inherit `formatNumber`'s near-0/near-1
+ * protection with the shared significant-digit cap.
+ */
+export const formatChartAxisNumber = (
+  value: number,
+  options: Omit<
+    Partial<NumberFormatOptions>,
+    'abbreviate' | 'formatter' | 'maximumSignificantDigits' | 'minimumSignificantDigits'
+  > & {
+    /**
+     * Chart labels need compact, comparable values. Significant digits keep labels like `4013` readable while preserving
+     * small price moves better than a fixed decimal count.
+     */
+    significantDigits?: number
+    /**
+     * Axis labels only abbreviate above 10k by default so values like `4013` stay literal instead of becoming `4.013k`.
+     * Pass `false` for price ranges or tooltips that should never abbreviate.
+     */
+    abbreviateFrom?: number | false
+  } = {},
+) => {
+  const {
+    significantDigits = DEFAULT_CHART_SIGNIFICANT_DIGITS,
+    abbreviateFrom = DEFAULT_CHART_ABBREVIATE_FROM,
+    useGrouping = false,
+    ...formatOptions
+  } = options
+
+  return formatNumber(value, {
+    ...formatOptions,
+    abbreviate: abbreviateFrom !== false && Math.abs(value) >= abbreviateFrom,
+    maximumSignificantDigits: significantDigits,
+    useGrouping,
+  })
+}
 
 export function addMovingAverages<T>(
   data: T[],


### PR DESCRIPTION
Changes:
- Added a shared `formatChartAxisNumber` utility for compact chart label formatting