### PR TITLE
fix: rpc test market fetching

### DIFF
--- a/apps/main/src/lend/hooks/useLendMarket.ts
+++ b/apps/main/src/lend/hooks/useLendMarket.ts
@@ -4,15 +4,15 @@ import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useLendMarkets } from '../queries/lend-markets.query'
 import { ChainId } from '../types/lend.types'
 
-export function useLendMarketData(chainId: ChainId, rMarket: string) {
-  const { data, error, isSuccess } = useLendMarkets({ chainId, enableLLv2: useLLv2() })
+export function useLendMarketData(chainId: ChainId, rMarket: string, enabled?: boolean) {
+  const { data, error, isSuccess } = useLendMarkets({ chainId, enableLLv2: useLLv2() }, enabled)
   const marketData = useMemo(() => data?.[rMarket], [data, rMarket])
   return { error, isSuccess, data: marketData }
 }
 
-export const useLendMarket = (chainId: ChainId, rMarket: string) => {
+export const useLendMarket = (chainId: ChainId, rMarket: string, enabled?: boolean) => {
   const { llamaApi: api } = useCurve()
-  const { data, error, isSuccess } = useLendMarketData(chainId, rMarket)
+  const { data, error, isSuccess } = useLendMarketData(chainId, rMarket, enabled)
   const market = useMemo(() => api && data && api.getLendMarketByData(data.id, data), [api, data])
   return { data: market, error, isSuccess: isSuccess && !!api }
 }

--- a/apps/main/src/loan/hooks/useMintMarket.ts
+++ b/apps/main/src/loan/hooks/useMintMarket.ts
@@ -3,15 +3,15 @@ import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useMintMarkets } from '../entities/mint-markets.query'
 import { ChainId } from '../types/loan.types'
 
-export function useMintMarketData(chainId: ChainId, rMarket: string) {
-  const { data, error, isSuccess } = useMintMarkets({ chainId })
+export function useMintMarketData(chainId: ChainId, rMarket: string, enabled?: boolean) {
+  const { data, error, isSuccess } = useMintMarkets({ chainId }, enabled)
   const marketData = useMemo(() => data?.[rMarket], [data, rMarket])
   return { error, isSuccess, data: marketData }
 }
 
-export const useMintMarket = (chainId: ChainId, rMarket: string) => {
+export const useMintMarket = (chainId: ChainId, rMarket: string, enabled?: boolean) => {
   const { llamaApi: api } = useCurve()
-  const { data, error, isSuccess } = useMintMarketData(chainId, rMarket)
+  const { data, error, isSuccess } = useMintMarketData(chainId, rMarket, enabled)
   const market = useMemo(() => api && data && api.getMintMarketByData(data.id, data), [api, data])
   return { data: market, error, isSuccess: isSuccess && !!api }
 }

--- a/tests/cypress/component/llamalend/supply.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/supply.rpc.cy.tsx
@@ -99,7 +99,7 @@ testCases.forEach(
       })
 
       it('deposits into the vault', () => {
-        cy.mount(<SupplyTestWrapper />)
+        cy.mount(<SupplyTestWrapper tab="deposit" />)
         writeDepositForm({ amount: deposit })
         checkDepositDetailsLoaded({ amountSupplied: deposit, prevAmountSupplied: '0' })
         submitDepositForm({})
@@ -133,7 +133,7 @@ testCases.forEach(
       })
 
       it('deposits into the vault again', () => {
-        cy.mount(<SupplyTestWrapper />)
+        cy.mount(<SupplyTestWrapper tab="deposit" />)
         writeDepositForm({ amount: deposit })
         checkDepositDetailsLoaded({ amountSupplied: deposit, prevAmountSupplied: '0' })
         submitDepositForm({})

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -84,7 +84,7 @@ function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: Ll
       {...props}
     />
   ) : market ? (
-    `Invalid arguments given to LlammalendTestCase: ${JSON.stringify({ tab, isLoan, loanExists, marketType })}.`
+    `Invalid arguments given to LlammalendTestCase: ${JSON.stringify({ tab, type, loanExists, marketType })}.`
   ) : error ? (
     `Error retrieving market: ${error.message}`
   ) : (

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useLendMarket } from '@/lend/hooks/useLendMarket'
 import { CreateLoanForm } from '@/llamalend/features/borrow/components/CreateLoanForm'
 import { AddCollateralForm } from '@/llamalend/features/manage-loan/components/AddCollateralForm'
 import { BorrowMoreForm } from '@/llamalend/features/manage-loan/components/BorrowMoreForm'
@@ -11,8 +11,9 @@ import { DepositForm } from '@/llamalend/features/supply/components/DepositForm'
 import { StakeForm } from '@/llamalend/features/supply/components/StakeForm'
 import { UnstakeForm } from '@/llamalend/features/supply/components/UnstakeForm'
 import { WithdrawForm } from '@/llamalend/features/supply/components/WithdrawForm'
-import { getLlamaMarket } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
+import { useMintMarket } from '@/loan/hooks/useMintMarket'
+import { ChainId as MintChain } from '@/loan/types/loan.types'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import { fakeCollateralEvents } from '@cy/support/helpers/llamalend/mock-loan-test-data'
@@ -22,7 +23,6 @@ import { type TenderlyWagmiConfigFromVNet } from '@cy/support/helpers/tenderly/v
 import Box from '@mui/material/Box'
 import Skeleton from '@mui/material/Skeleton'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useCurve } from '@ui-kit/features/connect-wallet/lib/CurveContext'
 import { CurveProvider } from '@ui-kit/features/connect-wallet/lib/CurveProvider'
 import type { UserMarketQuery } from '@ui-kit/lib/model'
 import { LlamaMarketType } from '@ui-kit/types/market'
@@ -49,29 +49,31 @@ const SupplyComponents = {
 type LoanTab = keyof typeof LoanComponents
 type SupplyTab = keyof typeof SupplyComponents
 
-type LlammalendTestProps = {
+type LlammalendTestProps = UserMarketQuery<LlamaChainId> & {
   type: 'loan' | 'supply'
   tab?: LoanTab | SupplyTab
   onSuccess?: ReturnType<typeof cy.stub>
   onPricesUpdated?: (prices: Range<Decimal> | undefined) => void
-} & UserMarketQuery<LlamaChainId>
+  marketType: LlamaMarketType
+}
 
-function LlammalendTest({ tab, onPricesUpdated, type, ...props }: LlammalendTestProps) {
-  const { isHydrated } = useCurve()
+function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: LlammalendTestProps) {
   const isLoan = type === 'loan'
-  const { data: loanExists } = useLoanExists(props, isHydrated && isLoan)
-  const marketId = isHydrated && props.marketId
-  const market = useMemo(() => marketId && getLlamaMarket(marketId), [marketId])
-
-  if (!market || (loanExists && !tab)) return <Skeleton width="100%" height={400} />
+  const { marketId, chainId } = props
+  const mintChain = chainId as MintChain
+  const { data: lendMarket, error: lendError } = useLendMarket(chainId, marketId, marketType === LlamaMarketType.Lend)
+  const { data: mintMarket, error: mintError } = useMintMarket(mintChain, marketId, marketType === LlamaMarketType.Mint)
+  const market = lendMarket ?? mintMarket
+  const error = lendError ?? mintError
+  const { data: loanExists } = useLoanExists(props, isLoan && !!market)
 
   const Component = isLoan
     ? loanExists
-      ? LoanComponents[tab as LoanTab]
+      ? tab && LoanComponents[tab as LoanTab]
       : CreateLoanForm
-    : SupplyComponents[(tab ?? 'deposit') as SupplyTab]
+    : tab && SupplyComponents[tab as SupplyTab]
 
-  return (
+  return market && Component ? (
     <Component
       market={market}
       networks={llamaNetworks}
@@ -81,17 +83,22 @@ function LlammalendTest({ tab, onPricesUpdated, type, ...props }: LlammalendTest
       collateralEvents={constQ(fakeCollateralEvents)}
       {...props}
     />
+  ) : market ? (
+    `Invalid arguments given to LlammalendTestCase: ${JSON.stringify({ tab, isLoan, loanExists, marketType })}.`
+  ) : error ? (
+    `Error retrieving market: ${error.message}`
+  ) : (
+    <Skeleton width="100%" height={400} />
   )
 }
 
-export type LlammalendTestCaseProps = LlammalendTestProps &
-  TenderlyWagmiConfigFromVNet & { marketType: LlamaMarketType }
+export type LlammalendTestCaseProps = LlammalendTestProps & TenderlyWagmiConfigFromVNet
 
 export const LlammalendTestCase = ({ vnet, privateKey, chainId, marketType, ...props }: LlammalendTestCaseProps) => (
   <ComponentTestWrapper config={createTenderlyWagmiConfigFromVNet({ vnet, privateKey })} autoConnect>
     <CurveProvider app="llamalend" network={llamaNetworks[chainId]} onChainUnavailable={console.error}>
       <Box sx={{ maxWidth: 520 }}>
-        <LlammalendTest {...props} chainId={chainId} />
+        <LlammalendTest {...props} chainId={chainId} marketType={marketType} />
       </Box>
     </CurveProvider>
   </ComponentTestWrapper>


### PR DESCRIPTION
- RPC tests have been broken by #2522 because the hydration no longer fetches all markets
- I've added market fetching depending on the given market type
- [RPC test run](https://github.com/curvefi/curve-frontend/actions/runs/26090483302/job/76714561640)