### PR TITLE
styling: use proper inline cards for llamalend advanced details

### DIFF
--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -108,7 +108,7 @@ export const PoolParameters = ({ poolData, rChainId }: PoolParametersProps) => {
   if (!poolMetadata || !snapshotData) return null
 
   return (
-    <Card size="inline">
+    <Card size="inline" sx={{ backgroundColor: t => t.design.Layer[1].Fill }}>
       <CardContent component={Grid} container columnSpacing={Spacing.md}>
         <Grid size={{ mobile: 12, desktop: 8 }} sx={cardContentSmallStyles}>
           <Stack sx={{ gap: Spacing.lg }}>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/index.tsx
@@ -48,7 +48,7 @@ export const PoolStats = ({ routerParams, poolAlert, poolData, poolDataCacheOrAp
   }, [curveApi, fetchPoolStats, poolData])
 
   return (
-    <Card size="inline">
+    <Card size="inline" sx={{ backgroundColor: t => t.design.Layer[1].Fill }}>
       <CardContent component={Grid} container columnSpacing={Spacing.md}>
         <Grid size={{ mobile: 12, desktop: 8 }} sx={cardContentSmallStyles}>
           <Stack sx={{ gap: Spacing.md }}>

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketContractsSection.tsx
@@ -5,6 +5,8 @@ import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { useMarketOracleAddress } from '@/llamalend/queries/market'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -101,9 +103,9 @@ export const MarketContractsSection = ({ chainId, market, network }: MarketContr
     : []
 
   return (
-    <Stack sx={{ gap: Spacing.md }}>
-      <Stack sx={{ gap: Spacing.sm }}>
-        <CardHeader title={t`Contracts`} size="inline" />
+    <Card size="inline">
+      <CardHeader title={t`Contracts`} />
+      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm, gap: Spacing.sm }}>
         <WithSkeleton loading={loading} variant="rectangular" height={'4lh'} width="100%">
           <Stack>
             {tokenItems.map(({ key, label, address }) => (
@@ -111,16 +113,16 @@ export const MarketContractsSection = ({ chainId, market, network }: MarketContr
             ))}
           </Stack>
         </WithSkeleton>
-      </Stack>
-      <Stack>
-        {infraItems.map(({ key, label, address, fallbackValue }) =>
-          fallbackValue ? (
-            <ActionInfo key={key} label={label} value={fallbackValue ?? t`No gauge`} />
-          ) : (
-            <AddressActionInfo key={key} network={network} title={label} address={address} />
-          ),
-        )}
-      </Stack>
-    </Stack>
+        <Stack>
+          {infraItems.map(({ key, label, address, fallbackValue }) =>
+            fallbackValue ? (
+              <ActionInfo key={key} label={label} value={fallbackValue ?? t`No gauge`} />
+            ) : (
+              <AddressActionInfo key={key} network={network} title={label} address={address} />
+            ),
+          )}
+        </Stack>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketParametersSection.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketParametersSection.tsx
@@ -1,5 +1,8 @@
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { CardHeader, Stack } from '@mui/material'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import CardHeader from '@mui/material/CardHeader'
+import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
@@ -14,29 +17,31 @@ type MarketParametersProps = {
   marketType: LlamaMarketType
 }
 
-export const MarketParametersSection = ({ chainId, marketId, marketType }: MarketParametersProps) => {
-  const enablePricePerShare = marketType === LlamaMarketType.Lend
+export const MarketParametersSection = ({ chainId, marketId, marketType }: MarketParametersProps) => (
+  <Stack>
+    <Card size="inline">
+      <CardHeader title={t`Parameters`} />
+      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm }}>
+        <MarketLoanParameters chainId={chainId} marketId={marketId} />
+      </CardContent>
+    </Card>
 
-  return (
-    <Stack>
-      <Stack sx={{ gap: Spacing.sm }}>
-        <CardHeader title={t`Parameters`} size="inline" />
-        <Stack>
-          <MarketLoanParameters chainId={chainId} marketId={marketId} />
-        </Stack>
-      </Stack>
-      <Stack sx={{ gap: Spacing.sm }}>
-        <CardHeader title={t`Prices`} size="inline" />
-        <Stack>
-          <MarketPricesRows chainId={chainId} marketId={marketId} enablePricePerShare={enablePricePerShare} />
-        </Stack>
-      </Stack>
-      <Stack sx={{ gap: Spacing.sm }}>
-        <CardHeader title={t`Market`} size="inline" />
-        <Stack>
-          <MarketIdRow marketId={marketId} />
-        </Stack>
-      </Stack>
-    </Stack>
-  )
-}
+    <Card size="inline">
+      <CardHeader title={t`Prices`} />
+      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm }}>
+        <MarketPricesRows
+          chainId={chainId}
+          marketId={marketId}
+          enablePricePerShare={marketType === LlamaMarketType.Lend}
+        />
+      </CardContent>
+    </Card>
+
+    <Card size="inline">
+      <CardHeader title={t`Market`} />
+      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm }}>
+        <MarketIdRow marketId={marketId} />
+      </CardContent>
+    </Card>
+  </Stack>
+)

--- a/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-content/mui-card-content.ts
@@ -1,6 +1,7 @@
 /// <reference types="./mui-card-content.d.ts" />
 import type { Components } from '@mui/material/styles'
 import { DesignSystem } from '@ui-kit/themes/design'
+import { Transparent } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { handleBreakpoints } from '../../basic-theme'
 
@@ -21,6 +22,9 @@ export const cardContentSmallStyles = {
 export const cardContentInlineStyles = {
   ...handleBreakpoints({ padding: 0 }),
   '&:last-child': handleBreakpoints({ paddingBlockEnd: 0 }),
+  '&.MuiCardContent-root': {
+    backgroundColor: Transparent,
+  },
 }
 
 export const defineMuiCardContent = (design: DesignSystem): Components['MuiCardContent'] => ({

--- a/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.ts
+++ b/packages/curve-ui-kit/src/themes/components/card-header/mui-card-header.ts
@@ -4,17 +4,18 @@ import { handleBreakpoints } from '@ui-kit/themes/basic-theme'
 import { DesignSystem } from '@ui-kit/themes/design'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
-const { Spacing, ButtonSize } = SizesAndSpaces
+const { Spacing, Sizing } = SizesAndSpaces
 
 export const cardHeaderSmallStyles = (typography: TypographyVariantsOptions) => ({
   '& .MuiCardHeader-title': typography.headingXsBold,
-  ...handleBreakpoints({ minHeight: ButtonSize.sm }),
+  ...handleBreakpoints({ minHeight: Sizing.lg }),
 })
 
 export const cardHeaderInlineStyles = (design: DesignSystem, typography: TypographyVariantsOptions) => ({
   ...cardHeaderSmallStyles(typography),
   borderBottom: `1px solid ${design.Layer[3].Outline}`,
   ...handleBreakpoints({
+    minHeight: Sizing.md,
     paddingInline: 0,
   }),
 })
@@ -28,7 +29,7 @@ export const defineMuiCardHeader = (
       padding: 0,
       ...handleBreakpoints({
         paddingBlockEnd: Spacing.xs,
-        minHeight: ButtonSize.lg,
+        minHeight: Sizing.xl,
         gap: Spacing.xs,
       }),
       '& .MuiCardHeader-title': { color: design.Text.TextColors.Secondary },


### PR DESCRIPTION
* Use correct card header heights from Figma
* Inline cards should have a transparant bg (by defualt it's layer 1 for normal cards)
* Advanced details in llamalend are now proper inline cards