### PR TITLE
fix: add llv2 support to liquidity utilization metric

### DIFF
--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -87,12 +87,16 @@ export const MetricsRow = ({
         label={t`Available liquidity`}
         value={availableLiquidity?.value}
         loading={availableLiquidity?.loading}
-        valueOptions={{ unit: 'dollar' }}
+        valueOptions={{ unit: 'none' }} // We could've shown the supply token symbol, but it's a bit ugly and it's implicit anyway
         valueTooltip={{
           title: t`Available Liquidity ${MarketTypeSuffix[marketType]}`,
           body: <AvailableLiquidityTooltip marketType={marketType} />,
           ...TooltipOptions,
         }}
+        notional={maybe(availableLiquidity?.notional, x => ({
+          value: x,
+          unit: 'dollar',
+        }))}
       />
     </Stack>
   )

--- a/apps/main/src/llamalend/widgets/page-header/PageHeader.stories.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/PageHeader.stories.tsx
@@ -64,6 +64,7 @@ const supplyRate: SupplyRate = {
 const availableLiquidity: AvailableLiquidity = {
   value: 12_500_000,
   max: 30_000_000,
+  notional: 12_500_000 * 1.02, // Assuming a $1.02 USD rate for the borrow token
   loading: false,
 }
 

--- a/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
+++ b/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
@@ -18,16 +18,18 @@ import {
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
-import { notFalsyArray } from '@primitives/objects.utils'
+import { maybes, notFalsyArray } from '@primitives/objects.utils'
 import { useCampaignsByAddress, type CampaignRewards } from '@ui-kit/entities/campaigns'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
+import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import type { Range } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, type AverageCategory } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, CRVUSD_ADDRESS, type AverageCategory } from '@ui-kit/utils'
 
 export type AvailableLiquidity = {
   value: number | null | undefined
   max: number | null | undefined
+  notional: number | null | undefined
   loading: boolean
 }
 
@@ -106,6 +108,7 @@ export const usePageHeader = ({
   const isLendMarket = market instanceof LendMarketTemplate
   const vaultAddress = (isLendMarket ? market.addresses.vault : undefined) as Address | undefined
   const controllerAddress = (isLendMarket ? market.addresses.controller : market?.controller) as Address | undefined
+  const borrowTokenAddress = (isLendMarket ? market.addresses.borrowed_token : CRVUSD_ADDRESS) as Address | undefined
   const marketType = isLendMarket ? LlamaMarketType.Lend : LlamaMarketType.Mint
 
   const { data: snapshots, isLoading: isSnapshotsLoading } = useLlamaSnapshot(
@@ -120,6 +123,10 @@ export const usePageHeader = ({
     !isMarketMetadataLoading,
   )
   const { data: capAndAvailable, isLoading: isCapAndAvailableLoading } = useMarketCapAndAvailable({ chainId, marketId })
+  const { data: borrowUsdRate, isLoading: isBorrowUsdRateLoading } = useTokenUsdRate({
+    chainId,
+    tokenAddress: borrowTokenAddress,
+  })
   const { data: marketOnChainRewards, isLoading: isMarketOnChainRewardsLoading } = useMarketVaultOnChainRewards(
     { chainId, marketId },
     isLendMarket,
@@ -170,7 +177,8 @@ export const usePageHeader = ({
   const availableLiquidity: AvailableLiquidity = {
     value: toNumberOrNull(capAndAvailable?.available),
     max: toNumberOrNull(capAndAvailable?.totalAssets),
-    loading: isCapAndAvailableLoading || isMarketMetadataLoading,
+    notional: maybes([toNumberOrNull(capAndAvailable?.available), borrowUsdRate], ([liq, rate]) => liq * rate),
+    loading: isCapAndAvailableLoading || isMarketMetadataLoading || isBorrowUsdRateLoading,
   }
 
   return { borrowRate, supplyRate, availableLiquidity }


### PR DESCRIPTION
Removes the dollar unit from the available liquidity metric, and then puts the actual dollar value as the notional. Initially I added the borrow token as unit for the metric, but it was kinda ugly and implicit anyway, so I kept it unitless for now.

Turns out this was also a bug that would be visible in the now deprecated CRV short market. This PR will now show the correct values that correspond to available liquidity value in the market list.

<img width="107" height="77" alt="image" src="https://github.com/user-attachments/assets/614eaafa-c113-426c-ad4a-4153562363c0" />
<img width="1360" height="136" alt="image" src="https://github.com/user-attachments/assets/d7b48ca3-9f7e-4510-aff5-7ab7189c3fd1" />