### PR TITLE
fix: popover jumping to top on open

### DIFF
--- a/apps/main/src/index.css
+++ b/apps/main/src/index.css
@@ -16,11 +16,11 @@ html {
 
 /*
  * Locks page scroll when a MUI modal or drawer is open.
- * MUI sets aria-hidden="true" on #root (the app root) to hide background content from
- * assistive technologies when an overlay is active. This uses that signal to prevent
- * the page from scrolling behind the overlay.
+ * MUI sets aria-hidden="true" on #root (the app root) to hide background content from assistive technologies when an 
+ * overlay is active. This uses that signal to prevent the page from scrolling behind blocking overlays. 
+ * Popovers and menus are excluded because they make the page jump to the top otherwise.
  */
-html:has(#root[aria-hidden='true']) {
+html:has(#root[aria-hidden='true']):has(body > .MuiModal-root:not(.MuiPopover-root)) {
   overflow: hidden;
 }
 

--- a/packages/curve-ui-kit/src/themes/components/index.ts
+++ b/packages/curve-ui-kit/src/themes/components/index.ts
@@ -176,6 +176,7 @@ export const createComponents = (
   },
   MuiPopover: {
     defaultProps: {
+      disableScrollLock,
       marginThreshold: 8, // allows the popover to be closer to the edge of the screen. Default is 16px
       elevation: 3,
     },


### PR DESCRIPTION
Depends on https://github.com/curvefi/curve-frontend/pull/2607

- fix popover jumping to top on open

You can test it by opening the filters on llamalend (Beta) or the column settings popover