### PR TITLE
fix: legacy deleverage action card overflowing

### DIFF
--- a/apps/main/src/loan/components/PageMintMarket/LoanDeleverage/components/DetailInfoTradeRoutes.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/LoanDeleverage/components/DetailInfoTradeRoutes.tsx
@@ -31,6 +31,13 @@ export const DetailInfoTradeRoutes = ({
   return (
     <ActionInfo
       label={t`Trade routed through:`}
+      sx={{
+        '& > .MuiTypography-root:first-of-type': {
+          overflow: 'visible',
+          textOverflow: 'clip',
+          whiteSpace: 'normal',
+        },
+      }}
       value={
         parsedRoutes?.length ? (
           <WithWrapper shouldWrap={isMultiRoutes} Wrapper={Stack} direction="row" sx={{ gap: Spacing.sm }}>


### PR DESCRIPTION
The legacy `DetailInfoTradeRoutes` was making the action card overflow for the legacy deleverage tab. This is a minimal fix and a workaround since these component and tab are legacy

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="467" height="594" alt="Screenshot 2026-06-02 at 18 13 46" src="https://github.com/user-attachments/assets/bdf663eb-c6b5-4406-b610-e323a6c4fd36" />

</td>
    <td>
<img width="466" height="601" alt="Screenshot 2026-06-02 at 18 07 46" src="https://github.com/user-attachments/assets/6aa339e1-1801-4e42-881b-c4efbbe759f8" />
</td>
  </tr>
</table>