### PR TITLE
fix: maintenance page theme

### DIFF
--- a/apps/main/src/routes/RootLayout.tsx
+++ b/apps/main/src/routes/RootLayout.tsx
@@ -22,6 +22,7 @@ import type { Maintenance } from '@ui-kit/features/maintenance/hooks/useMaintena
 import { addBreadcrumb } from '@ui-kit/features/sentry'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { usePathname } from '@ui-kit/hooks/router'
+import { useBodyThemeClass } from '@ui-kit/hooks/useBodyThemeClass'
 import { useLayoutStoreResponsive } from '@ui-kit/hooks/useLayoutStoreResponsive'
 import { useNetworkFromUrl } from '@ui-kit/hooks/useNetworkFromUrl'
 import { useOnChainUnavailable } from '@ui-kit/hooks/useOnChainUnavailable'
@@ -90,6 +91,8 @@ export const RootLayout = () => {
   const theme = useUserProfileStore(state => state.theme)
   const backendMaintenance = useMaintenance(BACKEND_MAINTENANCE)
   const devTools = !isCypress
+  useBodyThemeClass()
+
   return (
     <StyleSheetManager shouldForwardProp={shouldForwardProp}>
       <ThemeProvider theme={theme}>

--- a/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
+++ b/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
@@ -6,6 +6,7 @@ import { CURVE_LOGO_URL, CURVE_SOCIALS } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { XIcon } from '@ui-kit/shared/icons/XIcon'
 import { Badge } from '@ui-kit/shared/ui/Badge'
+import { ThemeProvider } from '@ui-kit/shared/ui/ThemeProvider'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { MinHeight, Spacing, MaxWidth } = SizesAndSpaces
@@ -13,54 +14,57 @@ const { MinHeight, Spacing, MaxWidth } = SizesAndSpaces
 const Image = styled('img')({})
 
 export const MaintenancePage = () => (
-  <Stack
-    component="main"
-    alignItems="center"
-    justifyContent="center"
-    padding={Spacing.md}
-    minHeight={MinHeight.pageContent}
-    textAlign={'center'}
-    sx={{
-      backgroundColor: theme => theme.design.Layer.App.Background,
-    }}
-    data-testid="maintenance-page"
-  >
-    <Stack gap={Spacing.xxl} alignItems="center" maxWidth={MaxWidth.maintenanceContent}>
-      <Stack component="header" alignItems="center" gap={Spacing.xs}>
-        <Typography component="h1" variant="headingSBold">
-          {t`Curve.finance`}
-        </Typography>
-        <Typography variant="bodySRegular" color="textTertiary">
-          {t`swap · earn · deploy`}
-        </Typography>
-      </Stack>
+  <ThemeProvider theme="light">
+    <Stack
+      component="main"
+      alignItems="center"
+      justifyContent="center"
+      padding={Spacing.md}
+      minHeight={MinHeight.pageContent}
+      textAlign={'center'}
+      sx={{
+        backgroundColor: theme => theme.design.Layer.App.Background,
+        colorScheme: 'light',
+      }}
+      data-testid="maintenance-page"
+    >
+      <Stack gap={Spacing.xxl} alignItems="center" maxWidth={MaxWidth.maintenanceContent}>
+        <Stack component="header" alignItems="center" gap={Spacing.xs}>
+          <Typography component="h1" variant="headingSBold">
+            {t`Curve.finance`}
+          </Typography>
+          <Typography variant="bodySRegular" color="textTertiary">
+            {t`swap · earn · deploy`}
+          </Typography>
+        </Stack>
 
-      <Image
-        alt={t`Curve Logo`}
-        src={CURVE_LOGO_URL}
-        width="50%" //image to big vertically on 14" screens
-      />
+        <Image
+          alt={t`Curve Logo`}
+          src={CURVE_LOGO_URL}
+          width="50%" //image to big vertically on 14" screens
+        />
 
-      <Stack
-        alignItems="center"
-        gap={Spacing.sm.desktop} // gap is fixed at 10px on Figma
-      >
-        <Badge label={t`Upgrade in progress`} color="highlight" size="extraLarge" />
+        <Stack
+          alignItems="center"
+          gap={Spacing.sm.desktop} // gap is fixed at 10px on Figma
+        >
+          <Badge label={t`Upgrade in progress`} color="highlight" size="extraLarge" />
 
-        <Typography>
-          {t`Curve is currently undergoing scheduled maintenance. We're upgrading our infrastructure to make your experience faster.`}
-        </Typography>
+          <Typography>
+            {t`Curve is currently undergoing scheduled maintenance. We're upgrading our infrastructure to make your experience faster.`}
+          </Typography>
 
-        <Typography variant="bodySRegular" color="textSecondary">
-          {t`Contracts are running as expected, immutable and always available onchain.`}
-          <br />
-          {t`We'll be back online shortly.`}
-        </Typography>
+          <Typography variant="bodySRegular" color="textSecondary">
+            {t`Contracts are running as expected, immutable and always available onchain.`}
+            <br />
+            {t`We'll be back online shortly.`}
+          </Typography>
 
-        <Button href={CURVE_SOCIALS.twitter} target="_blank" rel="noreferrer" variant="contained" startIcon={<XIcon />}>
-          {t`Get updates`}
-        </Button>
+          <Button href={CURVE_SOCIALS.twitter} target="_blank" rel="noreferrer" variant="contained" startIcon={<XIcon />}>
+            {t`Get updates`}
+          </Button>
+        </Stack>
       </Stack>
     </Stack>
-  </Stack>
+  </ThemeProvider>
 )

--- a/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
+++ b/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
@@ -6,7 +6,6 @@ import { CURVE_LOGO_URL, CURVE_SOCIALS } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { XIcon } from '@ui-kit/shared/icons/XIcon'
 import { Badge } from '@ui-kit/shared/ui/Badge'
-import { ThemeProvider } from '@ui-kit/shared/ui/ThemeProvider'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { MinHeight, Spacing, MaxWidth } = SizesAndSpaces
@@ -14,63 +13,54 @@ const { MinHeight, Spacing, MaxWidth } = SizesAndSpaces
 const Image = styled('img')({})
 
 export const MaintenancePage = () => (
-  <ThemeProvider theme="light">
-    <Stack
-      component="main"
-      alignItems="center"
-      justifyContent="center"
-      padding={Spacing.md}
-      minHeight={MinHeight.pageContent}
-      textAlign={'center'}
-      sx={{
-        backgroundColor: theme => theme.design.Layer.App.Background,
-        colorScheme: 'light',
-      }}
-      data-testid="maintenance-page"
-    >
-      <Stack gap={Spacing.xxl} alignItems="center" maxWidth={MaxWidth.maintenanceContent}>
-        <Stack component="header" alignItems="center" gap={Spacing.xs}>
-          <Typography component="h1" variant="headingSBold">
-            {t`Curve.finance`}
-          </Typography>
-          <Typography variant="bodySRegular" color="textTertiary">
-            {t`swap · earn · deploy`}
-          </Typography>
-        </Stack>
+  <Stack
+    component="main"
+    alignItems="center"
+    justifyContent="center"
+    padding={Spacing.md}
+    minHeight={MinHeight.maintenancePage}
+    textAlign={'center'}
+    sx={{
+      backgroundColor: theme => theme.design.Layer.App.Background,
+    }}
+    data-testid="maintenance-page"
+  >
+    <Stack gap={Spacing.xxl} alignItems="center" maxWidth={MaxWidth.maintenanceContent}>
+      <Stack component="header" alignItems="center" gap={Spacing.xs}>
+        <Typography component="h1" variant="headingSBold">
+          {t`Curve.finance`}
+        </Typography>
+        <Typography variant="bodySRegular" color="textTertiary">
+          {t`swap · earn · deploy`}
+        </Typography>
+      </Stack>
 
-        <Image
-          alt={t`Curve Logo`}
-          src={CURVE_LOGO_URL}
-          width="50%" //image to big vertically on 14" screens
-        />
+      <Image
+        alt={t`Curve Logo`}
+        src={CURVE_LOGO_URL}
+        width="50%" //image to big vertically on 14" screens
+      />
 
-        <Stack
-          alignItems="center"
-          gap={Spacing.sm.desktop} // gap is fixed at 10px on Figma
-        >
-          <Badge label={t`Upgrade in progress`} color="highlight" size="extraLarge" />
+      <Stack
+        alignItems="center"
+        gap={Spacing.sm.desktop} // gap is fixed at 10px on Figma
+      >
+        <Badge label={t`Upgrade in progress`} color="highlight" size="extraLarge" />
 
-          <Typography>
-            {t`Curve is currently undergoing scheduled maintenance. We're upgrading our infrastructure to make your experience faster.`}
-          </Typography>
+        <Typography>
+          {t`Curve is currently undergoing scheduled maintenance. We're upgrading our infrastructure to make your experience faster.`}
+        </Typography>
 
-          <Typography variant="bodySRegular" color="textSecondary">
-            {t`Contracts are running as expected, immutable and always available onchain.`}
-            <br />
-            {t`We'll be back online shortly.`}
-          </Typography>
+        <Typography variant="bodySRegular" color="textSecondary">
+          {t`Contracts are running as expected, immutable and always available onchain.`}
+          <br />
+          {t`We'll be back online shortly.`}
+        </Typography>
 
-          <Button
-            href={CURVE_SOCIALS.twitter}
-            target="_blank"
-            rel="noreferrer"
-            variant="contained"
-            startIcon={<XIcon />}
-          >
-            {t`Get updates`}
-          </Button>
-        </Stack>
+        <Button href={CURVE_SOCIALS.twitter} target="_blank" rel="noreferrer" variant="contained" startIcon={<XIcon />}>
+          {t`Get updates`}
+        </Button>
       </Stack>
     </Stack>
-  </ThemeProvider>
+  </Stack>
 )

--- a/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
+++ b/packages/curve-ui-kit/src/features/maintenance/components/MaintenancePage.tsx
@@ -60,7 +60,13 @@ export const MaintenancePage = () => (
             {t`We'll be back online shortly.`}
           </Typography>
 
-          <Button href={CURVE_SOCIALS.twitter} target="_blank" rel="noreferrer" variant="contained" startIcon={<XIcon />}>
+          <Button
+            href={CURVE_SOCIALS.twitter}
+            target="_blank"
+            rel="noreferrer"
+            variant="contained"
+            startIcon={<XIcon />}
+          >
             {t`Get updates`}
           </Button>
         </Stack>

--- a/packages/curve-ui-kit/src/hooks/useBodyThemeClass.ts
+++ b/packages/curve-ui-kit/src/hooks/useBodyThemeClass.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { notFalsy } from '@primitives/objects.utils'
+import { useLayoutStore } from '@ui-kit/features/layout'
+import { useUserProfileStore } from '@ui-kit/features/user-profile'
+
+export const useBodyThemeClass = () => {
+  const { document } = typeof window === 'undefined' ? {} : window
+  const theme = useUserProfileStore(state => state.theme)
+  const pageWidth = useLayoutStore(state => state.pageWidth)
+
+  useEffect(() => {
+    if (!document) return
+    document.body.className = notFalsy(`theme-${theme}`, pageWidth).join(' ')
+    document.body.setAttribute('data-theme', theme)
+  }, [document, pageWidth, theme])
+}

--- a/packages/curve-ui-kit/src/hooks/useLayoutStoreResponsive.ts
+++ b/packages/curve-ui-kit/src/hooks/useLayoutStoreResponsive.ts
@@ -1,23 +1,14 @@
 import { useCallback, useEffect } from 'react'
 import { getPageWidthClassName, useLayoutStore } from '@ui-kit/features/layout'
-import { useUserProfileStore } from '@ui-kit/features/user-profile'
 
 export const useLayoutStoreResponsive = () => {
   const { document } = typeof window === 'undefined' ? {} : window
-  const theme = useUserProfileStore(state => state.theme)
-  const pageWidth = useLayoutStore(state => state.pageWidth)
   const setLayoutWidth = useLayoutStore(state => state.setLayoutWidth)
   const setPageVisible = useLayoutStore(state => state.setPageVisible)
 
   const handleResizeListener = useCallback(() => {
     if (window?.innerWidth) setLayoutWidth(getPageWidthClassName(window.innerWidth))
   }, [setLayoutWidth])
-
-  useEffect(() => {
-    if (!pageWidth || !document) return
-    document.body.className = `theme-${theme} ${pageWidth}`.replace(/ +(?= )/g, '').trim()
-    document.body.setAttribute('data-theme', theme)
-  }, [document, pageWidth, theme])
 
   useEffect(() => {
     if (!window || !document) return
@@ -27,11 +18,11 @@ export const useLayoutStoreResponsive = () => {
     handleVisibilityChange()
 
     document.addEventListener('visibilitychange', handleVisibilityChange)
-    window.addEventListener('resize', () => handleResizeListener())
+    window.addEventListener('resize', handleResizeListener)
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      window.removeEventListener('resize', () => handleResizeListener())
+      window.removeEventListener('resize', handleResizeListener)
     }
   }, [document, handleResizeListener, setPageVisible])
 }

--- a/packages/curve-ui-kit/src/themes/design/1_sizes_spaces.ts
+++ b/packages/curve-ui-kit/src/themes/design/1_sizes_spaces.ts
@@ -172,6 +172,7 @@ export const SizesAndSpaces = {
     tableNoResults: { sm: '15vh', lg: '35vh' },
     pageContent: '80vh',
     popoverHeader: '2rem', // 32px
+    maintenancePage: '100vh',
   },
   MaxHeight: {
     popover: '17rem', // 272px


### PR DESCRIPTION
The maintenance page highlighted two bugs: the theme class was not applied outside the `NetworkAwareLayout`, so some text was not visible with the dark theme, and the page didn’t take the full height.

- Extracted `useBodyThemeClass` outside of the `NetworkAwareLayout`
- Fixed the maintenance page `minHeight` to `100vh`

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="1353" height="1001" alt="Screenshot 2026-05-25 at 09 26 19" src="https://github.com/user-attachments/assets/0a94e6a5-e113-4c6e-b310-79f3586345c7" />
</td>
    <td>
<img width="1166" height="821" alt="Screenshot 2026-05-25 at 10 41 41" src="https://github.com/user-attachments/assets/127cb1ef-dedb-4486-bc9c-15fd527f5686" />
</td>
  </tr>
</table>