### PR TITLE
feat: remove setCustomFeeData call for ethereum

### DIFF
--- a/packages/curve-ui-kit/src/lib/model/entities/gas-info.ts
+++ b/packages/curve-ui-kit/src/lib/model/entities/gas-info.ts
@@ -90,11 +90,6 @@ const {
       if (gasInfo) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Existing violation before enabling this rule.
         parsedGasInfo = parseEthereumGasInfo(gasInfo, gas)
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Existing violation before enabling this rule.
-        const customFeeDataValues = getEthereumCustomFeeDataValues(gasInfo)
-        if (customFeeDataValues) {
-          curve.setCustomFeeData(customFeeDataValues)
-        }
       }
     } else if (chainId === Chain.Polygon) {
       // Polygon uses api
@@ -161,17 +156,6 @@ const {
     })
   }),
 })
-
-function getEthereumCustomFeeDataValues(gasInfo: { max: number[]; prio: number[] } | undefined) {
-  if (gasInfo) {
-    const maxFeePerGas = gasInfo.max[1] ? weiToGwei(gasInfo.max[1]) : null
-    const maxPriorityFeePerGas = gasInfo.prio[1] ? weiToGwei(gasInfo.prio[1]) : null
-    if (maxFeePerGas && maxPriorityFeePerGas) {
-      return { maxFeePerGas, maxPriorityFeePerGas }
-    }
-  }
-  return null
-}
 
 async function fetchCustomGasFees(curve: AnyCurveApi) {
   const resp: { customFeeData: Record<string, number | null> | null; error: string } = {


### PR DESCRIPTION
Previous PR also deleted the `parsedGasInfo = parseEthereumGasInfo(gasInfo, gas)` line, but that was a bit aggressive as now Ethereum didn't have any gas info whatsoever for dollar value estimation.

So this PR only deletes the `setCustomFeeData` call.

RPC component test run on Github Actions: https://github.com/curvefi/curve-frontend/actions/runs/27148286134