### PR TITLE
fix: remove mona sans mono font

### DIFF
--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -100,7 +100,7 @@ const ChipPoolWrapper = styled.span`
 
 const ChipPoolAddress = styled.span`
   margin-right: 2px;
-  font-family: var(--font-mono);
+  font-family: var(--button-font);
   font-size: var(--font-size-2);
 `
 

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -110,7 +110,7 @@ const ChipTokenWrapper = styled.span`
   }
 `
 const ChipTokenAddress = styled.span`
-  font-family: var(--font-mono);
+  font-family: var(--button-font);
   font-size: var(--font-size-2);
   margin-bottom: 2px;
 `

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolParameters/index.tsx
@@ -417,7 +417,7 @@ const StyledTokenIcon = styled(TokenIcon)`
 `
 
 const Numeral = styled.p`
-  font-family: var(--font-mono);
+  font-family: var(--button-font);
 `
 
 const IndentDataTitle = styled.p`

--- a/apps/main/src/dex/components/PoolLabel.tsx
+++ b/apps/main/src/dex/components/PoolLabel.tsx
@@ -55,7 +55,7 @@ export const PoolLabel = ({
   }
 
   return (
-    <div data-testid={'pool-label'}>
+    <div>
       <Wrapper className={className} onClick={({ target }) => handleClick(target)}>
         <IconsWrapper>{isVisible && <TokenIcons blockchainId={blockchainId} tokens={tokens} />}</IconsWrapper>
         <Box fillWidth>

--- a/apps/main/src/dex/components/PoolLabel.tsx
+++ b/apps/main/src/dex/components/PoolLabel.tsx
@@ -55,7 +55,7 @@ export const PoolLabel = ({
   }
 
   return (
-    <div>
+    <div data-testid={'pool-label'}>
       <Wrapper className={className} onClick={({ target }) => handleClick(target)}>
         <IconsWrapper>{isVisible && <TokenIcons blockchainId={blockchainId} tokens={tokens} />}</IconsWrapper>
         <Box fillWidth>
@@ -96,7 +96,6 @@ export const PoolLabel = ({
           {quickViewValue && <Chip>{quickViewValue}</Chip>}
         </Box>
       </Wrapper>
-
       {tokenAlert && isMobile && <StyledAlertBox alertType={tokenAlert.alertType}>{tokenAlert.message}</StyledAlertBox>}
       {poolAlert && !poolAlert.isPoolPageOnly && (
         <>

--- a/apps/main/src/index.css
+++ b/apps/main/src/index.css
@@ -8,7 +8,6 @@ body {
 body.theme-chad {
   --font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
   --button-font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
-  --button--font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
 }
 
 html {

--- a/apps/main/src/index.css
+++ b/apps/main/src/index.css
@@ -2,12 +2,12 @@
 
 body {
   --font: 'Mona Sans', 'Helvetica Neue', Helvetica, sans-serif;
-  --font-mono: 'Mona Sans Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
+  --button-font: 'Mona Sans', 'Helvetica Neue', Helvetica, sans-serif;
 }
 
 body.theme-chad {
   --font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
-  --font-mono: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
+  --button-font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
   --button--font: 'Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', monospace;
 }
 
@@ -150,16 +150,6 @@ li {
   src:
     local('Mona Sans'),
     url('../../../packages/curve-ui-kit/public/fonts/Mona-Sans.woff2') format('woff2');
-  font-weight: 200 900;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Mona Sans Mono';
-  src:
-    local('Mona Sans Mono'),
-    url('../../../packages/curve-ui-kit/public/fonts/Mona-Sans-Mono.woff2') format('woff2');
   font-weight: 200 900;
   font-style: normal;
   font-display: swap;

--- a/packages/curve-ui-kit/.storybook/preview.tsx
+++ b/packages/curve-ui-kit/.storybook/preview.tsx
@@ -44,14 +44,6 @@ const decorators: Decorator[] = [
           unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF;
         }
         @font-face {
-          font-family: 'Mona Sans Mono';
-          font-weight: 200 900;
-          font-style: normal;
-          font-display: swap;
-          src: url('fonts/Mona-Sans-Mono.woff2') format('woff2');
-          unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF;
-        }
-        @font-face {
           font-family: 'Ioskeley Mono';
           font-weight: 400;
           font-style: normal;

--- a/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-button.ts
@@ -6,7 +6,6 @@ import { handleBreakpoints } from '../../basic-theme'
 import { DesignSystem } from '../../design'
 import { Sizing } from '../../design/0_primitives'
 import { SizesAndSpaces } from '../../design/1_sizes_spaces'
-import { Fonts } from '../../fonts'
 import { buttonColor } from './utils'
 
 const { LineHeight, OutlineWidth, ButtonSize, FontSize } = SizesAndSpaces
@@ -105,7 +104,6 @@ export const defineMuiButton = ({ Button, Text }: DesignSystem): Components['Mui
         border: `${OutlineWidth} solid transparent`,
         boxSizing: 'border-box',
         '&:focus-visible': { borderColor: Focus_Outline },
-        fontFamily: Fonts[Button.FontFamily],
         textTransform: 'uppercase',
         transition: Transition,
       },

--- a/packages/curve-ui-kit/src/themes/components/button/mui-icon-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-icon-button.ts
@@ -6,7 +6,6 @@ import { recordEntries } from '@primitives/objects.utils'
 import { handleBreakpoints } from '@ui-kit/themes/basic-theme'
 import { DesignSystem } from '../../design'
 import { SizesAndSpaces } from '../../design/1_sizes_spaces'
-import { Fonts } from '../../fonts'
 import { buttonColor } from './utils'
 
 const { ButtonSize, OutlineWidth, IconSize } = SizesAndSpaces
@@ -56,7 +55,6 @@ export const defineMuiIconButton = ({ Button }: DesignSystem): Components['MuiIc
         ...buttonColor(Ghost),
         transition: Transition,
         ':focus-visible': { borderColor: Focus_Outline },
-        fontFamily: Fonts[Button.FontFamily],
       },
       sizeExtraExtraSmall: iconButtonSize('xxs', 'extraExtraSmall'),
       sizeExtraSmall: iconButtonSize('xs', 'extraSmall'),

--- a/packages/curve-ui-kit/src/themes/components/button/mui-toggle-button.ts
+++ b/packages/curve-ui-kit/src/themes/components/button/mui-toggle-button.ts
@@ -4,7 +4,6 @@ import type { Components } from '@mui/material/styles'
 import { handleBreakpoints } from '../../basic-theme'
 import { DesignSystem } from '../../design'
 import { SizesAndSpaces } from '../../design/1_sizes_spaces'
-import { Fonts } from '../../fonts'
 
 const { Spacing, ButtonSize, FontSize, LineHeight, OutlineWidth } = SizesAndSpaces
 
@@ -78,7 +77,6 @@ export const defineMuiToggleButton = ({ Toggles, Button, Text }: DesignSystem): 
         border: `${OutlineWidth} solid transparent !important`, // Not even '&&' works, hence the !important
         borderRadius: 0,
         transition: Button.Transition,
-        fontFamily: Fonts[Button.FontFamily],
         textTransform: 'uppercase',
       },
 

--- a/packages/curve-ui-kit/src/themes/design/2_theme.ts
+++ b/packages/curve-ui-kit/src/themes/design/2_theme.ts
@@ -151,7 +151,6 @@ export const createLightDesign = (
   } as const
 
   const Button = {
-    FontFamily: 'Mona Sans Mono',
     Focus_Outline_Width: '0.125rem', // 2px
     Focus_Outline: Color.Primary[500],
     Radius: {
@@ -706,7 +705,6 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
   } as const
 
   const Button = {
-    FontFamily: 'Mona Sans Mono',
     Focus_Outline_Width: '0.125rem', // 2px
     Focus_Outline: Color.Primary[500],
     Radius: {
@@ -1222,7 +1220,6 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
   } as const
 
   const Button = {
-    FontFamily: 'Ioskeley Mono',
     Focus_Outline_Width: '0.125rem', // 2px
     Focus_Outline: Color.Primary[300],
     Radius: {

--- a/packages/curve-ui-kit/src/themes/fonts.ts
+++ b/packages/curve-ui-kit/src/themes/fonts.ts
@@ -6,6 +6,5 @@ const fontStack = (...fonts: string[]) => fonts.map(f => (CSS_GENERIC_FAMILIES.h
 
 export const Fonts = {
   'Mona Sans': fontStack('Mona Sans', 'Helvetica Neue', 'Helvetica', 'sans-serif'),
-  'Mona Sans Mono': fontStack('Mona Sans Mono', 'SF Mono Regular 11', 'Ubuntu Mono', 'monospace'),
   'Ioskeley Mono': fontStack('Ioskeley Mono', 'SF Mono Regular 11', 'Ubuntu Mono', 'monospace'),
 }

--- a/packages/ui/src/Typography/Chip.tsx
+++ b/packages/ui/src/Typography/Chip.tsx
@@ -24,7 +24,7 @@ const Label = styled.span<
 >`
   ${({ isBold }) => isBold && `font-weight: var(--font-weight--bold);`}
   ${({ fontVariantNumeric }) => fontVariantNumeric && `font-variant-numeric: ${fontVariantNumeric};`}
-  ${({ isMono }) => (isMono ? 'font-family: var(--font-mono);' : 'font-family: var(--font);')}
+  ${({ isMono }) => (isMono ? 'font-family: var(--button-font);' : 'font-family: var(--font);')}
   ${({ isError }) => isError && `color: var(--danger_darkBg-400);`}
   ${({ opacity }) => opacity !== undefined && `opacity: ${opacity};`}
   

--- a/packages/ui/src/styles/theme-default.css
+++ b/packages/ui/src/styles/theme-default.css
@@ -124,7 +124,7 @@ body.theme-default {
   --button--disabled--border-color: var(--gray-500);
   --button--disabled--background-color: var(--gray-500);
   --button--disabled_spinner--background-color: var(--gray-500a20);
-  --button--font: var(--font-mono);
+  --button--font: var(--button-font);
   --button--font-size: inherit;
   --button--font-weight: var(--bold);
   --button--shadow-color: var(--primary-200);


### PR DESCRIPTION
- the mona sans font was introduced in https://github.com/curvefi/curve-frontend/pull/2625/changes/c88cf6b0eed3e9900e32facf6088504d226bb713
- however, it was not supposed to apply to the light/dark buttons yet
- note: Do not judge me by the branch name, I reused the one from #2625