### PR TITLE
fix: show health for repay with too much debt

### DIFF
--- a/apps/main/src/llamalend/queries/repay/repay-health.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-health.query.ts
@@ -69,6 +69,6 @@ export const { getQueryOptions: getRepayHealthOptions, invalidate: invalidateRep
     }
   },
   category: 'llamalend.repay',
-  validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: true }),
+  validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false }),
   dependencies: params => [repayExpectedBorrowedQueryKey(params)],
 })


### PR DESCRIPTION
- allow health calculation when the user tries to repay more than they have available in the wallet