### PR TITLE
fix: maybe helper distinguish between tuples and arrays

### DIFF
--- a/apps/main/src/dao/components/PageProposal/index.tsx
+++ b/apps/main/src/dao/components/PageProposal/index.tsx
@@ -10,7 +10,7 @@ import { useProposalsMapperQuery } from '@/dao/entities/proposals-mapper'
 import type { ProposalUrlParams } from '@/dao/types/dao.types'
 import { getEthPath } from '@/dao/utils'
 import type { ProposalType } from '@curvefi/prices-api/proposal'
-import { maybe } from '@primitives/objects.utils'
+import { maybes } from '@primitives/objects.utils'
 import { Box } from '@ui/Box'
 import { Icon } from '@ui/Icon'
 import { IconButton } from '@ui/IconButton'
@@ -78,7 +78,7 @@ export const Proposal = () => {
 
   const snapshotVeCrv = useMemo(
     () =>
-      maybe([proposal, votingPower], ([proposal, votingPower]) => ({
+      maybes([proposal, votingPower], ([proposal, votingPower]) => ({
         value: votingPower,
         blockNumber: proposal.block,
       })),

--- a/apps/main/src/llamalend/features/market-advanced-information/hooks/useAdvancedDetailsData.ts
+++ b/apps/main/src/llamalend/features/market-advanced-information/hooks/useAdvancedDetailsData.ts
@@ -9,7 +9,7 @@ import {
   useMarketUsers,
 } from '@/llamalend/queries/market'
 import type { Endpoint } from '@curvefi/prices-api/lending'
-import { maybe } from '@primitives/objects.utils'
+import { maybe, maybes } from '@primitives/objects.utils'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import type { MarketParams } from '@ui-kit/lib/model/query/root-keys'
 import { LlamaMarketType } from '@ui-kit/types/market'
@@ -68,7 +68,7 @@ export const useAdvancedDetailsData = ({
   const collateralUsdValue = collateralTotal && collateralUsdRate && collateralTotal * collateralUsdRate
   const borrowedUsdValue = borrowedTotal && borrowedUsdRate && borrowedTotal * borrowedUsdRate
   const combinedCollateralUsdValue =
-    maybe(
+    maybes(
       [collateralUsdValue, borrowedUsdValue],
       ([collateralUsdValue, borrowedUsdValue]) => collateralUsdValue + borrowedUsdValue,
     ) ?? null

--- a/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
@@ -4,7 +4,7 @@ import type { SupplyRate } from '@/llamalend/rates.types'
 import { BoostTooltipContent } from '@/llamalend/widgets/tooltips/BoostTooltipContent'
 import { MarketSupplyRateTooltipContent } from '@/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent'
 import { Grid, Stack } from '@mui/material'
-import { maybe } from '@primitives/objects.utils'
+import { maybes } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { TabsSwitcher } from '@ui-kit/shared/ui/Tabs/TabsSwitcher'
@@ -136,7 +136,7 @@ export const SupplyPositionDetails = ({ userSupplyRate, shares, supplyAsset, boo
             value={sharesValue}
             loading={sharesLoading}
             valueOptions={{}}
-            notional={maybe([sharesStaked, sharesValue], ([sharesStaked, sharesValue]) => ({
+            notional={maybes([sharesStaked, sharesValue], ([sharesStaked, sharesValue]) => ({
               value: (sharesStaked / sharesValue) * 100,
               unit: { symbol: t`% staked`, position: 'suffix' },
             }))}

--- a/apps/main/src/llamalend/hooks/useHealthQueries.ts
+++ b/apps/main/src/llamalend/hooks/useHealthQueries.ts
@@ -1,5 +1,5 @@
 import type { Decimal } from '@primitives/decimal.utils'
-import { maybe } from '@primitives/objects.utils'
+import { maybes } from '@primitives/objects.utils'
 import { useQueries } from '@tanstack/react-query'
 import type { UseQueryOptions } from '@tanstack/react-query'
 import { combineQueriesMeta } from '@ui-kit/lib/queries/combine'
@@ -37,7 +37,7 @@ type HealthQueryResults = QueryResultsArray<readonly HealthQueryOptions[]>
  *   When healthNotFull is below 0, the user is in soft-liq and we should return the corresponding metric.
  */
 const combineHealth = ([healthFull, healthNotFull]: HealthQueryResults) => ({
-  data: maybe([healthFull.data, healthNotFull.data], ([full, notFull]) => (+notFull < 0 ? notFull : full)),
+  data: maybes([healthFull.data, healthNotFull.data], ([full, notFull]) => (+notFull < 0 ? notFull : full)),
   ...combineQueriesMeta([healthFull, healthNotFull]),
 })
 

--- a/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
+++ b/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 import { isAddressEqual } from 'viem'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
-import { maybe } from '@primitives/objects.utils'
+import { maybes } from '@primitives/objects.utils'
 import type { QueriesResults } from '@tanstack/react-query'
 import { useQueries } from '@tanstack/react-query'
 import { RESOLVED_QUERY_RESULT } from '@ui-kit/lib/queries'
@@ -63,7 +63,7 @@ export const useSolvencyMarket = (
 
         return {
           ...combineQueriesMeta(results),
-          data: maybe([solvencyPercent, badDebtUsd], ([solvencyPercent, badDebtUsd]) => ({
+          data: maybes([solvencyPercent, badDebtUsd], ([solvencyPercent, badDebtUsd]) => ({
             solvencyPercent,
             badDebtUsd,
           })),

--- a/apps/main/src/llamalend/rates.utils.ts
+++ b/apps/main/src/llamalend/rates.utils.ts
@@ -1,5 +1,5 @@
 import { sumBy } from 'lodash'
-import { notFalsy, maybe } from '@primitives/objects.utils'
+import { notFalsy, maybe, maybes } from '@primitives/objects.utils'
 import type { CrvUsdSnapshot } from '@ui-kit/entities/crvusd-snapshots'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import type { ExtraIncentive } from '@ui-kit/types/market'
@@ -149,7 +149,7 @@ export const getSupplyApyMetrics = ({
 
   const crvMinBoostApy = aprToApy(crvMinBoostApr)
   const crvMaxBoostApy = aprToApy(crvMaxBoostApr)
-  const userBoostApy = maybe([crvMinBoostApr, userSupplyBoost], ([apr, boost]) => aprToApy(apr * boost)) ?? null
+  const userBoostApy = maybes([crvMinBoostApr, userSupplyBoost], ([apr, boost]) => aprToApy(apr * boost)) ?? null
 
   const totalWithoutBoost = sumRates(supplyApy, rebasingYieldApy, extraIncentivesApy)
 
@@ -162,7 +162,7 @@ export const getSupplyApyMetrics = ({
     extraIncentivesTotalApy: extraIncentivesApy,
     totalMinBoost: sumRates(totalWithoutBoost, crvMinBoostApy),
     totalMaxBoost: sumRates(totalWithoutBoost, crvMaxBoostApy),
-    totalUserBoost: maybe([totalWithoutBoost, userBoostApy], ([total, boost]) => sumRates(total, boost)) ?? null,
+    totalUserBoost: maybes([totalWithoutBoost, userBoostApy], ([total, boost]) => sumRates(total, boost)) ?? null,
   }
 }
 

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -11,7 +11,7 @@ import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
-import { notFalsy, maybe } from '@primitives/objects.utils'
+import { notFalsy, maybe, maybes } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import {
@@ -94,7 +94,7 @@ export const MarketRateCurveChart = ({
     return +borrowed < 0 ? decimal(0)! : borrowed
   }, [capAndAvailable])
   const totalBorrowedUsdValue =
-    maybe(
+    maybes(
       [totalBorrowed, borrowedUsdRate],
       ([totalBorrowed, borrowedUsdRate]) => Number(totalBorrowed) * borrowedUsdRate,
     ) ?? null
@@ -108,10 +108,10 @@ export const MarketRateCurveChart = ({
 
   const collateralTotal = maybe(totalCollateral, totalCollateral => Number(totalCollateral.collateral)) ?? null
   const borrowedCollateralTotal = maybe(totalCollateral, totalCollateral => Number(totalCollateral.borrowed)) ?? null
-  const collateralUsdValue = maybe([collateralTotal, collateralUsdRate], ([total, usdRate]) => total * usdRate) ?? null
+  const collateralUsdValue = maybes([collateralTotal, collateralUsdRate], ([total, usdRate]) => total * usdRate) ?? null
   const borrowedCollateralUsdValue =
-    maybe([borrowedCollateralTotal, borrowedUsdRate], ([total, usdRate]) => total * usdRate) ?? null
-  const combinedCollateralUsdValue = maybe([collateralUsdValue, borrowedCollateralUsdValue], ([c, b]) => c + b) ?? null
+    maybes([borrowedCollateralTotal, borrowedUsdRate], ([total, usdRate]) => total * usdRate) ?? null
+  const combinedCollateralUsdValue = maybes([collateralUsdValue, borrowedCollateralUsdValue], ([c, b]) => c + b) ?? null
   const isTotalCollateralMetricLoading =
     !market || isTotalCollateralLoading || isCollateralUsdRateLoading || isBorrowedUsdRateLoading
 

--- a/apps/main/src/llamalend/widgets/action-card/info-actions.helpers.ts
+++ b/apps/main/src/llamalend/widgets/action-card/info-actions.helpers.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
-import { notFalsy, maybe } from '@primitives/objects.utils'
+import { notFalsy, maybes } from '@primitives/objects.utils'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { QueryProp } from '@ui-kit/types/util'
@@ -35,4 +35,4 @@ export const combineActionInfoState = (...queries: (QueryProp<unknown> | undefin
 export const isQueryValueDifferent = (
   value: QueryProp<Decimal | null> | undefined,
   comparedValue: Decimal | null | undefined,
-) => maybe([value?.data, comparedValue], ([data, comparedValue]) => !new BigNumber(data).isEqualTo(comparedValue))
+) => maybes([value?.data, comparedValue], ([data, comparedValue]) => !new BigNumber(data).isEqualTo(comparedValue))

--- a/packages/primitives/src/objects.utils.ts
+++ b/packages/primitives/src/objects.utils.ts
@@ -72,13 +72,10 @@ type NonNullishTuple<T extends readonly unknown[]> = {
   [K in keyof T]: NonNullable<T[K]>
 }
 
-export function maybe<const T extends readonly unknown[], R>(
+export const maybes = <const T extends readonly unknown[], R>(
   value: readonly [...T] | null | undefined,
   mapper: (value: NonNullishTuple<T>) => R,
-): R | undefined
-export function maybe<T, R>(value: T | null | undefined, mapper: (value: NonNullable<T>) => R): R | undefined
-export function maybe<T, R>(value: T | null | undefined, mapper: (value: T) => R): R | undefined {
-  if (value == null) return undefined
-  if (Array.isArray(value) && value.some(x => x == null)) return undefined
-  return mapper(value)
-}
+): R | undefined => (value == null || value.some(x => x == null) ? undefined : mapper(value as NonNullishTuple<T>))
+export const maybe = <T, R>(value: T | null | undefined, mapper: (value: T) => R): R | undefined =>
+  // eslint-disable-next-line local/use-maybe-pattern
+  value == null ? undefined : mapper(value)


### PR DESCRIPTION
- A [late comment](https://github.com/curvefi/curve-frontend/pull/2570#pullrequestreview-4378896195) from @0xPearce has made me realize that the new maybe helper cannot distinguish  between tuples and arrays at runtime.
- This PR splits the helpers into a tuple one and a general one