### PR TITLE
fix: stale new range in candle chart

### DIFF
--- a/apps/main/src/lend/hooks/useOhlcChartState.ts
+++ b/apps/main/src/lend/hooks/useOhlcChartState.ts
@@ -13,6 +13,7 @@ import {
 import type { OhlcChartProps } from '@ui-kit/features/candle-chart/ChartWrapper'
 import type { FetchingStatus } from '@ui-kit/features/candle-chart/types'
 import { getThreeHundredResultsAgo, subtractTimeUnit } from '@ui-kit/features/candle-chart/utils'
+import { useLoanSlices } from '@ui-kit/hooks/useFeatureFlags'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Range } from '@ui-kit/types/util'
 import { useLendMarketData } from '../hooks/useLendMarket'
@@ -25,7 +26,7 @@ type UseOhlcChartStateProps = {
   previewPrices: Range<Decimal> | undefined
 }
 
-const useLegacyChartPrices = () => {
+const useLegacyChartPrices = (enabled: boolean) => {
   const borrowMoreActiveKey = useStore(state => state.loanBorrowMore.activeKey)
   const loanRepayActiveKey = useStore(state => state.loanRepay.activeKey)
   const loanCollateralAddActiveKey = useStore(state => state.loanCollateralAdd.activeKey)
@@ -41,20 +42,21 @@ const useLegacyChartPrices = () => {
     state => state.loanCollateralRemove.detailInfo[loanCollateralRemoveActiveKey]?.prices ?? null,
   )
   return useMemo(() => {
+    if (!enabled) return undefined
     if (repayLeveragePrices?.length) return repayLeveragePrices
     if (removeCollateralPrices?.length) return removeCollateralPrices
     if (addCollateralPrices?.length) return addCollateralPrices
     if (repayLoanPrices?.length) return repayLoanPrices
     if (borrowMorePrices?.length) return borrowMorePrices
-    return null
-  }, [repayLeveragePrices, removeCollateralPrices, addCollateralPrices, repayLoanPrices, borrowMorePrices]) as
+    return undefined
+  }, [enabled, repayLeveragePrices, removeCollateralPrices, addCollateralPrices, repayLoanPrices, borrowMorePrices]) as
     | Range<Decimal>
     | undefined
 }
 
 export const useOhlcChartState = ({ rChainId, marketId, previewPrices }: UseOhlcChartStateProps) => {
   const { address: userAddress } = useConnection()
-  const storePreviewPrices = useLegacyChartPrices()
+  const storePreviewPrices = useLegacyChartPrices(useLoanSlices())
   const { data: userPrices } = useUserPrices({
     chainId: rChainId,
     marketId,

--- a/apps/main/src/loan/hooks/useOhlcChartState.ts
+++ b/apps/main/src/loan/hooks/useOhlcChartState.ts
@@ -12,6 +12,7 @@ import {
 } from '@ui-kit/features/candle-chart'
 import type { OhlcChartProps } from '@ui-kit/features/candle-chart/ChartWrapper'
 import { getThreeHundredResultsAgo, subtractTimeUnit } from '@ui-kit/features/candle-chart/utils'
+import { useLoanSlices } from '@ui-kit/hooks/useFeatureFlags'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Range } from '@ui-kit/types/util'
 
@@ -24,7 +25,7 @@ type OhlcChartStateProps = {
   previewPrices: Range<Decimal> | undefined
 }
 
-const useLegacyChartPrices = () => {
+const useLegacyChartPrices = (enabled: boolean) => {
   const increaseActiveKey = useStore(state => state.loanIncrease.activeKey)
   const decreaseActiveKey = useStore(state => state.loanDecrease.activeKey)
   const deleverageActiveKey = useStore(state => state.loanDeleverage.activeKey)
@@ -40,20 +41,26 @@ const useLegacyChartPrices = () => {
     state => state.loanCollateralDecrease.detailInfo[collateralDecreaseActiveKey]?.prices ?? null,
   )
   return useMemo(() => {
+    if (!enabled) return undefined
     if (deleveragePrices?.length) return deleveragePrices
     if (decreaseCollateralPrices?.length) return decreaseCollateralPrices
     if (increaseCollateralPrices?.length) return increaseCollateralPrices
     if (decreaseLoanPrices?.length) return decreaseLoanPrices
     if (increaseLoanPrices?.length) return increaseLoanPrices
     return undefined
-  }, [deleveragePrices, decreaseCollateralPrices, increaseCollateralPrices, decreaseLoanPrices, increaseLoanPrices]) as
-    | Range<Decimal>
-    | undefined
+  }, [
+    enabled,
+    deleveragePrices,
+    decreaseCollateralPrices,
+    increaseCollateralPrices,
+    decreaseLoanPrices,
+    increaseLoanPrices,
+  ]) as Range<Decimal> | undefined
 }
 
 export const useOhlcChartState = ({ chainId, market, marketId, previewPrices }: OhlcChartStateProps) => {
   const { address: userAddress } = useConnection()
-  const storePreviewPrices = useLegacyChartPrices()
+  const storePreviewPrices = useLegacyChartPrices(useLoanSlices())
   const { data: userPrices } = useUserPrices({ chainId, marketId, userAddress })
   const oraclePoolFetchStatus = useStore(state => state.ohlcCharts.chartOraclePoolOhlc.fetchStatus)
   const oraclePoolData = useStore(state => state.ohlcCharts.chartOraclePoolOhlc.data)

--- a/packages/curve-ui-kit/src/features/forms/useCallbackSync.ts
+++ b/packages/curve-ui-kit/src/features/forms/useCallbackSync.ts
@@ -1,11 +1,13 @@
 import { useEffect } from 'react'
-import { maybe } from '@primitives/objects.utils'
 import type { Query } from '@ui-kit/types/util'
 
 /**
- * Syncs `data` to `callback` whenever it changes to a valid value. Clears it when unmounting.
+ * Syncs `data` to `callback` whenever it changes to a resolved value. Keeps the previous value while loading, and
+ * clears it when the query explicitly resolves to null or unmounts.
  */
 export function useCallbackSync<T>({ data }: Query<T | null>, callback: (data: T | undefined) => void): void {
-  useEffect(() => maybe(data, data => callback(data)), [callback, data]) // keep parent in sync, keep stale while revalidating
+  useEffect(() => {
+    if (data !== undefined) callback(data ?? undefined)
+  }, [callback, data])
   useEffect(() => () => callback(undefined), [callback]) // clear stale data only when unmounting
 }

--- a/packages/curve-ui-kit/src/features/forms/useCallbackSync.ts
+++ b/packages/curve-ui-kit/src/features/forms/useCallbackSync.ts
@@ -7,6 +7,7 @@ import type { Query } from '@ui-kit/types/util'
  */
 export function useCallbackSync<T>({ data }: Query<T | null>, callback: (data: T | undefined) => void): void {
   useEffect(() => {
+    // Keep parent in sync with resolved values, keep stale while revalidating, and clear resolved empty data.
     if (data !== undefined) callback(data ?? undefined)
   }, [callback, data])
   useEffect(() => () => callback(undefined), [callback]) // clear stale data only when unmounting


### PR DESCRIPTION
Closing a LlamaLend position makes the repay preview query resolve to `null`, meaning there is no new liquidation range to show. `useCallbackSync` previously skipped `null`, so the old preview range stayed in parent state and the candle chart could keep showing a stale “new range”.

This updates `useCallbackSync` to treat `null` as a resolved empty value and clear the synced callback state.