### PR TITLE
fix: activity table empty state

### DIFF
--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
@@ -84,7 +84,7 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
   return {
     table,
     isLoading: isLoading || !isHydrated,
-    isError: !!error && !isHydrated,
+    isError: !!error && isHydrated,
     emptyMessage: t`No liquidity data found.`,
     errorMessage: t`Could not load liquidity data.`,
   }

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_PAGE_SIZE,
 } from '@ui-kit/features/activity-table'
 import { useCurve } from '@ui-kit/features/connect-wallet'
+import { combineQueryState } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 
@@ -33,25 +34,21 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
   const network = networkConfig?.id.toLowerCase() as Chain
   const { pagination, onPaginationChange, apiPage } = useManualPagination()
 
-  const { data: pricesApiPoolsMapper, isLoading: isPricesApiPoolsLoading } = usePoolsPricesApi({
-    blockchainId: network,
-  })
+  const poolPriceApi = usePoolsPricesApi({ blockchainId: network })
+  const { data: pricesApiPoolsMapper } = poolPriceApi
   const poolTokens = useMemo(
     () => pricesApiPoolsMapper?.[poolAddress]?.coins ?? [],
     [pricesApiPoolsMapper, poolAddress],
   )
   const { liquidityColumnVisibility } = usePoolActivityVisibility({ poolTokens })
 
-  const {
-    data: liquidityData,
-    isLoading: isLiquidityLoading,
-    isError: isLiquidityError,
-  } = usePoolLiquidityEvents({
+  const poolLiquidityEvents = usePoolLiquidityEvents({
     chain: network,
     poolAddress,
     page: apiPage,
     perPage: DEFAULT_PAGE_SIZE,
   })
+  const { data: liquidityData } = poolLiquidityEvents
 
   const pageCount = getPageCount(liquidityData?.count, DEFAULT_PAGE_SIZE)
 
@@ -72,8 +69,7 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
 
   const liquidityColumns = useMemo(() => createPoolLiquidityColumns({ poolTokens }), [poolTokens])
 
-  const isLoading = isLiquidityLoading || isPricesApiPoolsLoading || !isHydrated
-  const isError = isLiquidityError && !isHydrated
+  const { error, isLoading } = combineQueryState(poolLiquidityEvents, poolPriceApi)
 
   const table = useTable({
     data: liquidityWithUrls,
@@ -85,5 +81,11 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
     ...getTableOptions(liquidityWithUrls),
   })
 
-  return { table, isLoading, isError, emptyMessage: t`No liquidity data found.` }
+  return {
+    table,
+    isLoading: isLoading || !isHydrated,
+    isError: !!error && !isHydrated,
+    emptyMessage: t`No liquidity data found.`,
+    errorMessage: t`Could not load liquidity data.`,
+  }
 }

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
@@ -81,7 +81,7 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
   return {
     table,
     isLoading: isLoading || !isHydrated,
-    isError: !!error && !isHydrated,
+    isError: !!error && isHydrated,
     emptyMessage: t`No swap data found.`,
     errorMessage: t`Could not load swap data.`,
   }

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_PAGE_SIZE,
 } from '@ui-kit/features/activity-table'
 import { useCurve } from '@ui-kit/features/connect-wallet'
+import { combineQueryState } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 
@@ -33,25 +34,21 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
   const { isHydrated } = useCurve()
   const { pagination, onPaginationChange, apiPage } = useManualPagination()
 
-  const { data: pricesApiPoolsMapper, isLoading: isPricesApiPoolsLoading } = usePoolsPricesApi({
-    blockchainId: network,
-  })
+  const poolPriceApi = usePoolsPricesApi({ blockchainId: network })
+  const { data: pricesApiPoolsMapper } = poolPriceApi
   const poolTokens = useMemo(
     () => pricesApiPoolsMapper?.[poolAddress]?.coins ?? [],
     [pricesApiPoolsMapper, poolAddress],
   )
   const { tradesColumnVisibility } = usePoolActivityVisibility({ poolTokens })
 
-  const {
-    data: tradesData,
-    isLoading: isTradesLoading,
-    isError: isTradesError,
-  } = usePoolTrades({
+  const poolTrades = usePoolTrades({
     chain: network,
     poolAddress,
     page: apiPage,
     perPage: DEFAULT_PAGE_SIZE,
   })
+  const { data: tradesData } = poolTrades
 
   const pageCount = getPageCount(tradesData?.count, DEFAULT_PAGE_SIZE)
 
@@ -69,8 +66,7 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
     [tradesData?.trades, networkConfig, network],
   )
 
-  const isLoading = isTradesLoading || isPricesApiPoolsLoading || !isHydrated
-  const isError = isTradesError && !isHydrated
+  const { error, isLoading } = combineQueryState(poolTrades, poolPriceApi)
 
   const table = useTable({
     data: tradesWithUrls,
@@ -82,5 +78,11 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
     ...getTableOptions(tradesWithUrls),
   })
 
-  return { table, isLoading, isError, emptyMessage: t`No swap data found.` }
+  return {
+    table,
+    isLoading: isLoading || !isHydrated,
+    isError: !!error && !isHydrated,
+    emptyMessage: t`No swap data found.`,
+    errorMessage: t`Could not load swap data.`,
+  }
 }

--- a/apps/main/src/dex/components/OhlcAndActivityComp/index.tsx
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/index.tsx
@@ -56,6 +56,7 @@ export const OhlcAndActivityComp = ({
             isLoading={liquidityTable.isLoading}
             isError={liquidityTable.isError}
             emptyMessage={liquidityTable.emptyMessage}
+            errorMessage={liquidityTable.errorMessage}
             expandedPanel={PoolLiquidityExpandedPanel}
           />
         )}
@@ -65,6 +66,7 @@ export const OhlcAndActivityComp = ({
             isLoading={tradesTable.isLoading}
             isError={tradesTable.isError}
             emptyMessage={tradesTable.emptyMessage}
+            errorMessage={tradesTable.errorMessage}
             expandedPanel={PoolTradesExpandedPanel}
           />
         )}

--- a/apps/main/src/llamalend/features/llamma-activity/LlammaActivityEvents.tsx
+++ b/apps/main/src/llamalend/features/llamma-activity/LlammaActivityEvents.tsx
@@ -11,7 +11,7 @@ export const LlammaActivityEvents = ({
   endpoint,
   networkConfig,
 }: LlammaActivityProps) => {
-  const { table, isLoading, isError, emptyMessage } = useLlammaActivityEventsConfig({
+  const { table, isLoading, isError, emptyMessage, errorMessage } = useLlammaActivityEventsConfig({
     isMarketAvailable,
     network,
     collateralToken,
@@ -27,6 +27,7 @@ export const LlammaActivityEvents = ({
       isLoading={isLoading}
       isError={isError}
       emptyMessage={emptyMessage}
+      errorMessage={errorMessage}
       expandedPanel={LlammaEventsExpandedPanel}
     />
   )

--- a/apps/main/src/llamalend/features/llamma-activity/LlammaActivityTrades.tsx
+++ b/apps/main/src/llamalend/features/llamma-activity/LlammaActivityTrades.tsx
@@ -11,7 +11,7 @@ export const LlammaActivityTrades = ({
   endpoint,
   networkConfig,
 }: LlammaActivityTradesProps) => {
-  const { table, isLoading, isError, emptyMessage } = useLlammaActivityTradesConfig({
+  const { table, isLoading, isError, emptyMessage, errorMessage } = useLlammaActivityTradesConfig({
     isMarketAvailable,
     network,
     ammAddress,
@@ -25,6 +25,7 @@ export const LlammaActivityTrades = ({
       isLoading={isLoading}
       isError={isError}
       emptyMessage={emptyMessage}
+      errorMessage={errorMessage}
       expandedPanel={LlammaTradesExpandedPanel}
     />
   )

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
@@ -71,5 +71,11 @@ export const useLlammaActivityEventsConfig = ({
     ...getTableOptions(eventsWithUrls),
   })
 
-  return { table, isLoading, isError, emptyMessage: t`No activity data found.` }
+  return {
+    table,
+    isLoading,
+    isError,
+    emptyMessage: t`No activity data found.`,
+    errorMessage: t`Could not load activity data.`,
+  }
 }

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
@@ -58,9 +58,6 @@ export const useLlammaActivityEventsConfig = ({
     [eventsData?.events, network, networkConfig, collateralToken, borrowToken],
   )
 
-  const isLoading = isEventsLoading || !isHydrated || !isMarketAvailable
-  const isError = isEventsError && isMarketAvailable && isHydrated
-
   const table = useTable({
     data: eventsWithUrls,
     columns: LLAMMA_EVENTS_COLUMNS,
@@ -73,8 +70,8 @@ export const useLlammaActivityEventsConfig = ({
 
   return {
     table,
-    isLoading,
-    isError,
+    isLoading: isEventsLoading || !isHydrated || !isMarketAvailable,
+    isError: isEventsError && isHydrated && isMarketAvailable,
     emptyMessage: t`No activity data found.`,
     errorMessage: t`Could not load activity data.`,
   }

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
@@ -67,5 +67,5 @@ export const useLlammaActivityTradesConfig = ({
     ...getTableOptions(tradesWithUrls),
   })
 
-  return { table, isLoading, isError, emptyMessage: t`No swap data found.` }
+  return { table, isLoading, isError, emptyMessage: t`No swap data found.`, errorMessage: t`Could not load swap data.` }
 }

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
@@ -54,9 +54,6 @@ export const useLlammaActivityTradesConfig = ({
     [tradesData?.trades, networkConfig, network],
   )
 
-  const isLoading = isTradesLoading || !isHydrated || !isMarketAvailable
-  const isError = isTradesError && isMarketAvailable && isHydrated
-
   const table = useTable({
     data: tradesWithUrls,
     columns: LLAMMA_TRADES_COLUMNS,
@@ -67,5 +64,11 @@ export const useLlammaActivityTradesConfig = ({
     ...getTableOptions(tradesWithUrls),
   })
 
-  return { table, isLoading, isError, emptyMessage: t`No swap data found.`, errorMessage: t`Could not load swap data.` }
+  return {
+    table,
+    isLoading: isTradesLoading || !isHydrated || !isMarketAvailable,
+    isError: isTradesError && isHydrated && isMarketAvailable,
+    emptyMessage: t`No swap data found.`,
+    errorMessage: t`Could not load swap data.`,
+  }
 }

--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
@@ -210,6 +210,7 @@ const DexPoolActivityComponent = () => {
         isLoading={false}
         isError={false}
         emptyMessage="No trades data found."
+        errorMessage="Could not load trades data."
         expandedPanel={PoolTradesExpandedPanel}
       />
       <ActivityTable
@@ -217,6 +218,7 @@ const DexPoolActivityComponent = () => {
         isLoading={false}
         isError={false}
         emptyMessage="No liquidity data found."
+        errorMessage="Could not load liquidity data."
         expandedPanel={PoolLiquidityExpandedPanel}
       />
     </>
@@ -250,6 +252,7 @@ const LendMarketActivityComponent = () => {
         isLoading={false}
         isError={false}
         emptyMessage="No AMM trades found."
+        errorMessage="Could not load AMM trades."
         expandedPanel={LlammaTradesExpandedPanel}
       />
       <ActivityTable
@@ -257,6 +260,7 @@ const LendMarketActivityComponent = () => {
         isLoading={false}
         isError={false}
         emptyMessage="No controller events found."
+        errorMessage="Could not load controller events."
         expandedPanel={LlammaEventsExpandedPanel}
       />
     </>
@@ -322,7 +326,15 @@ const LoadingStateComponent = () => {
     columns: POOL_TRADES_COLUMNS,
     ...getTableOptions([]),
   })
-  return <ActivityTable table={table} isLoading={true} isError={false} emptyMessage="Loading trades..." />
+  return (
+    <ActivityTable
+      table={table}
+      isLoading={true}
+      isError={false}
+      emptyMessage="Loading trades..."
+      errorMessage="Could not load trades data."
+    />
+  )
 }
 
 export const LoadingState: StoryObj = {
@@ -342,7 +354,15 @@ const EmptyStateComponent = () => {
     columns: POOL_TRADES_COLUMNS,
     ...getTableOptions([]),
   })
-  return <ActivityTable table={table} isLoading={false} isError={false} emptyMessage="No swap data found." />
+  return (
+    <ActivityTable
+      table={table}
+      isLoading={false}
+      isError={false}
+      emptyMessage="No swap data found."
+      errorMessage="Could not load swap data."
+    />
+  )
 }
 
 export const EmptyState: StoryObj = {
@@ -362,7 +382,15 @@ const ErrorStateComponent = () => {
     columns: POOL_TRADES_COLUMNS,
     ...getTableOptions([]),
   })
-  return <ActivityTable table={table} isLoading={false} isError={true} emptyMessage="Could not load data" />
+  return (
+    <ActivityTable
+      table={table}
+      isLoading={false}
+      isError={true}
+      emptyMessage="No swap data found."
+      errorMessage="Could not load swap data."
+    />
+  )
 }
 
 export const ErrorState: StoryObj = {

--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
@@ -5,6 +5,7 @@ import type { TableItem } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { LegacyDataTable } from '@ui-kit/shared/ui/DataTable/LegacyDataTable'
+import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
 import { ErrorMessage } from '@ui-kit/shared/ui/ErrorMessage'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
@@ -17,7 +18,8 @@ type ActivityTableProps<TData extends TableItem> = {
   table: Table<TData>
   isLoading: boolean
   isError: boolean
-  emptyMessage?: string
+  emptyMessage: string
+  errorMessage: string
   height?: `${number}rem`
   expandedPanel?: ExpandedPanel<TData>
 }
@@ -27,29 +29,26 @@ export const ActivityTable = <TData extends TableItem>({
   isLoading,
   isError,
   emptyMessage,
+  errorMessage,
   height = MaxHeight.userEventsTable,
   expandedPanel = DefaultExpandedPanel,
-}: ActivityTableProps<TData>) => {
-  const errorMessage = isError ? (emptyMessage ?? t`Could not load data`) : (emptyMessage ?? t`No data found`)
-
-  return (
-    <Box sx={{ minHeight: height }}>
-      <LegacyDataTable
-        table={table}
-        emptyState={
-          <EmptyStateRow table={table} size="lg">
-            <ErrorMessage
-              title={t`Hm... Something went wrong.`}
-              subtitle={errorMessage}
-              errorMessage={t`Couldn't load activity table data`}
-            />
-          </EmptyStateRow>
-        }
-        loading={isLoading}
-        maxHeight={height}
-        size="small"
-        expandedPanel={expandedPanel}
-      />
-    </Box>
-  )
-}
+}: ActivityTableProps<TData>) => (
+  <Box sx={{ minHeight: height }}>
+    <LegacyDataTable
+      table={table}
+      emptyState={
+        <EmptyStateRow table={table} size="lg">
+          {isError ? (
+            <ErrorMessage title={t`Hm... Something went wrong.`} subtitle={errorMessage} errorMessage={errorMessage} />
+          ) : (
+            <EmptyStateCard title={emptyMessage} />
+          )}
+        </EmptyStateRow>
+      }
+      loading={isLoading}
+      maxHeight={height}
+      size="small"
+      expandedPanel={expandedPanel}
+    />
+  </Box>
+)


### PR DESCRIPTION
- separate empty state from error state in the Activity Table
- fix pools error shown after hydration

example new V2 markets, activity tab: https://www.curve.finance/lend/optimism/markets/0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9