### PR TITLE
styling: remove new advanced details spacing

### DIFF
--- a/apps/main/src/dex/features/advanced-details/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/index.tsx
@@ -65,7 +65,6 @@ export const AdvancedDetails = ({
         size="inline"
         component={Grid}
         container
-        spacing={Spacing.md}
         sx={{ '&&': { backgroundColor: t => t.design.Layer[1].Fill } }}
       >
         <Grid size={{ mobile: 12, desktop: 8 }} sx={cardContentSmallStyles}>


### PR DESCRIPTION
As per Figma

**New**
<img width="1067" height="680" alt="image" src="https://github.com/user-attachments/assets/704f58d1-8911-426e-8519-dfcbcbc9d62f" />

**Old**
<img width="1067" height="683" alt="image" src="https://github.com/user-attachments/assets/db3f2aa2-cef3-4976-b128-11a7919ff19e" />
