### PR TITLE
chore: fix refuel timeout not working

### DIFF
--- a/tests/cypress/e2e/dex/refuel.cy.ts
+++ b/tests/cypress/e2e/dex/refuel.cy.ts
@@ -35,7 +35,7 @@ describe('Refuel page', () => {
     getTestById('monthly-action-info-value').should('have.attr', 'data-value', '-')
 
     getTestById('pool-information').should('be.visible')
-    getTestById('pool-tvl-value', API_LOAD_TIMEOUT).invoke('attr', 'data-value').should('match', /\d/)
+    getTestById('pool-tvl-value').invoke(API_LOAD_TIMEOUT, 'attr', 'data-value').should('match', /\d/)
     getTestById('pool-volume-value').invoke('attr', 'data-value').should('match', /\d/)
     getTestById('pool-fees-value').invoke('attr', 'data-value').should('match', /\d/)
     getTestById('pool-apr-value').invoke('attr', 'data-value').should('match', /\d/)


### PR DESCRIPTION
The timeout wasn't working properly because the `get` alway renders instantly, it's the data invocation that needs to wait for the API response.