### PR TITLE
fix: prefetch markets in RPC tests

### DIFF
--- a/apps/main/src/lend/queries/lend-market-names.query.ts
+++ b/apps/main/src/lend/queries/lend-market-names.query.ts
@@ -10,7 +10,11 @@ const V2 = 'v2' as const
 
 const v2chains = [Chain.Optimism]
 
-export const { useQuery: useLendMarketNames, reset: resetLendMarkets } = queryFactory({
+export const {
+  useQuery: useLendMarketNames,
+  reset: resetLendMarkets,
+  prefetchQuery: prefetchLendMarkets,
+} = queryFactory({
   queryKey: ({ chainId, enableLLv2 }: ChainParams & { enableLLv2: boolean }) =>
     [...rootKeys.chain({ chainId }), 'lendMarkets.getMarketList', { enableLLv2 }] as const,
   queryFn: async ({ chainId, enableLLv2 }: ChainQuery & { enableLLv2: boolean }): Promise<string[]> => {

--- a/apps/main/src/loan/entities/mint-market-names.query.ts
+++ b/apps/main/src/loan/entities/mint-market-names.query.ts
@@ -3,7 +3,11 @@ import { requireLib } from '@ui-kit/features/connect-wallet'
 import { ChainParams, queryFactory, rootKeys } from '@ui-kit/lib/model/query'
 import { llamaApiValidationSuite } from '@ui-kit/lib/model/query/curve-api-validation'
 
-export const { useQuery: useMintMarketNames, reset: resetMintMarkets } = queryFactory({
+export const {
+  useQuery: useMintMarketNames,
+  reset: resetMintMarkets,
+  prefetchQuery: prefetchMintMarkets,
+} = queryFactory({
   queryKey: ({ chainId }: ChainParams) => [...rootKeys.chain({ chainId }), 'mintMarkets.getMarketList'] as const,
   queryFn: async (): Promise<string[]> => {
     const api = requireLib('llamaApi')

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -1,6 +1,6 @@
-import { resetMintMarkets } from 'main/src/loan/entities/mint-market-names.query'
+import { prefetchMintMarkets } from 'main/src/loan/entities/mint-market-names.query'
 import { useMemo } from 'react'
-import { resetLendMarkets } from '@/lend/queries/lend-market-names.query'
+import { prefetchLendMarkets } from '@/lend/queries/lend-market-names.query'
 import { CreateLoanForm } from '@/llamalend/features/borrow/components/CreateLoanForm'
 import { AddCollateralForm } from '@/llamalend/features/manage-loan/components/AddCollateralForm'
 import { BorrowMoreForm } from '@/llamalend/features/manage-loan/components/BorrowMoreForm'
@@ -98,8 +98,8 @@ export const LlammalendTestCase = ({ vnet, privateKey, chainId, marketType, ...p
       hydrate={useMemo(
         () => ({
           llamalend: {
-            [LlamaMarketType.Lend]: () => resetLendMarkets({ chainId, enableLLv2: true }),
-            [LlamaMarketType.Mint]: () => resetMintMarkets({ chainId }),
+            [LlamaMarketType.Lend]: () => prefetchLendMarkets({ chainId, enableLLv2: true }),
+            [LlamaMarketType.Mint]: () => prefetchMintMarkets({ chainId }),
           }[marketType],
         }),
         [chainId, marketType],


### PR DESCRIPTION
- the ultimate solution for the tests is to share the same market retrieval as the production code (done in #2544)
- however, we removed the market prefetch in #2521 before #2544 was merged
- this PR should fix the RPC tests that are now failing in `main`
- [rpc test run](https://github.com/curvefi/curve-frontend/actions/runs/26292628336/job/77396660267)