### PR TITLE
fix: form validation

### DIFF
--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -129,9 +129,7 @@ export const RepayForm = <ChainId extends IChainId>({
   useEffect(
     () => () => {
       // Reset when selectedField changes and the field is dirty (unmounting the field)
-      if (selectedField in dirtyFields) {
-        updateForm({ [selectedField]: undefined }, { automated: true })
-      }
+      if (selectedField in dirtyFields) updateForm({ [selectedField]: undefined })
     },
     [dirtyFields, selectedField, updateForm],
   )
@@ -163,7 +161,7 @@ export const RepayForm = <ChainId extends IChainId>({
         blockchainId={network.id}
         name={selectedField}
         form={form}
-        max={q(max[selectedField])}
+        max={max[selectedField]}
         {...(selectedField === 'stateCollateral' && {
           positionBalance: { position: max.stateCollateral, tooltip: t`Current collateral in position` },
         })}
@@ -213,7 +211,7 @@ export const RepayForm = <ChainId extends IChainId>({
       <FormAlerts
         error={repayError}
         formErrors={formErrors}
-        handledErrors={notFalsy(selectedField, max[selectedField]?.field)}
+        handledErrors={notFalsy(selectedField, max[selectedField]?.fieldName)}
       />
     </Form>
   )

--- a/apps/main/src/llamalend/features/manage-loan/hooks/useMaxRepayTokenValues.ts
+++ b/apps/main/src/llamalend/features/manage-loan/hooks/useMaxRepayTokenValues.ts
@@ -13,7 +13,7 @@ import { useFormSync, useOnChangeCallback } from '@ui-kit/features/forms'
 import type { UseFormReturn } from '@ui-kit/features/forms'
 import { useTokenBalance } from '@ui-kit/hooks/useTokenBalance'
 import { queryMinimum } from '@ui-kit/lib'
-import { mapQuery } from '@ui-kit/types/util'
+import { mapQuery, q } from '@ui-kit/types/util'
 
 export function useMaxRepayTokenValues(
   {
@@ -63,9 +63,9 @@ export function useMaxRepayTokenValues(
   return {
     isFull,
     max: {
-      userCollateral: { ...maxUserCollateral, field: 'maxCollateral' as const },
-      userBorrowed: { ...maxBorrowed, field: 'maxBorrowed' as const },
-      stateCollateral: { ...mapQuery(userState, d => d.collateral), field: 'maxStateCollateral' as const },
+      userCollateral: { ...q(maxUserCollateral), fieldName: 'maxCollateral' as const },
+      userBorrowed: { ...q(maxBorrowed), fieldName: 'maxBorrowed' as const },
+      stateCollateral: { ...mapQuery(userState, d => d.collateral), fieldName: 'maxStateCollateral' as const },
       expected: useRepayExpectedBorrowed(params),
     },
   }

--- a/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
@@ -6,7 +6,6 @@ import Button from '@mui/material/Button'
 import { notFalsy } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { AlertDisableForm } from '@ui-kit/shared/ui/AlertDisableForm'
-import { q } from '@ui-kit/types/util'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
 import { useDepositForm } from '../hooks/useDepositForm'
@@ -58,7 +57,7 @@ export const DepositForm = <ChainId extends IChainId>({
         blockchainId={network.id}
         name="depositAmount"
         form={form}
-        max={q(max)}
+        max={max}
         testId={`${TEST_ID_PREFIX}-input`}
         network={network}
       />

--- a/apps/main/src/llamalend/features/supply/hooks/useMaxDeposit.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useMaxDeposit.ts
@@ -6,6 +6,7 @@ import { useFormSync } from '@ui-kit/features/forms'
 import type { UseFormReturn } from '@ui-kit/features/forms'
 import { useTokenBalance } from '@ui-kit/hooks/useTokenBalance'
 import { queryMinimum } from '@ui-kit/lib'
+import { q } from '@ui-kit/types/util'
 
 export function useMaxDepositTokenValues<ChainId extends LlamaChainId>(
   {
@@ -30,5 +31,5 @@ export function useMaxDepositTokenValues<ChainId extends LlamaChainId>(
 
   useFormSync(form, { maxDepositAmount: maxDepositAmount.data })
 
-  return maxDepositAmount
+  return { ...q(maxDepositAmount), fieldName: 'maxDepositAmount' as const }
 }

--- a/apps/main/src/llamalend/features/supply/hooks/useMaxWithdraw.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useMaxWithdraw.ts
@@ -66,7 +66,7 @@ export function useMaxWithdrawTokenValues<ChainId extends LlamaChainId>(
   )
 
   return {
-    maxWithdrawAmount: q(maxWithdrawAmount),
+    maxWithdrawAmount: { ...q(maxWithdrawAmount), fieldName: 'maxWithdrawAmount' as const },
     maxStakedShares: mapQuery(userBalances, d => d.stakedShares),
     isFull,
   }

--- a/apps/main/src/llamalend/features/supply/hooks/useStakeForm.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useStakeForm.ts
@@ -50,7 +50,7 @@ export const useStakeForm = <ChainId extends LlamaChainId>({
   const { borrowToken, collateralToken } = market ? getTokens(market) : {}
 
   const userBalances = useVaultUserBalances({ chainId, marketId, userAddress }, enabled)
-  const maxUserStake = mapQuery(userBalances, d => d.depositedShares)
+  const maxUserStake = { ...mapQuery(userBalances, d => d.depositedShares), fieldName: 'maxStakeAmount' as const }
 
   const form = useForm<StakeForm>({
     validation: stakeFormValidationSuite,

--- a/apps/main/src/llamalend/features/supply/hooks/useUnstakeForm.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useUnstakeForm.ts
@@ -48,7 +48,7 @@ export const useUnstakeForm = <ChainId extends LlamaChainId>({
   const { borrowToken, collateralToken } = market ? getTokens(market) : {}
 
   const userBalances = useVaultUserBalances({ chainId, marketId, userAddress }, enabled)
-  const maxUserUnstake = mapQuery(userBalances, d => d.stakedShares)
+  const maxUserUnstake = { ...mapQuery(userBalances, d => d.stakedShares), fieldName: 'maxUnstakeAmount' as const }
 
   const form = useForm<UnstakeForm>({
     validation: unstakeFormValidationSuite,

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -5,7 +5,7 @@ import type { INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { PartialRecord } from '@primitives/objects.utils'
-import { type FormUpdates, FieldPath, FieldPathByValue, FieldValues, UseFormReturn } from '@ui-kit/features/forms'
+import { FieldPath, FieldPathByValue, FieldValues, type FormUpdates, UseFormReturn } from '@ui-kit/features/forms'
 import { useTokenBalance } from '@ui-kit/hooks/useTokenBalance'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import { LlamaIcon } from '@ui-kit/shared/icons/LlamaIcon'
@@ -29,7 +29,7 @@ export type LoanFormTokenInputProps<
    * Optional max-value query for this field, including loading and error state.
    * When present, it also carries an optional related max-field name whose errors should be reflected here.
    */
-  max?: QueryProp<Decimal> & { fieldName?: TMaxFieldName }
+  max?: QueryProp<Decimal> & { fieldName: TMaxFieldName }
   name: TFieldName
   form: UseFormReturn<TFieldValues> // the form, used to set the value and get errors
   testId: string


### PR DESCRIPTION
- while testing zapv2 I noticed that the max errors were not showing properly anymore
- I'm not sure which PR caused this problem, but the max field should always be passed