### PR TITLE
fix: change gauge type away from fundraiser in vote creation

### DIFF
--- a/apps/main/src/dao/components/PageGauges/CreateVote/create-vote.mutation.ts
+++ b/apps/main/src/dao/components/PageGauges/CreateVote/create-vote.mutation.ts
@@ -17,7 +17,7 @@ const buildEvmScript = (gaugeAddress: Address) => {
   const callData = encodeFunctionData({
     abi: abiGauge,
     functionName: 'add_gauge',
-    args: [gaugeAddress, 10n, 0n],
+    args: [gaugeAddress, 0n, 0n],
   })
 
   const agentCalldata = encodeFunctionData({


### PR DESCRIPTION
Fixes an incorrect (fundraiser) gauge type being used during vote creation. This was a leftover from the original intent of the code, oopsie!