### PR TITLE
styling: make refuel page more mobile friendly

### DIFF
--- a/apps/main/src/dex/components/PageRefuel/index.tsx
+++ b/apps/main/src/dex/components/PageRefuel/index.tsx
@@ -72,19 +72,19 @@ export const Refuel = () => {
             <BorrowInformationContainer blockchainId={blockchainId} poolAddress={poolAddress} />
           </Grid>
 
-          <Grid size={{ mobile: 12, tablet: 6 }}>
+          <Grid size={{ mobile: 12, desktop: 6 }}>
             <RefuelPricesChart blockchainId={blockchainId} poolAddress={poolAddress} />
           </Grid>
 
-          <Grid size={{ mobile: 12, tablet: 6 }}>
+          <Grid size={{ mobile: 12, desktop: 6 }}>
             <RefuelSharesChart chainId={chainId} blockchainId={blockchainId} poolAddress={poolAddress} />
           </Grid>
 
-          <Grid size={{ mobile: 12, tablet: 6 }}>
+          <Grid size={{ mobile: 12, desktop: 6 }}>
             <ReservesCompositionChart blockchainId={blockchainId} poolAddress={poolAddress} />
           </Grid>
 
-          <Grid size={{ mobile: 12, tablet: 6 }}>
+          <Grid size={{ mobile: 12, desktop: 6 }}>
             <DailyRefuelsChart blockchainId={blockchainId} poolAddress={poolAddress} />
           </Grid>
 

--- a/apps/main/src/dex/features/refuel/components/BorrowInformationContainer.tsx
+++ b/apps/main/src/dex/features/refuel/components/BorrowInformationContainer.tsx
@@ -4,12 +4,15 @@ import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
 import Grid from '@mui/material/Grid'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { useRefuelPool } from '../queries/pools.query'
 
 const { Spacing } = SizesAndSpaces
+
+const METRIC_SIZE = { mobile: 3, desktop: 2 }
 
 export const BorrowInformationContainer = ({
   blockchainId,
@@ -19,16 +22,17 @@ export const BorrowInformationContainer = ({
   poolAddress: Address
 }) => {
   const { data: pool, isLoading: isPoolLoading, error: poolError } = useRefuelPool({ blockchainId, poolAddress })
+  const isMobile = useIsMobile()
 
   return (
     <Card size="small" data-testid="refuel-pool-information">
       <CardHeader title={t`Pool Information`} />
       <CardContent>
         <Grid container columnSpacing={Spacing.md}>
-          {/** Sizes might sum up to something else than 12 just for sizing and spacing consistency with other cards */}
-          <Grid size={2}>
+          <Grid size={METRIC_SIZE}>
             <Metric
               label={t`TVL`}
+              size={isMobile ? 'small' : 'medium'}
               value={pool?.tvlUsd}
               valueOptions={{ unit: 'dollar', abbreviate: true }}
               loading={isPoolLoading}
@@ -37,9 +41,10 @@ export const BorrowInformationContainer = ({
             />
           </Grid>
 
-          <Grid size={2}>
+          <Grid size={METRIC_SIZE}>
             <Metric
               label={t`Volume`}
+              size={isMobile ? 'small' : 'medium'}
               value={pool?.tradingVolume24h}
               valueOptions={{ unit: 'dollar', abbreviate: true }}
               loading={isPoolLoading}
@@ -48,9 +53,10 @@ export const BorrowInformationContainer = ({
             />
           </Grid>
 
-          <Grid size={2}>
+          <Grid size={METRIC_SIZE}>
             <Metric
               label={t`24h fees`}
+              size={isMobile ? 'small' : 'medium'}
               value={pool?.tradingFee24h}
               valueOptions={{ unit: 'dollar', abbreviate: true }}
               loading={isPoolLoading}
@@ -59,9 +65,10 @@ export const BorrowInformationContainer = ({
             />
           </Grid>
 
-          <Grid size={2}>
+          <Grid size={METRIC_SIZE}>
             <Metric
               label={t`1W APR`}
+              size={isMobile ? 'small' : 'medium'}
               value={pool?.baseWeeklyApr}
               valueOptions={{ unit: 'percentage', abbreviate: true }}
               loading={isPoolLoading}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
@@ -32,7 +32,7 @@ export const TimestampCell = ({ timestamp, txUrl, align = 'start' }: TimestampCe
       sx={{ gap: Spacing.xxs }}
     >
       <Typography variant="tableCellMBold" sx={{ textAlign: align }}>
-        {formatDate(timestamp, 'short')}
+        {formatDate(timestamp, 'short', { omitYear: isMobile })}
       </Typography>
       <Stack
         direction="row"

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/inline-cells/TimestampCell.tsx
@@ -43,7 +43,7 @@ export const TimestampCell = ({ timestamp, txUrl, align = 'start' }: TimestampCe
         }}
       >
         <Typography variant="tableCellSRegular" className={TableSecondaryTextClass}>
-          {formatTime(timestamp)}
+          {formatTime(timestamp, { precise: !isMobile })}
         </Typography>
         {clickable && <ArrowOutwardIcon className={TableSecondaryTextClass} sx={{ fontSize: 20 }} />}
       </Stack>

--- a/packages/ui/src/utils/utilsDate.ts
+++ b/packages/ui/src/utils/utilsDate.ts
@@ -26,7 +26,11 @@ const convertDate = (input: Date | number | string): Date => {
  *
  * @returns A formatted date string adjusted for the local timezone.
  */
-export const formatDate = (date: Date | string | number, variant: 'short' | 'long' = 'short') =>
+export const formatDate = (
+  date: Date | string | number,
+  variant: 'short' | 'long' = 'short',
+  { omitYear = false } = {},
+) =>
   new Intl.DateTimeFormat(
     undefined,
     variant === 'short'
@@ -34,13 +38,13 @@ export const formatDate = (date: Date | string | number, variant: 'short' | 'lon
           // short - example: 31/01/25 adjusted for local timezone
           day: '2-digit',
           month: 'short',
-          year: 'numeric',
+          year: omitYear ? undefined : 'numeric',
         }
       : {
           // long - example: 31 January, 2026, 12:00 AM adjusted for local timezone
           month: 'short',
           day: 'numeric',
-          year: 'numeric',
+          year: omitYear ? undefined : 'numeric',
           hour: 'numeric',
           minute: '2-digit',
           hour12: true,


### PR DESCRIPTION
* Pool information uses full width in tablet and mobile.
* Pool information metric size is small for mobile (wrapping was super ugly, a row of 3 and a row of 1 otherwise...)
* Charts are stacked vertically and not in 4x4 fashion in mobile.
* No seconds and year for timestamp cell in datatables.