### PR TITLE
fix: dex tvl test

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.tsx
@@ -9,6 +9,7 @@ import TableFooter from '@mui/material/TableFooter'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import { useLayoutStore } from '@ui-kit/features/layout'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
 import { TablePagination } from '@ui-kit/shared/ui/DataTable/TablePagination'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
@@ -125,7 +126,11 @@ export const DataTable = <T extends TableItem>({
   return (
     <WithWrapper Wrapper={Box} shouldWrap={maxHeight} sx={{ maxHeight, overflowY: 'auto' }} ref={containerRef}>
       <Table
-        sx={{ borderCollapse: 'separate' /* Don't collapse to avoid funky stuff with the sticky header */ }}
+        sx={{
+          borderCollapse: 'separate', // Don't collapse to avoid funky stuff with the sticky header
+          // Prevent a long content of a column to push the other column outside the viewport
+          ...(useIsMobile() && { tableLayout: 'fixed' }),
+        }}
         data-testid={!isLoading && 'data-table'}
       >
         {!hideHeader && (

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
@@ -9,6 +9,7 @@ import TableFooter from '@mui/material/TableFooter'
 import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import { useLayoutStore } from '@ui-kit/features/layout'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
 import { TablePagination } from '@ui-kit/shared/ui/DataTable/TablePagination'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
@@ -129,6 +130,8 @@ export const LegacyDataTable = <T extends TableItem>({
         sx={{
           backgroundColor: t => t.design.Layer[1].Fill,
           borderCollapse: 'separate' /* Don't collapse to avoid funky stuff with the sticky header */,
+          // Prevent a long content of a column to push the other column outside the viewport
+          ...(useIsMobile() && { tableLayout: 'fixed' }),
         }}
         data-testid={!loading && 'data-table'}
       >


### PR DESCRIPTION
- prevent the content of the first column to overflow the table on mobile
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="253" height="281" alt="Screenshot 2026-06-02 at 11 02 34" src="https://github.com/user-attachments/assets/2ef327ee-999b-4c4e-a4e8-f199091c6ed8" />
</td>
    <td>
<img width="271" height="280" alt="Screenshot 2026-06-02 at 11 01 35" src="https://github.com/user-attachments/assets/6c457dec-0037-4b32-aa8f-28a2dbd88820" />
</td>
  </tr>
</table>