### PR TITLE
fix: position time column title to the right in UserEventsTable and resize table header to "small"

### DIFF
--- a/apps/main/src/llamalend/features/user-position-history/UserEventsTable.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/UserEventsTable.tsx
@@ -41,6 +41,7 @@ export const UserEventsTable = ({ events, loading, isError }: UserEventsTablePro
       }
       loading={loading}
       maxHeight={MaxHeight.userEventsTable}
+      size="small"
       expandedPanel={RowExpandedPanel}
     />
   )

--- a/apps/main/src/llamalend/features/user-position-history/columns/column.definitions.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/columns/column.definitions.tsx
@@ -40,5 +40,6 @@ export const USER_POSITION_HISTORY_COLUMNS = [
     cell: ({ row }) => (
       <TimestampCell timestamp={new Date(row.original.timestamp)} txUrl={row.original.url} align="end" />
     ),
+    meta: { type: 'numeric' },
   }),
 ]


### PR DESCRIPTION
Missed this table in https://github.com/curvefi/curve-frontend/pull/2681

Changes:
- Fixes "Time" column title position regression in `UserEventsTable`
- Sets `UserEventsTable` header size to "small"