### PR TITLE
chore: upgrade llamalend.js to 2.2.0

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.1.3",
+    "@curvefi/llamalend-api": "2.2.0",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.169.1",
     "@tanstack/react-router-devtools": "1.166.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,15 +394,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@curvefi/llamalend-api@npm:2.1.3"
+"@curvefi/llamalend-api@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@curvefi/llamalend-api@npm:2.2.0"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.16"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.15.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/d6537f94751dde0ff4f93b20dc1fa627dd6e86004fb03c3dd66d5ab7da176325b0dc2b02b3ef3c73bd5d9d38605c5b50814efdc5c8e4f53e4ceecd6e9944238e
+  checksum: 10c0/e9365c44c5a4726d3ebfa692f8f9f3b27b093a761e28df4bfc76d834bd84b574df0502fc1f1249d178447dde7547a240a690d85ebd98c8d86e0086558d32817b
   languageName: node
   linkType: hard
 
@@ -11567,7 +11567,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.1.3"
+    "@curvefi/llamalend-api": "npm:2.2.0"
     "@sentry/vite-plugin": "npm:5.2.1"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.169.1"


### PR DESCRIPTION
- upgrade llamalend.js to 2.2.0 https://github.com/curvefi/curve-llamalend.js/pull/107