### PR TITLE
feat: stop waiting for user data queries

### DIFF
--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -12,6 +12,7 @@ import { useQueries } from '@tanstack/react-query'
 import { type CampaignRewards, combineCampaigns } from '@ui-kit/entities/campaigns'
 import { getCampaignsExternalOptions } from '@ui-kit/entities/campaigns/campaigns-external'
 import { getCampaignsMarketsMerklOptions } from '@ui-kit/entities/campaigns/campaigns-markets-merkl'
+import { useStateTimeout } from '@ui-kit/hooks/useStateTimeout'
 import { combineQueriesMeta, PartialQueryResult, RESOLVED_QUERY_RESULT } from '@ui-kit/lib'
 import { CRVUSD_ROUTES, getInternalUrl, LEND_ROUTES } from '@ui-kit/shared/routes'
 import { type ExtraIncentive, LlamaMarketType, LlamaMarketVersion, MarketRateType } from '@ui-kit/types/market'
@@ -329,6 +330,7 @@ type LlamaMarketsQueries = [
   ReturnType<typeof getUserMintMarketsOptions>,
 ]
 type LlamaMarketParams = { userAddress: Address | undefined; enableLLv2: boolean; enableDeprecatedMarkets: boolean }
+
 /**
  * Query hook combining all lend and mint markets of all chains into a single list, converting them to a common format.
  * It also fetches the user's favorite markets and user's positions list (without the details).
@@ -336,8 +338,9 @@ type LlamaMarketParams = { userAddress: Address | undefined; enableLLv2: boolean
 export const useLlamaMarkets = (
   { userAddress, enableLLv2, enableDeprecatedMarkets }: LlamaMarketParams,
   enabled = true,
-) =>
-  useQueries({
+) => {
+  const [isTimedOut, setIsReady] = useStateTimeout()
+  return useQueries({
     queries: useMemo<LlamaMarketsQueries>(
       () => [
         getLendingVaultsOptions({}, enabled),
@@ -380,62 +383,58 @@ export const useLlamaMarkets = (
         const getLendMarketBadDebt = createGetBadDebtMarket(badDebtLendMarkets.data)
         const getMintMarketBadDebt = createGetBadDebtMarket(badDebtMintMarkets.data)
 
-        // only render table when both lending and mint markets are ready, however show one of them if the other is in error
-        const showData = (lendingVaults.data && mintMarkets.data) || lendingVaults.isError || mintMarkets.isError
-        const showUserData =
-          !userAddress ||
-          (userLendingVaults.data && userSuppliedMarkets.data && userMintMarkets.data) ||
-          userLendingVaults.isError ||
-          userSuppliedMarkets.isError ||
-          userMintMarkets.isError
+        const userDataReady =
+          !userAddress || [userLendingVaults, userSuppliedMarkets, userMintMarkets].every(q => q.data || q.error)
+        const marketsReady = [lendingVaults, mintMarkets].every(q => q.data || q.error)
+        const isReady = setIsReady(marketsReady && (userDataReady || isTimedOut))
 
-        const data: LlamaMarketsResult | undefined =
-          showData && showUserData
-            ? {
-                userHasPositions:
-                  userBorrows.size > 0 || userMints.size > 0 || userSupplied.size > 0
-                    ? {
-                        [LlamaMarketType.Mint]: {
-                          [MarketRateType.Borrow]: userMints.size > 0,
-                          [MarketRateType.Supply]: false,
-                        },
-                        [LlamaMarketType.Lend]: {
-                          [MarketRateType.Borrow]: userBorrows.size > 0,
-                          [MarketRateType.Supply]: userSupplied.size > 0,
-                        },
-                      }
-                    : null,
-                hasFavorites: favoriteMarketsSet.size > 0,
-                markets: [
-                  ...(lendingVaults.data ?? []).map(vault =>
-                    convertLendingVault(
-                      vault,
-                      favoriteMarketsSet,
-                      campaigns,
-                      userBorrows,
-                      userSupplied,
-                      getLendMarketBadDebt(vault.chain, vault.controller),
-                    ),
+        const data: LlamaMarketsResult | undefined = isReady
+          ? {
+              userHasPositions:
+                userBorrows.size > 0 || userMints.size > 0 || userSupplied.size > 0
+                  ? {
+                      [LlamaMarketType.Mint]: {
+                        [MarketRateType.Borrow]: userMints.size > 0,
+                        [MarketRateType.Supply]: false,
+                      },
+                      [LlamaMarketType.Lend]: {
+                        [MarketRateType.Borrow]: userBorrows.size > 0,
+                        [MarketRateType.Supply]: userSupplied.size > 0,
+                      },
+                    }
+                  : null,
+              hasFavorites: favoriteMarketsSet.size > 0,
+              markets: [
+                ...(lendingVaults.data ?? []).map(vault =>
+                  convertLendingVault(
+                    vault,
+                    favoriteMarketsSet,
+                    campaigns,
+                    userBorrows,
+                    userSupplied,
+                    getLendMarketBadDebt(vault.chain, vault.controller),
                   ),
-                  ...(mintMarkets.data ?? []).map(market =>
-                    convertMintMarket(
-                      market,
-                      favoriteMarketsSet,
-                      campaigns,
-                      userMints,
-                      countMarket(market),
-                      getMintMarketBadDebt(market.chain, market.address),
-                    ),
-                  ),
-                ].filter(
-                  ({ createdAt, deprecatedMessage, userHasPositions }) =>
-                    (createdAt <= LLAMMALEND_V2_DATE.getTime() || enableLLv2) &&
-                    (!deprecatedMessage || enableDeprecatedMarkets || userHasPositions),
                 ),
-              }
-            : undefined
+                ...(mintMarkets.data ?? []).map(market =>
+                  convertMintMarket(
+                    market,
+                    favoriteMarketsSet,
+                    campaigns,
+                    userMints,
+                    countMarket(market),
+                    getMintMarketBadDebt(market.chain, market.address),
+                  ),
+                ),
+              ].filter(
+                ({ createdAt, deprecatedMessage, userHasPositions }) =>
+                  (createdAt <= LLAMMALEND_V2_DATE.getTime() || enableLLv2) &&
+                  (!deprecatedMessage || enableDeprecatedMarkets || userHasPositions),
+              ),
+            }
+          : undefined
         return { ...combineQueriesMeta(results), data }
       },
-      [enabled, userAddress, enableLLv2, enableDeprecatedMarkets],
+      [enabled, userAddress, enableLLv2, enableDeprecatedMarkets, isTimedOut, setIsReady],
     ),
   })
+}

--- a/packages/curve-ui-kit/src/hooks/useStateTimeout.ts
+++ b/packages/curve-ui-kit/src/hooks/useStateTimeout.ts
@@ -1,0 +1,30 @@
+import { useCallback, useRef, useState } from 'react'
+import { Duration } from '@ui-kit/themes/design/0_primitives'
+
+/**
+ * Timeout hook that returns a boolean indicating if the data has taken too long to load.
+ * @returns [isTimedOut, setIsReady]
+ * - isTimedOut is true if the data has been loaded for longer than Duration.LoadingTimeout
+ * - setIsReady is a function that takes a boolean indicating if the data is ready.
+ *   If the data is ready, the timeout is cleared and isTimedOut is set to false.
+ *   If the data is not ready and there is no timeout yet, a timer is started.
+ */
+export function useStateTimeout() {
+  const [isTimedOut, setIsTimedOut] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const setIsReady = useCallback((isReady: boolean) => {
+    if (isReady && timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+      setIsTimedOut(false)
+    }
+    if (!isReady && !timeoutRef.current) {
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null
+        setIsTimedOut(true)
+      }, Duration.LoadingTimeout) // if the query takes more than 5 seconds, show the data we have (even if user data is not ready, as it's less important)
+    }
+    return isReady
+  }, [])
+  return [isTimedOut, setIsReady] as const
+}

--- a/packages/curve-ui-kit/src/themes/design/0_primitives.ts
+++ b/packages/curve-ui-kit/src/themes/design/0_primitives.ts
@@ -154,6 +154,7 @@ export const Duration = {
   Tooltip: { Enter: 500, Exit: 500 },
   Transition: 256,
   LoadingAnimation: 1000,
+  LoadingTimeout: 5000,
   Banner: {
     Daily: TIME_FRAMES.DAY_MS,
     Monthly: TIME_FRAMES.MONTH_MS,


### PR DESCRIPTION
- the user queries are sometimes taking much longer than the market queries
- the user gets stuck waiting for the data while most of it is already available
- ultimately we should improve the load time on the prices API, but for now let's at least show the rest of the data