### PR TITLE
fix: use scrvUSD redeem for withdraw

### DIFF
--- a/apps/main/src/loan/entities/scrvusd-preview.query.ts
+++ b/apps/main/src/loan/entities/scrvusd-preview.query.ts
@@ -29,10 +29,8 @@ export const { useQuery: useScrvUsdPreviewWithdraw } = queryFactory({
     ] as const,
   queryFn: async ({ withdrawAmount, isFull, maxWithdrawAmount }: ScrvUsdWithdrawQuery) => {
     const { st_crvUSD } = requireLib('llamaApi')
-    const r = isFull
-      ? await st_crvUSD.previewRedeem(maxWithdrawAmount)
-      : await st_crvUSD.previewWithdraw(withdrawAmount)
-    return r as Decimal
+    const shares = isFull ? maxWithdrawAmount : withdrawAmount
+    return (await st_crvUSD.previewRedeem(shares)) as Decimal
   },
   category: 'savings.user',
   validationSuite: scrvUsdWithdrawValidationSuite,

--- a/apps/main/src/loan/entities/scrvusd-withdraw-estimate-gas.query.ts
+++ b/apps/main/src/loan/entities/scrvusd-withdraw-estimate-gas.query.ts
@@ -15,9 +15,7 @@ export const { useQuery: useScrvUsdWithdrawEstimateGasQuery } = queryFactory({
       { maxWithdrawAmount },
     ] as const,
   queryFn: async ({ withdrawAmount, isFull, maxWithdrawAmount }: ScrvUsdWithdrawQuery) =>
-    await (isFull
-      ? requireLib('llamaApi').st_crvUSD.estimateGas.redeem(maxWithdrawAmount)
-      : requireLib('llamaApi').st_crvUSD.estimateGas.withdraw(withdrawAmount)),
+    await requireLib('llamaApi').st_crvUSD.estimateGas.redeem(isFull ? maxWithdrawAmount : withdrawAmount),
   category: 'savings.user',
   validationSuite: scrvUsdWithdrawMaxValidationSuite,
 })

--- a/apps/main/src/loan/entities/scrvusd-withdraw.mutation.ts
+++ b/apps/main/src/loan/entities/scrvusd-withdraw.mutation.ts
@@ -24,10 +24,8 @@ export const useScrvUsdWithdrawMutation = ({ chainId, userAddress, onSuccess, ..
     mutationKey: [...rootKeys.userChain({ chainId, userAddress }), 'st_crvUSD.withdraw'] as const,
     mutationFn: async ({ withdrawAmount, isFull, maxWithdrawAmount }) => {
       const { st_crvUSD } = requireLib('llamaApi')
-      const hash = (
-        isFull ? await st_crvUSD.redeem(maxWithdrawAmount) : await st_crvUSD.withdraw(withdrawAmount)
-      ) as Hex
-      return { hash }
+      const shares = isFull ? maxWithdrawAmount : withdrawAmount
+      return { hash: (await st_crvUSD.redeem(shares)) as Hex }
     },
     validationSuite: scrvUsdWithdrawMaxValidationSuite,
     validationParams: { chainId, userAddress },

--- a/tests/cypress/component/llamalend/scrvusd.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/scrvusd.rpc.cy.tsx
@@ -10,6 +10,7 @@ import {
   checkScrvUsdDepositAllowance,
   checkScrvUsdPositionDetails,
   checkScrvUsdWithdrawBalanceGreaterThan,
+  checkScrvUsdWithdrawBalanceDecreasedBy,
   checkScrvUsdWithdrawBalanceLessThan,
   checkScrvUsdWithdrawBalanceZero,
   checkScrvUsdWithdrawDetailsLoaded,
@@ -110,6 +111,7 @@ describe('scrvUSD', () => {
       writeInvalidThenValidScrvUsdWithdraw({ invalidAmount: invalidWithdrawValue, validAmount: withdrawValue })
       checkScrvUsdWithdrawDetailsLoaded()
       submitScrvUsdWithdrawForm('Withdraw')
+      checkScrvUsdWithdrawBalanceDecreasedBy(balance, withdrawValue)
       checkScrvUsdWithdrawBalanceGreaterThan('0')
       checkScrvUsdWithdrawBalanceLessThan(balance)
     })

--- a/tests/cypress/support/helpers/llamalend/scrvusd.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/scrvusd.helpers.ts
@@ -3,7 +3,7 @@ import { CRVUSD_ADDRESS, SCRVUSD_VAULT_ADDRESS } from '@/loan/constants'
 import { CRVUSD_DECIMALS } from '@cy/support/helpers/llamalend/supply/supply-setup.helpers'
 import { LOAD_TIMEOUT, TRANSACTION_LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
-import { decimalCompare } from '@ui-kit/utils'
+import { decimalCompare, decimalMinus } from '@ui-kit/utils'
 import { DECIMAL_REGEX, getActionValue, getMetricValue } from './action-info.helpers'
 
 type ScrvUsdFormType = 'deposit' | 'withdraw'
@@ -180,6 +180,11 @@ export const checkScrvUsdWithdrawBalanceGreaterThan = (expectedMinimum: Decimal)
 
 export const checkScrvUsdWithdrawBalanceLessThan = (expectedMaximum: Decimal) =>
   readScrvUsdWithdrawBalance().should(balance => expect(decimalCompare(balance, expectedMaximum)).to.equal(-1))
+
+export const checkScrvUsdWithdrawBalanceDecreasedBy = (initialBalance: Decimal, withdrawAmount: Decimal) =>
+  readScrvUsdWithdrawBalance().should(balance =>
+    expect(+balance).to.be.closeTo(+decimalMinus(initialBalance, withdrawAmount), 0.000001),
+  )
 
 export const checkScrvUsdWithdrawBalanceZero = () =>
   readScrvUsdWithdrawBalance().should(balance => expect(+balance, `Expected ${balance} to be zero`).to.equal(0))


### PR DESCRIPTION
- Form input is scrvUSD shares
- `withdraw` expects crvUSD assets, causing wrong partial withdrawals
- Use `redeem` for shares to match the old form
- Update preview and gas to use redeem path too