### PR TITLE
fix: keep routes in cache while page is open

### DIFF
--- a/apps/main/src/llamalend/hooks/useMarketRoutes.ts
+++ b/apps/main/src/llamalend/hooks/useMarketRoutes.ts
@@ -11,6 +11,7 @@ import {
   type GetGasCallback,
   type RouteQueries,
   type RouteResponse,
+  usePinRouteById,
   useRouterQueries,
 } from '@ui-kit/entities/router-api'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -98,6 +99,8 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [chosenRouter, ...recordValues(queries)],
   )
+
+  usePinRouteById(selectedRoute?.id)
 
   const onChangeEffect = useEffectEvent(onChangeProp)
   useEffect(() => startTransition(() => onChangeEffect(selectedRoute)), [selectedRoute])

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
@@ -19,7 +19,11 @@ import { routerApiValidation } from './router-api.validation'
 type RouteByIdQuery = { routeId: string }
 type RouteByIdParams = FieldsOf<RouteByIdQuery>
 
-const { getQueryData: getRouteQueryData, setQueryData: setRouteQueryData } = queryFactory({
+const {
+  getQueryData: getRouteQueryData,
+  setQueryData: setRouteQueryData,
+  useQuery: useRouteByIdQuery,
+} = queryFactory({
   queryKey: ({ routeId }: RouteByIdParams) => ['router-api', 'v1/routes', { routeId }] as const,
   // eslint-disable-next-line @typescript-eslint/require-await -- Existing violation before enabling this rule.
   queryFn: async (_params: RouteByIdQuery): Promise<RouteResponse> => {
@@ -33,6 +37,13 @@ const { getQueryData: getRouteQueryData, setQueryData: setRouteQueryData } = que
   disableLog: true,
   category: 'global.routerApi',
 })
+
+/**
+ * Keeps the selected route-by-id cache entry active while a form references it.
+ * The route-by-id query is write-through only, so this hook must never enable fetching.
+ * A disabled useQuery still creates/subscribes an observer for that queryKey; it just does not auto-fetch.
+ */
+export const usePinRouteById = (routeId: string | undefined) => useRouteByIdQuery({ routeId }, false)
 
 /**
  * Returns a previously fetched router route from a local query-cache entry keyed by `routeId`.


### PR DESCRIPTION
- The form kept a routeId, but its route payload could be garbage-collected.
- Render then tried to look up that missing payload and crashed.
- The fix pins the selected route payload while the form uses its routeId.
- It does not fetch anything or keep old unselected routes alive.
