### PR TITLE
refactor: add inline size to cards

### DIFF
--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -108,13 +108,8 @@ export const PoolParameters = ({ poolData, rChainId }: PoolParametersProps) => {
   if (!poolMetadata || !snapshotData) return null
 
   return (
-    <Card size="small">
-      <CardContent
-        component={Grid}
-        container
-        columnSpacing={Spacing.md}
-        sx={{ padding: '0 !important' /** The default padding interferes with background colors of the inner grids */ }}
-      >
+    <Card size="inline">
+      <CardContent component={Grid} container columnSpacing={Spacing.md}>
         <Grid size={{ mobile: 12, desktop: 8 }} sx={cardContentSmallStyles}>
           <Stack gap={Spacing.lg}>
             <Stack>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
@@ -48,13 +48,8 @@ export const PoolStats = ({ routerParams, poolAlert, poolData, poolDataCacheOrAp
   }, [curveApi, fetchPoolStats, poolData])
 
   return (
-    <Card size="small">
-      <CardContent
-        component={Grid}
-        container
-        columnSpacing={Spacing.md}
-        sx={{ padding: '0 !important' /** The default padding interferes with background colors of the inner grids */ }}
-      >
+    <Card size="inline">
+      <CardContent component={Grid} container columnSpacing={Spacing.md}>
         <Grid size={{ mobile: 12, desktop: 8 }} sx={cardContentSmallStyles}>
           <Stack gap={Spacing.md}>
             <CurrencyReserves chainId={chainId} poolId={poolId ?? ''} tokensMapper={tokensMapper} />

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
@@ -103,7 +103,7 @@ export const MarketContractsSection = ({ chainId, market, network }: MarketContr
   return (
     <Stack gap={Spacing.md}>
       <Stack gap={Spacing.sm}>
-        <CardHeader title={t`Contracts`} size="small" data-inline />
+        <CardHeader title={t`Contracts`} size="inline" />
         <WithSkeleton loading={loading} variant="rectangular" height={'4lh'} width="100%">
           <Stack>
             {tokenItems.map(({ key, label, address }) => (

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketParametersSection.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketParametersSection.tsx
@@ -20,21 +20,21 @@ export const MarketParametersSection = ({ chainId, marketId, marketType }: Marke
   return (
     <Stack>
       <Stack gap={Spacing.sm}>
-        <CardHeader title={t`Parameters`} size="small" data-inline />
+        <CardHeader title={t`Parameters`} size="inline" />
         <Stack>
           <MarketLoanParameters chainId={chainId} marketId={marketId} />
         </Stack>
       </Stack>
 
       <Stack gap={Spacing.sm}>
-        <CardHeader title={t`Prices`} size="small" data-inline />
+        <CardHeader title={t`Prices`} size="inline" />
         <Stack>
           <MarketPricesRows chainId={chainId} marketId={marketId} enablePricePerShare={enablePricePerShare} />
         </Stack>
       </Stack>
 
       <Stack gap={Spacing.sm}>
-        <CardHeader title={t`Market`} size="small" data-inline />
+        <CardHeader title={t`Market`} size="inline" />
         <Stack>
           <MarketIdRow marketId={marketId} />
         </Stack>

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/AdvancedDetails.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/AdvancedDetails.tsx
@@ -5,14 +5,9 @@ import { t } from '@ui-kit/lib/i18n'
 import { AddressActionInfo } from '@ui-kit/shared/ui/AddressActionInfo'
 
 export const AdvancedDetails = ({ network }: { network: BaseConfig | undefined }) => (
-  <Card size="small">
-    <CardHeader
-      data-inline
-      title={t`Advanced Details`}
-      slotProps={{ title: { variant: 'small' }, root: { variant: 'small' } }}
-    />
-
-    <CardContent sx={{ paddingInline: '0 !important' }} /** TODO: no data-inline support yet like in header */>
+  <Card size="inline">
+    <CardHeader title={t`Advanced Details`} />
+    <CardContent>
       <AddressActionInfo network={network} title={t`Vault Contract Address`} address={SCRVUSD_VAULT_ADDRESS} />
     </CardContent>
   </Card>

--- a/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.d.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.d.ts
@@ -2,6 +2,6 @@ import '@mui/material/CardContent'
 
 declare module '@mui/material/CardContent' {
   export interface CardContentOwnProps {
-    size?: 'small'
+    size?: 'small' | 'inline'
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
@@ -18,6 +18,11 @@ export const cardContentSmallStyles = {
   '&:last-child': handleBreakpoints({ paddingBlockEnd: Padding.sm }),
 }
 
+export const cardContentInlineStyles = {
+  ...handleBreakpoints({ padding: 0 }),
+  '&:last-child': handleBreakpoints({ paddingBlockEnd: 0 }),
+}
+
 export const defineMuiCardContent = (design: DesignSystem): Components['MuiCardContent'] => ({
   styleOverrides: {
     root: {
@@ -30,6 +35,10 @@ export const defineMuiCardContent = (design: DesignSystem): Components['MuiCardC
     {
       props: { size: 'small' },
       style: cardContentSmallStyles,
+    },
+    {
+      props: { size: 'inline' },
+      style: cardContentInlineStyles,
     },
   ],
 })

--- a/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.d.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.d.ts
@@ -2,7 +2,6 @@ import '@mui/material/CardHeader'
 
 declare module '@mui/material/CardHeader' {
   export interface CardHeaderOwnProps {
-    size?: 'small'
-    'data-inline'?: boolean
+    size?: 'small' | 'inline'
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.ts
@@ -11,6 +11,14 @@ export const cardHeaderSmallStyles = (typography: TypographyVariantsOptions) => 
   ...handleBreakpoints({ minHeight: ButtonSize.sm }),
 })
 
+export const cardHeaderInlineStyles = (design: DesignSystem, typography: TypographyVariantsOptions) => ({
+  ...cardHeaderSmallStyles(typography),
+  borderBottom: `1px solid ${design.Layer[3].Outline}`,
+  ...handleBreakpoints({
+    paddingInline: 0,
+  }),
+})
+
 export const defineMuiCardHeader = (
   design: DesignSystem,
   typography: TypographyVariantsOptions,
@@ -36,13 +44,8 @@ export const defineMuiCardHeader = (
       style: cardHeaderSmallStyles(typography),
     },
     {
-      props: { 'data-inline': true },
-      style: {
-        borderBottom: `1px solid ${design.Layer[3].Outline}`,
-        ...handleBreakpoints({
-          paddingInline: 0,
-        }),
-      },
+      props: { size: 'inline' },
+      style: cardHeaderInlineStyles(design, typography),
     },
   ],
 })

--- a/packages/curve-ui-kit/src/themes/components/card/mui-card.d.ts
+++ b/packages/curve-ui-kit/src/themes/components/card/mui-card.d.ts
@@ -2,6 +2,6 @@ import '@mui/material/Card'
 
 declare module '@mui/material/Card' {
   export interface CardOwnProps {
-    size?: 'small'
+    size?: 'small' | 'inline'
   }
 }

--- a/packages/curve-ui-kit/src/themes/components/card/mui-card.ts
+++ b/packages/curve-ui-kit/src/themes/components/card/mui-card.ts
@@ -1,9 +1,10 @@
 /// <reference types="./mui-card.d.ts" />
 import type { Components, TypographyVariantsOptions } from '@mui/material/styles'
-import { cardContentSmallStyles } from '../card-content'
-import { cardHeaderSmallStyles } from '../card-header'
+import { DesignSystem } from '@ui-kit/themes/design'
+import { cardContentInlineStyles, cardContentSmallStyles } from '../card-content'
+import { cardHeaderInlineStyles, cardHeaderSmallStyles } from '../card-header'
 
-export const defineMuiCard = (typography: TypographyVariantsOptions): Components['MuiCard'] => ({
+export const defineMuiCard = (design: DesignSystem, typography: TypographyVariantsOptions): Components['MuiCard'] => ({
   styleOverrides: {
     root: {
       backgroundColor: 'transparent', // We want the paper elevation only on the card content, not the header. Mui adds a bgColor by default.
@@ -16,6 +17,13 @@ export const defineMuiCard = (typography: TypographyVariantsOptions): Components
       style: {
         '& .MuiCardHeader-root': cardHeaderSmallStyles(typography),
         '& .MuiCardContent-root': cardContentSmallStyles,
+      },
+    },
+    {
+      props: { size: 'inline' },
+      style: {
+        '& .MuiCardHeader-root': cardHeaderInlineStyles(design, typography),
+        '& .MuiCardContent-root': cardContentInlineStyles,
       },
     },
   ],

--- a/packages/curve-ui-kit/src/themes/components/index.ts
+++ b/packages/curve-ui-kit/src/themes/components/index.ts
@@ -44,7 +44,7 @@ export const createComponents = (
       disableRipple: true,
     },
   },
-  MuiCard: defineMuiCard(typography),
+  MuiCard: defineMuiCard(design, typography),
   MuiCardContent: defineMuiCardContent(design),
   MuiCardHeader: defineMuiCardHeader(design, typography),
   MuiCardActions: {

--- a/packages/curve-ui-kit/src/themes/stories/Card.stories.tsx
+++ b/packages/curve-ui-kit/src/themes/stories/Card.stories.tsx
@@ -75,6 +75,23 @@ const CardStoryHeaderOnly = (props: CardProps) => (
   </Card>
 )
 
+const CardStoryInline = (props: CardProps) => (
+  <Card sx={{ maxWidth: '20rem' }} {...props} size="inline">
+    <CardHeader title="Inline card" />
+
+    <CardContent>
+      <Stack gap={Spacing.sm}>
+        <Typography variant="bodySRegular" color="textSecondary">
+          Inline content starts flush with the card edge.
+        </Typography>
+        <Button fullWidth color="secondary">
+          Inline Action
+        </Button>
+      </Stack>
+    </CardContent>
+  </Card>
+)
+
 const CardStoryTokenPairAvatar = (props: CardProps) => (
   <Card sx={{ maxWidth: '20rem' }} {...props}>
     <CardHeader
@@ -120,6 +137,7 @@ type Story = StoryObj<typeof CardStory>
 export const Default: Story = { render: args => <CardStory {...args} /> }
 export const Simple: Story = { render: args => <CardStorySimple {...args} /> }
 export const HeaderOnly: Story = { render: args => <CardStoryHeaderOnly {...args} /> }
+export const Inline: Story = { render: args => <CardStoryInline {...args} /> }
 export const TokenPairAvatar: Story = { render: args => <CardStoryTokenPairAvatar {...args} /> }
 
 export default meta


### PR DESCRIPTION
Small refactor that gets rid of the padding exceptions and introduces `inline` as a proper size, like `small`. The dividing line between `size` and a new prop that also changes sizes (for the header) is blurry, so I've decided to just make it a proper `size`.

Inline looks a bit stupid but it's ment for cards within cards.

<img width="297" height="112" alt="image" src="https://github.com/user-attachments/assets/5036eedb-0135-4221-a64b-355c94f20cbd" />
