### PR TITLE
fix: use useMarketOraclePrice query in candle-charts

### DIFF
--- a/apps/main/src/lend/hooks/useOhlcChartState.ts
+++ b/apps/main/src/lend/hooks/useOhlcChartState.ts
@@ -148,15 +148,7 @@ export const useOhlcChartState = ({ rChainId, marketId, previewPrices }: UseOhlc
         chartTimeSettings.end,
       )
     }
-  }, [
-    chartInterval,
-    chartTimeSettings,
-    fetchLlammaOhlcData,
-    fetchOraclePoolOhlcData,
-    market,
-    rChainId,
-    timeUnit,
-  ])
+  }, [chartInterval, chartTimeSettings, fetchLlammaOhlcData, fetchOraclePoolOhlcData, market, rChainId, timeUnit])
 
   // Eagerly reset chart state as soon as the market identity changes, before the market entity resolves.
   // Without this, stale data from the previous market stays visible during the gap between navigation and fetch.

--- a/apps/main/src/lend/hooks/useOhlcChartState.ts
+++ b/apps/main/src/lend/hooks/useOhlcChartState.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { useConnection } from 'wagmi'
 import { useStore } from '@/lend/store/useStore'
 import { ChainId } from '@/lend/types/lend.types'
+import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useUserPrices } from '@/llamalend/queries/user'
 import type { Decimal } from '@primitives/decimal.utils'
 import {
@@ -76,9 +77,8 @@ export const useOhlcChartState = ({ rChainId, marketId, previewPrices }: UseOhlc
   const fetchOraclePoolOhlcData = useStore(state => state.ohlcCharts.fetchOraclePoolOhlcData)
   const fetchMoreData = useStore(state => state.ohlcCharts.fetchMoreData)
   const resetOhlcState = useStore(state => state.ohlcCharts.resetState)
-  const priceInfo = useStore(state => state.markets.pricesMapper[rChainId]?.[marketId]?.prices ?? null)
 
-  const { oraclePrice } = priceInfo ?? {}
+  const { data: oraclePrice } = useMarketOraclePrice({ chainId: rChainId, marketId })
 
   // Token symbols for chart labels (oracle tokens comes from API response)
   const oracleTokens = useMemo(
@@ -141,7 +141,6 @@ export const useOhlcChartState = ({ rChainId, marketId, previewPrices }: UseOhlc
     if (market?.addresses.amm) {
       void fetchLlammaOhlcData(
         rChainId,
-        marketId,
         market.addresses.amm,
         chartInterval,
         timeUnit,
@@ -156,7 +155,6 @@ export const useOhlcChartState = ({ rChainId, marketId, previewPrices }: UseOhlc
     fetchOraclePoolOhlcData,
     market,
     rChainId,
-    marketId,
     timeUnit,
   ])
 

--- a/apps/main/src/lend/store/createOhlcChartSlice.ts
+++ b/apps/main/src/lend/store/createOhlcChartSlice.ts
@@ -52,7 +52,6 @@ export type OhlcChartSlice = {
   [sliceKey]: SliceState & {
     fetchLlammaOhlcData: (
       chainId: ChainId,
-      llammaId: string,
       poolAddress: string,
       interval: number,
       timeUnit: string,
@@ -148,7 +147,6 @@ export const createOhlcChart = (set: StoreApi<State>['setState'], get: StoreApi<
     ...DEFAULT_STATE,
     fetchLlammaOhlcData: async (
       chainId: ChainId,
-      llammaId: string,
       poolAddress: string,
       interval: number,
       timeUnit: string,
@@ -203,14 +201,6 @@ export const createOhlcChart = (set: StoreApi<State>['setState'], get: StoreApi<
               value: item.oraclePrice,
             })
           }
-        }
-
-        const arrLength = oraclePriceArray.length - 1
-        const marketPrices = get().markets.pricesMapper[llammaId]
-        const { prices: oraclePrice } = marketPrices ?? {}
-        oraclePriceArray[arrLength] = {
-          ...oraclePriceArray[arrLength],
-          value: oraclePrice ? +oraclePrice : oraclePriceArray[arrLength].value,
         }
 
         set(

--- a/apps/main/src/loan/hooks/useOhlcChartState.ts
+++ b/apps/main/src/loan/hooks/useOhlcChartState.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { useConnection } from 'wagmi'
+import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useUserPrices } from '@/llamalend/queries/user'
 import { useStore } from '@/loan/store/useStore'
 import { ChainId, Llamma } from '@/loan/types/loan.types'
@@ -70,11 +71,10 @@ export const useOhlcChartState = ({ chainId, market, marketId, previewPrices }: 
   const fetchOracleOhlcData = useStore(state => state.ohlcCharts.fetchOracleOhlcData)
   const fetchMoreData = useStore(state => state.ohlcCharts.fetchMoreData)
   const resetOhlcState = useStore(state => state.ohlcCharts.resetState)
-  const priceInfo = useStore(state => state.loans.detailsMapper[marketId]?.priceInfo ?? null)
   const poolAddress = market?.address ?? ''
   const controllerAddress = market?.controller ?? ''
 
-  const { oraclePrice } = priceInfo ?? {}
+  const { data: oraclePrice } = useMarketOraclePrice({ chainId, marketId })
 
   // Token symbols for chart labels (oracle tokens comes from API response)
   const oracleTokens = useMemo(
@@ -134,7 +134,6 @@ export const useOhlcChartState = ({ chainId, market, marketId, previewPrices }: 
     )
     void fetchLlammaOhlcData(
       chainId,
-      marketId,
       poolAddress,
       chartInterval,
       timeUnit,
@@ -150,7 +149,6 @@ export const useOhlcChartState = ({ chainId, market, marketId, previewPrices }: 
     fetchOracleOhlcData,
     poolAddress,
     chainId,
-    marketId,
     timeUnit,
   ])
 

--- a/apps/main/src/loan/store/createOhlcChartSlice.ts
+++ b/apps/main/src/loan/store/createOhlcChartSlice.ts
@@ -82,7 +82,6 @@ export type OhlcChartSlice = {
     }>
     fetchLlammaOhlcData: (
       chainId: ChainId,
-      llammaId: string,
       poolAddress: string,
       interval: number,
       timeUnit: string,
@@ -345,7 +344,6 @@ export const createOhlcChart = (set: StoreApi<State>['setState'], get: StoreApi<
     },
     fetchLlammaOhlcData: async (
       chainId: ChainId,
-      llammaId: string,
       poolAddress: string,
       interval: number,
       timeUnit: string,
@@ -400,14 +398,6 @@ export const createOhlcChart = (set: StoreApi<State>['setState'], get: StoreApi<
               value: item.oraclePrice,
             })
           }
-        }
-
-        const arrLength = oraclePriceArray.length - 1
-        const priceInfo = get().loans.priceInfoMapper[llammaId]
-        const { oraclePrice } = priceInfo ?? {}
-        oraclePriceArray[arrLength] = {
-          ...oraclePriceArray[arrLength],
-          value: oraclePrice ? +oraclePrice : oraclePriceArray[arrLength].value,
         }
 
         set(


### PR DESCRIPTION
The ohlc chart state was still relying on an old zustand store data source for the latest oracle price while the rest of the UI had moved on

Changes:
- Use `useMarketOraclePrice` query for llamalend ohlc candle-chart latest oracle price data