### PR TITLE
styling: fix numeric text field border and chip colors to match figma

### DIFF
--- a/packages/curve-ui-kit/src/themes/components/mui-input-base.ts
+++ b/packages/curve-ui-kit/src/themes/components/mui-input-base.ts
@@ -22,6 +22,7 @@ export const defineMuiInputBase = (
         '& svg': { color: 'rgb(232, 240, 254)' },
       },
       '& .MuiOutlinedInput-notchedOutline': {
+        borderColor: Base.Default.Border.Default,
         borderWidth: 1,
         transition: `border-color ${TransitionFunction}`,
       },

--- a/packages/curve-ui-kit/src/themes/design/2_theme.ts
+++ b/packages/curve-ui-kit/src/themes/design/2_theme.ts
@@ -275,11 +275,44 @@ export const createLightDesign = (
     Transition: 'Transition',
   } as const
 
+  const Inputs = {
+    Base: {
+      Default: {
+        Fill: {
+          Default: Grays[100],
+          Active: Grays[50],
+        },
+        Border: {
+          Default: Grays[200],
+          Active: Light.Text.Highlight,
+          Filled: Grays[850],
+          Error: Reds[500],
+        },
+      },
+      Nested: {
+        Nested: Grays[10],
+        Fill: Grays[100],
+        Border: {
+          Default: Grays[400],
+          Active: Light.Text.Highlight,
+          Filled: Grays[850],
+          Error: Reds[500],
+        },
+      },
+    },
+    Large: {
+      Default: {
+        Fill: Grays[100],
+        Outline: Grays[200],
+      },
+    },
+  } as const
+
   const Chips = {
     Default: {
       Label: Text.TextColors.Primary,
-      Fill: Layer[1].Fill,
-      Stroke: Text.TextColors.Primary,
+      Fill: Layer[2].Fill,
+      Stroke: Inputs.Base.Default.Border.Default,
     },
     Hover: {
       Label: Color.Neutral[50],
@@ -396,39 +429,6 @@ export const createLightDesign = (
       Hover: {
         Primary: Light.Text.Primary,
         Secondary: Light.Text.Secondary,
-      },
-    },
-  } as const
-
-  const Inputs = {
-    Base: {
-      Default: {
-        Fill: {
-          Default: Grays[100],
-          Active: Grays[50],
-        },
-        Border: {
-          Default: Grays[200],
-          Active: Light.Text.Highlight,
-          Filled: Grays[850],
-          Error: Reds[500],
-        },
-      },
-      Nested: {
-        Nested: Grays[10],
-        Fill: Grays[100],
-        Border: {
-          Default: Grays[400],
-          Active: Light.Text.Highlight,
-          Filled: Grays[850],
-          Error: Reds[500],
-        },
-      },
-    },
-    Large: {
-      Default: {
-        Fill: Grays[100],
-        Outline: Grays[200],
       },
     },
   } as const
@@ -781,11 +781,44 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
     Transition: 'Transition',
   } as const
 
+  const Inputs = {
+    Base: {
+      Default: {
+        Fill: {
+          Default: Grays[900],
+          Active: Grays[900],
+        },
+        Border: {
+          Default: Grays[800],
+          Active: Dark.Text.Highlight,
+          Filled: Grays[75],
+          Error: Reds[500],
+        },
+      },
+      Nested: {
+        Nested: Grays[850],
+        Fill: Grays[850],
+        Border: {
+          Default: Grays[600],
+          Active: Dark.Text.Highlight,
+          Filled: Grays[75],
+          Error: Reds[500],
+        },
+      },
+    },
+    Large: {
+      Default: {
+        Fill: Grays[900],
+        Outline: Grays[800],
+      },
+    },
+  } as const
+
   const Chips = {
     Default: {
       Label: Text.TextColors.Primary,
-      Fill: Layer[1].Fill,
-      Stroke: Text.TextColors.Primary,
+      Fill: Layer[2].Fill,
+      Stroke: Inputs.Base.Default.Border.Default,
     },
     Hover: {
       Label: Color.Neutral[50],
@@ -793,7 +826,7 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
     },
     Current: {
       Label: Color.Primary[500],
-      Fill: Color.Neutral[75],
+      Fill: Layer[2].Fill,
       Outline: Layer.Highlight.Outline,
     },
     BorderRadius: {
@@ -902,39 +935,6 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
       Hover: {
         Primary: Dark.Text.Primary,
         Secondary: Dark.Text.Secondary,
-      },
-    },
-  } as const
-
-  const Inputs = {
-    Base: {
-      Default: {
-        Fill: {
-          Default: Grays[900],
-          Active: Grays[900],
-        },
-        Border: {
-          Default: Grays[800],
-          Active: Dark.Text.Highlight,
-          Filled: Grays[75],
-          Error: Reds[500],
-        },
-      },
-      Nested: {
-        Nested: Grays[850],
-        Fill: Grays[850],
-        Border: {
-          Default: Grays[600],
-          Active: Dark.Text.Highlight,
-          Filled: Grays[75],
-          Error: Reds[500],
-        },
-      },
-    },
-    Large: {
-      Default: {
-        Fill: Grays[900],
-        Outline: Grays[800],
       },
     },
   } as const
@@ -1248,11 +1248,44 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
     Transition: 'Transition',
   } as const
 
+  const Inputs = {
+    Base: {
+      Default: {
+        Fill: {
+          Default: Grays[100],
+          Active: Grays[100],
+        },
+        Border: {
+          Default: Grays[400],
+          Active: Violets[400],
+          Filled: Violets[600],
+          Error: Reds[500],
+        },
+      },
+      Nested: {
+        Nested: Grays[50],
+        Fill: Violets[50],
+        Border: {
+          Default: Grays[200],
+          Active: Violets[400],
+          Filled: Violets[400],
+          Error: Reds[500],
+        },
+      },
+    },
+    Large: {
+      Default: {
+        Fill: Grays[100],
+        Outline: Grays[400],
+      },
+    },
+  } as const
+
   const Chips = {
     Default: {
       Label: Grays[950],
       Fill: Layer[1].Fill,
-      Stroke: Grays[950],
+      Stroke: Inputs.Base.Default.Border.Default,
     },
     Hover: {
       Label: Color.Neutral[50],
@@ -1369,39 +1402,6 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
       Hover: {
         Primary: Chad.Text.Primary,
         Secondary: Chad.Text.Secondary,
-      },
-    },
-  } as const
-
-  const Inputs = {
-    Base: {
-      Default: {
-        Fill: {
-          Default: Grays[100],
-          Active: Grays[100],
-        },
-        Border: {
-          Default: Grays[400],
-          Active: Violets[400],
-          Filled: Violets[600],
-          Error: Reds[500],
-        },
-      },
-      Nested: {
-        Nested: Grays[50],
-        Fill: Violets[50],
-        Border: {
-          Default: Grays[200],
-          Active: Violets[400],
-          Filled: Violets[400],
-          Error: Reds[500],
-        },
-      },
-    },
-    Large: {
-      Default: {
-        Fill: Grays[100],
-        Outline: Grays[400],
       },
     },
   } as const


### PR DESCRIPTION
<img width="263" height="118" alt="image" src="https://github.com/user-attachments/assets/f1f48c7c-9626-4bfe-8935-3a14a7f0b5ae" />
<img width="468" height="657" alt="image" src="https://github.com/user-attachments/assets/01311b9c-c3b0-4289-b1d8-621ef985a895" />

<img width="286" height="120" alt="image" src="https://github.com/user-attachments/assets/baea6f70-1515-48dd-b4f7-4908fe5cc962" />
<img width="475" height="662" alt="image" src="https://github.com/user-attachments/assets/06ba11e3-e575-4f2a-872f-9f9ef0fa92d5" />
