### PR TITLE
refactor: update range to liquidation calculation and tooltip description

### DIFF
--- a/apps/main/src/llamalend/features/market-position-details/BorrowInformation.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/BorrowInformation.tsx
@@ -5,6 +5,7 @@ import { useRangeToLiquidation } from '@/llamalend/queries/user/user-prices.quer
 import { CollateralMetricTooltipContent } from '@/llamalend/widgets/tooltips/CollateralMetricTooltipContent'
 import { TotalDebtTooltipContent } from '@/llamalend/widgets/tooltips/TotalDebtTooltipContent'
 import { Stack } from '@mui/material'
+import { maybe } from '@primitives/objects.utils'
 import { combineQueryState } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import type { UserMarketParams } from '@ui-kit/lib/model'
@@ -114,14 +115,10 @@ export const BorrowInformation = ({ params, tokens: { collateralToken, borrowTok
             arrow: false,
             clickable: true,
           }}
-          notional={
-            rangeToLiquidation.data
-              ? {
-                  value: rangeToLiquidation.data,
-                  unit: { symbol: `% distance to LT`, position: 'suffix' },
-                }
-              : undefined
-          }
+          notional={maybe(rangeToLiquidation.data, value => ({
+            value,
+            unit: { symbol: `% distance to LT`, position: 'suffix' },
+          }))}
         />
         <Metric
           size="small"

--- a/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
@@ -29,7 +29,7 @@ export const LiquidationThresholdTooltipContent = ({
       <TooltipDescription
         text={[
           t`The price at which your position enters the liquidation range  and your collateral starts to be eroded by LLAMMA.`,
-          t`The distance to LT indicates the distance between the current price and the LT.`,
+          t`The distance to LT indicates how much the current price can drop before reaching the LT.`,
         ].join(' ')}
       />
       <TooltipItems secondary>

--- a/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/tooltips/LiquidationThresholdMetricTooltipContent.tsx
@@ -14,7 +14,7 @@ import { formatNumber } from '@ui-kit/utils'
 
 type LiquidationThresholdTooltipContentProps = {
   userPrices: QueryProp<Range<Decimal>>
-  rangeToLiquidation: QueryProp<number>
+  rangeToLiquidation: QueryProp<Decimal>
   params: UserMarketParams
 }
 
@@ -34,7 +34,7 @@ export const LiquidationThresholdTooltipContent = ({
       />
       <TooltipItems secondary>
         <TooltipItem title={t`Distance to LT`} variant="independent">
-          {rangeToLiquidation ? formatNumber(rangeToLiquidation, 'percent.value') : UnavailableNotation}
+          {rangeToLiquidation != null ? formatNumber(rangeToLiquidation, 'percent.value') : UnavailableNotation}
         </TooltipItem>
         <TooltipItem title={t`Liquidation range`} variant="independent">
           {liquidationRange?.map(price => formatNumber(price, 'usd.amount')).join(' to ') ?? UnavailableNotation}

--- a/apps/main/src/llamalend/queries/user/user-prices.query.ts
+++ b/apps/main/src/llamalend/queries/user/user-prices.query.ts
@@ -12,6 +12,9 @@ import { useLoanExists } from './user-loan-exists.query'
 type UserPricesQuery = UserMarketQuery & { loanExists: boolean }
 type UserPricesParams = FieldsOf<UserPricesQuery>
 
+const calculatePriceDropToLiquidationThreshold = (currentPrice: Decimal, liquidationThreshold: Decimal) =>
+  ((+currentPrice - +liquidationThreshold) / +currentPrice) * 100
+
 const { useQuery: useUserPricesQuery, queryKey: getUserPricesKey } = queryFactory({
   queryKey: ({ chainId, marketId, userAddress, loanExists }: UserPricesParams) =>
     [...rootKeys.userMarket({ chainId, marketId, userAddress }), 'userPrices', { loanExists }] as const,
@@ -35,7 +38,9 @@ export function useRangeToLiquidation({ params }: { params: UserMarketParams }) 
   const oraclePrice = useMarketOraclePrice(params)
   const rangeToLiquidation = {
     data:
-      oraclePrice.data && userPrices.data && ((+oraclePrice.data - +userPrices.data[1]) / +userPrices.data[1]) * 100,
+      oraclePrice.data &&
+      userPrices.data &&
+      calculatePriceDropToLiquidationThreshold(oraclePrice.data, userPrices.data[1]),
     ...combineQueryState(userPrices, oraclePrice),
   }
   return { rangeToLiquidation, userPrices }

--- a/apps/main/src/llamalend/queries/user/user-prices.query.ts
+++ b/apps/main/src/llamalend/queries/user/user-prices.query.ts
@@ -7,13 +7,14 @@ import { loanExistsValidationGroup } from '@ui-kit/lib/model/query/loan-exists-v
 import { marketIdValidationSuite } from '@ui-kit/lib/model/query/market-id-validation'
 import { createValidationSuite } from '@ui-kit/lib/validation'
 import { q, type Range } from '@ui-kit/types/util'
+import { decimalMultiply, decimalDiv, decimalMinus } from '@ui-kit/utils'
 import { useLoanExists } from './user-loan-exists.query'
 
 type UserPricesQuery = UserMarketQuery & { loanExists: boolean }
 type UserPricesParams = FieldsOf<UserPricesQuery>
 
-const calculatePriceDropToLiquidationThreshold = (currentPrice: Decimal, liquidationThreshold: Decimal) =>
-  ((+currentPrice - +liquidationThreshold) / +currentPrice) * 100
+const calculatePriceDropToLiquidationThreshold = (currentPrice: Decimal, [, liquidationThreshold]: Range<Decimal>) =>
+  decimalMultiply(decimalDiv(decimalMinus(currentPrice, liquidationThreshold), currentPrice), `100`)
 
 const { useQuery: useUserPricesQuery, queryKey: getUserPricesKey } = queryFactory({
   queryKey: ({ chainId, marketId, userAddress, loanExists }: UserPricesParams) =>
@@ -40,7 +41,7 @@ export function useRangeToLiquidation({ params }: { params: UserMarketParams }) 
     data:
       oraclePrice.data &&
       userPrices.data &&
-      calculatePriceDropToLiquidationThreshold(oraclePrice.data, userPrices.data[1]),
+      calculatePriceDropToLiquidationThreshold(oraclePrice.data, userPrices.data),
     ...combineQueryState(userPrices, oraclePrice),
   }
   return { rangeToLiquidation, userPrices }

--- a/packages/curve-ui-kit/src/shared/ui/Metric.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Metric.tsx
@@ -54,7 +54,7 @@ const MetricChangeSize = {
 export const SIZES = Object.keys(MetricSize) as (keyof typeof MetricSize)[]
 
 type Notional = Omit<NumberFormatOptions, 'abbreviate'> & {
-  value: number
+  value: Amount
   abbreviate?: boolean // Defaults to true
 }
 


### PR DESCRIPTION
Changes:
- Updates "range to liquidation" calculation to show "how much the current price can drop before reaching the LT" instead of "the distance between the current price and the LT"