### PR TITLE
chore: expand double-negative lint rule

### DIFF
--- a/.eslint/no-double-negative.rule.mjs
+++ b/.eslint/no-double-negative.rule.mjs
@@ -1,12 +1,19 @@
-/** Forbids negated ternary conditions like `!x ? a : b`, which should be `x ? b : a`. */
+/**
+ * Forbids negated conditions with two swappable branches like `!x ? a : b` and `if (!x) {} else {}`.
+ * @type {eslint.Rule.Module}
+ **/
 export const noDoubleNegativeRule = {
   meta: {
     type: 'suggestion',
-    docs: { description: 'Disallow negated conditions in ternary expressions' },
-    messages: { negated: 'Negated ternary conditions are hard to read. Swap the branches and remove the `!`.' },
+    docs: { description: 'Disallow negated conditions in ternary expressions and if statements' },
+    messages: { negated: 'Double-negatives are hard to read. Swap the branches and remove the `!`.' },
   },
-  create: context => ({
-    ConditionalExpression: ({ test }) =>
-      test.type === 'UnaryExpression' && test.operator === '!' && context.report({ node: test, messageId: 'negated' }),
-  }),
+  create: context => {
+    const reportNegatedCondition = ({ test }) =>
+      test.type === 'UnaryExpression' && test.operator === '!' && context.report({ node: test, messageId: 'negated' })
+    return {
+      ConditionalExpression: reportNegatedCondition,
+      IfStatement: node => node.alternate?.type !== 'IfStatement' && node.alternate && reportNegatedCondition(node),
+    }
+  },
 }

--- a/.eslint/no-double-negative.rule.mjs
+++ b/.eslint/no-double-negative.rule.mjs
@@ -1,5 +1,6 @@
 /**
  * Forbids negated conditions with two swappable branches like `!x ? a : b` and `if (!x) {} else {}`.
+ * It ignores statements without an `else` branch and ignores `else if` statements.
  * @type {eslint.Rule.Module}
  **/
 export const noDoubleNegativeRule = {
@@ -9,11 +10,11 @@ export const noDoubleNegativeRule = {
     messages: { negated: 'Double-negatives are hard to read. Swap the branches and remove the `!`.' },
   },
   create: context => {
-    const reportNegatedCondition = ({ test }) =>
-      test.type === 'UnaryExpression' && test.operator === '!' && context.report({ node: test, messageId: 'negated' })
+    const isNegated = ({ operator, type }) => type === 'UnaryExpression' && operator === '!'
+    const reportNegatedCondition = ({ test }) => isNegated(test) && context.report({ node: test, messageId: 'negated' })
     return {
       ConditionalExpression: reportNegatedCondition,
-      IfStatement: node => node.alternate?.type !== 'IfStatement' && node.alternate && reportNegatedCondition(node),
+      IfStatement: node => node.alternate && node.alternate.type !== 'IfStatement' && reportNegatedCondition(node),
     }
   },
 }

--- a/.eslint/no-redundant-ternary.rule.mjs
+++ b/.eslint/no-redundant-ternary.rule.mjs
@@ -1,7 +1,7 @@
 /**
  * Check if two AST nodes are structurally equivalent.
- * Returns true if both nodes represent the same source code structure.
- */
+ * @return true if both nodes represent the same source code structure.
+ **/
 const areNodesEqual = (node1, node2) => {
   if (!node1 || !node2) return node1 === node2
   if (node1.type !== node2.type) return false
@@ -56,26 +56,27 @@ const areNodesEqual = (node1, node2) => {
   }
 }
 
-/** Forbids redundant ternary patterns like `x ? x : y`, which should be `x || y`. */
+/**
+ * Forbids redundant ternary patterns like `x ? x : y`, which should be `x || y`.
+ * @type {eslint.Rule.Module}
+ */
 export const noRedundantTernaryRule = {
   meta: {
     type: 'suggestion',
     docs: { description: 'Disallow redundant ternary expressions that can be simplified to logical OR' },
     messages: { redundant: 'Prefer `{{test}} || {{alternate}}` instead of `{{test}} ? {{test}} : {{alternate}}`.' },
   },
-  create: context => {
-    return {
-      ConditionalExpression(node) {
-        const { test, consequent, alternate } = node
-        // Only report if test and consequent are identical
-        if (areNodesEqual(test, consequent)) {
-          context.report({
-            node,
-            messageId: 'redundant',
-            data: { test: context.sourceCode.getText(test), alternate: context.sourceCode.getText(alternate) },
-          })
-        }
-      },
-    }
-  },
+  create: context => ({
+    ConditionalExpression(node) {
+      const { test, consequent, alternate } = node
+      // Only report if test and consequent are identical
+      if (areNodesEqual(test, consequent)) {
+        context.report({
+          node,
+          messageId: 'redundant',
+          data: { test: context.sourceCode.getText(test), alternate: context.sourceCode.getText(alternate) },
+        })
+      }
+    },
+  }),
 }

--- a/apps/main/src/lend/hooks/useAbiGaugeTotalSupply.ts
+++ b/apps/main/src/lend/hooks/useAbiGaugeTotalSupply.ts
@@ -18,18 +18,14 @@ export const useAbiGaugeTotalSupply = (
     async (jsonModuleName: string, contractAddress: string, provider: Provider | JsonRpcProvider) => {
       try {
         const abi = await import(`@/lend/abis/${jsonModuleName}.json`).then(module => module.default.abi)
-
-        if (!abi) {
-          console.error('cannot find abi')
-          return null
-        } else {
-          const iface = new Interface(abi)
-          return new Contract(contractAddress, iface.format(), provider)
+        if (abi) {
+          return new Contract(contractAddress, new Interface(abi).format(), provider)
         }
+        console.error('cannot find abi')
       } catch (error) {
         console.error(error)
-        return null
       }
+      return null
     },
     [],
   )


### PR DESCRIPTION
- depends on #2588
- expands #2586 to catch `if` statements