### PR TITLE
fix: activity table time column alignment and column header size

### DIFF
--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
@@ -47,6 +47,7 @@ export const ActivityTable = <TData extends TableItem>({
         }
         loading={isLoading}
         maxHeight={height}
+        size="small"
         expandedPanel={expandedPanel}
       />
     </Box>

--- a/packages/curve-ui-kit/src/features/activity-table/columns/llamma-events-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/llamma-events-columns.tsx
@@ -42,5 +42,6 @@ export const LLAMMA_EVENTS_COLUMNS = [
     cell: ({ row }) => (
       <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} align="end" />
     ),
+    meta: { type: 'numeric' },
   }),
 ]

--- a/packages/curve-ui-kit/src/features/activity-table/columns/llamma-trades-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/llamma-trades-columns.tsx
@@ -57,5 +57,6 @@ export const LLAMMA_TRADES_COLUMNS = [
     cell: ({ row }) => (
       <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.txUrl} align="end" />
     ),
+    meta: { type: 'numeric' },
   }),
 ]

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
@@ -73,6 +73,7 @@ export const createPoolLiquidityColumns = ({ poolTokens }: CreatePoolLiquidityCo
       cell: ({ row }) => (
         <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} align="end" />
       ),
+      meta: { type: 'numeric' },
     }),
   ]
 

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-trades-columns.tsx
@@ -57,5 +57,6 @@ export const POOL_TRADES_COLUMNS = [
     id: PoolTradesColumnId.Time,
     header: t`Time`,
     cell: ({ row }) => <TimestampCell timestamp={new Date(row.original.time)} txUrl={row.original.txUrl} align="end" />,
+    meta: { type: 'numeric' },
   }),
 ]


### PR DESCRIPTION
There had been a regression and the "Time" column title was aligned to the left when the cell content is aligned to the right. I also thought the new smaller table header size looks much better for the inline tables so made that adjustment too 😇

<img width="1076" height="362" alt="SCR-20260609-swrt" src="https://github.com/user-attachments/assets/a62326b5-95a4-43f2-84a6-acbc7f9d0716" />
