### PR TITLE
e2e: reuse llamalend list mocks

### DIFF
--- a/tests/cypress/e2e/all/error-boundary.cy.ts
+++ b/tests/cypress/e2e/all/error-boundary.cy.ts
@@ -1,5 +1,6 @@
 import { oneBool } from '@cy/support/generators'
-import { createLendingVaultChainsResponse, mockLendingVaults } from '@cy/support/helpers/lending-mocks'
+import { createLendingVaultChainsResponse } from '@cy/support/helpers/lending-mocks'
+import { setupLlamalendListMocks } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { API_LOAD_TIMEOUT, e2eBaseUrl, LOAD_TIMEOUT } from '@cy/support/ui'
 import type { ErrorContext } from '@ui-kit/features/report-error'
 import { SENTRY_DSN } from '@ui-kit/features/sentry'
@@ -7,19 +8,18 @@ import { SENTRY_DSN } from '@ui-kit/features/sentry'
 const invalidIconAddress = '0x0000000000000000000000000000000000000001' as const
 
 const visitErrorBoundary = () => {
-  cy.intercept(`https://prices.curve.finance/v1/crvusd/markets`, {
-    body: { chains: { ethereum: { count: 0, data: [] } } },
-  })
-  const chains = createLendingVaultChainsResponse()
-  chains.ethereum = {
-    ...chains.ethereum,
-    data: chains.ethereum.data.map(market => ({
-      // Keep the API response valid, then trigger the render error from the icon path below.
-      ...market,
-      collateral_token: { ...market.collateral_token, address: invalidIconAddress },
-    })),
-  }
-  mockLendingVaults(chains).as('error')
+  const { ethereum, ...otherChains } = createLendingVaultChainsResponse()
+  setupLlamalendListMocks({
+    ethereum: {
+      ...ethereum,
+      data: ethereum.data.map(market => ({
+        ...market,
+        // Keep the API response valid, then trigger the render error from the icon path below.
+        collateral_token: { ...market.collateral_token, address: invalidIconAddress },
+      })),
+    },
+    ...otherChains,
+  }).lendingVaults.as('error')
   const url = '/llamalend/ethereum/markets'
   cy.visit(url, {
     timeout: API_LOAD_TIMEOUT.timeout,

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -6,26 +6,12 @@ import {
   closeDrawer,
   closeSlider,
   expandFirstRowOnMobile,
-  openFilters,
   openDrawer,
+  openFilters,
   withFilterChips,
 } from '@cy/support/helpers/data-table.helpers'
-import {
-  Chain,
-  createLendingVaultChainsResponse,
-  HighTVLAddress,
-  HighUtilizationAddress,
-  mockLendingSnapshots,
-  mockLendingVaults,
-  mockMerklCampaigns,
-} from '@cy/support/helpers/lending-mocks'
-import {
-  blockUnmockedLlamaMarketApis,
-  mockEmptyLlamaMarketUserData,
-  mockEmptyLlamaMarketBadDebt,
-} from '@cy/support/helpers/llamalend/market-list-mocks'
-import { mockMintMarkets, mockMintSnapshots } from '@cy/support/helpers/minting-mocks'
-import { mockTokenPrices } from '@cy/support/helpers/tokens'
+import { Chain, HighTVLAddress, HighUtilizationAddress } from '@cy/support/helpers/lending-mocks'
+import { setupLlamalendListMocks } from '@cy/support/helpers/llamalend/market-list-mocks'
 import {
   assertInViewport,
   assertNotInViewport,
@@ -49,7 +35,7 @@ testCases.forEach(([width, height, breakpoint]) => {
     const itMobileOnly = breakpoint === 'mobile' ? it : it.skip
 
     beforeEach(() => {
-      vaultData = setupMocks()
+      ;({ vaultData } = setupLlamalendListMocks())
       visitAndWait([width, height])
     })
 
@@ -350,20 +336,6 @@ function enableGraphColumn() {
   cy.get(`[data-testid="visibility-toggle-borrowChart"]`).click()
   cy.get(`[data-testid="line-graph-${MarketRateType.Borrow}"]`).should('exist')
   cy.get('body').click(0, 0) // close popover
-}
-
-function setupMocks() {
-  const generatedData = createLendingVaultChainsResponse()
-  blockUnmockedLlamaMarketApis()
-  mockEmptyLlamaMarketUserData()
-  mockEmptyLlamaMarketBadDebt()
-  mockTokenPrices()
-  mockLendingVaults(generatedData)
-  mockLendingSnapshots().as('lend-snapshots')
-  mockMintMarkets()
-  mockMintSnapshots()
-  mockMerklCampaigns()
-  return generatedData
 }
 
 const getMaxLiquidity = (vaultData: Record<Chain, GetMarketsResponse>) =>

--- a/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
@@ -1,5 +1,13 @@
-import { LendingChains } from '@cy/support/helpers/lending-mocks'
+import {
+  createLendingVaultChainsResponse,
+  LendingChains,
+  mockLendingSnapshots,
+  mockLendingVaults,
+  mockMerklCampaigns,
+} from '@cy/support/helpers/lending-mocks'
 import { fromEntries } from '@primitives/objects.utils'
+import { mockMintMarkets, mockMintSnapshots } from '../minting-mocks'
+import { mockTokenPrices } from '../tokens'
 
 /**
  * To make sure our tests do not depend on real APIs, we just block them.
@@ -36,3 +44,16 @@ export const mockEmptyLlamaMarketBadDebt = () =>
   ['/v1/crvusd/liquidations/bad_debt', '/v1/lending/liquidations/bad_debt'].map(pathname =>
     cy.intercept({ method: 'GET', pathname, query: { fetch_on_chain: 'true' } }, { body: { data: [] } }),
   )
+
+export function setupLlamalendListMocks(vaultData = createLendingVaultChainsResponse()) {
+  blockUnmockedLlamaMarketApis()
+  mockEmptyLlamaMarketUserData()
+  mockEmptyLlamaMarketBadDebt()
+  mockTokenPrices()
+  const lendingVaults = mockLendingVaults(vaultData)
+  mockLendingSnapshots().as('lend-snapshots')
+  mockMintMarkets()
+  mockMintSnapshots()
+  mockMerklCampaigns()
+  return { vaultData, lendingVaults }
+}


### PR DESCRIPTION
- This should fix the flaky error-boundary tests that sometimes time out due to slow API.