### PR TITLE
refactor: remove setCustomFee call for ethereum mainnet

### DIFF
--- a/packages/curve-ui-kit/src/lib/model/entities/gas-info.ts
+++ b/packages/curve-ui-kit/src/lib/model/entities/gas-info.ts
@@ -80,23 +80,7 @@ const {
 
     let parsedGasInfo
 
-    if (chainId === Chain.Ethereum) {
-      // Ethereum uses api
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation before enabling this rule.
-      const json = await httpFetcher(gasPricesUrl)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Existing violation before enabling this rule.
-      const { eip1559Gas: gasInfo, gas } = json?.data ?? {}
-
-      if (gasInfo) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Existing violation before enabling this rule.
-        parsedGasInfo = parseEthereumGasInfo(gasInfo, gas)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Existing violation before enabling this rule.
-        const customFeeDataValues = getEthereumCustomFeeDataValues(gasInfo)
-        if (customFeeDataValues) {
-          curve.setCustomFeeData(customFeeDataValues)
-        }
-      }
-    } else if (chainId === Chain.Polygon) {
+    if (chainId === Chain.Polygon) {
       // Polygon uses api
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Existing violation before enabling this rule.
       const json: PolygonGasInfo = await httpFetcher(gasPricesUrl)
@@ -162,17 +146,6 @@ const {
   }),
 })
 
-function getEthereumCustomFeeDataValues(gasInfo: { max: number[]; prio: number[] } | undefined) {
-  if (gasInfo) {
-    const maxFeePerGas = gasInfo.max[1] ? weiToGwei(gasInfo.max[1]) : null
-    const maxPriorityFeePerGas = gasInfo.prio[1] ? weiToGwei(gasInfo.prio[1]) : null
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      return { maxFeePerGas, maxPriorityFeePerGas }
-    }
-  }
-  return null
-}
-
 async function fetchCustomGasFees(curve: AnyCurveApi) {
   const resp: { customFeeData: Record<string, number | null> | null; error: string } = {
     customFeeData: null,
@@ -211,25 +184,6 @@ async function fetchL1AndL2GasPrice(curve: AnyCurveApi) {
     console.error(error)
     resp.error = 'error-get-gas'
     return resp
-  }
-}
-
-function parseEthereumGasInfo(gasInfo: { base: number; prio: number[]; max: number[] }, gas: { rapid: number }) {
-  if (gasInfo.base && gasInfo.prio && gasInfo.max) {
-    const base = Math.trunc(gasInfo.base)
-    const priority = gasInfo.prio.map(Math.trunc)
-    const max = gasInfo.max.map(Math.trunc)
-
-    return {
-      gasInfo: {
-        gasPrice: gas?.rapid || null,
-        base,
-        priority,
-        max,
-        basePlusPriority: priority.map((p: number) => base + p),
-      },
-      label: ['fastest', 'fast', 'medium', 'slow'],
-    }
   }
 }
 


### PR DESCRIPTION
This only removes the call for mainnet. I've asked Denis if we can remove it for L2s too, but I'm not too optimistic (no pun intended).