### PR TITLE
feat: add semantic number format categories

### DIFF
--- a/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdPrice.tsx
+++ b/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdPrice.tsx
@@ -19,7 +19,7 @@ import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import type { LegendItem } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SelectTimeOption } from '@ui-kit/shared/ui/Chart/SelectTimeOption'
-import { formatNumber, formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 const PRICE_LABEL = t`Price`
 const PERIODS = ['7d', '1m', '3m', '6m'] as const satisfies Period[]
@@ -58,7 +58,7 @@ export function ChartCrvUsdPrice() {
       createChartOptions({
         legendSets,
         options: {
-          tooltip: createTooltip(value => formatUsd(value)),
+          tooltip: createTooltip(value => formatNumber(value, 'usd.notional')),
           xAxis: { data: chartData.map(x => x.time).map(timeToCategory) },
           yAxis: {
             axisLabel: {

--- a/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdSupplyBreakdown.tsx
+++ b/apps/main/src/analytics/components/PageHome/components/ChartCrvUsdSupplyBreakdown.tsx
@@ -18,7 +18,7 @@ import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import type { LegendItem } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SelectTimeOption } from '@ui-kit/shared/ui/Chart/SelectTimeOption'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { useCrvUsdSupply } from '../queries/useCrvUsdSupply.query'
 
 /**
@@ -110,9 +110,9 @@ export function ChartCrvUsdSupplyBreakdown() {
       createChartOptions({
         legendSets,
         options: {
-          tooltip: createTooltip(value => formatUsd(value)),
+          tooltip: createTooltip(value => formatNumber(value, 'usd.notional')),
           xAxis: { data: chartData.map(x => x.time).map(timeToCategory) },
-          yAxis: { axisLabel: { formatter: (v: number) => formatUsd(v) } },
+          yAxis: { axisLabel: { formatter: (v: number) => formatNumber(v, 'usd.notional') } },
           series: [
             {
               name: MINT_MARKETS_LABEL,

--- a/apps/main/src/dao/components/Charts/GaugeWeightHistoryChart.tsx
+++ b/apps/main/src/dao/components/Charts/GaugeWeightHistoryChart.tsx
@@ -61,7 +61,7 @@ export const GaugeWeightHistoryChart = ({ gaugeAddress, height = Height.chart }:
           xKey="timestamp"
           series={series}
           xTickFormatter={value => formatDate(value)}
-          yTickFormatter={value => formatNumber(+value, { unit: 'percentage', abbreviate: false, fallback: '-' })}
+          yTickFormatter={value => formatNumber(+value, 'percent.value')}
           yPaddingRatio={0.1}
           renderTooltip={({ datum, visibleSeries }) => (
             <ChartTooltipShell title={formatDate(datum.timestamp, 'long')}>

--- a/apps/main/src/dao/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dao/components/DetailInfoEstGas.tsx
@@ -56,11 +56,7 @@ export const DetailInfoEstGas = ({
   return (
     <DetailInfo isDivider={isDivider} loading={loading} loadingSkeleton={[50, 20]} label={Label} tooltip={Tooltip}>
       {estGasCost &&
-        (estGasCostUsd ? (
-          <span>{formatNumber(estGasCostUsd, { unit: 'dollar', abbreviate: false })}</span>
-        ) : (
-          t`Unable to get USD rate`
-        ))}
+        (estGasCostUsd ? <span>{formatNumber(estGasCostUsd, 'usd.amount')}</span> : t`Unable to get USD rate`)}
     </DetailInfo>
   )
 }

--- a/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/CrvStats/index.tsx
@@ -94,7 +94,7 @@ export const CrvStats = () => {
             notional={
               loading || veCrvFeesLoading || aprLoading
                 ? undefined
-                : `${formatNumber(veCrvApr.fourDayAverage, { unit: 'percentage', abbreviate: false })} 4w avg`
+                : `${formatNumber(veCrvApr.fourDayAverage, 'percent.value')} 4w avg`
             }
           />
         </MetricsContainer>

--- a/apps/main/src/dao/components/PageAnalytics/VeCrvFeesChart/FeesBarChartTooltip.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/VeCrvFeesChart/FeesBarChartTooltip.tsx
@@ -28,7 +28,7 @@ export const FeesBarChartTooltip = ({ active, payload }: TooltipProps<ValueType,
         <Box flex flexColumn flexGap={'var(--spacing-1)'}>
           <TooltipColumn>
             <TooltipDataTitle>{t`veCRV Fees`}</TooltipDataTitle>
-            <TooltipData>{formatNumber(feesUsd, { unit: 'dollar', abbreviate: true, fallback: '-' })}</TooltipData>
+            <TooltipData>{formatNumber(feesUsd, 'usd.notional')}</TooltipData>
           </TooltipColumn>
         </Box>
       </TooltipWrapper>

--- a/apps/main/src/dao/components/PageAnalytics/VeCrvFeesTable/index.tsx
+++ b/apps/main/src/dao/components/PageAnalytics/VeCrvFeesTable/index.tsx
@@ -49,13 +49,13 @@ export const VeCrcFees = () => {
                           {formatDate(item.timestamp)}
                           {new Date(item.timestamp) > new Date() && <span> {t`(in progress)`}</span>}
                         </FeeDate>
-                        <FeeData>{formatNumber(item.feesUsd, { unit: 'dollar', abbreviate: true })}</FeeData>
+                        <FeeData>{formatNumber(item.feesUsd, 'usd.notional')}</FeeData>
                       </FeeRow>
                     ))}
                   </FeesContainer>
                   <TotalFees>
                     <FeeDate>{t`Total Fees:`}</FeeDate>
-                    <FeeData>{formatNumber(veCrvFees.veCrvTotalFees, { unit: 'dollar', abbreviate: true })}</FeeData>
+                    <FeeData>{formatNumber(veCrvFees.veCrvTotalFees, 'usd.notional')}</FeeData>
                   </TotalFees>
                 </>
               )}

--- a/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
@@ -167,7 +167,7 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
             loading={dataLoading}
             title={t`Pool TVL`}
             data={
-              <StyledMetricsColumnData>{t`${formatNumber(gaugeData?.pool?.tvl_usd, { unit: 'dollar', abbreviate: true, fallback: '-' })}`}</StyledMetricsColumnData>
+              <StyledMetricsColumnData>{t`${formatNumber(gaugeData?.pool?.tvl_usd, 'usd.notional')}`}</StyledMetricsColumnData>
             }
           />
         ) : (
@@ -178,7 +178,7 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
             loading={dataLoading}
             title={t`24h Pool Volume`}
             data={
-              <StyledMetricsColumnData>{t`${formatNumber(gaugeData?.pool?.trading_volume_24h, { unit: 'dollar', abbreviate: true, fallback: '-' })}`}</StyledMetricsColumnData>
+              <StyledMetricsColumnData>{t`${formatNumber(gaugeData?.pool?.trading_volume_24h, 'usd.notional')}`}</StyledMetricsColumnData>
             }
           />
         ) : (

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetailsSm.tsx
@@ -86,13 +86,11 @@ export const GaugeDetailsSm = ({ gaugeData, userGaugeWeightVoteData, className }
           <>
             <StatsRow>
               <StatTitle>{t`24 Volume`}</StatTitle>
-              <StatData>
-                {formatNumber(gaugeData.pool.trading_volume_24h, { unit: 'dollar', abbreviate: false })}
-              </StatData>
+              <StatData>{formatNumber(gaugeData.pool.trading_volume_24h, 'usd.amount')}</StatData>
             </StatsRow>
             <StatsRow>
               <StatTitle>{t`TVL`}</StatTitle>
-              <StatData>{formatNumber(gaugeData.pool.tvl_usd, { unit: 'dollar', abbreviate: false })}</StatData>
+              <StatData>{formatNumber(gaugeData.pool.tvl_usd, 'usd.amount')}</StatData>
             </StatsRow>
           </>
         )}

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeWeightVotesColumns.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeWeightVotesColumns.tsx
@@ -47,7 +47,7 @@ export const GaugeWeightVotesColumns = ({ userGaugeWeightVoteData }: GaugeWeight
                     abbreviate: false,
                   })}
                 </strong>
-                {` (${formatNumber(staleVeCrvPct, { unit: 'percentage', abbreviate: false })} increase)`}
+                {` (${formatNumber(staleVeCrvPct, 'percent.value')} increase)`}
               </p>
             }
           >

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/SmallScreenCard.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/SmallScreenCard.tsx
@@ -41,21 +41,21 @@ export const SmallScreenCard = ({
     if (key === 'gauge_relative_weight') {
       return {
         title: t`Weight`,
-        value: formatNumber(gaugeData.gauge_relative_weight, { unit: 'percentage', abbreviate: false }),
+        value: formatNumber(gaugeData.gauge_relative_weight, 'percent.value'),
       }
     }
     if (key === 'gauge_relative_weight_7d_delta') {
       return {
         title: t`7d Delta`,
         value: gaugeData.gauge_relative_weight_7d_delta
-          ? formatNumber(gaugeData.gauge_relative_weight_7d_delta, { unit: 'percentage', abbreviate: false })
+          ? formatNumber(gaugeData.gauge_relative_weight_7d_delta, 'percent.value')
           : 'N/A',
       }
     }
     return {
       title: t`60d Delta`,
       value: gaugeData.gauge_relative_weight_60d_delta
-        ? formatNumber(gaugeData.gauge_relative_weight_60d_delta, { unit: 'percentage', abbreviate: false })
+        ? formatNumber(gaugeData.gauge_relative_weight_60d_delta, 'percent.value')
         : 'N/A',
     }
   }

--- a/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserGaugeVotesTable/index.tsx
@@ -63,7 +63,7 @@ export const UserGaugeVotesTable = ({ userAddress, tableMinWidth }: UserGaugeVot
             <TableData
               className={userGaugeVotesSortBy.key === 'weight' ? 'sortby-active right-padding' : 'right-padding'}
             >
-              {formatNumber(gaugeVote.weight / 100, { unit: 'percentage', abbreviate: false })}
+              {formatNumber(gaugeVote.weight / 100, 'percent.value')}
             </TableData>
             <TableDataLink href={getEthPath(`${DAO_ROUTES.PAGE_GAUGES}/${gaugeVote.gauge}`)} className="right-padding">
               {shortenAddress(gaugeVote.gauge)}

--- a/apps/main/src/dao/components/UserBox/VoteDialog.tsx
+++ b/apps/main/src/dao/components/UserBox/VoteDialog.tsx
@@ -24,8 +24,7 @@ type Props = {
   className?: string
 }
 
-const votePercentage = (vote: number, total: number) =>
-  `(${formatNumber((vote / total) * 100, { unit: 'percentage', abbreviate: false })})`
+const votePercentage = (vote: number, total: number) => `(${formatNumber((vote / total) * 100, 'percent.value')})`
 
 export const VoteDialog = ({
   userAddress,

--- a/apps/main/src/dex/components/AlertSlippage.tsx
+++ b/apps/main/src/dex/components/AlertSlippage.tsx
@@ -21,8 +21,7 @@ export const AlertSlippage = ({ maxSlippage, usdAmount }: Props) => {
     <AlertBox alertType="warning">
       <div>
         <Trans>
-          With your current slippage tolerance setting (
-          {formatNumber(amount(maxSlippage), { unit: 'percentage', abbreviate: false, fallback: '-' })}
+          With your current slippage tolerance setting ({formatNumber(amount(maxSlippage), 'percent.value')}
           ), the expected output displayed above might incur up to{' '}
           <strong>
             {formatNumber(maxUsdSlippage, {

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -46,7 +46,7 @@ type ChipTokenProps = {
 export const ChipToken = ({ className, tokenName, tokenAddress, ...props }: ChipTokenProps) => {
   const chainId = useChainId()
   const [usdRate, setUsdRate] = useState<number | undefined>(undefined)
-  const parsedUsdRate = formatNumber(usdRate, { unit: 'dollar', abbreviate: false, fallback: '-' })
+  const parsedUsdRate = formatNumber(usdRate, 'usd.amount')
 
   const handleMouseEnter = useCallback(() => {
     if (usdRate == null) {

--- a/apps/main/src/dex/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dex/components/DetailInfoEstGas.tsx
@@ -61,11 +61,7 @@ export const DetailInfoEstGas = ({
   return (
     <DetailInfo isDivider={isDivider} loading={loading} loadingSkeleton={[50, 20]} label={Label} tooltip={Tooltip}>
       {estGasCostUsd &&
-        (haveUsdRate ? (
-          <span>{formatNumber(estGasCostUsd, { unit: 'dollar', abbreviate: false })}</span>
-        ) : (
-          t`Unable to get USD rate`
-        ))}
+        (haveUsdRate ? <span>{formatNumber(estGasCostUsd, 'usd.amount')}</span> : t`Unable to get USD rate`)}
     </DetailInfo>
   )
 }

--- a/apps/main/src/dex/components/FieldHelperUsdRate.tsx
+++ b/apps/main/src/dex/components/FieldHelperUsdRate.tsx
@@ -16,8 +16,7 @@ export const FieldHelperUsdRate = ({ amount, usdRate }: { amount: string; usdRat
 
   return (
     <StyledChip size="xs">
-      x {usdRate && formatNumber(usdRate, { unit: 'dollar', abbreviate: false })} ≈
-      {formatNumber(toAmount(usdRateTotal), { unit: 'dollar', abbreviate: false, fallback: '-' })}
+      x {usdRate && formatNumber(usdRate, 'usd.amount')} ≈ {formatNumber(toAmount(usdRateTotal), 'usd.amount')}
     </StyledChip>
   )
 }

--- a/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/FormVecrv.tsx
@@ -165,10 +165,7 @@ export const FormVecrv = () => {
               {t`Balance in voting escrow:`}{' '}
               <strong>{formatNumber(amount(veCrv), { abbreviate: false, fallback: '-' })}</strong> veCRV <br />
               <Chip size="sm">
-                <strong>
-                  {formatNumber(amount(veCrvPct), { unit: 'percentage', abbreviate: false, fallback: '-' })}
-                </strong>{' '}
-                {t`share of total`}
+                <strong>{formatNumber(amount(veCrvPct), 'percent.value')}</strong> {t`share of total`}
               </Chip>
             </li>
           </Items>

--- a/apps/main/src/dex/components/PageDashboard/components/SummaryClaimable.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/SummaryClaimable.tsx
@@ -75,7 +75,7 @@ export const SummaryClaimable = ({ title }: Props) => {
             <StyledStats isOneLine isBorderBottom key={token} label={symbol}>
               <Chip
                 size="md"
-                tooltip={`${formatNumber(1, { abbreviate: false })} ${symbol} = ${formatNumber(price, { unit: 'dollar', abbreviate: false })}`}
+                tooltip={`${formatNumber(1, { abbreviate: false })} ${symbol} = ${formatNumber(price, 'usd.amount')}`}
                 tooltipProps={tooltipProps}
               >
                 {formatNumber(total, { abbreviate: false })}
@@ -84,7 +84,7 @@ export const SummaryClaimable = ({ title }: Props) => {
           ))}
         <Stats isOneLine label={t`USD Total`}>
           <Chip isBold isNumber size="md">
-            ≈ {formatNumber(totalUsd, { unit: 'dollar', abbreviate: false })}
+            ≈ {formatNumber(totalUsd, 'usd.amount')}
           </Chip>
         </Stats>
       </SummaryInnerContent>

--- a/apps/main/src/dex/components/PageDashboard/components/SummaryRecurrence.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/SummaryRecurrence.tsx
@@ -83,7 +83,7 @@ export const TotalRecurrence = ({ title }: Props) => {
                   {...(token === 'base'
                     ? {}
                     : {
-                        tooltip: `${formatNumber(1, { abbreviate: false })} ${symbol} = ${formatNumber(price, { unit: 'dollar', abbreviate: false })}`,
+                        tooltip: `${formatNumber(1, { abbreviate: false })} ${symbol} = ${formatNumber(price, 'usd.amount')}`,
                         tooltipProps,
                       })}
                 >
@@ -95,7 +95,7 @@ export const TotalRecurrence = ({ title }: Props) => {
 
         <Stats label={t`USD Total`} isOneLine>
           <Chip isBold size="md">
-            ≈ {formatNumber(totalUsd, { unit: 'dollar', abbreviate: false })}
+            ≈ {formatNumber(totalUsd, 'usd.amount')}
           </Chip>
         </Stats>
       </SummaryInnerContent>

--- a/apps/main/src/dex/components/PageDashboard/components/SummaryTotal.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/SummaryTotal.tsx
@@ -33,7 +33,7 @@ export const SummaryTotal = () => {
           tooltip={formatNumber(total, { abbreviate: false, fallback: '-' })}
           tooltipProps={{ noWrap: true }}
         >
-          {total === null ? '?' : formatNumber(total, { unit: 'dollar', abbreviate: true })}
+          {total === null ? '?' : formatNumber(total, 'usd.notional')}
         </TotalBalancesValue>
       </SummaryInnerContent>
     </StyledTotalBalanceWrapper>

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellBalances.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellBalances.tsx
@@ -14,17 +14,11 @@ export const TableCellBalances = ({ isHighLight, liquidityUsd, percentStaked }: 
       isNumber
       isBold={isHighLight}
       size="md"
-      tooltip={formatNumber(amount(liquidityUsd), { unit: 'dollar', abbreviate: false, fallback: '-' })}
+      tooltip={formatNumber(amount(liquidityUsd), 'usd.amount')}
       tooltipProps={tooltipProps}
     >
-      {formatNumber(amount(liquidityUsd), { unit: 'dollar', abbreviate: true, fallback: '-' })}
+      {formatNumber(amount(liquidityUsd), 'usd.notional')}
     </Chip>
-    <div>
-      {percentStaked && (
-        <DetailText>
-          {formatNumber(amount(percentStaked), { unit: 'percentage', abbreviate: false, fallback: '-' })} staked
-        </DetailText>
-      )}
-    </div>
+    <div>{percentStaked && <DetailText>{formatNumber(amount(percentStaked), 'percent.value')} staked</DetailText>}</div>
   </>
 )

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellClaimables.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellClaimables.tsx
@@ -28,7 +28,7 @@ export const TableCellClaimables = ({
     })}
     <div>
       {isHighLight && claimablesTotalUsd > 0 && (
-        <DetailText>{formatNumber(claimablesTotalUsd, { unit: 'dollar', abbreviate: false })}</DetailText>
+        <DetailText>{formatNumber(claimablesTotalUsd, 'usd.amount')}</DetailText>
       )}
     </div>
     {isMobile && !claimableCrv && claimableOthers?.length === 0 && t`None`}

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellProfit.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellProfit.tsx
@@ -34,9 +34,7 @@ export const TableCellProfit = ({ profitBase, profitCrv, profitOthers, profitsTo
       })}
 
       <div>
-        {isHighLight && profitsTotalUsd > 0 && (
-          <DetailText>{formatNumber(profitsTotalUsd, { unit: 'dollar', abbreviate: false })}</DetailText>
-        )}
+        {isHighLight && profitsTotalUsd > 0 && <DetailText>{formatNumber(profitsTotalUsd, 'usd.amount')}</DetailText>}
       </div>
     </>
   )

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellRewards.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellRewards.tsx
@@ -63,11 +63,9 @@ export const TableCellRewards = ({
           >
             {/* eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Existing violation before enabling this rule. */}
             <WithWrapper shouldWrap={sortBy === SORT_ID.userCrvApy} Wrapper={Bold}>
-              {`${formatNumber(userCrvApy, { unit: 'percentage', abbreviate: false })} CRV`}
+              {`${formatNumber(userCrvApy, 'percent.value')} CRV`}
             </WithWrapper>{' '}
-            {boostedCrvApy ? (
-              <DetailText> of {formatNumber(boostedCrvApy, { unit: 'percentage', abbreviate: false })}</DetailText>
-            ) : null}
+            {boostedCrvApy ? <DetailText> of {formatNumber(boostedCrvApy, 'percent.value')}</DetailText> : null}
           </Chip>
         ) : null
       ) : (

--- a/apps/main/src/dex/components/PageDashboard/components/TableCellRewardsTooltip.tsx
+++ b/apps/main/src/dex/components/PageDashboard/components/TableCellRewardsTooltip.tsx
@@ -36,7 +36,7 @@ export const TableCellRewardsTooltip = ({ crv = [], userCrvApy, fetchUserPoolBoo
     <Box grid gridRowGap={1}>
       <Title>CRV tAPR</Title>
       <div>Min/max: {rewardsApyCrvText(crv)}</div>
-      <div>Your: {formatNumber(userCrvApy, { unit: 'percentage', abbreviate: false })}</div>
+      <div>Your: {formatNumber(userCrvApy, 'percent.value')}</div>
       <div>Boost: {boost ? `${lodash.round(+boost, 2)}x` : '-'}</div>
     </Box>
   )

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/CurrencyReservesContent.tsx
@@ -45,7 +45,7 @@ export const CurrencyReservesContent = ({
         </TokenLabelLink>
 
         <Box flex flexAlignItems="center" gridGap={2}>
-          <Chip opacity={0.7}>{formatNumber(cr?.usdRate, { unit: 'dollar', abbreviate: false, fallback: '-' })}</Chip>
+          <Chip opacity={0.7}>{formatNumber(cr?.usdRate, 'usd.amount')}</Chip>
           <TooltipButton clickable onClick={() => handleCopyClick(tokenAddress)} noWrap tooltip={t`Copy address`}>
             <Icon name="Copy" size={16} />
           </TooltipButton>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/index.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/CurrencyReserves/index.tsx
@@ -56,7 +56,7 @@ export const CurrencyReserves = ({ chainId, poolId, tokensMapper }: Props) => {
       <StyledStats flex flexJustifyContent="space-between">
         {t`USD total`}
         <StyledChip size="md">
-          {formatNumber(amount(tvl), { unit: 'dollar', abbreviate: false, fallback: '-' })}{' '}
+          {formatNumber(amount(tvl), 'usd.amount')}{' '}
           <IconTooltip placement="bottom-end">{t`USD total balance updates every ~5 minute`}</IconTooltip>
         </StyledChip>
       </StyledStats>

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/PoolParameters.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/PoolParameters.tsx
@@ -44,7 +44,7 @@ export const PoolParameters = ({
     () =>
       tvl && volume
         ? +tvl && +volume
-          ? formatNumber(amount((+volume / +tvl) * 100), { unit: 'percentage', abbreviate: false, fallback: '-' })
+          ? formatNumber(amount((+volume / +tvl) * 100), 'percent.value')
           : formatNumber(0, { maximumFractionDigits: 0, unit: 'percentage', abbreviate: false })
         : '-',
     [tvl, volume],
@@ -103,7 +103,7 @@ export const PoolParameters = ({
           value={
             typeof staked?.totalStakedPercent === 'string'
               ? staked.totalStakedPercent
-              : formatNumber(staked?.totalStakedPercent, { unit: 'percentage', abbreviate: false, fallback: '-' })
+              : formatNumber(staked?.totalStakedPercent, 'percent.value')
           }
         />
 

--- a/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
+++ b/apps/main/src/dex/components/PagePool/PoolDetails/PoolStats/Rewards.tsx
@@ -86,9 +86,7 @@ export const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
                 ) : +value > LARGE_APY ? (
                   <ChipVolatileBaseApy isBold showIcon />
                 ) : (
-                  <strong title={value}>
-                    {formatNumber(amount(value), { unit: 'percentage', abbreviate: false, fallback: '-' })}
-                  </strong>
+                  <strong title={value}>{formatNumber(amount(value), 'percent.value')}</strong>
                 )}
               </BaseApyItem>
             ))}
@@ -129,7 +127,7 @@ export const Rewards = ({ chainId, poolData, rewardsApy }: RewardsProps) => {
                     </StyledIconButton>
                   </Box>
                   <Chip isBold isNumber size="md">
-                    {formatNumber(apy, { unit: 'percentage', abbreviate: false })}{' '}
+                    {formatNumber(apy, 'percent.value')}{' '}
                   </Chip>
                 </StyledStyledStats>
               ))}

--- a/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
+++ b/apps/main/src/dex/components/PagePool/UserDetails/index.tsx
@@ -57,11 +57,11 @@ export const MySharesStats = ({
   const userShareLabel = useMemo(() => {
     if (userLpShare && Number(userLpShare)) {
       if (Number(userLpShare) > 0.01) {
-        return formatNumber(amount(userLpShare), { unit: 'percentage', abbreviate: false, fallback: '-' })
+        return formatNumber(amount(userLpShare), 'percent.value')
       }
-      return `< ${formatNumber(0.01, { unit: 'percentage', abbreviate: false })}`
+      return `< ${formatNumber(0.01, 'percent.value')}`
     }
-    return formatNumber(0, { unit: 'percentage', abbreviate: false })
+    return formatNumber(0, 'percent.value')
   }, [userLpShare])
 
   const withdrawTotal = useMemo(() => {
@@ -87,19 +87,15 @@ export const MySharesStats = ({
         <CrvRewardsTooltipWrapper>
           <tbody>
             <tr>
-              <td className="right">
-                {formatNumber(crvRewards[0], { unit: 'percentage', abbreviate: false, fallback: '-' })}
-              </td>
+              <td className="right">{formatNumber(crvRewards[0], 'percent.value')}</td>
               <td>&nbsp;({t`min. CRV tAPR %`})</td>
             </tr>
             <tr>
-              <td className="right">
-                x {formatNumber(amount(userBoostApy), { unit: 'percentage', abbreviate: false, fallback: '-' })}
-              </td>
+              <td className="right">x {formatNumber(amount(userBoostApy), 'percent.value')}</td>
               <td>&nbsp;({t`your boost`})</td>
             </tr>
             <tr>
-              <td className="right">= {formatNumber(userCrvApyValue, { unit: 'percentage', abbreviate: false })}</td>
+              <td className="right">= {formatNumber(userCrvApyValue, 'percent.value')}</td>
               <td>%</td>
             </tr>
           </tbody>
@@ -145,8 +141,7 @@ export const MySharesStats = ({
                   </Chip>
                 ) : (
                   <Chip size="md" tooltip={crvRewardsTooltipText} tooltipProps={{ minWidth: '350px' }}>
-                    {t`Your CRV Rewards tAPR:`}{' '}
-                    <strong>{formatNumber(userCrvApyValue, { unit: 'percentage', abbreviate: false })}</strong>
+                    {t`Your CRV Rewards tAPR:`} <strong>{formatNumber(userCrvApyValue, 'percent.value')}</strong>
                   </Chip>
                 )}
                 {haveBoosting && (

--- a/apps/main/src/dex/components/PagePool/components/DetailInfoExpectedApy.tsx
+++ b/apps/main/src/dex/components/PagePool/components/DetailInfoExpectedApy.tsx
@@ -49,9 +49,9 @@ export const DetailInfoExpectedApy = ({
           }
         >
           <StyledBox>
-            {formatNumber(crvApr, { unit: 'percentage', abbreviate: false })}
+            {formatNumber(crvApr, 'percent.value')}
             <Icon name="ArrowRight" size={16} className="svg-arrow" />
-            {formatNumber(newCrvApr.apr, { unit: 'percentage', abbreviate: false })}
+            {formatNumber(newCrvApr.apr, 'percent.value')}
           </StyledBox>
         </DetailInfo>
       ) : null}

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -48,7 +48,7 @@ import { ActionInfo, ActionInfoGasEstimate } from '@ui-kit/shared/ui/ActionInfo'
 import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { q } from '@ui-kit/types/util'
-import { decimal, formatNumber, formatPercent } from '@ui-kit/utils'
+import { decimal, formatNumber } from '@ui-kit/utils'
 import { getPriceImpactDisplay } from '@ui-kit/widgets/DetailPageLayout/price-impact.util'
 import { SlippageToleranceActionInfo, type SlippageType } from '@ui-kit/widgets/SlippageSettings'
 
@@ -568,7 +568,9 @@ export const QuickSwap = ({
           />
           <ActionInfo
             label={priceImpactLabel}
-            value={routesAndOutput?.priceImpact == null ? '-' : formatPercent(routesAndOutput.priceImpact)}
+            value={
+              routesAndOutput?.priceImpact == null ? '-' : formatNumber(routesAndOutput.priceImpact, 'percent.rate')
+            }
             valueColor={priceImpactColor}
             loading={routesAndOutputLoading}
             size="small"

--- a/apps/main/src/dex/components/PoolRewardsCrv.tsx
+++ b/apps/main/src/dex/components/PoolRewardsCrv.tsx
@@ -31,13 +31,9 @@ export const PoolRewardsCrv = ({
       if (base < 0.01) return '< 0.01% CRV' // Anything less is basically not worth the time
       return (
         <>
-          {formatNumber(base, { unit: 'percentage', abbreviate: false })}
+          {formatNumber(base, 'percent.value')}
           {boosted && ' → '}
-          {boosted && (
-            <span style={{ whiteSpace: 'nowrap' }}>
-              {formatNumber(boosted, { unit: 'percentage', abbreviate: false })}
-            </span>
-          )}
+          {boosted && <span style={{ whiteSpace: 'nowrap' }}>{formatNumber(boosted, 'percent.value')}</span>}
           {' CRV'}
         </>
       )

--- a/apps/main/src/dex/components/TableCellRewardsBase.tsx
+++ b/apps/main/src/dex/components/TableCellRewardsBase.tsx
@@ -38,7 +38,7 @@ export const TableCellRewardsBase = ({ base, isHighlight, poolData }: Props) => 
                   ...(base && Number(base.day) < 0 ? { minWidth: '200px' } : {}),
                 }}
               >
-                {formatNumber(amount(base.day), { unit: 'percentage', abbreviate: false, fallback: '-' })}
+                {formatNumber(amount(base.day), 'percent.value')}
               </Chip>
             )}
           </>

--- a/apps/main/src/dex/components/TableCellRewardsOthers.tsx
+++ b/apps/main/src/dex/components/TableCellRewardsOthers.tsx
@@ -18,7 +18,7 @@ export const TableCellRewardsOthers = ({ isHighlight, rewardsApy }: Prop) => {
       {rewardsApy?.other?.map(o => (
         <Fragment key={o.tokenAddress}>
           <Chip size="md" isBold={isHighlight}>
-            {formatNumber(o.apy, { unit: 'percentage', abbreviate: false })} {o.symbol}
+            {formatNumber(o.apy, 'percent.value')} {o.symbol}
           </Chip>
           <br />
         </Fragment>

--- a/apps/main/src/dex/components/TooltipBaseApy.tsx
+++ b/apps/main/src/dex/components/TooltipBaseApy.tsx
@@ -32,8 +32,8 @@ export const TooltipBaseApy = ({
         {label} <Chip size="xs">(annualized)</Chip>
       </Title>
       <ul>
-        <li>Daily: {formatNumber(amount(baseApy?.day), { unit: 'percentage', abbreviate: false, fallback: '-' })}</li>
-        <li>Weekly: {formatNumber(amount(baseApy?.week), { unit: 'percentage', abbreviate: false, fallback: '-' })}</li>
+        <li>Daily: {formatNumber(amount(baseApy?.day), 'percent.value')}</li>
+        <li>Weekly: {formatNumber(amount(baseApy?.week), 'percent.value')}</li>
       </ul>
 
       {baseApy?.day && Number(baseApy.day) < 0 && (

--- a/apps/main/src/dex/entities/gauge/model/gauge-validation.ts
+++ b/apps/main/src/dex/entities/gauge/model/gauge-validation.ts
@@ -79,6 +79,6 @@ function validateAmount({ rewardTokenId, amount, userBalance }: DepositRewardApp
   enforce(amount).condition(amount => ({
     pass: +amount <= +userBalance!,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Existing violation before enabling this rule.
-    message: t`Amount ${formatNumber(toAmount(amount), { decimals: 5, abbreviate: false, fallback: '-' })} > wallet balance ${formatNumber(toAmount(userBalance), { decimals: 5, abbreviate: false, fallback: '-' })}`,
+    message: t`Amount ${formatNumber(toAmount(amount), 'token.balance')} > wallet balance ${formatNumber(toAmount(userBalance), 'token.balance')}`,
   }))
 }

--- a/apps/main/src/dex/features/pool-list/cells/RewardsBaseCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/RewardsBaseCell.tsx
@@ -6,7 +6,7 @@ import type { CellContext } from '@tanstack/react-table'
 import { TooltipIcon as IconTooltip } from '@ui/Tooltip/TooltipIcon'
 import { isSortedBy } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { PoolListItem } from '../types'
 
 export const RewardsBaseCell = ({ table, row, getValue, column }: CellContext<PoolListItem, number | null>) => {
@@ -25,7 +25,7 @@ export const RewardsBaseCell = ({ table, row, getValue, column }: CellContext<Po
         <ChipVolatileBaseApy isBold={isHighlight} />
       ) : (
         <Tooltip title={rewards?.base && <TooltipBaseApy poolData={poolData} baseApy={rewards.base} />}>
-          <Stack>{formatPercent(day)}</Stack>
+          <Stack>{formatNumber(day, 'percent.rate')}</Stack>
         </Tooltip>
       ))
   )

--- a/apps/main/src/dex/features/pool-list/cells/RewardsIncentivesCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/RewardsIncentivesCell.tsx
@@ -24,7 +24,7 @@ export const RewardsIncentivesCell = ({ getValue, table, row: { original: poolDa
           key={o.tokenAddress}
           sx={{ fontWeight: isSortedBy(table, PoolColumnId.RewardsIncentives) ? 'bold' : 'normal' }}
         >
-          {formatNumber(o.apy, { unit: 'percentage', abbreviate: false })} {o.symbol}
+          {formatNumber(o.apy, 'percent.value')} {o.symbol}
         </Typography>
       ))}
       {campaigns.length > 0 && <CampaignRewardsRow rewardItems={campaigns} />}

--- a/apps/main/src/dex/features/pool-list/cells/UsdCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/UsdCell.tsx
@@ -1,14 +1,14 @@
 import Stack from '@mui/material/Stack'
 import type { CellContext } from '@tanstack/react-table'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { PoolListItem } from '../types'
 
 export const UsdCell = ({ getValue }: CellContext<PoolListItem, number | null>) => {
   const value = getValue()
   return (
-    <Tooltip title={value && formatUsd(value, { abbreviate: false })}>
-      <Stack>{value == null ? '-' : formatUsd(value)}</Stack>
+    <Tooltip title={value && formatNumber(value, 'usd.amount')}>
+      <Stack>{value == null ? '-' : formatNumber(value, 'usd.notional')}</Stack>
     </Tooltip>
   )
 }

--- a/apps/main/src/dex/features/refuel/components/DailyRefuelsChart.tsx
+++ b/apps/main/src/dex/features/refuel/components/DailyRefuelsChart.tsx
@@ -20,7 +20,7 @@ import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import type { LegendItem } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SelectTimeOption } from '@ui-kit/shared/ui/Chart/SelectTimeOption'
-import { formatNumber, formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { useRefuelDailyRefuels } from '../queries/daily-refuels.query'
 
 const REFUELS_LABEL = t`Daily refuels`
@@ -30,7 +30,9 @@ const REFUELS_VALUE_KEY = 'totalUsd'
 const REFUELS_COUNT_KEY = 'count'
 
 const formatDonationTooltip = (value: number, seriesName: string) =>
-  seriesName === REFUELS_COUNT_LABEL ? formatNumber(value, { abbreviate: false, decimals: 0 }) : formatUsd(value)
+  seriesName === REFUELS_COUNT_LABEL
+    ? formatNumber(value, { abbreviate: false, decimals: 0 })
+    : formatNumber(value, 'usd.notional')
 
 export const DailyRefuelsChart = ({ blockchainId, poolAddress }: { blockchainId: Chain; poolAddress: Address }) => {
   const [period, setPeriod] = useState<(typeof PERIODS)[number]>('6m')
@@ -96,7 +98,7 @@ export const DailyRefuelsChart = ({ blockchainId, poolAddress }: { blockchainId:
             ...yAxisBase,
             position: 'right',
             splitLine: { lineStyle: { color: palette.gridLinesColor } },
-            axisLabel: { ...yAxisBase.axisLabel, formatter: (value: number) => formatUsd(value) },
+            axisLabel: { ...yAxisBase.axisLabel, formatter: (value: number) => formatNumber(value, 'usd.notional') },
           },
           {
             type: 'value',

--- a/apps/main/src/dex/features/refuel/components/ReservesCompositionChart.tsx
+++ b/apps/main/src/dex/features/refuel/components/ReservesCompositionChart.tsx
@@ -26,8 +26,7 @@ import { REFUEL_TIMESERIES_PAGE_SIZE, useRefuelTimeseries } from '../queries/tim
 
 const PERIODS = ['7d', '1m', '3m', '6m', '1y'] as const satisfies Period[]
 
-const formatReserveShare = (value: number | null | undefined) =>
-  formatNumber(value, { unit: 'percentage', abbreviate: false, fallback: '-' })
+const formatReserveShare = (value: number | null | undefined) => formatNumber(value, 'percent.value')
 
 const getTokenLabel = (symbol: string | undefined, index: number) => symbol || t`Token ${index + 1}`
 

--- a/apps/main/src/dex/features/refuel/components/recent-refuels/cells/AmountCell.tsx
+++ b/apps/main/src/dex/features/refuel/components/recent-refuels/cells/AmountCell.tsx
@@ -11,7 +11,7 @@ type AmountCellProps = {
 }
 
 export const AmountCell = ({ amount, usdAmount }: AmountCellProps) => {
-  const formattedUsd = formatNumber(usdAmount, { unit: 'dollar', abbreviate: false })
+  const formattedUsd = formatNumber(usdAmount, 'usd.amount')
 
   return (
     <Stack sx={{ gap: Spacing.xxs, alignItems: 'end' }}>

--- a/apps/main/src/dex/hooks/useDexAppStats.ts
+++ b/apps/main/src/dex/hooks/useDexAppStats.ts
@@ -18,18 +18,18 @@ export const useDexAppStats = ({ isLite, chainId }: NetworkDef, enabled: boolean
     enabled && [
       {
         label: t`Total Deposits`,
-        value: formatNumber(tvlTotal, { unit: 'dollar', abbreviate: true, fallback: '-' }),
+        value: formatNumber(tvlTotal, 'usd.notional'),
       },
       ...notFalsyArray(
         !isLite && [
           // only show total deposits on curve-lite networks
           {
             label: t`Daily Volume`,
-            value: formatNumber(volumeTotal?.totalVolume, { unit: 'dollar', abbreviate: true, fallback: '-' }),
+            value: formatNumber(volumeTotal?.totalVolume, 'usd.notional'),
           },
           {
             label: t`Crypto Volume Share`,
-            value: formatNumber(volumeTotal?.cryptoShare, { unit: 'percentage', abbreviate: false, fallback: '-' }),
+            value: formatNumber(volumeTotal?.cryptoShare, 'percent.value'),
           },
         ],
       ),

--- a/apps/main/src/dex/utils/utilsCurvejs.ts
+++ b/apps/main/src/dex/utils/utilsCurvejs.ts
@@ -31,10 +31,10 @@ export function haveRewardsApy({ base, other, crv }: Partial<RewardsApy>) {
 
 export function rewardsApyCrvText([base, boosted]: number[]) {
   if (!base && !boosted) return ''
-  const formattedBase = formatNumber(base, { unit: 'percentage', abbreviate: false })
+  const formattedBase = formatNumber(base, 'percent.value')
 
   if (boosted) {
-    return `${formattedBase} → ${formatNumber(boosted, { unit: 'percentage', abbreviate: false })} CRV`
+    return `${formattedBase} → ${formatNumber(boosted, 'percent.value')} CRV`
   } else {
     return `${formattedBase} CRV`
   }

--- a/apps/main/src/lend/components/DetailInfoCrvIncentives.tsx
+++ b/apps/main/src/lend/components/DetailInfoCrvIncentives.tsx
@@ -109,7 +109,7 @@ function _getDataApr(
   lpTokenAmount: string,
 ) {
   const resp = {
-    aprCurr: formatNumber(amount(currApr), { unit: 'percentage', abbreviate: false, fallback: '-' }),
+    aprCurr: formatNumber(amount(currApr), 'percent.value'),
     aprNew: '',
     ratio: 0,
   }
@@ -117,7 +117,7 @@ function _getDataApr(
   if (+currApr > 0 && gaugeTotalSupply && +(gaugeTotalSupply || '0') > 0 && +lpTokenAmount > 0) {
     const newGaugeTotalLocked = Number(lpTokenAmount) + gaugeTotalSupply
     const aprNew = (gaugeTotalSupply / newGaugeTotalLocked) * +currApr
-    resp.aprNew = formatNumber(aprNew, { unit: 'percentage', abbreviate: false })
+    resp.aprNew = formatNumber(aprNew, 'percent.value')
     resp.ratio = +currApr / aprNew
   }
   return resp

--- a/apps/main/src/lend/components/DetailInfoEstimateGas.tsx
+++ b/apps/main/src/lend/components/DetailInfoEstimateGas.tsx
@@ -61,7 +61,7 @@ export const DetailInfoEstimateGas = ({ chainId, isDivider = false, loading, est
         estGasCostUsd == null ? (
           t`Unable to get USD rate`
         ) : (
-          <strong>{formatNumber(estGasCostUsd, { unit: 'dollar', abbreviate: false })}</strong>
+          <strong>{formatNumber(estGasCostUsd, 'usd.amount')}</strong>
         )
       ) : (
         ''

--- a/apps/main/src/lend/components/DetailInfoRate.tsx
+++ b/apps/main/src/lend/components/DetailInfoRate.tsx
@@ -39,12 +39,12 @@ export const DetailInfoRate = ({
           '?'
         ) : (
           <strong>
-            {formatNumber(rate, { unit: 'percentage', abbreviate: false, fallback: '-' })}
+            {formatNumber(rate, 'percent.value')}
             {typeof futureRates !== 'undefined' && (
               <>
                 {' '}
                 <Icon name="ArrowRight" size={16} className="svg-arrow" />{' '}
-                {formatNumber(amount(futureRate), { unit: 'percentage', abbreviate: false, fallback: '-' })}
+                {formatNumber(amount(futureRate), 'percent.value')}
               </>
             )}
           </strong>

--- a/apps/main/src/lend/hooks/useSupplyTotalApr.ts
+++ b/apps/main/src/lend/hooks/useSupplyTotalApr.ts
@@ -52,12 +52,12 @@ export function useSupplyTotalApr(rChainId: ChainId, marketId: string) {
 
 function _getTooltipValue(lendApr: number, lendApy: number, crvBase: number, crvBoost: number, others: RewardOther[]) {
   return {
-    lendApr: formatNumber(lendApr, { unit: 'percentage', abbreviate: false }),
-    lendApy: `${formatNumber(lendApy, { unit: 'percentage', abbreviate: false })} APY`,
+    lendApr: formatNumber(lendApr, 'percent.value'),
+    lendApy: `${formatNumber(lendApy, 'percent.value')} APY`,
     crvBase,
-    crv: crvBase > 0 ? formatNumber(crvBase, { unit: 'percentage', abbreviate: false }) : '',
-    crvBoosted: crvBoost > 0 ? formatNumber(crvBoost, { unit: 'percentage', abbreviate: false }) : '',
-    incentives: others.map(o => `${formatNumber(o.apy, { unit: 'percentage', abbreviate: false })} ${o.symbol}`),
+    crv: crvBase > 0 ? formatNumber(crvBase, 'percent.value') : '',
+    crvBoosted: crvBoost > 0 ? formatNumber(crvBoost, 'percent.value') : '',
+    incentives: others.map(o => `${formatNumber(o.apy, 'percent.value')} ${o.symbol}`),
     incentivesObj: others,
   }
 }

--- a/apps/main/src/lend/utils/utilsRewards.ts
+++ b/apps/main/src/lend/utils/utilsRewards.ts
@@ -15,7 +15,7 @@ export function getTotalApr(lendApy: number, crvBase: number, crvBoost: number, 
     max,
     minMax:
       min === max
-        ? formatNumber(amount(min), { unit: 'percentage', abbreviate: false, fallback: '-' })
-        : `${formatNumber(amount(min), { unit: 'percentage', abbreviate: false, fallback: '-' })} - ${formatNumber(amount(max), { unit: 'percentage', abbreviate: false, fallback: '-' })}`,
+        ? formatNumber(amount(min), 'percent.value')
+        : `${formatNumber(amount(min), 'percent.value')} - ${formatNumber(amount(max), 'percent.value')}`,
   }
 }

--- a/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
+++ b/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
@@ -4,7 +4,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { LegendBox } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatNumber, formatPercent, formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { useBandsChartPalette } from './hooks/useBandsChartPalette'
 import { BandsChartToken, ChartDataPoint } from './types'
 
@@ -18,13 +18,14 @@ type TooltipContentProps = {
 
 const calculateBandShare = (numerator: number | undefined, denominator: number | undefined): string =>
   typeof denominator === 'number' && denominator > 0 && typeof numerator === 'number'
-    ? `${formatPercent((numerator / denominator) * 100)}`
+    ? `${formatNumber((numerator / denominator) * 100, 'percent.rate')}`
     : '?'
 
 const formatAbbreviatedNumber = (value: number | undefined): string =>
   typeof value === 'number' ? `${formatNumber(value, { abbreviate: true })}` : '?'
 
-const formatUsdValue = (value: number | undefined): string => (typeof value === 'number' ? formatUsd(value) : '?')
+const formatUsdNotional = (value: number | undefined): string =>
+  typeof value === 'number' ? formatNumber(value, 'usd.notional') : '?'
 const formatBandPrice = (value: number): string =>
   formatChartAxisNumber(value, { unit: 'dollar', abbreviateFrom: false })
 
@@ -59,7 +60,7 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
                 titleAdornment={<LegendBox outline="none" fill={palette.userCollateralShareColor} />}
               >
                 {formatAbbreviatedNumber(data.userBandCollateralAmount)}
-                {formatUsdValue(data.userBandCollateralValueUsd)}
+                {formatUsdNotional(data.userBandCollateralValueUsd)}
               </TooltipItem>
               <TooltipItem
                 variant="subItem"
@@ -67,11 +68,11 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
                 titleAdornment={<LegendBox outline="none" fill={palette.userBorrowedShareColor} />}
               >
                 {formatAbbreviatedNumber(data.userBandBorrowedAmount)}
-                {formatUsdValue(data.userBandBorrowedValueUsd)}
+                {formatUsdNotional(data.userBandBorrowedValueUsd)}
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Your band liquidity`}>
-              {formatUsdValue(data.userBandTotalCollateralValueUsd)}
+              {formatUsdNotional(data.userBandTotalCollateralValueUsd)}
             </TooltipItem>
           </Stack>
         )}
@@ -88,15 +89,15 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
               >{`${calculateBandShare(data.bandCollateralValueUsd, data.bandTotalCollateralValueUsd)} / ${calculateBandShare(data.bandBorrowedValueUsd, data.bandTotalCollateralValueUsd)}`}</TooltipItem>
               <TooltipItem variant="subItem" title={collateralToken?.symbol}>
                 {formatAbbreviatedNumber(data.bandCollateralAmount)}
-                {formatUsdValue(data.bandCollateralValueUsd)}
+                {formatUsdNotional(data.bandCollateralValueUsd)}
               </TooltipItem>
               <TooltipItem variant="subItem" title={borrowToken?.symbol}>
                 {formatAbbreviatedNumber(data.bandBorrowedAmount)}
-                {formatUsdValue(data.bandBorrowedValueUsd)}
+                {formatUsdNotional(data.bandBorrowedValueUsd)}
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Band liquidity`}>
-              {formatUsdValue(data.bandTotalCollateralValueUsd)}
+              {formatUsdNotional(data.bandTotalCollateralValueUsd)}
             </TooltipItem>
           </>
         )}

--- a/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
@@ -2,7 +2,7 @@ import { useMarketParameters } from '@/llamalend/queries/market'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
-import { formatNumber, formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 // In [1]: ltv = lambda x: ((x[0] - 1) / x[0])**2 * (1 - x[1])
 // In [2]: ltv((30, 0.11))
@@ -27,14 +27,14 @@ export const MarketLoanParameters = ({ chainId, marketId }: { chainId: IChainId;
     <>
       <ActionInfo
         label={t`AMM swap fee`}
-        value={formatPercent(parameters?.fee)}
+        value={formatNumber(parameters?.fee, 'percent.rate')}
         loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Admin fee`}
-        value={formatPercent(parameters?.admin_fee)}
+        value={formatNumber(parameters?.admin_fee, 'percent.rate')}
         loading={loading}
         error={errorParameters}
       />
@@ -48,21 +48,21 @@ export const MarketLoanParameters = ({ chainId, marketId }: { chainId: IChainId;
 
       <ActionInfo
         label={t`Loan discount`}
-        value={formatPercent(parameters?.loan_discount)}
+        value={formatNumber(parameters?.loan_discount, 'percent.rate')}
         loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Liquidation discount`}
-        value={formatPercent(parameters?.liquidation_discount)}
+        value={formatNumber(parameters?.liquidation_discount, 'percent.rate')}
         loading={loading}
         error={errorParameters}
       />
 
       <ActionInfo
         label={t`Max LTV`}
-        value={formatPercent(getMaxLTV(parameters?.A ?? 0, parameters?.loan_discount))}
+        value={formatNumber(getMaxLTV(parameters?.A ?? 0, parameters?.loan_discount), 'percent.rate')}
         valueTooltip={t`Max possible loan at N=4`}
         loading={loading}
         error={errorParameters}

--- a/apps/main/src/llamalend/features/market-list/LegacyLendingMarketsFilters.tsx
+++ b/apps/main/src/llamalend/features/market-list/LegacyLendingMarketsFilters.tsx
@@ -9,7 +9,7 @@ import { TableFilterColumn } from '@ui-kit/shared/ui/DataTable/TableFilterColumn
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatPercent, formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { type AssetDetails, LlamaMarket } from '../../queries/market-list/llama-markets'
 import { LlamaMarketColumnId } from './columns'
 import { LegacyMultiSelectFilter } from './filters/LegacyMultiSelectFilter'
@@ -99,7 +99,7 @@ export const LegacyLendingMarketsFilters = ({
           id={LlamaMarketColumnId.Tvl}
           field={LlamaMarketColumnId.Tvl}
           title={t`TVL`}
-          format={formatUsd}
+          format={value => formatNumber(value, 'usd.notional')}
           data={markets}
           adornment="dollar"
           scale="power"
@@ -111,7 +111,7 @@ export const LegacyLendingMarketsFilters = ({
           id={LlamaMarketColumnId.LiquidityUsd}
           field={LlamaMarketColumnId.LiquidityUsd}
           title={t`Liquidity`}
-          format={formatUsd}
+          format={value => formatNumber(value, 'usd.notional')}
           data={markets}
           adornment="dollar"
           scale="power"
@@ -123,7 +123,7 @@ export const LegacyLendingMarketsFilters = ({
           id={LlamaMarketColumnId.UtilizationPercent}
           field={LlamaMarketColumnId.UtilizationPercent}
           title={t`Utilization`}
-          format={formatPercent}
+          format={value => formatNumber(value, 'percent.rate')}
           data={markets}
           adornment="percentage"
           max={100}

--- a/apps/main/src/llamalend/features/market-list/cells/CompactUsdCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/CompactUsdCell.tsx
@@ -4,5 +4,5 @@ import { formatNumber } from '@ui-kit/utils'
 
 export const CompactUsdCell = ({ getValue }: CellContext<LlamaMarket, number>) => {
   const value = getValue()
-  return value != null && formatNumber(value, { unit: 'dollar', abbreviate: true })
+  return value != null && formatNumber(value, 'usd.notional')
 }

--- a/apps/main/src/llamalend/features/market-list/cells/HealthCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/HealthCell.tsx
@@ -29,7 +29,7 @@ export const HealthCell = ({ row }: CellContext<LlamaMarket, number>) => {
       placement="top"
     >
       <Stack sx={{ gap: Spacing.xs }}>
-        {formatNumber(health, { unit: 'percentage', abbreviate: false })}
+        {formatNumber(health, 'percent.value')}
         <HealthBar small health={health} softLiquidation={softLiquidation} />
       </Stack>
     </Tooltip>

--- a/apps/main/src/llamalend/features/market-list/cells/LtvCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/LtvCell.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography'
 import type { CellContext } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { LlamaMarketColumnId } from '../columns'
 
 export const LtvCell = ({ row }: CellContext<LlamaMarket, number>) => {
@@ -39,7 +39,7 @@ export const LtvCell = ({ row }: CellContext<LlamaMarket, number>) => {
       placement="top"
     >
       <Typography variant="tableCellMBold" color="textPrimary" sx={{ textAlign: 'right' }}>
-        {formatPercent(data.ltv)}
+        {formatNumber(data.ltv, 'percent.rate')}
       </Typography>
     </Tooltip>
   )

--- a/apps/main/src/llamalend/features/market-list/cells/PercentCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/PercentCell.tsx
@@ -1,10 +1,10 @@
 import type { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import Typography from '@mui/material/Typography'
 import type { CellContext } from '@tanstack/react-table'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 export const PercentCell = ({ getValue }: CellContext<LlamaMarket, number>) => (
   <Typography variant="tableCellMBold" color="textPrimary" sx={{ textAlign: 'right' }}>
-    {formatPercent(getValue())}
+    {formatNumber(getValue(), 'percent.rate')}
   </Typography>
 )

--- a/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
@@ -137,7 +137,7 @@ const AssetUsdValue = ({
   <WithSkeleton loading={isPriceLoading}>
     <Tooltip title={formatNumber(usdValue, { decimals: 5, unit: 'dollar', abbreviate: false, fallback: '-' })}>
       <Typography variant="bodySRegular" sx={{ color: 'text.secondary' }}>
-        {formatNumber(usdValue, { unit: 'dollar', abbreviate: true, fallback: '-' })}
+        {formatNumber(usdValue, 'usd.notional')}
       </Typography>
     </Tooltip>
   </WithSkeleton>

--- a/apps/main/src/llamalend/features/market-list/cells/RateCell/RateCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/RateCell/RateCell.tsx
@@ -8,7 +8,7 @@ import { CellContext } from '@tanstack/react-table'
 import { TooltipProps } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { LlamaMarketColumnId } from '../../columns'
 import { BorrowRateTooltip } from './BorrowRateTooltip'
 import { RewardsIcons } from './RewardsIcons'
@@ -50,7 +50,7 @@ export const RateCell = ({
       <Tooltip market={market}>
         <Stack sx={{ gap: Spacing.xs, alignItems: 'end' }}>
           <Typography variant="tableCellMBold" color="textPrimary">
-            {rate == null ? '—' : formatPercent(rate)}
+            {rate == null ? '—' : formatNumber(rate, 'percent.rate')}
           </Typography>
 
           <RewardsIcons market={market} rateType={rateType} />

--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -11,7 +11,7 @@ import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { formatPercent, formatNumber } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -108,7 +108,7 @@ const UtilizationTooltip = ({ market, children }: { market: LlamaMarket; childre
 export const UtilizationCell = ({ row, getValue }: CellContext<LlamaMarket, number>) => (
   <UtilizationTooltip market={row.original}>
     <Stack sx={{ gap: Spacing.xs }}>
-      {formatPercent(getValue())}
+      {formatNumber(getValue(), 'percent.rate')}
       <LinearProgress percent={getValue()} size="medium" />
     </Stack>
   </UtilizationTooltip>

--- a/apps/main/src/llamalend/features/market-position-details/tooltips/AmountSuppliedTooltipContent.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/tooltips/AmountSuppliedTooltipContent.tsx
@@ -6,7 +6,7 @@ import {
   TooltipItem,
 } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import { t } from '@ui-kit/lib/i18n'
-import { formatNumber, formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { Shares, SupplyAsset } from '../SupplyPositionDetails'
 
 const isAvailable = (value: number | null | undefined): value is number => value != null
@@ -21,7 +21,7 @@ const formatAmount = (
 }
 
 const formatPercentageDisplay = (percentage: number | null) =>
-  percentage === null ? UnavailableNotation : formatPercent(percentage * 100)
+  percentage === null ? UnavailableNotation : formatNumber(percentage * 100, 'percent.rate')
 
 export const AmountSuppliedTooltipContent = ({ shares, supplyAsset }: { shares: Shares; supplyAsset: SupplyAsset }) => {
   const { value, staked } = shares

--- a/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
@@ -34,13 +34,10 @@ export const LiquidationThresholdTooltipContent = ({
       />
       <TooltipItems secondary>
         <TooltipItem title={t`Distance to LT`} variant="independent">
-          {rangeToLiquidation
-            ? formatNumber(rangeToLiquidation, { unit: 'percentage', abbreviate: false })
-            : UnavailableNotation}
+          {rangeToLiquidation ? formatNumber(rangeToLiquidation, 'percent.value') : UnavailableNotation}
         </TooltipItem>
         <TooltipItem title={t`Liquidation range`} variant="independent">
-          {liquidationRange?.map(price => formatNumber(price, { unit: 'dollar', abbreviate: false })).join(' to ') ??
-            UnavailableNotation}
+          {liquidationRange?.map(price => formatNumber(price, 'usd.amount')).join(' to ') ?? UnavailableNotation}
         </TooltipItem>
         <TooltipItem title={t`Amount of bands`} variant="independent">
           {bandRange ? formatNumber(Math.abs(bandRange[0] - bandRange[1]), { abbreviate: false }) : UnavailableNotation}

--- a/apps/main/src/llamalend/features/supply/components/columns/notional-cells.tsx
+++ b/apps/main/src/llamalend/features/supply/components/columns/notional-cells.tsx
@@ -5,13 +5,14 @@ import { t } from '@ui-kit/lib/i18n'
 import { type TableItem } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { InlineTableCell } from '@ui-kit/shared/ui/DataTable/inline-cells/InlineTableCell'
 import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
-import { formatUsd, type SxProps } from '@ui-kit/utils'
+import { formatNumber, type SxProps } from '@ui-kit/utils'
 
 type NotionalCellData = TableItem & {
   isLoading?: boolean // used for partial loading states e.g. notional rates
 }
 
-const formatNotional = (notional: number | undefined) => (notional == null ? '-' : formatUsd(notional))
+const formatNotional = (notional: number | undefined) =>
+  notional == null ? '-' : formatNumber(notional, 'usd.notional')
 
 const NotionalTypographyWithSkeleton = ({
   notional,

--- a/apps/main/src/llamalend/features/user-position-history/cells/CollateralChangeCell.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/cells/CollateralChangeCell.tsx
@@ -21,9 +21,7 @@ export const CollateralChangeCell = ({
       {collateralChange != null && collateralChange !== 0 && collateralChangeUsd !== 0 && collateralToken?.symbol}
     </Typography>
     {collateralChangeUsd !== 0 && collateralChangeUsd !== null && (
-      <Typography variant="bodySRegular">
-        {formatNumber(collateralChangeUsd, { unit: 'dollar', abbreviate: false, fallback: '-' })}
-      </Typography>
+      <Typography variant="bodySRegular">{formatNumber(collateralChangeUsd, 'usd.amount')}</Typography>
     )}
   </InlineTableCell>
 )

--- a/apps/main/src/llamalend/hooks/useLlamalendAppStats.tsx
+++ b/apps/main/src/llamalend/hooks/useLlamalendAppStats.tsx
@@ -11,7 +11,7 @@ import { EmptyValidationSuite } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { queryFactory } from '@ui-kit/lib/model'
 import { type AppName, LLAMALEND_ROUTES } from '@ui-kit/shared/routes'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 /** Query for getting the daily volume of all crvUSD AMMs */
 const { useQuery: useAppStatsDailyVolume } = queryFactory({
@@ -55,11 +55,11 @@ export function useLlamalendAppStats(
     ? [
         {
           label: 'TVL',
-          value: (tvl && formatUsd(tvl)) || '-',
+          value: (tvl && formatNumber(tvl, 'usd.notional')) || '-',
         },
         {
           label: t`Daily volume`,
-          value: (dailyVolume && formatUsd(dailyVolume)) || '-',
+          value: (dailyVolume && formatNumber(dailyVolume, 'usd.notional')) || '-',
         },
       ]
     : []

--- a/apps/main/src/llamalend/widgets/ChartLiquidationRange.tsx
+++ b/apps/main/src/llamalend/widgets/ChartLiquidationRange.tsx
@@ -319,12 +319,12 @@ export const ChartLiquidationRange = ({
                 wrapperStyle={{ color: chartLabelColor }}
                 payload={[
                   {
-                    value: `${t`Oracle Price`} (${formatNumber(amount(oraclePrice), { unit: 'dollar', abbreviate: false, fallback: '-' })})`,
+                    value: `${t`Oracle Price`} (${formatNumber(amount(oraclePrice), 'usd.amount')})`,
                     type: 'line',
                     color: chartReferenceLineColor,
                   },
                   {
-                    value: `${t`Liquidation Range`} (${data.map(d => d.new.map(n => formatNumber(n, { unit: 'dollar', abbreviate: false })).join(' - ')).join(', ')})`,
+                    value: `${t`Liquidation Range`} (${data.map(d => d.new.map(n => formatNumber(n, 'usd.amount')).join(' - ')).join(', ')})`,
                     type: 'rect',
                     color: chartHealthColor,
                   },

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -26,7 +26,7 @@ import {
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { decimal, decimalMinus, formatNumber, formatPercent, formatUsd } from '@ui-kit/utils'
+import { decimal, decimalMinus, formatNumber } from '@ui-kit/utils'
 
 const { Spacing, Height } = SizesAndSpaces
 
@@ -125,7 +125,7 @@ export const MarketRateCurveChart = ({
       notFalsy(
         currentUtilization != null && {
           value: currentUtilization,
-          label: formatPercent(currentUtilization),
+          label: formatNumber(currentUtilization, 'percent.rate'),
           color: Color.Primary[500],
           dash: CHART_LINE_DASH_PATTERNS.tight,
         },
@@ -188,7 +188,9 @@ export const MarketRateCurveChart = ({
               unit: borrowToken?.symbol ? { symbol: ` ${borrowToken.symbol}`, position: 'suffix' } : undefined,
               abbreviate: true,
             }}
-            notional={maybe(totalBorrowedUsdValue, totalBorrowedUsdValue => formatUsd(totalBorrowedUsdValue))}
+            notional={maybe(totalBorrowedUsdValue, totalBorrowedUsdValue =>
+              formatNumber(totalBorrowedUsdValue, 'usd.notional'),
+            )}
           />
           <Metric
             size="medium"
@@ -238,8 +240,8 @@ export const MarketRateCurveChart = ({
             visibleSeries={visibleSeries}
             xAxisType="value"
             markLines={markLines}
-            xTickFormatter={value => formatPercent(+value)}
-            yTickFormatter={value => formatPercent(+value)}
+            xTickFormatter={value => formatNumber(+value, 'percent.rate')}
+            yTickFormatter={value => formatNumber(+value, 'percent.rate')}
             yPaddingRatio={0.05}
             renderTooltip={RateCurveTooltip}
           />

--- a/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
@@ -13,7 +13,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate, type TxGasInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { mapQuery, type QueryProp, type Range } from '@ui-kit/types/util'
-import { decimal, formatNumber, formatPercent } from '@ui-kit/utils'
+import { decimal, formatNumber } from '@ui-kit/utils'
 import { getPriceImpactDisplay } from '@ui-kit/widgets/DetailPageLayout/price-impact.util'
 import { RouteProvidersAccordion } from '@ui-kit/widgets/RouteProvider'
 import { SlippageToleranceActionInfo } from '@ui-kit/widgets/SlippageSettings'
@@ -140,8 +140,8 @@ export const LoanActionInfoList = ({
           {(rates ?? prevRates) && (
             <ActionInfo
               label={t`Borrow APR`}
-              value={rates?.data?.borrowApr && formatPercent(rates.data.borrowApr)}
-              prevValue={prevRates?.data?.borrowApr && formatPercent(prevRates.data.borrowApr)}
+              value={rates?.data?.borrowApr && formatNumber(rates.data.borrowApr, 'percent.rate')}
+              prevValue={prevRates?.data?.borrowApr && formatNumber(prevRates.data.borrowApr, 'percent.rate')}
               {...combineActionInfoState(rates, prevRates)}
               size="small"
               testId="borrow-apr"
@@ -150,8 +150,8 @@ export const LoanActionInfoList = ({
           {shouldShowNetBorrowApr && (
             <ActionInfo
               label={t`Net borrow APR`}
-              value={netBorrowApr?.data && formatPercent(netBorrowApr.data)}
-              prevValue={prevNetBorrowApr?.data && formatPercent(prevNetBorrowApr.data)}
+              value={netBorrowApr?.data && formatNumber(netBorrowApr.data, 'percent.rate')}
+              prevValue={prevNetBorrowApr?.data && formatNumber(prevNetBorrowApr.data, 'percent.rate')}
               {...combineActionInfoState(netBorrowApr, prevNetBorrowApr)}
               size="small"
               testId="borrow-net-apr"
@@ -182,8 +182,8 @@ export const LoanActionInfoList = ({
                   <span>{t`LTV`}</span>
                 </Tooltip>
               }
-              value={loanToValue?.data && formatPercent(loanToValue.data)}
-              prevValue={prevLoanToValue?.data && formatPercent(prevLoanToValue.data)}
+              value={loanToValue?.data && formatNumber(loanToValue.data, 'percent.rate')}
+              prevValue={prevLoanToValue?.data && formatNumber(prevLoanToValue.data, 'percent.rate')}
               {...combineActionInfoState(loanToValue, prevLoanToValue)}
               size="small"
               testId="borrow-ltv"
@@ -279,7 +279,7 @@ export const LoanActionInfoList = ({
         {priceImpact && (
           <ActionInfo
             label={priceImpactLabel}
-            value={priceImpact.data == null ? '-' : formatPercent(priceImpact.data)}
+            value={priceImpact.data == null ? '-' : formatNumber(priceImpact.data, 'percent.rate')}
             valueColor={priceImpactColor}
             error={priceImpact.error}
             loading={priceImpact.isLoading}

--- a/apps/main/src/llamalend/widgets/action-card/SupplyActionInfoList.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/SupplyActionInfoList.tsx
@@ -5,7 +5,7 @@ import { useShowNetRate } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate, type TxGasInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { QueryProp } from '@ui-kit/types/util'
-import { formatNumber, formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { ActionInfoCollapse } from './ActionInfoCollapse'
 import { useShouldShowNetRate } from './hooks/useShouldShowNetRate'
 import { formatAmount, ACTION_INFO_GROUP_SX, combineActionInfoState } from './info-actions.helpers'
@@ -71,8 +71,8 @@ export const SupplyActionInfoList = ({
           {(supplyApy ?? prevSupplyApy) && (
             <ActionInfo
               label={t`Supply APY`}
-              value={supplyApy?.data && formatPercent(supplyApy.data)}
-              prevValue={prevSupplyApy?.data && formatPercent(prevSupplyApy.data)}
+              value={supplyApy?.data && formatNumber(supplyApy.data, 'percent.rate')}
+              prevValue={prevSupplyApy?.data && formatNumber(prevSupplyApy.data, 'percent.rate')}
               {...combineActionInfoState(supplyApy, prevSupplyApy)}
               size="small"
               testId="supply-apy"
@@ -81,8 +81,8 @@ export const SupplyActionInfoList = ({
           {shouldShowNetSupplyApy && (
             <ActionInfo
               label={NET_SUPPLY_RATE_TITLE}
-              value={netSupplyApy?.data && formatPercent(netSupplyApy.data)}
-              prevValue={prevNetSupplyApy?.data && formatPercent(prevNetSupplyApy.data)}
+              value={netSupplyApy?.data && formatNumber(netSupplyApy.data, 'percent.rate')}
+              prevValue={prevNetSupplyApy?.data && formatNumber(prevNetSupplyApy.data, 'percent.rate')}
               {...combineActionInfoState(netSupplyApy, prevNetSupplyApy)}
               size="small"
               testId="supply-net-apy"

--- a/apps/main/src/llamalend/widgets/banners/LowSolvencyBanner.tsx
+++ b/apps/main/src/llamalend/widgets/banners/LowSolvencyBanner.tsx
@@ -1,7 +1,7 @@
 import { SOLVENCY_THRESHOLDS } from '@/llamalend/llama-markets.constants'
 import { t } from '@ui-kit/lib/i18n'
 import { Banner } from '@ui-kit/shared/ui/Banner'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 type Props = {
   solvencyPercent: number
@@ -27,7 +27,7 @@ export const LowSolvencyBanner = ({ solvencyPercent }: Props) => {
     banner && (
       <Banner
         severity={banner.severity}
-        subtitle={t`Market solvency is ${formatPercent(solvencyPercent)}. Part of the supplied funds is no longer fully covered.`}
+        subtitle={t`Market solvency is ${formatNumber(solvencyPercent, 'percent.rate')}. Part of the supplied funds is no longer fully covered.`}
         testId={`bad-debt-banner-${banner.id}`}
         learnMoreUrl="https://docs.curve.finance/user/llamalend/bad-debt"
       >

--- a/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/CollateralMetricTooltipContent.tsx
@@ -8,7 +8,7 @@ import {
 import { Stack } from '@mui/material'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 type TokenValues = {
   value: Decimal | undefined | null
@@ -52,7 +52,7 @@ export const CollateralMetricTooltipContent = ({
       </Stack>
 
       <TooltipItem title={t`Total collateral value`} variant="independent">
-        {totalValue == null ? UnavailableNotation : formatUsd(totalValue, { abbreviate: false })}
+        {totalValue == null ? UnavailableNotation : formatNumber(totalValue, 'usd.amount')}
       </TooltipItem>
     </TooltipWrapper>
   )

--- a/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
@@ -10,7 +10,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { formatNumber } from '@ui-kit/utils'
 
-const format = (value: number) => formatNumber(value, { unit: 'dollar', abbreviate: true })
+const format = (value: number) => formatNumber(value, 'usd.notional')
 
 export const LiquidityUsdTooltipContent = ({
   market: {

--- a/apps/main/src/llamalend/widgets/tooltips/MarketNetBorrowAprTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketNetBorrowAprTooltipContent.tsx
@@ -8,7 +8,7 @@ import Stack from '@mui/material/Stack'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { RewardsTooltipItems } from './RewardTooltipItems'
 
 export type MarketNetBorrowAprTooltipContentProps = {
@@ -52,9 +52,9 @@ export const MarketNetBorrowAprTooltipContent = ({
 
     <Stack>
       <TooltipItems secondary>
-        <TooltipItem title={t`Borrow APR`}>{formatPercent(borrowApr ?? 0)}</TooltipItem>
+        <TooltipItem title={t`Borrow APR`}>{formatNumber(borrowApr ?? 0, 'percent.rate')}</TooltipItem>
         <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-          {averageApr == null ? 'N/A' : formatPercent(averageApr)}
+          {averageApr == null ? 'N/A' : formatNumber(averageApr, 'percent.rate')}
         </TooltipItem>
       </TooltipItems>
 
@@ -71,10 +71,10 @@ export const MarketNetBorrowAprTooltipContent = ({
 
       {rebasingYieldApr != null && (
         <TooltipItems secondary>
-          <TooltipItem title={t`Yield bearing tokens`}>{formatPercent(-rebasingYieldApr)}</TooltipItem>
+          <TooltipItem title={t`Yield bearing tokens`}>{formatNumber(-rebasingYieldApr, 'percent.rate')}</TooltipItem>
           {!!collateralSymbol && (
             <TooltipItem variant="subItem" title={collateralSymbol}>
-              {formatPercent(-rebasingYieldApr)}
+              {formatNumber(-rebasingYieldApr, 'percent.rate')}
             </TooltipItem>
           )}
         </TooltipItems>
@@ -83,10 +83,10 @@ export const MarketNetBorrowAprTooltipContent = ({
       {totalBorrowApr != null && (extraRewards.length || rebasingYieldApr != null) && (
         <TooltipItems>
           <TooltipItem variant="primary" title={t`Net borrow APR`}>
-            {formatPercent(totalBorrowApr)}
+            {formatNumber(totalBorrowApr, 'percent.rate')}
           </TooltipItem>
           <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-            {totalAverageBorrowApr == null ? 'N/A' : formatPercent(totalAverageBorrowApr)}
+            {totalAverageBorrowApr == null ? 'N/A' : formatNumber(totalAverageBorrowApr, 'percent.rate')}
           </TooltipItem>
         </TooltipItems>
       )}

--- a/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
@@ -9,7 +9,7 @@ import {
 import Stack from '@mui/material/Stack'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
-import { AVERAGE_CATEGORIES, formatPercent } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, formatNumber } from '@ui-kit/utils'
 import { RewardsTooltipItems } from './RewardTooltipItems'
 
 type SupplyBoostType = 'market' | 'user'
@@ -60,10 +60,10 @@ export const MarketSupplyRateTooltipContent = ({
       <Stack>
         <TooltipItems secondary>
           <TooltipItem title={t`Supply APY`} loading={isLoading}>
-            {formatPercent(supplyApy)}
+            {formatNumber(supplyApy, 'percent.rate')}
           </TooltipItem>
           <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-            {averageSupplyApy == null ? 'N/A' : formatPercent(averageSupplyApy)}
+            {averageSupplyApy == null ? 'N/A' : formatNumber(averageSupplyApy, 'percent.rate')}
           </TooltipItem>
         </TooltipItems>
 
@@ -81,11 +81,11 @@ export const MarketSupplyRateTooltipContent = ({
         {hasRebasingYield && (
           <TooltipItems secondary>
             <TooltipItem title={t`Yield bearing APY*`} loading={isLoading}>
-              {formatPercent(rebasingYieldApy)}
+              {formatNumber(rebasingYieldApy, 'percent.rate')}
             </TooltipItem>
             {!!rebasingSymbol && (
               <TooltipItem variant="subItem" title={rebasingSymbol}>
-                {formatPercent(rebasingYieldApy)}
+                {formatNumber(rebasingYieldApy, 'percent.rate')}
               </TooltipItem>
             )}
           </TooltipItems>
@@ -94,12 +94,12 @@ export const MarketSupplyRateTooltipContent = ({
         {totalApy != null && (hasIncentives || hasRebasingYield) && (
           <TooltipItems borderTop>
             <TooltipItem variant="primary" title={t`Net total APY`} loading={isLoading}>
-              {formatPercent(totalApy)}
+              {formatNumber(totalApy, 'percent.rate')}
             </TooltipItem>
             {/* Historical boost data is only available at the market level, so user totals do not show an average. */}
             {boost.type === 'market' && (
               <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-                {totalAverageApy == null ? 'N/A' : formatPercent(totalAverageApy)}
+                {totalAverageApy == null ? 'N/A' : formatNumber(totalAverageApy, 'percent.rate')}
               </TooltipItem>
             )}
           </TooltipItems>
@@ -108,7 +108,7 @@ export const MarketSupplyRateTooltipContent = ({
         {showBoostRow && (
           <TooltipItems secondary extraMargin>
             <TooltipItem title={t`Max veCRV Boost (2.5x)`} loading={isLoading}>
-              {formatPercent(boost.apy)}
+              {formatNumber(boost.apy, 'percent.rate')}
             </TooltipItem>
           </TooltipItems>
         )}
@@ -116,10 +116,10 @@ export const MarketSupplyRateTooltipContent = ({
         {showBoostRow && (
           <TooltipItems borderTop>
             <TooltipItem variant="primary" title={t`Total max veCRV APY`} loading={isLoading}>
-              {formatPercent(boost.totalApy)}
+              {formatNumber(boost.totalApy, 'percent.rate')}
             </TooltipItem>
             <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-              {boost.totalAverageApy == null ? 'N/A' : formatPercent(boost.totalAverageApy)}
+              {boost.totalAverageApy == null ? 'N/A' : formatNumber(boost.totalAverageApy, 'percent.rate')}
             </TooltipItem>
           </TooltipItems>
         )}

--- a/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
@@ -6,7 +6,7 @@ import { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { RewardsAction } from '@external-rewards'
 import { TooltipItem } from './TooltipComponents'
 
@@ -28,7 +28,10 @@ export const RewardsTooltipItems = ({
 }: RewardsTooltipItemsProps) => {
   const totalExtraPercentage =
     extraIncentives.length > 0
-      ? formatPercent(extraIncentives.reduce((sum, item) => sum + (item.percentage || 0), 0))
+      ? formatNumber(
+          extraIncentives.reduce((sum, item) => sum + (item.percentage || 0), 0),
+          'percent.rate',
+        )
       : undefined
 
   return (
@@ -37,7 +40,7 @@ export const RewardsTooltipItems = ({
       {extraIncentives.map(({ percentage, title, address, blockchainId }, i) => (
         // eslint-disable-next-line @eslint-react/no-array-index-key -- Existing violation before enabling this rule.
         <TooltipItem key={i} variant="subItem" title={title} titleIcon={{ blockchainId, address, size: 'mui-sm' }}>
-          {formatPercent(percentage)}
+          {formatNumber(percentage, 'percent.rate')}
         </TooltipItem>
       ))}
       {extraRewards.map(

--- a/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import { Stack } from '@mui/material'
 import { t } from '@ui-kit/lib/i18n'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 type TotalCollateralTooltipProps = {
   collateralSymbol: string | null | undefined
@@ -35,9 +35,7 @@ export const TotalCollateralTooltip = ({
   const borrowPercentage = formatPercentage(totalBorrowed, combinedCollateralUsdValue, borrowedUsdRate)
 
   const totalValueFormatted =
-    combinedCollateralUsdValue != null
-      ? formatUsd(combinedCollateralUsdValue, { abbreviate: false })
-      : UnavailableNotation
+    combinedCollateralUsdValue != null ? formatNumber(combinedCollateralUsdValue, 'usd.amount') : UnavailableNotation
 
   return (
     <TooltipWrapper>

--- a/apps/main/src/llamalend/widgets/tooltips/TvlTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TvlTooltipContent.tsx
@@ -10,7 +10,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { formatNumber } from '@ui-kit/utils'
 
-const format = (value: number) => formatNumber(value, { unit: 'dollar', abbreviate: true })
+const format = (value: number) => formatNumber(value, 'usd.notional')
 
 export const TvlTooltipContent = ({
   market: { totalCollateralUsd, liquidityUsd, tvl, type },

--- a/apps/main/src/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip.tsx
@@ -20,7 +20,7 @@ export const HistoricalRatesTooltip = ({ datum, visibleSeries }: HistoricalRates
           label={activeSeries.label}
           lineColor={activeSeries.color}
           dash={activeSeries.dash}
-          value={formatNumber(datum[activeSeries.key], { unit: 'percentage', abbreviate: false })}
+          value={formatNumber(datum[activeSeries.key], 'percent.value')}
         />
       ))}
     </ChartTooltipSeriesGroup>

--- a/apps/main/src/llamalend/widgets/tooltips/chart/RateCurveTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/chart/RateCurveTooltip.tsx
@@ -3,7 +3,7 @@ import Typography from '@mui/material/Typography'
 import { t } from '@ui-kit/lib/i18n'
 import { ChartTooltipSeriesGroup, ChartTooltipSeriesRow, ChartTooltipShell } from '@ui-kit/shared/ui/Chart'
 import type { LineSeriesConfig } from '@ui-kit/shared/ui/Chart/EChartsLineChart'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 type RateCurveSeriesKey = keyof Omit<RateCurveChartPoint, 'utilization'>
 
@@ -13,7 +13,7 @@ type RateCurveTooltipProps = {
 }
 
 export const RateCurveTooltip = ({ datum, visibleSeries }: RateCurveTooltipProps) => (
-  <ChartTooltipShell title={`${formatPercent(datum.utilization)} ${t`Utilization`}`}>
+  <ChartTooltipShell title={`${formatNumber(datum.utilization, 'percent.rate')} ${t`Utilization`}`}>
     <ChartTooltipSeriesGroup>
       {visibleSeries.map(activeSeries => (
         <ChartTooltipSeriesRow
@@ -21,7 +21,7 @@ export const RateCurveTooltip = ({ datum, visibleSeries }: RateCurveTooltipProps
           label={activeSeries.label}
           lineColor={activeSeries.color}
           dash={activeSeries.dash}
-          value={formatPercent(datum[activeSeries.key])}
+          value={formatNumber(datum[activeSeries.key], 'percent.rate')}
         />
       ))}
     </ChartTooltipSeriesGroup>

--- a/apps/main/src/llamalend/widgets/tooltips/tooltip.utils.ts
+++ b/apps/main/src/llamalend/widgets/tooltips/tooltip.utils.ts
@@ -1,5 +1,5 @@
 import { Amount } from '@primitives/decimal.utils'
-import { formatNumber, formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 export const UnavailableNotation = '-'
 
@@ -11,4 +11,7 @@ export const formatPercentage = (
   value: Amount | undefined | null,
   totalValue: Amount | undefined | null,
   usdRate: number | undefined | null,
-) => (totalValue && value != null && usdRate != null ? formatPercent(((+value * usdRate) / +totalValue) * 100) : null)
+) =>
+  totalValue && value != null && usdRate != null
+    ? formatNumber(((+value * usdRate) / +totalValue) * 100, 'percent.rate')
+    : null

--- a/apps/main/src/loan/components/DetailInfoBorrowRate.tsx
+++ b/apps/main/src/loan/components/DetailInfoBorrowRate.tsx
@@ -17,11 +17,8 @@ export const DetailInfoBorrowRate = ({ parameters }: Props) => {
   return (
     <DetailInfo loading={loading} loadingSkeleton={[100, 20]} label={t`Borrow APR:`}>
       <span>
-        {formatNumber(amount(borrowApr), { unit: 'percentage', abbreviate: false, fallback: '-' })}{' '}
-        <Icon name="ArrowRight" size={16} className="svg-arrow" />{' '}
-        <strong>
-          {formatNumber(amount(futureBorrowApr), { unit: 'percentage', abbreviate: false, fallback: '-' })}
-        </strong>
+        {formatNumber(amount(borrowApr), 'percent.value')} <Icon name="ArrowRight" size={16} className="svg-arrow" />{' '}
+        <strong>{formatNumber(amount(futureBorrowApr), 'percent.value')}</strong>
       </span>
     </DetailInfo>
   )

--- a/apps/main/src/loan/components/DetailInfoEstimateGas.tsx
+++ b/apps/main/src/loan/components/DetailInfoEstimateGas.tsx
@@ -61,7 +61,7 @@ export const DetailInfoEstimateGas = ({ chainId, isDivider = false, loading, est
         estGasCostUsd == null ? (
           t`Unable to get USD rate`
         ) : (
-          <span>{formatNumber(estGasCostUsd, { unit: 'dollar', abbreviate: false })}</span>
+          <span>{formatNumber(estGasCostUsd, 'usd.amount')}</span>
         )
       ) : (
         ''

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/DistributionsChartTooltip.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/DistributionsChartTooltip.tsx
@@ -4,7 +4,7 @@ import type { ScrvUsdRevenue } from '@/loan/entities/scrvusd-revenue'
 import { formatDate } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { ChartTooltipDataRow, ChartTooltipSeriesGroup, ChartTooltipShell } from '@ui-kit/shared/ui/Chart'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 type Epoch = ScrvUsdRevenue['epochs'][number]
 
@@ -16,7 +16,7 @@ export const DistributionsChartTooltip = ({ active, payload }: TooltipProps<Valu
   return (
     <ChartTooltipShell title={formatDate(endDate, 'long')}>
       <ChartTooltipSeriesGroup>
-        <ChartTooltipDataRow label={t`Weekly Revenue`} value={formatUsd(weeklyRevenue)} />
+        <ChartTooltipDataRow label={t`Weekly Revenue`} value={formatNumber(weeklyRevenue, 'usd.notional')} />
       </ChartTooltipSeriesGroup>
     </ChartTooltipShell>
   )

--- a/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/RevenueChartTooltip.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/Statistics/RevenueChartTooltip.tsx
@@ -12,7 +12,7 @@ const lineLabels: Record<YieldKeys, string> = {
   proj_apy_total_avg: t`Average APY`,
 }
 
-const format = (value: number) => formatNumber(value, { unit: 'percentage', abbreviate: false })
+const format = (value: number) => formatNumber(value, 'percent.value')
 
 type RevenueChartTooltipProps = {
   datum: ScrvUsdYieldWithAverages

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -2,7 +2,7 @@ import { capitalize, groupBy } from 'lodash'
 import type { Address } from 'viem'
 import { paginate } from '@curvefi/prices-api/paginate'
 import { addQueryString, FetchError } from '@primitives/fetch.utils'
-import { formatPercent, isCypress } from '@ui-kit/utils'
+import { formatNumber, isCypress } from '@ui-kit/utils'
 import type { RewardsAction } from '@external-rewards'
 import type { CampaignRewards } from './types'
 
@@ -78,7 +78,7 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] 
         lock: false, // Merkl doesn't offer 'locked' rewards.
 
         // Merkl campaigns don't have a multiplier, just a token. And APR is only available for the whole opportunity.
-        multiplier: opp.apr ? formatPercent(opp.apr) : token.symbol,
+        multiplier: opp.apr ? formatNumber(opp.apr, 'percent.rate') : token.symbol,
 
         tags: ['tokens'], // Merkl rewards are tokens only as far as I know; no points.
         action: ACTIONS[opp.action],

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
@@ -31,7 +31,7 @@ export const POOL_TRADES_COLUMNS = [
           blockchainId={row.original.network}
           iconPosition="right"
           primary={formatNumber(row.original.tokensBought, { abbreviate: false })}
-          secondary={formatNumber(row.original.tokensBoughtUsd, { unit: 'dollar', abbreviate: true })}
+          secondary={formatNumber(row.original.tokensBoughtUsd, 'usd.notional')}
         />
       </InlineTableCell>
     ),
@@ -47,7 +47,7 @@ export const POOL_TRADES_COLUMNS = [
           blockchainId={row.original.network}
           iconPosition="right"
           primary={formatNumber(-row.original.tokensSold, { abbreviate: false })}
-          secondary={formatNumber(-row.original.tokensSoldUsd, { unit: 'dollar', abbreviate: true })}
+          secondary={formatNumber(-row.original.tokensSoldUsd, 'usd.notional')}
         />
       </InlineTableCell>
     ),

--- a/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
+++ b/packages/curve-ui-kit/src/features/select-token/ui/modal/TokenOption.tsx
@@ -80,14 +80,14 @@ export const TokenOption = ({
             {hasBalance && (
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation before enabling this rule.
               <Typography variant="bodyMBold" color={primary}>
-                {formatNumber(amount(balance), { decimals: 5, abbreviate: false, fallback: '-' })}
+                {formatNumber(amount(balance), 'token.balance')}
               </Typography>
             )}
 
             {hasBalanceUsd && (
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation before enabling this rule.
               <Typography variant="bodyXsRegular" color={secondary}>
-                {formatNumber(tokenPrice! * +balance!, { unit: 'dollar', abbreviate: false })}
+                {formatNumber(tokenPrice! * +balance!, 'usd.amount')}
               </Typography>
             )}
 

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfoGasEstimate.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfoGasEstimate.tsx
@@ -6,7 +6,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { FireIcon } from '@ui-kit/shared/icons/FireIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { QueryProp } from '@ui-kit/types/util'
-import { formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { ActionInfo } from './ActionInfo'
 
 export type TxGasInfo = {
@@ -39,7 +39,7 @@ export const ActionInfoGasEstimate = ({
         </Typography>
       </>
     }
-    value={maybe(gas.data?.estGasCostUsd, data => formatUsd(data))}
+    value={maybe(gas.data?.estGasCostUsd, data => formatNumber(data, 'usd.notional'))}
     valueTooltip={gas.data?.tooltip}
     loading={gas.isLoading}
     valueLeft={<FireIcon sx={{ width: IconSize.xs, height: IconSize.xs }} />}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.stories.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/DataTable.stories.tsx
@@ -15,8 +15,8 @@ import { EmptyStateRow } from './EmptyStateRow'
 const { Spacing } = SizesAndSpaces
 
 const formatTokenAmount = (value: number, symbol: string) => `${formatNumber(value, { abbreviate: false })} ${symbol}`
-const formatPercentage = (value: number) => formatNumber(value, { unit: 'percentage', abbreviate: false })
-const formatUsd = (value: number) => formatNumber(value, { unit: 'dollar', abbreviate: true })
+const formatPercentage = (value: number) => formatNumber(value, 'percent.value')
+const formatUsdNotional = (value: number) => formatNumber(value, 'usd.notional')
 
 type MarketRow = TableItem & {
   id: number
@@ -112,19 +112,19 @@ const createMarketColumns = (extraColumnCount = 0): ColumnDefinition<MarketRow>[
   }),
   columnHelper.accessor('liquidity', {
     header: 'Available Liquidity',
-    cell: ({ row }) => formatUsd(row.original.liquidity),
+    cell: ({ row }) => formatUsdNotional(row.original.liquidity),
     meta: { type: 'numeric' },
   }),
   columnHelper.accessor('totalDebt', {
     header: 'Total Debt',
-    cell: ({ row }) => formatUsd(row.original.totalDebt),
+    cell: ({ row }) => formatUsdNotional(row.original.totalDebt),
     meta: { type: 'numeric' },
   }),
   ...Array.from({ length: extraColumnCount }, (_, index) =>
     columnHelper.accessor(row => row.extraMetrics[index], {
       id: `extraMetric${index + 1}`,
       header: `Metric ${index + 1}`,
-      cell: ({ row }) => formatUsd(row.original.extraMetrics[index]),
+      cell: ({ row }) => formatUsdNotional(row.original.extraMetrics[index]),
       meta: { type: 'numeric' },
     }),
   ),

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/Balance.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/Balance.tsx
@@ -101,7 +101,7 @@ export const Balance = <T extends Amount>({
             sx={{ ...VERTICAL_CENTER_TEXT, color: t => t.design.Inputs.Text.MetaSubtle }}
             {...(inline && { component: 'span' })}
           >
-            {formatNumber(notionalValueUsd, { unit: 'dollar', abbreviate: true })}
+            {formatNumber(notionalValueUsd, 'usd.notional')}
           </Typography>
         )}{' '}
       </Box>

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/BalanceAmount.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/BalanceAmount.tsx
@@ -33,7 +33,7 @@ export const BalanceAmount = <T extends Amount>({
         ...sx,
       }}
     >
-      {loading ? '?????' : children == null ? '-' : formatNumber(children, { abbreviate: true })}
+      {loading ? '?????' : children == null ? '-' : formatNumber(children, 'token.balance')}
     </Typography>
   </WithSkeleton>
 )

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/BalanceAmount.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/BalanceAmount.tsx
@@ -33,7 +33,7 @@ export const BalanceAmount = <T extends Amount>({
         ...sx,
       }}
     >
-      {loading ? '?????' : children == null ? '-' : formatNumber(children, 'token.balance')}
+      {loading ? '?????' : children == null ? '-' : formatNumber(children, 'token.compact')}
     </Typography>
   </WithSkeleton>
 )

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
@@ -367,7 +367,7 @@ export const LargeTokenInput = ({
           <Stack direction="row" sx={{ justifyContent: 'end' }}>
             {inputBalanceUsd != null && (
               <Typography variant="bodyXsRegular" sx={{ flexGrow: 1, color: t => t.design.Inputs.Text.MetaSubtle }}>
-                ≈ {formatNumber(inputBalanceUsd, { unit: 'dollar', abbreviate: false })}
+                ≈ {formatNumber(inputBalanceUsd, 'usd.amount')}
               </Typography>
             )}
 

--- a/packages/curve-ui-kit/src/shared/ui/LiquidationRangeSlider.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LiquidationRangeSlider.tsx
@@ -53,7 +53,7 @@ export const LiquidationRangeSlider = ({
           <Slider
             aria-label={t`Liquidation range`}
             size="medium"
-            getAriaValueText={value => formatNumber(value, { unit: 'dollar', abbreviate: false, fallback: '-' })}
+            getAriaValueText={value => formatNumber(value, 'usd.amount')}
             value={sliderValue}
             onChange={(_, n) => setSliderValue(n as number)}
             onChangeCommitted={(_, n) => handleSelLiqRange(n as number)}

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -500,7 +500,9 @@ describe('formatNumber', () => {
     })
 
     it('formats percent categories', () => {
+      expect(formatNumber(1200.345, 'percent.value')).toBe('1,200.35%')
       expect(formatNumber(12.345, 'percent.value')).toBe('12.35%')
+      expect(formatNumber(1200.345, 'percent.rate')).toBe('1.20k%')
       expect(formatNumber(12.3, 'percent.rate')).toBe('12.30%')
       expect(formatNumber(0.1234, 'percent.rate')).toBe('0.12%')
     })

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -9,7 +9,6 @@ import {
   scaleSuffix,
   log10Exp,
   getFractionDigitsOptions,
-  NUMBER_FORMAT_CATEGORIES,
 } from './number'
 
 describe('getFractionDigitsOptions', () => {
@@ -484,18 +483,6 @@ describe('formatNumber', () => {
   })
 
   describe('categories', () => {
-    it('exposes semantic formatter categories', () => {
-      expect(Object.keys(NUMBER_FORMAT_CATEGORIES)).toEqual([
-        'token.amount',
-        'token.compact',
-        'token.balance',
-        'usd.notional',
-        'usd.amount',
-        'percent.value',
-        'percent.rate',
-      ])
-    })
-
     it('formats token categories', () => {
       expect(formatNumber(1234.56, 'token.amount')).toBe('1,234.56')
       expect(formatNumber(1234.56, 'token.compact')).toBe('1.23k')

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -488,10 +488,19 @@ describe('formatNumber', () => {
       expect(formatNumber(1234.56, 'token.compact')).toBe('1.23k')
     })
 
-    it('formats token balances with at least five significant digits', () => {
-      expect(formatNumber(12, 'token.balance')).toBe('12.000')
-      expect(formatNumber(1.2, 'token.balance')).toBe('1.2000')
+    it('formats token balances with at most five significant digits below 1 without padding', () => {
+      expect(formatNumber(0.00000123456789, 'token.balance')).toBe('0.0000012346')
+      expect(formatNumber(-0.00000123456789, 'token.balance')).toBe('-0.0000012346')
+      expect(formatNumber(12, 'token.balance')).toBe('12')
+      expect(formatNumber(-12, 'token.balance')).toBe('-12')
+      expect(formatNumber(1.2, 'token.balance')).toBe('1.20')
+      expect(formatNumber(-1.2, 'token.balance')).toBe('-1.20')
       expect(formatNumber(123456, 'token.balance')).toBe('123,456')
+      expect(formatNumber(-123456, 'token.balance')).toBe('-123,456')
+      expect(formatNumber(123456789, 'token.balance')).toBe('123,456,789')
+      expect(formatNumber(-123456789, 'token.balance')).toBe('-123,456,789')
+      expect(formatNumber(123456789.1234, 'token.balance')).toBe('123,456,789.12')
+      expect(formatNumber(-123456789.1234, 'token.balance')).toBe('-123,456,789.12')
     })
 
     it('formats USD categories', () => {

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -488,13 +488,17 @@ describe('formatNumber', () => {
       expect(formatNumber(1234.56, 'token.compact')).toBe('1.23k')
     })
 
-    it('formats token balances with at most five significant digits below 1 without padding', () => {
+    it('formats token balances with precision-sensitive decimal handling', () => {
       expect(formatNumber(0.00000123456789, 'token.balance')).toBe('0.0000012346')
       expect(formatNumber(-0.00000123456789, 'token.balance')).toBe('-0.0000012346')
       expect(formatNumber(12, 'token.balance')).toBe('12')
       expect(formatNumber(-12, 'token.balance')).toBe('-12')
       expect(formatNumber(1.2, 'token.balance')).toBe('1.20')
       expect(formatNumber(-1.2, 'token.balance')).toBe('-1.20')
+      expect(formatNumber(5.123567, 'token.balance')).toBe('5.1236')
+      expect(formatNumber(-5.123567, 'token.balance')).toBe('-5.1236')
+      expect(formatNumber(12.34567, 'token.balance')).toBe('12.346')
+      expect(formatNumber(-12.34567, 'token.balance')).toBe('-12.346')
       expect(formatNumber(123456, 'token.balance')).toBe('123,456')
       expect(formatNumber(-123456, 'token.balance')).toBe('-123,456')
       expect(formatNumber(123456789, 'token.balance')).toBe('123,456,789')

--- a/packages/curve-ui-kit/src/utils/number.spec.ts
+++ b/packages/curve-ui-kit/src/utils/number.spec.ts
@@ -9,6 +9,7 @@ import {
   scaleSuffix,
   log10Exp,
   getFractionDigitsOptions,
+  NUMBER_FORMAT_CATEGORIES,
 } from './number'
 
 describe('getFractionDigitsOptions', () => {
@@ -310,6 +311,14 @@ describe('defaultNumberFormatter', () => {
       expect(defaultNumberFormatter(1234567.89, { useGrouping: true })).toBe('1,234,567.89')
       expect(defaultNumberFormatter(1000, { decimals: 0, useGrouping: true })).toBe('1,000')
     })
+
+    it('uses explicit significant digit options without applying default fraction digit constraints', () => {
+      expect(defaultNumberFormatter(12, { minimumSignificantDigits: 5, trailingZeroDisplay: 'auto' })).toBe('12.000')
+      expect(defaultNumberFormatter(1.2, { minimumSignificantDigits: 5, trailingZeroDisplay: 'auto' })).toBe('1.2000')
+      expect(defaultNumberFormatter(123456, { minimumSignificantDigits: 5, trailingZeroDisplay: 'auto' })).toBe(
+        '123,456',
+      )
+    })
   })
 })
 
@@ -471,6 +480,49 @@ describe('formatNumber', () => {
 
     it('keeps formatting NaN as NaN when no fallback is provided', () => {
       expect(formatNumber(NaN, { abbreviate: false })).toBe('NaN')
+    })
+  })
+
+  describe('categories', () => {
+    it('exposes semantic formatter categories', () => {
+      expect(Object.keys(NUMBER_FORMAT_CATEGORIES)).toEqual([
+        'token.amount',
+        'token.compact',
+        'token.balance',
+        'usd.notional',
+        'usd.amount',
+        'percent.value',
+        'percent.rate',
+      ])
+    })
+
+    it('formats token categories', () => {
+      expect(formatNumber(1234.56, 'token.amount')).toBe('1,234.56')
+      expect(formatNumber(1234.56, 'token.compact')).toBe('1.23k')
+    })
+
+    it('formats token balances with at least five significant digits', () => {
+      expect(formatNumber(12, 'token.balance')).toBe('12.000')
+      expect(formatNumber(1.2, 'token.balance')).toBe('1.2000')
+      expect(formatNumber(123456, 'token.balance')).toBe('123,456')
+    })
+
+    it('formats USD categories', () => {
+      expect(formatNumber(1234567, 'usd.notional')).toBe('$1.23m')
+      expect(formatNumber(1234.56, 'usd.amount')).toBe('$1,234.56')
+    })
+
+    it('formats percent categories', () => {
+      expect(formatNumber(12.345, 'percent.value')).toBe('12.35%')
+      expect(formatNumber(12.3, 'percent.rate')).toBe('12.30%')
+      expect(formatNumber(0.1234, 'percent.rate')).toBe('0.12%')
+    })
+
+    it('uses category fallbacks for missing-like and NaN values', () => {
+      expect(formatNumber(undefined, 'token.amount')).toBe('-')
+      expect(formatNumber(null, 'usd.notional')).toBe('-')
+      expect(formatNumber('', 'percent.value')).toBe('-')
+      expect(formatNumber(NaN, 'percent.rate')).toBe('-')
     })
   })
 

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -180,18 +180,28 @@ export type NumberFormatOptions = {
   fallback?: string
 } & Omit<Intl.NumberFormatOptions, 'unit' | 'style' | 'compact' | 'notation' | 'currency'>
 
+const TOKEN_BALANCE_SIGNIFICANT_DIGITS = 5
+
 const NUMBER_FORMAT_CATEGORIES = {
   'token.amount': { abbreviate: false, fallback: '-' },
   'token.compact': { abbreviate: true, fallback: '-' },
   'token.balance': {
     abbreviate: false,
     formatter: (value: Amount) => {
-      const numericValue = typeof value === 'number' ? value : Number(value)
-      const absValue = Math.abs(numericValue)
+      const absValue = Math.abs(Number(value))
+      const options: Partial<NumberFormatOptions> | undefined =
+        absValue > 0 && absValue < 1
+          ? { maximumSignificantDigits: TOKEN_BALANCE_SIGNIFICANT_DIGITS, trailingZeroDisplay: 'auto' }
+          : absValue >= 1 && Number.isFinite(absValue)
+            ? {
+                maximumFractionDigits: Math.max(
+                  2,
+                  TOKEN_BALANCE_SIGNIFICANT_DIGITS - Math.floor(Math.log10(absValue)) - 1,
+                ),
+              }
+            : undefined
 
-      return absValue > 0 && absValue < 1
-        ? defaultNumberFormatter(value, { maximumSignificantDigits: 5, trailingZeroDisplay: 'auto' })
-        : defaultNumberFormatter(value)
+      return defaultNumberFormatter(value, options)
     },
     fallback: '-',
   },

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -181,7 +181,7 @@ export type NumberFormatOptions = {
   fallback?: string
 } & Omit<Intl.NumberFormatOptions, 'unit' | 'style' | 'compact' | 'notation' | 'currency'>
 
-export const NUMBER_FORMAT_CATEGORIES = {
+const NUMBER_FORMAT_CATEGORIES = {
   'token.amount': { abbreviate: false, fallback: '-' },
   'token.compact': { abbreviate: true, fallback: '-' },
   'token.balance': {
@@ -204,7 +204,7 @@ export const NUMBER_FORMAT_CATEGORIES = {
   },
 } as const satisfies Record<string, NumberFormatOptions & { fallback: string }>
 
-export type NumberFormatCategory = keyof typeof NUMBER_FORMAT_CATEGORIES
+type NumberFormatCategory = keyof typeof NUMBER_FORMAT_CATEGORIES
 
 /**
  * Decomposes a number into its formatted parts including prefix, main value, suffix, and scale suffix.

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -117,9 +117,14 @@ export const defaultNumberFormatter = (
   const absValue = Math.abs(value)
   if (absValue > 0 && absValue < 0.00001) return value > 0 ? '<0.00001' : '>-0.00001'
 
+  const usesSignificantDigits =
+    options.minimumSignificantDigits !== undefined || options.maximumSignificantDigits !== undefined
+
   const formatted = value.toLocaleString(LOCALE, {
-    minimumFractionDigits: Math.min(decimals, options.maximumFractionDigits ?? Infinity),
-    maximumFractionDigits: highPrecision ? Math.max(4, decimals) : decimals,
+    ...(!usesSignificantDigits && {
+      minimumFractionDigits: Math.min(decimals, options.maximumFractionDigits ?? Infinity),
+      maximumFractionDigits: highPrecision ? Math.max(4, decimals) : decimals,
+    }),
     trailingZeroDisplay,
     ...options,
     ...formatterReset,
@@ -175,6 +180,31 @@ export type NumberFormatOptions = {
   /** Value returned when the input is nullish, an empty string, or numeric NaN */
   fallback?: string
 } & Omit<Intl.NumberFormatOptions, 'unit' | 'style' | 'compact' | 'notation' | 'currency'>
+
+export const NUMBER_FORMAT_CATEGORIES = {
+  'token.amount': { abbreviate: false, fallback: '-' },
+  'token.compact': { abbreviate: true, fallback: '-' },
+  'token.balance': {
+    abbreviate: false,
+    // Ensure small balances show significant digits instead of being rounded to 0, but don't force it for larger numbers where it would be noisy.
+    minimumSignificantDigits: 5,
+    trailingZeroDisplay: 'auto',
+    fallback: '-',
+  },
+  'usd.notional': { unit: 'dollar', abbreviate: true, fallback: '-' },
+  'usd.amount': { unit: 'dollar', abbreviate: false, fallback: '-' },
+  'percent.value': { unit: 'percentage', abbreviate: false, fallback: '-' },
+  'percent.rate': {
+    unit: 'percentage',
+    abbreviate: true,
+    // Disregard the precision edge case around 0 and 1 and force using 2 decimals.
+    minimumFractionDigits: 2,
+    maximumSignificantDigits: undefined,
+    fallback: '-',
+  },
+} as const satisfies Record<string, NumberFormatOptions & { fallback: string }>
+
+export type NumberFormatCategory = keyof typeof NUMBER_FORMAT_CATEGORIES
 
 /**
  * Decomposes a number into its formatted parts including prefix, main value, suffix, and scale suffix.
@@ -237,7 +267,7 @@ type MissingAmount = null | undefined | ''
  * and reassembling them into a formatted string.
  *
  * @param value - The number to format. Nullish values and empty strings return `options.fallback` or `undefined`.
- * @param options - Formatting configuration options
+ * @param options - Formatting configuration options or semantic category preset
  * @param options.fallback - Returned for nullish values, empty strings, and numeric NaN values
  * @returns The formatted number as a string with prefix, main value, scale suffix, and suffix combined. Returns
  * `undefined` for nullish or empty values when no fallback is provided.
@@ -275,11 +305,17 @@ type MissingAmount = null | undefined | ''
  *
  * formatNumber(NaN, { abbreviate: false })
  * // Returns "NaN"
+ *
+ * formatNumber(1000000, 'usd.notional')
+ * // Returns "$1m"
  */
+export function formatNumber(value: Amount | MissingAmount, category: NumberFormatCategory): string
 export function formatNumber(value: Amount, options: NumberFormatOptions): string
 export function formatNumber(value: Amount | MissingAmount, options: NumberFormatOptions & { fallback: string }): string
 export function formatNumber(value: Amount | MissingAmount, options: NumberFormatOptions): string | undefined
-export function formatNumber(value: Amount | MissingAmount, options: NumberFormatOptions) {
+export function formatNumber(value: Amount | MissingAmount, options: NumberFormatOptions | NumberFormatCategory) {
+  options = typeof options === 'string' ? NUMBER_FORMAT_CATEGORIES[options] : options
+
   if (value == null || value === '' || (typeof value === 'number' && isNaN(value) && options.fallback !== undefined)) {
     return options.fallback
   }
@@ -290,19 +326,6 @@ export function formatNumber(value: Amount | MissingAmount, options: NumberForma
   const mainValue = isNegative ? decomposed.mainValue.slice(1) : decomposed.mainValue
   return [sign, decomposed.prefix, mainValue, decomposed.scaleSuffix, decomposed.suffix].filter(Boolean).join('')
 }
-
-/** Common percentage formatter across the board for most llamalend percentages */
-export const formatPercent = (value?: Amount | null) =>
-  formatNumber(value || 0, {
-    unit: 'percentage',
-    abbreviate: true,
-    // Disregard the precision edge case around 0 and 1 and force using 2 decimals
-    minimumFractionDigits: 2,
-    maximumSignificantDigits: undefined,
-  })
-
-export const formatUsd = (value: Amount, options?: NumberFormatOptions) =>
-  formatNumber(value, { unit: 'dollar', abbreviate: true, ...options })
 
 export const formatNumberRange = (numbers: number[] | null | undefined) =>
   !numbers || numbers?.some(n => n == null) || numbers.every(n => !n)

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -114,11 +114,10 @@ export const defaultNumberFormatter = (
   if (value === -Infinity) return '-∞'
   if (value === 0) return '0'
 
-  const absValue = Math.abs(value)
-  if (absValue > 0 && absValue < 0.00001) return value > 0 ? '<0.00001' : '>-0.00001'
+  const usesSignificantDigits = options.minimumSignificantDigits != null || options.maximumSignificantDigits != null
 
-  const usesSignificantDigits =
-    options.minimumSignificantDigits !== undefined || options.maximumSignificantDigits !== undefined
+  const absValue = Math.abs(value)
+  if (!usesSignificantDigits && absValue > 0 && absValue < 0.00001) return value > 0 ? '<0.00001' : '>-0.00001'
 
   const formatted = value.toLocaleString(LOCALE, {
     ...(!usesSignificantDigits && {
@@ -186,9 +185,14 @@ const NUMBER_FORMAT_CATEGORIES = {
   'token.compact': { abbreviate: true, fallback: '-' },
   'token.balance': {
     abbreviate: false,
-    // Ensure small balances show significant digits instead of being rounded to 0, but don't force it for larger numbers where it would be noisy.
-    minimumSignificantDigits: 5,
-    trailingZeroDisplay: 'auto',
+    formatter: (value: Amount) => {
+      const numericValue = typeof value === 'number' ? value : Number(value)
+      const absValue = Math.abs(numericValue)
+
+      return absValue > 0 && absValue < 1
+        ? defaultNumberFormatter(value, { maximumSignificantDigits: 5, trailingZeroDisplay: 'auto' })
+        : defaultNumberFormatter(value)
+    },
     fallback: '-',
   },
   'usd.amount': { unit: 'dollar', abbreviate: false, fallback: '-' },

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -191,8 +191,8 @@ const NUMBER_FORMAT_CATEGORIES = {
     trailingZeroDisplay: 'auto',
     fallback: '-',
   },
-  'usd.notional': { unit: 'dollar', abbreviate: true, fallback: '-' },
   'usd.amount': { unit: 'dollar', abbreviate: false, fallback: '-' },
+  'usd.notional': { unit: 'dollar', abbreviate: true, fallback: '-' },
   'percent.value': { unit: 'percentage', abbreviate: false, fallback: '-' },
   'percent.rate': {
     unit: 'percentage',

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
@@ -11,7 +11,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { type QueryProp } from '@ui-kit/types/util'
-import { formatPercent, getErrorMessage } from '@ui-kit/utils'
+import { formatNumber, getErrorMessage } from '@ui-kit/utils'
 import { getPriceImpactSeverity } from '@ui-kit/widgets/DetailPageLayout/price-impact.util'
 import type { SlippageType } from '@ui-kit/widgets/SlippageSettings'
 
@@ -94,7 +94,7 @@ export const HighPriceImpactAlert = ({
       <WithSkeleton loading={isLoading}>
         <Alert severity={severity ?? 'warning'} data-testid="high-price-impact-alert" variant="outlined">
           <AlertTitle sx={{ color: { warning: 'warning.main', error: 'error.main' }[severity!] }}>
-            {t`High price impact:`} -{formatPercent(data)}
+            {t`High price impact:`} -{formatNumber(data, 'percent.rate')}
           </AlertTitle>
           {t`Consider reducing the amount or waiting for better market conditions.`}
         </Alert>

--- a/packages/curve-ui-kit/src/widgets/RouteProvider/RouteComparisonChip.tsx
+++ b/packages/curve-ui-kit/src/widgets/RouteProvider/RouteComparisonChip.tsx
@@ -2,10 +2,13 @@ import { BigNumber } from 'bignumber.js'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { Badge } from '@ui-kit/shared/ui/Badge'
-import { formatPercent } from '@ui-kit/utils/number'
+import { formatNumber } from '@ui-kit/utils/number'
 
 const showPercentage = (toAmountOutput: Decimal, bestOutputAmount: Decimal) =>
-  formatPercent(BigNumber(toAmountOutput).minus(bestOutputAmount).div(bestOutputAmount).div(100).toFixed() as Decimal)
+  formatNumber(
+    BigNumber(toAmountOutput).minus(bestOutputAmount).div(bestOutputAmount).div(100).toFixed() as Decimal,
+    'percent.rate',
+  )
 
 export const RouteComparisonChip = ({
   maxAmountOut,

--- a/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
+++ b/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
@@ -15,7 +15,6 @@ import { LoadingAnimation } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { QueryProp } from '@ui-kit/types/util'
 import { formatNumber, fromWei } from '@ui-kit/utils'
-import { formatUsd } from '@ui-kit/utils/number'
 import { RouteComparisonChip } from '@ui-kit/widgets/RouteProvider/RouteComparisonChip'
 
 const { Spacing, IconSize } = SizesAndSpaces
@@ -87,13 +86,15 @@ export const RouteProviderCard = ({
           <Stack direction="row" sx={{ gap: Spacing.xxs, alignItems: 'center' }}>
             <WithSkeleton loading={isLoading}>
               <Typography variant="bodyXsRegular" color="textTertiary" data-testid="route-provider-usd">
-                {amountOut == null || usdRate == null ? '-' : `~${formatUsd(parseFloat(amountOut) * usdRate)}`}
+                {amountOut == null || usdRate == null
+                  ? '-'
+                  : `~${formatNumber(parseFloat(amountOut) * usdRate, 'usd.notional')}`}
               </Typography>
             </WithSkeleton>
             {gasEstimate?.estGasCostUsd != null && !isFetching && (
               <Typography variant="bodyXsRegular" color="textTertiary" data-testid="route-provider-gas">
                 {' - '}
-                {formatUsd(gasEstimate.estGasCostUsd)}
+                {formatNumber(gasEstimate.estGasCostUsd, 'usd.notional')}
               </Typography>
             )}
             {isFetching && <ReloadIcon sx={{ ...LoadingAnimation, width: IconSize.xxs, height: IconSize.xxs }} />}

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageFormField.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageFormField.tsx
@@ -13,7 +13,7 @@ import type { UseFormReturn } from '@ui-kit/features/forms'
 import { t } from '@ui-kit/lib/i18n'
 import { Badge } from '@ui-kit/shared/ui/Badge'
 import { NumericTextField } from '@ui-kit/shared/ui/NumericTextField'
-import { decimal, decimalGreaterThan, formatPercent } from '@ui-kit/utils'
+import { decimal, decimalGreaterThan, formatNumber } from '@ui-kit/utils'
 import { SLIPPAGE, type SlippageType } from './slippage.utils'
 import { type SlippageSettingsFormData } from './useSlipageSettingsForm'
 
@@ -54,7 +54,7 @@ export const SlippageFormField = ({
       >
         {presets.map(preset => (
           <Grid size={3} key={preset} sx={{ display: 'flex', alignItems: 'middle' }}>
-            <FormControlLabel value={preset} label={formatPercent(preset)} control={<Radio />} />
+            <FormControlLabel value={preset} label={formatNumber(preset, 'percent.rate')} control={<Radio />} />
           </Grid>
         ))}
         <Grid size={6}>
@@ -82,14 +82,14 @@ export const SlippageFormField = ({
         <Alert severity="warning" variant="outlined">
           <AlertTitle>{t`High ${type} slippage selected!`}</AlertTitle>
           {t`This may lead to fewer tokens received and potential loss of funds. Proceed with caution.`}{' '}
-          {t`Max. recommended slippage is ${formatPercent(max)}`}
+          {t`Max. recommended slippage is ${formatNumber(max, 'percent.rate')}`}
         </Alert>
       ) : (
         decimalGreaterThan(min, value) && (
           <Alert severity="warning" variant="outlined">
             <AlertTitle>{t`Low ${type} slippage selected!`}</AlertTitle>
             {t`Your transaction may fail if price moves slightly. Consider increasing slippage if it doesn't go through.`}{' '}
-            {t`Min. slippage is ${formatPercent(min)}`}
+            {t`Min. slippage is ${formatNumber(min, 'percent.rate')}`}
           </Alert>
         )
       )}

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageToleranceActionInfo.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageToleranceActionInfo.tsx
@@ -30,7 +30,7 @@ export const SlippageToleranceActionInfo = ({
     <>
       <ActionInfo
         label={t`Slippage`}
-        value={maxSlippage ? formatNumber(maxSlippage, 'percent.rate') : '-'}
+        value={formatNumber(maxSlippage, 'percent.rate')}
         valueLeft={active && <Badge size="extraSmall" label={capitalize(active)} />}
         valueRight={
           <IconButton onClick={openModal} size="extraExtraSmall" data-testid="slippage-settings-button">

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageToleranceActionInfo.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageToleranceActionInfo.tsx
@@ -7,7 +7,7 @@ import { GearIcon } from '@ui-kit/shared/icons/GearIcon'
 import { ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { ActionInfoSize } from '@ui-kit/shared/ui/ActionInfo/ActionInfo'
 import { Badge } from '@ui-kit/shared/ui/Badge'
-import { formatPercent as formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { SlippageType } from './slippage.utils'
 import { SlippageSettingsModal } from './SlippageSettingsModal'
 import type { SlippageSettingsFormData } from './useSlipageSettingsForm'
@@ -30,7 +30,7 @@ export const SlippageToleranceActionInfo = ({
     <>
       <ActionInfo
         label={t`Slippage`}
-        value={maxSlippage ? formatPercent(maxSlippage) : '-'}
+        value={maxSlippage ? formatNumber(maxSlippage, 'percent.rate') : '-'}
         valueLeft={active && <Badge size="extraSmall" label={capitalize(active)} />}
         valueRight={
           <IconButton onClick={openModal} size="extraExtraSmall" data-testid="slippage-settings-button">

--- a/packages/ui/src/AlertBox/AlertInfoSelfLiquidation.tsx
+++ b/packages/ui/src/AlertBox/AlertInfoSelfLiquidation.tsx
@@ -5,7 +5,7 @@ import { DetailInfo } from '../DetailInfo'
 import { TextCaption } from '../TextCaption'
 import { AlertBox } from './AlertBox'
 
-const formatAmount = (value: string | number) => formatNumber(amount(value), { abbreviate: false, fallback: '-' })
+const formatAmount = (value: string | number) => formatNumber(amount(value), 'token.amount')
 
 export const AlertInfoSelfLiquidation = ({
   errorMessage,

--- a/packages/ui/src/InpChipUsdRate/InpChipUsdRate.tsx
+++ b/packages/ui/src/InpChipUsdRate/InpChipUsdRate.tsx
@@ -28,7 +28,7 @@ export const InpChipUsdRate = ({ className = '', amount, hideRate, usdRate, ...p
         </TextCaption>
       ) : (
         <StyledInpChip className={className} size="xs">
-          x {formatNumber(toAmount(usdRate), { abbreviate: false, fallback: '-' })} ≈ {formattedAmountUsd}
+          x {formatNumber(toAmount(usdRate), 'token.amount')} ≈ {formattedAmountUsd}
         </StyledInpChip>
       )}
     </>

--- a/packages/ui/src/InpChipUsdRate/InpChipUsdRate.tsx
+++ b/packages/ui/src/InpChipUsdRate/InpChipUsdRate.tsx
@@ -18,7 +18,7 @@ export const InpChipUsdRate = ({ className = '', amount, hideRate, usdRate, ...p
     return +amount * +usdRate
   }, [usdRate, amount])
 
-  const formattedAmountUsd = formatNumber(amountUsd, { unit: 'dollar', abbreviate: false, fallback: '-' })
+  const formattedAmountUsd = formatNumber(amountUsd, 'usd.amount')
 
   return (
     <>

--- a/tests/cypress/component/llamalend/low-solvency-banner.cy.tsx
+++ b/tests/cypress/component/llamalend/low-solvency-banner.cy.tsx
@@ -1,7 +1,7 @@
 import { LowSolvencyBanner } from '@/llamalend/widgets/banners/LowSolvencyBanner'
 import { oneFloat } from '@cy/support/generators'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
-import { formatPercent } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 
 const mountBanner = ({ solvencyPercent }: { solvencyPercent: number }) =>
   cy.mount(
@@ -38,7 +38,7 @@ describe('LowSolvencyBanner', () => {
       mountBanner({ solvencyPercent })
 
       cy.get(`[data-testid="${BANNER_PREFIX_ID}${id}"]`).should('be.visible')
-      cy.contains(formatPercent(solvencyPercent)).should('be.visible')
+      cy.contains(formatNumber(solvencyPercent, 'percent.rate')).should('be.visible')
     })
   })
 })

--- a/tests/cypress/support/helpers/llamalend/supply/claim.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/claim.helpers.ts
@@ -3,7 +3,7 @@ import { advanceVirtualNetworkClock } from '@cy/support/helpers/tenderly/vnet-ad
 import type { CreateVirtualTestnetResponse } from '@cy/support/helpers/tenderly/vnet-create'
 import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
-import { formatNumber, formatUsd } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import { loadTenderlyAccount } from '../../tenderly/account'
 import { sendVnetTransaction } from '../../tenderly/vnet-transaction'
 import { getActionInfo, getActionValue } from '../action-info.helpers'
@@ -190,11 +190,11 @@ export function checkClaimTableState({
 
     cy.get('[data-testid="data-table-cell-notional"]')
       .eq(index)
-      .contains(notional == null ? '-' : formatUsd(notional))
+      .contains(notional == null ? '-' : formatNumber(notional, 'usd.notional'))
   })
 
   if (rows.length > 1 && totalNotional != null) {
     cy.get('[data-testid="rewards-value"]').should('be.visible')
-    cy.contains(formatUsd(totalNotional)).should('be.visible')
+    cy.contains(formatNumber(totalNotional, 'usd.notional')).should('be.visible')
   }
 }

--- a/tests/cypress/support/helpers/llamalend/supply/supply.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/supply.helpers.ts
@@ -2,7 +2,7 @@ import type { Address } from 'viem'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { LOAD_TIMEOUT, TRANSACTION_LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
-import { formatNumber, formatPercent, Chain } from '@ui-kit/utils'
+import { formatNumber, Chain } from '@ui-kit/utils'
 import { getActionValue } from '../action-info.helpers'
 
 type SupplyRpcTestMarket = {
@@ -124,10 +124,10 @@ export const checkSupplyActionInfoValues = ({
   cy.get('[data-testid="supply-action-info-list"]').should('be.visible')
 
   if (supplyApy != null) {
-    getActionValue('supply-apy').should('equal', formatPercent(supplyApy as Decimal))
+    getActionValue('supply-apy').should('equal', formatNumber(supplyApy as Decimal, 'percent.rate'))
   }
   if (prevSupplyApy != null) {
-    getActionValue('supply-apy', 'previous').should('equal', formatPercent(prevSupplyApy as Decimal))
+    getActionValue('supply-apy', 'previous').should('equal', formatNumber(prevSupplyApy as Decimal, 'percent.rate'))
   }
   if (vaultShares != null) {
     getActionValue('supply-vault-shares').should('equal', formatNumber(vaultShares as Decimal, { abbreviate: true }))


### PR DESCRIPTION
Add `NUMBER_FORMAT_CATEGORIES` and a category overload for `formatNumber` so common number formatting presets can be reused by semantic intent.

* Migrate existing `formatUsd` and `formatPercent` usages to category-based `formatNumber` calls, then remove the legacy wrappers.
* Add category coverage for USD, percentage, token amount, compact token amount, and token balance formats, including fallback behavior and token balance significant-digit handling.

Categories added:
<img width="1374" height="1017" alt="image" src="https://github.com/user-attachments/assets/6ffa60f4-c959-435f-b91a-e0d3aada13b3" />

`token.balance` is complicated because "just use 5 significant digets" is not as easy as it sounds. For example when you have 123,456,789 max sig digits of 5 as it'll be rounded to 123,450,000. But you do want 0.00001234567 to round to 0.000012346. Check the test cases in `number.spec.ts` to see what's covered.
<img width="1081" height="531" alt="image" src="https://github.com/user-attachments/assets/232ce905-1b94-40c9-b0f1-136f2134142e" />
