### PR TITLE
chore: fix refuel timeouts as timeseries endpoint can be slower than pools endpoint for pool-information

### DIFF
--- a/tests/cypress/e2e/dex/refuel.cy.ts
+++ b/tests/cypress/e2e/dex/refuel.cy.ts
@@ -41,7 +41,7 @@ describe('Refuel page', () => {
     getTestById('pool-apr-value').invoke('attr', 'data-value').should('match', /\d/)
 
     getTestById('prices-chart').should('be.visible')
-    getTestById('lp-token-value-value').invoke('attr', 'data-value').should('match', /\d/)
+    getTestById('lp-token-value-value').invoke(API_LOAD_TIMEOUT, 'attr', 'data-value').should('match', /\d/)
     getTestById('virtual-price-value').invoke('attr', 'data-value').should('match', /\d/)
     getTestById('prices-chart').contains('Last price').should('be.visible')
     getTestById('prices-chart').contains('Oracle price').should('be.visible')


### PR DESCRIPTION
The flaky `undefined` timeout error comes most likely from the price metrics, not the pool metrics. The test waits for `pool-tvl-value`, which only proves the pool info query loaded, while `lp-token-value-value` and `virtual-price-value` depend on a separate refuel timeseries query (which can be way slower).