### PR TITLE
fix: use on-chain rates

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.1.1",
+    "@curvefi/llamalend-api": "2.1.2",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.169.1",
     "@tanstack/react-router-devtools": "1.166.13",

--- a/apps/main/src/llamalend/queries/market/market-future-rates.query.ts
+++ b/apps/main/src/llamalend/queries/market/market-future-rates.query.ts
@@ -1,11 +1,11 @@
 import { enforce, group, test } from 'vest'
 import { getLlamaMarket } from '@/llamalend/llama.utils'
+import { USE_API } from '@/llamalend/queries/market/market.constants'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Decimal } from '@primitives/decimal.utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
-import { type MarketQuery } from '@ui-kit/lib/model'
-import { queryFactory, rootKeys } from '@ui-kit/lib/model'
+import { type MarketQuery, queryFactory, rootKeys } from '@ui-kit/lib/model'
 import { marketIdValidationSuite } from '@ui-kit/lib/model/query/market-id-validation'
 import { convertRates } from '../../rates.utils'
 
@@ -23,7 +23,7 @@ const DEBT = '0' // Used in supply scenarios where only reserves change, debt st
 const fetchFutureRates = async (marketId: string, reserves: Decimal, debtDelta: Decimal) => {
   const market = getLlamaMarket(marketId)
   return market instanceof LendMarketTemplate
-    ? convertRates(await market.stats.futureRates(reserves, debtDelta))
+    ? convertRates(await market.stats.futureRates(reserves, debtDelta, USE_API))
     : convertRates((await market.stats.parameters()).future_rates)
 }
 

--- a/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
@@ -197,7 +197,7 @@ export const createDepositScenario = ({
     expected: {
       walletBalances: [] as const,
       marketRates: [false, false] as const,
-      futureRates: [amount, '0'] as const,
+      futureRates: [amount, '0', false] as const,
       maxDeposit: [] as const,
       previewDeposit: amountArgs,
       isApproved: amountArgs,
@@ -362,7 +362,7 @@ export const createWithdrawScenario = ({
     expected: {
       walletBalances: [] as const,
       marketRates: [false, false] as const,
-      futureRates: [decimalMinus('0', amount), '0'] as const,
+      futureRates: [decimalMinus('0', amount), '0', false] as const,
       maxWithdraw: [] as const,
       maxRedeem: [] as const,
       previewWithdraw: [amount] as const,

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,15 +394,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.1.1":
-  version: 2.1.1
-  resolution: "@curvefi/llamalend-api@npm:2.1.1"
+"@curvefi/llamalend-api@npm:2.1.2":
+  version: 2.1.2
+  resolution: "@curvefi/llamalend-api@npm:2.1.2"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.16"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.15.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/820f19c70036af2e17b9eb524bcf7d810de4715b789309c9b7dcdb972553c5589292ac446398d5e97a2b817aa3174158ef47a26d0f36e9906c453d213c44e94a
+  checksum: 10c0/e4c39140f5be091aa9b3b6a81d19a34989497668b9e027fc9b6b5694ca9d674b8df3faa3a8a8ad36574a8cb2d510f0095472ba9ccab5f97f9193170a8a42d5ca
   languageName: node
   linkType: hard
 
@@ -11567,7 +11567,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.1.1"
+    "@curvefi/llamalend-api": "npm:2.1.2"
     "@sentry/vite-plugin": "npm:5.2.1"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.169.1"


### PR DESCRIPTION
- use onchain rates for the future loan rates
- this should be more up-to-date and works also for LLv2
- update llamalend to make the useApi flag available https://github.com/curvefi/curve-llamalend.js/pull/106