### PR TITLE
fix: use debounce reset to initial

### DIFF
--- a/packages/curve-ui-kit/src/hooks/useDebounce.ts
+++ b/packages/curve-ui-kit/src/hooks/useDebounce.ts
@@ -135,7 +135,7 @@ export function useUniqueDebounce<T>({
   equals?: (a: T, b: T) => boolean
   sanitize?: (value: T) => T
 }) {
-  const [initialValue, setInitialValue] = useState<T>(defaultValue)
+  const [value, setValue] = useState<T>(defaultValue)
   const lastCallbackValue = useRef(defaultValue)
 
   useEffect(() => {
@@ -143,7 +143,7 @@ export function useUniqueDebounce<T>({
     // update the initial value to reflect the change. This will override the input contents and the debounced value.
     if (!equals(lastCallbackValue.current, defaultValue)) {
       lastCallbackValue.current = defaultValue
-      setInitialValue(defaultValue)
+      setValue(defaultValue)
     }
   }, [defaultValue, equals])
 
@@ -158,5 +158,5 @@ export function useUniqueDebounce<T>({
     [onChange, sanitize, equals],
   )
 
-  return useDebounce({ initialValue, debounceMs, callback })
+  return [value, ...useDebounced(callback, debounceMs, setValue)] as const
 }


### PR DESCRIPTION
- #2532 introduced a slight bug that broke the RPC tests.\
  - When the forms reset back to undefined, the check `initial!=default` will not trigger
  - The internal value in `useDebounce` would stay stale and the field would show the old value.
- This was impossible to solve without inlining the call to `useDebounced`, but it was trivial to fix once I did it
