### PR TITLE
feat: allow custom timestamp cell alignment

### DIFF
--- a/apps/main/src/llamalend/features/user-position-history/columns/column.definitions.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/columns/column.definitions.tsx
@@ -37,7 +37,8 @@ export const USER_POSITION_HISTORY_COLUMNS = [
   columnHelper.accessor('timestamp', {
     id: UserPositionHistoryColumnId.Time,
     header: headers[UserPositionHistoryColumnId.Time],
-    cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.url} />,
-    meta: { type: 'numeric' },
+    cell: ({ row }) => (
+      <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.url} align="end" />
+    ),
   }),
 ]

--- a/packages/curve-ui-kit/src/features/activity-table/columns/llamma-events-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/llamma-events-columns.tsx
@@ -39,7 +39,8 @@ export const LLAMMA_EVENTS_COLUMNS = [
   columnHelper.accessor('timestamp', {
     id: LlammaEventsColumnId.Time,
     header: t`Time`,
-    cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} />,
-    meta: { type: 'numeric' },
+    cell: ({ row }) => (
+      <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} align="end" />
+    ),
   }),
 ]

--- a/packages/curve-ui-kit/src/features/activity-table/columns/llamma-trades-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/llamma-trades-columns.tsx
@@ -49,7 +49,8 @@ export const LLAMMA_TRADES_COLUMNS = [
   columnHelper.accessor('timestamp', {
     id: LlammaTradesColumnId.Time,
     header: t`Time`,
-    cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} />,
-    meta: { type: 'numeric' },
+    cell: ({ row }) => (
+      <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} align="end" />
+    ),
   }),
 ]

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
@@ -62,8 +62,9 @@ export const createPoolLiquidityColumns = ({ poolTokens }: CreatePoolLiquidityCo
     columnHelper.accessor('time', {
       id: PoolLiquidityColumnId.Time,
       header: t`Time`,
-      cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} />,
-      meta: { type: 'numeric' },
+      cell: ({ row }) => (
+        <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} align="end" />
+      ),
     }),
   ]
 

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
@@ -51,7 +51,6 @@ export const POOL_TRADES_COLUMNS = [
   columnHelper.accessor('time', {
     id: PoolTradesColumnId.Time,
     header: t`Time`,
-    cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} />,
-    meta: { type: 'numeric' },
+    cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} align="end" />,
   }),
 ]

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
@@ -11,12 +11,13 @@ const { Spacing } = SizesAndSpaces
 type TimestampCellProps = {
   timestamp: Date
   txUrl?: string | null
+  align?: 'start' | 'end'
 }
 
 /**
  * Cell component for displaying timestamps with optional transaction link.
  */
-export const TimestampCell = ({ timestamp, txUrl }: TimestampCellProps) => {
+export const TimestampCell = ({ timestamp, txUrl, align = 'start' }: TimestampCellProps) => {
   const isMobile = useIsMobile()
   const clickable = !isMobile && txUrl // on mobile we use row expansion
 
@@ -29,9 +30,12 @@ export const TimestampCell = ({ timestamp, txUrl }: TimestampCellProps) => {
       })}
       sx={{ gap: Spacing.xxs }}
     >
-      <Typography variant="tableCellMBold">{formatDate(timestamp, 'short')}</Typography>
-      <Stack direction="row" alignItems="center" justifyContent="end" gap={Spacing.xs}>
-        <Typography variant="tableCellSRegular" sx={t => ({ color: t.design.Text.TextColors.Secondary })}>
+      <Typography variant="tableCellMBold" textAlign={align}>
+        {formatDate(timestamp, 'short')}
+      </Typography>
+
+      <Stack direction="row" alignItems="center" justifyContent={align} gap={Spacing.xs}>
+        <Typography variant="tableCellSRegular" color="textSecondary">
           {formatTime(timestamp)}
         </Typography>
         {clickable && <ArrowOutwardIcon sx={{ fontSize: 20, color: t => t.design.Text.TextColors.Secondary }} />}


### PR DESCRIPTION
`meta: 'numeric'` works if you have a single number in your cell, but breaks when you have composite components like a Stack. Better to just make it a custom prop.

Here's an example where it breaks in the refuel table:

<img width="219" height="142" alt="image" src="https://github.com/user-attachments/assets/c6342d38-09cc-477c-95f6-def4ad41a048" />
