### PR TITLE
chore: add timeout to Tenderly calls

### DIFF
--- a/tests/cypress/support/helpers/llamalend/loan-setup.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/loan-setup.helpers.ts
@@ -4,6 +4,7 @@ import { getRpcUrls } from '@cy/support/helpers/tenderly/vnet'
 import type { CreateVirtualTestnetResponse } from '@cy/support/helpers/tenderly/vnet-create'
 import { fundErc20, fundEth } from '@cy/support/helpers/tenderly/vnet-fund'
 import { sendVnetTransaction } from '@cy/support/helpers/tenderly/vnet-transaction'
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
 
 const ERC20_ABI = parseAbi(['function approve(address spender, uint256 amount)'])
@@ -127,7 +128,7 @@ export const setupTenderlyLoan = ({
   })
 
   // the call above uses cy.request, but to use async we need cy.then()
-  loadTenderlyAccount().then(async tenderlyAccount => {
+  loadTenderlyAccount().then(LOAD_TIMEOUT, async tenderlyAccount => {
     await approveTokenForSpender({
       vnet,
       userAddress,

--- a/tests/cypress/support/helpers/llamalend/supply/claim.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/claim.helpers.ts
@@ -53,7 +53,7 @@ const checkpointTenderlySupplyRewards = (
     gaugeAddress: Address
   }, // Some gauges expose freshly accrued rewards only after a user checkpoint updates internal reward accounting for that address.
 ) =>
-  loadTenderlyAccount().then(async tenderlyAccount => {
+  loadTenderlyAccount().then(LOAD_TIMEOUT, async tenderlyAccount => {
     await sendVnetTransaction({
       tenderly: { ...tenderlyAccount, vnetId: vnet.id },
       tx: {

--- a/tests/cypress/support/helpers/tenderly/vnet-admin.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-admin.ts
@@ -1,3 +1,4 @@
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import { getRpcUrls } from './vnet'
 import type { CreateVirtualTestnetResponse } from './vnet-create'
 
@@ -20,6 +21,7 @@ export const advanceVirtualNetworkClock = ({
         method: 'POST',
         url: adminRpcUrl,
         body: { jsonrpc: '2.0', method: 'evm_increaseTime', params: [seconds], id: 1 },
+        ...LOAD_TIMEOUT,
       })
       .then(response => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- Existing violation before enabling this rule.
@@ -28,6 +30,7 @@ export const advanceVirtualNetworkClock = ({
           method: 'POST',
           url: adminRpcUrl,
           body: { jsonrpc: '2.0', method: 'evm_mine', params: [], id: 2 },
+          ...LOAD_TIMEOUT,
         })
       })
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access -- Existing violation before enabling this rule.

--- a/tests/cypress/support/helpers/tenderly/vnet-create.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-create.ts
@@ -1,3 +1,4 @@
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { MakeOptional } from '@ui-kit/types/util'
 import type { TenderlyAccount } from './account'
 import type { TestnetProps } from './types'
@@ -36,6 +37,7 @@ export const createVirtualTestnet = ({
       headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-Access-Key': accessKey },
       body: createOptions,
       failOnStatusCode: false,
+      ...LOAD_TIMEOUT,
     })
     .then(response => {
       if (!response.isOkStatusCode) {

--- a/tests/cypress/support/helpers/tenderly/vnet-delete.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-delete.ts
@@ -1,3 +1,4 @@
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { TenderlyAccount } from './account'
 import type { TestnetProps } from './types'
 
@@ -22,6 +23,7 @@ export const deleteVirtualTestnet = ({
         'X-Access-Key': accessKey,
       },
       failOnStatusCode: false,
+      ...LOAD_TIMEOUT,
     })
     .then(response => {
       if (!response.isOkStatusCode) {

--- a/tests/cypress/support/helpers/tenderly/vnet-fork.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-fork.ts
@@ -1,3 +1,4 @@
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { TenderlyAccount } from './account'
 import type { TestnetProps } from './types'
 
@@ -48,6 +49,7 @@ export const forkVirtualTestnet = ({
       },
       body: forkOptions,
       failOnStatusCode: false,
+      ...LOAD_TIMEOUT,
     })
     .then(response => {
       if (!response.isOkStatusCode) {

--- a/tests/cypress/support/helpers/tenderly/vnet-fund.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-fund.ts
@@ -1,4 +1,5 @@
 import { oneInt } from '@cy/support/generators'
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Hex } from '@primitives/address.utils'
 
 /**
@@ -26,6 +27,7 @@ export const fundEth = ({
       params: [recipientAddresses, amountWei],
       id: oneInt(),
     },
+    ...LOAD_TIMEOUT,
   })
 
 /**
@@ -56,4 +58,5 @@ export const fundErc20 = ({
       params: [tokenAddress, recipientAddresses, amountWei],
       id: oneInt(),
     },
+    ...LOAD_TIMEOUT,
   })

--- a/tests/cypress/support/helpers/tenderly/vnet-get.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet-get.ts
@@ -1,3 +1,4 @@
+import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { TenderlyAccount } from './account'
 import type { TestnetProps } from './types'
 
@@ -38,6 +39,7 @@ export const getVirtualTestnet = ({
         'X-Access-Key': accessKey,
       },
       failOnStatusCode: false,
+      ...LOAD_TIMEOUT,
     })
     .then(response => {
       if (!response.isOkStatusCode) {


### PR DESCRIPTION
- sometimes our rpc tests are failing due to tenderly failing after 5 seconds