### PR TITLE
feat: use list endpoint for supply positions

### DIFF
--- a/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
@@ -162,7 +162,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
               <Metric
                 label={t`Supplied Amount`}
                 value={lendingPosition.supplied}
-                valueOptions={{ symbol: assets.borrowed.symbol, position: 'suffix' }}
+                valueOptions={{ unit: { symbol: assets.borrowed.symbol, position: 'suffix' } }}
               />
             </Grid>
           )}

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
@@ -14,7 +14,7 @@ import { type ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { RouterLink as Link } from '@ui-kit/shared/ui/RouterLink'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
+import { MarketRateType } from '@ui-kit/types/market'
 import { AVERAGE_CATEGORIES, borderStyle } from '@ui-kit/utils'
 import type { LlamaMarket } from '../../queries/market-list/llama-markets'
 import { LineGraphCell, RateTooltipProps } from './cells'
@@ -91,11 +91,6 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
   } = market
   const graphSize = useMobileGraphSize()
 
-  const UnitMapping = {
-    [LlamaMarketType.Lend]: { symbol: assets.borrowed.symbol, position: 'suffix' },
-    [LlamaMarketType.Mint]: 'dollar',
-  } as const
-
   return (
     <>
       <Grid container spacing={Spacing.md}>
@@ -162,12 +157,12 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
               <Metric label={t`Earnings`} value={lendingPosition.earnings} valueOptions={{ unit: 'dollar' }} />
             </Grid>
           )}
-          {lendingPosition != null && (
+          {lendingPosition && (
             <Grid size={6}>
               <Metric
                 label={t`Supplied Amount`}
-                value={lendingPosition.currentShares}
-                valueOptions={{ unit: UnitMapping[type] }}
+                value={lendingPosition.supplied}
+                valueOptions={{ symbol: assets.borrowed.symbol, position: 'suffix' }}
               />
             </Grid>
           )}

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
@@ -16,14 +16,12 @@ import { RouterLink as Link } from '@ui-kit/shared/ui/RouterLink'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import { AVERAGE_CATEGORIES, borderStyle } from '@ui-kit/utils'
-import { useUserMarketStats } from '../../queries/market-list/llama-market-stats'
 import type { LlamaMarket } from '../../queries/market-list/llama-markets'
 import { LineGraphCell, RateTooltipProps } from './cells'
 import { BorrowRateTooltip } from './cells/RateCell/BorrowRateTooltip'
 import { RewardsIcons } from './cells/RateCell/RewardsIcons'
 import { SupplyRateLendTooltip } from './cells/RateCell/SupplyRateLendTooltip'
 import { FavoriteMarketButton } from './chips/FavoriteMarketButton'
-import { LlamaMarketColumnId } from './columns'
 
 const { Spacing } = SizesAndSpaces
 
@@ -76,9 +74,6 @@ const RateItem = ({ market, type }: { market: LlamaMarket; type: MarketRateType 
 }
 
 export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { original: market } }) => {
-  // todo: update metric component(?) to show the errors when appropriate
-  const { data: earnings } = useUserMarketStats(market, LlamaMarketColumnId.UserEarnings)
-  const { data: deposited } = useUserMarketStats(market, LlamaMarketColumnId.UserDeposited)
   const {
     controllerAddress,
     favoriteKey,
@@ -88,6 +83,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
     type,
     url,
     userHasPositions,
+    lendingPosition,
     utilizationPercent,
     tvl,
     totalCollateralUsd,
@@ -161,16 +157,16 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
           <Grid size={12}>
             <CardHeader title={t`Your Position`} sx={{ paddingInline: 0 }}></CardHeader>
           </Grid>
-          {earnings?.earnings != null && (
+          {lendingPosition && (
             <Grid size={6}>
-              <Metric label={t`Earnings`} value={earnings.earnings.earnings} valueOptions={{ unit: 'dollar' }} />
+              <Metric label={t`Earnings`} value={lendingPosition.earnings} valueOptions={{ unit: 'dollar' }} />
             </Grid>
           )}
-          {deposited?.earnings != null && (
+          {lendingPosition != null && (
             <Grid size={6}>
               <Metric
                 label={t`Supplied Amount`}
-                value={deposited.earnings.totalCurrentAssets}
+                value={lendingPosition.currentShares}
                 valueOptions={{ unit: UnitMapping[type] }}
               />
             </Grid>

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -13,7 +13,7 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { q } from '@ui-kit/types/util'
 import { ListPageWrapper } from '@ui-kit/widgets/ListPageWrapper'
 import {
-  invalidateAllUserLendingSupplies,
+  invalidateUserLendingSupplies,
   invalidateAllUserLendingVaults,
   invalidateLendingVaults,
 } from '../../queries/market-list/lending-vaults'
@@ -46,7 +46,7 @@ const useOnReload = ({ address: userAddress, isFetching }: { address?: Address; 
       invalidateMintMarkets({}),
       invalidateBadDebtMarkets(),
       invalidateAllUserLendingVaults(userAddress),
-      invalidateAllUserLendingSupplies(userAddress),
+      invalidateUserLendingSupplies({ userAddress }),
       invalidateAllUserMintMarkets(userAddress),
     ])
   }, [isReloading, userAddress])

--- a/apps/main/src/llamalend/features/market-list/cells/BoostCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/BoostCell.tsx
@@ -15,7 +15,7 @@ export const BoostCell = ({ getValue }: CellContext<LlamaMarket, number>) => (
     clickable
     title={t`Boost`}
     body={<BoostTooltipContent />}
-    placement={'top'}
+    placement="top"
   >
     <Typography variant="tableCellMBold" color="textPrimary" sx={{ textAlign: 'right' }}>
       {maybe(getValue(), boost => `${formatNumber(boost, { maximumFractionDigits: 2, abbreviate: false })}x`) ?? '-'}

--- a/apps/main/src/llamalend/features/market-list/cells/BoostCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/BoostCell.tsx
@@ -1,40 +1,24 @@
-import { useUserMarketStats } from '@/llamalend/queries/market-list/llama-market-stats'
 import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { BoostTooltipContent } from '@/llamalend/widgets/tooltips/BoostTooltipContent'
-import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
+import { maybe } from '@primitives/objects.utils'
 import type { CellContext } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
+import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { formatNumber } from '@ui-kit/utils'
-import { LlamaMarketColumnId } from '../columns'
 
-export const BoostCell = ({ row }: CellContext<LlamaMarket, number>) => {
-  const market = row.original
-  const { data: stats, isLoading } = useUserMarketStats(market, LlamaMarketColumnId.UserBoostMultiplier)
-  const boostMultiplier = stats?.earnings?.boostMultiplier
-
-  if (isLoading) {
-    return (
-      <Typography variant="tableCellMBold" sx={{ textAlign: 'right' }}>
-        <Skeleton variant="text" width={40} />
-      </Typography>
-    )
-  }
-
-  if (!boostMultiplier) {
-    return (
-      <Typography variant="tableCellMBold" color="textSecondary" sx={{ textAlign: 'right' }}>
-        -
-      </Typography>
-    )
-  }
-
-  return (
-    <Tooltip clickable title={t`Boost`} body={<BoostTooltipContent />} placement="top">
-      <Typography variant="tableCellMBold" color="textPrimary" sx={{ textAlign: 'right' }}>
-        {formatNumber(boostMultiplier, { maximumFractionDigits: 2, abbreviate: false })}x
-      </Typography>
-    </Tooltip>
-  )
-}
+export const BoostCell = ({ getValue }: CellContext<LlamaMarket, number>) => (
+  <WithWrapper
+    Wrapper={Tooltip}
+    shouldWrap={getValue()}
+    clickable
+    title={t`Boost`}
+    body={<BoostTooltipContent />}
+    placement={'top'}
+  >
+    <Typography variant="tableCellMBold" color="textPrimary" sx={{ textAlign: 'right' }}>
+      {maybe(getValue(), boost => `${formatNumber(boost, { maximumFractionDigits: 2, abbreviate: false })}x`) ?? '-'}
+    </Typography>
+  </WithWrapper>
+)

--- a/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from 'react'
-import { useUserMarketStats } from '@/llamalend/queries/market-list/llama-market-stats'
+import type { LendingPosition } from '@/llamalend/queries/market-list/lending-vaults'
+import { type MarketStats, useUserMarketStats } from '@/llamalend/queries/market-list/llama-market-stats'
 import { AssetDetails, LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { CollateralMetricTooltipContent } from '@/llamalend/widgets/tooltips/CollateralMetricTooltipContent'
 import { TotalDebtTooltipContent } from '@/llamalend/widgets/tooltips/TotalDebtTooltipContent'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import { notFalsyArray } from '@primitives/objects.utils'
 import type { CellContext } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -39,17 +41,18 @@ const getAssets = (columnId: LlamaMarketColumnId, assets: LlamaMarket['assets'])
 /**
  * Maps a column ID to the corresponding values from user market stats.
  * Returns a tuple of [primary value, secondary value] where secondary may be undefined.
- *
- * @param columnId - The column identifier to determine which values to retrieve
- * @param stats - The user's market statistics containing borrowed, collateral, and earnings data
  */
-const getAssetValues = (columnId: LlamaMarketColumnId, stats: ReturnType<typeof useUserMarketStats>['data']) =>
+const getAssetValues = (
+  columnId: LlamaMarketColumnId,
+  stats: MarketStats,
+  lendingPosition: LendingPosition | undefined,
+) =>
   (
     ({
       [LlamaMarketColumnId.UserCollateral]: [stats?.collateral?.amount, stats?.borrowToken?.amount],
       [LlamaMarketColumnId.UserBorrowed]: [stats?.borrowed, undefined],
-      [LlamaMarketColumnId.UserEarnings]: [stats?.earnings?.earnings, undefined],
-      [LlamaMarketColumnId.UserDeposited]: [stats?.earnings?.totalCurrentAssets, undefined],
+      [LlamaMarketColumnId.UserEarnings]: [lendingPosition?.earnings, undefined],
+      [LlamaMarketColumnId.UserDeposited]: [lendingPosition?.currentShares, undefined],
     }) as Partial<Record<LlamaMarketColumnId, [number, number | undefined]>>
   )[columnId]
 
@@ -68,10 +71,7 @@ const getTooltipTitle = (columnId: LlamaMarketColumnId) =>
  * @param columnId - The column identifier
  * @param stats - The user's market statistics
  */
-const getTooltipBody = (
-  columnId: LlamaMarketColumnId,
-  stats: ReturnType<typeof useUserMarketStats>['data'],
-): ReactNode | undefined => {
+const getTooltipBody = (columnId: LlamaMarketColumnId, stats: MarketStats): ReactNode | undefined => {
   if (columnId === LlamaMarketColumnId.UserBorrowed) {
     return <TotalDebtTooltipContent />
   }
@@ -160,13 +160,13 @@ const AssetUsdValue = ({
  */
 export const PriceCell = ({ getValue, row, column }: CellContext<LlamaMarket, number>) => {
   const market = row.original
-  const { assets } = market
+  const { assets, lendingPosition } = market
   const columnId = column.id as LlamaMarketColumnId
 
   const { data: stats, error: statsError, isLoading: isLoadingStats } = useUserMarketStats(market, columnId)
 
   const [primaryAsset, secondaryAsset] = getAssets(columnId, assets) ?? [assets.borrowed, undefined]
-  const [primaryValue, secondaryValue] = getAssetValues(columnId, stats) ?? [getValue(), undefined]
+  const [primaryValue, secondaryValue] = getAssetValues(columnId, stats, lendingPosition) ?? [getValue(), undefined]
 
   const { data: primaryPrice, isLoading: isPrimaryPriceLoading } = useTokenUsdRate({
     chainId: requireChainId(primaryAsset.chain),
@@ -197,16 +197,16 @@ export const PriceCell = ({ getValue, row, column }: CellContext<LlamaMarket, nu
 
   const gridAssets = [
     { asset: primaryAsset, value: primaryValue, usdValue: primaryUsdValue, isPriceLoading: isPrimaryPriceLoading },
-    ...(hasSecondaryAsset
-      ? [
-          {
-            asset: secondaryAsset,
-            value: secondaryValue,
-            usdValue: secondaryUsdValue,
-            isPriceLoading: isSecondaryPriceLoading,
-          },
-        ]
-      : []),
+    ...notFalsyArray(
+      hasSecondaryAsset && [
+        {
+          asset: secondaryAsset,
+          value: secondaryValue,
+          usdValue: secondaryUsdValue,
+          isPriceLoading: isSecondaryPriceLoading,
+        },
+      ],
+    ),
   ]
 
   return (

--- a/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/PriceCell.tsx
@@ -52,7 +52,7 @@ const getAssetValues = (
       [LlamaMarketColumnId.UserCollateral]: [stats?.collateral?.amount, stats?.borrowToken?.amount],
       [LlamaMarketColumnId.UserBorrowed]: [stats?.borrowed, undefined],
       [LlamaMarketColumnId.UserEarnings]: [lendingPosition?.earnings, undefined],
-      [LlamaMarketColumnId.UserDeposited]: [lendingPosition?.currentShares, undefined],
+      [LlamaMarketColumnId.UserDeposited]: [lendingPosition?.supplied, undefined],
     }) as Partial<Record<LlamaMarketColumnId, [number, number | undefined]>>
   )[columnId]
 

--- a/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
+++ b/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
@@ -111,18 +111,18 @@ export const LLAMA_MARKET_COLUMNS = [
     meta: { type: 'numeric' },
     sortUndefined: 'last',
   }),
-  display(LlamaMarketColumnId.UserEarnings, {
+  accessor(LlamaMarketColumnId.UserEarnings, 'lendingPosition.earnings', {
     cell: PriceCell,
     meta: { type: 'numeric', hidden: true }, // hidden until we have a backend
     sortUndefined: 'last',
   }),
-  display(LlamaMarketColumnId.UserDeposited, {
+  accessor(LlamaMarketColumnId.UserDeposited, 'lendingPosition.totalCurrentAssets', {
     cell: PriceCell,
     meta: { type: 'numeric' },
     filterFn: boolFilterFn,
     sortUndefined: 'last',
   }),
-  display(LlamaMarketColumnId.UserBoostMultiplier, {
+  accessor(LlamaMarketColumnId.UserBoostMultiplier, 'lendingPosition.boostMultiplier', {
     cell: BoostCell,
     meta: { type: 'numeric' },
     sortUndefined: 'last',

--- a/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
+++ b/apps/main/src/llamalend/features/market-list/columns/column.definitions.tsx
@@ -116,7 +116,7 @@ export const LLAMA_MARKET_COLUMNS = [
     meta: { type: 'numeric', hidden: true }, // hidden until we have a backend
     sortUndefined: 'last',
   }),
-  accessor(LlamaMarketColumnId.UserDeposited, 'lendingPosition.totalCurrentAssets', {
+  accessor(LlamaMarketColumnId.UserDeposited, 'lendingPosition.supplied', {
     cell: PriceCell,
     meta: { type: 'numeric' },
     filterFn: boolFilterFn,

--- a/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
@@ -1,4 +1,4 @@
-import { sum } from 'lodash'
+import { sum, uniqBy } from 'lodash'
 import { useMemo } from 'react'
 import { useConnection } from 'wagmi'
 import { getUserLendingVaultStatsOptions } from '@/llamalend/queries/market-list/lending-vaults'
@@ -7,6 +7,7 @@ import { getUserMintMarketsStatsOptions } from '@/llamalend/queries/market-list/
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { splitAt, zip } from '@primitives/array.utils'
+import type { Amount } from '@primitives/decimal.utils'
 import { useQueries, type UseQueryResult } from '@tanstack/react-query'
 import { t } from '@ui-kit/lib/i18n'
 import { getTokenUsdRateQueryOptions } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -16,56 +17,33 @@ import { LlamaMarketType } from '@ui-kit/types/market'
 import { mapQuery, type Query } from '@ui-kit/types/util'
 import { requireChainId } from '@ui-kit/utils'
 
-export type UserPositionSummaryMetric = { label: string; metric: Query<number> }
-
-type StatsQueryOptions =
-  | ReturnType<typeof getUserLendingVaultStatsOptions>
-  | ReturnType<typeof getUserMintMarketsStatsOptions>
+export type UserPositionSummaryMetric = { label: string; metric: Query<Amount> }
 
 type LendBorrowStatsData = QueryOptionsData<ReturnType<typeof getUserLendingVaultStatsOptions>>
 type MintBorrowStatsData = QueryOptionsData<ReturnType<typeof getUserMintMarketsStatsOptions>>
 type BorrowStatsData = LendBorrowStatsData | MintBorrowStatsData
-type TokenPriceData = QueryOptionsData<ReturnType<typeof getTokenUsdRateQueryOptions>>
-
-type BorrowPositionQuery = {
-  query: StatsQueryOptions
-  blockchainId: LlamaMarket['chain']
-  debtTokenAddress: Address
-  collateralTokenAddress: Address
-  marketType: LlamaMarketType
-}
+type TokenPrice = number
 
 type TokenPriceEntry = { chainId: number; tokenAddress: Address }
 
-const MISSING_PRICE_RESULT: TokenPriceData = 0
+const MISSING_PRICE_RESULT: TokenPrice = 0
 
-const createMetric = (label: string, metric: Query<number>): UserPositionSummaryMetric => ({ label, metric })
-
-const getBorrowEntry = (
-  { assets: { borrowed, collateral }, chain, controllerAddress, type }: LlamaMarket,
-  userAddress: Address | undefined,
-): BorrowPositionQuery => ({
-  query: { Lend: getUserLendingVaultStatsOptions, Mint: getUserMintMarketsStatsOptions }[type]({
-    contractAddress: controllerAddress,
-    userAddress,
-    blockchainId: chain,
-  }),
-  blockchainId: chain,
-  debtTokenAddress: borrowed.address,
-  collateralTokenAddress: collateral.address,
-  marketType: type,
+const createMetric = <T extends Amount>(label: string, metric: Query<T>): UserPositionSummaryMetric => ({
+  label,
+  metric,
 })
 
 const createTokenPriceQueries = (entries: TokenPriceEntry[]) =>
-  entries.map(({ chainId, tokenAddress }) => getTokenUsdRateQueryOptions({ chainId, tokenAddress }))
+  uniqBy(entries, e => `${e.chainId}:${e.tokenAddress}`).map(({ chainId, tokenAddress }) =>
+    getTokenUsdRateQueryOptions({ chainId, tokenAddress }),
+  )
 
 /** Build a token price lookup that hides key formatting. */
-const buildGetPrice = (entries: TokenPriceEntry[], priceResults: UseQueryResult<TokenPriceData>[]) => {
+const buildGetPrice = (entries: TokenPriceEntry[], priceResults: UseQueryResult<TokenPrice>[]) => {
   const getKey = (chainId: number, address: Address) => `${chainId}:${address.toLowerCase()}`
   const tokenMap = Object.fromEntries(
     entries.map(({ chainId, tokenAddress }, index) => [getKey(chainId, tokenAddress), priceResults[index]?.data]),
-  ) as Record<string, TokenPriceData | undefined>
-
+  ) as Record<string, TokenPrice | undefined>
   return (blockchainId: Chain, address: Address) =>
     tokenMap[getKey(requireChainId(blockchainId), address)] ?? MISSING_PRICE_RESULT
 }
@@ -101,7 +79,7 @@ function useSupplySummary(markets: LlamaMarket[]) {
           markets.map(
             ({ lendingPosition, assets: { borrowed }, chain }) =>
               // Missing USD prices contribute 0 and surface as summary errors
-              (lendingPosition?.totalCurrentAssets ?? 0) * getPrice(chain, borrowed.address),
+              (lendingPosition?.supplied ?? 0) * getPrice(chain, borrowed.address),
           ),
         ),
       }
@@ -115,7 +93,17 @@ function useBorrowSummary(markets: LlamaMarket[]) {
     () =>
       markets
         .filter(({ userHasPositions }) => userHasPositions?.Borrow)
-        .map(market => getBorrowEntry(market, userAddress)),
+        .map(({ assets: { borrowed, collateral }, chain, controllerAddress, type }) => ({
+          query: { Lend: getUserLendingVaultStatsOptions, Mint: getUserMintMarketsStatsOptions }[type]({
+            contractAddress: controllerAddress,
+            userAddress,
+            blockchainId: chain,
+          }),
+          blockchainId: chain,
+          debtTokenAddress: borrowed.address,
+          collateralTokenAddress: collateral.address,
+          marketType: type,
+        })),
     [markets, userAddress],
   )
 
@@ -136,7 +124,7 @@ function useBorrowSummary(markets: LlamaMarket[]) {
     combine: results => {
       const [positionResults, priceResults] = splitAt(results, borrowEntries?.length ?? 0) as [
         UseQueryResult<BorrowStatsData>[],
-        UseQueryResult<TokenPriceData>[],
+        UseQueryResult<TokenPrice>[],
       ]
 
       const getPrice = buildGetPrice(tokenPriceEntries, priceResults)

--- a/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
@@ -1,22 +1,19 @@
-import { partition, sum, uniqBy } from 'lodash'
+import { sum } from 'lodash'
 import { useMemo } from 'react'
 import { useConnection } from 'wagmi'
-import {
-  getUserLendingVaultEarningsOptions,
-  getUserLendingVaultStatsOptions,
-} from '@/llamalend/queries/market-list/lending-vaults'
+import { getUserLendingVaultStatsOptions } from '@/llamalend/queries/market-list/lending-vaults'
 import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { getUserMintMarketsStatsOptions } from '@/llamalend/queries/market-list/mint-markets'
+import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
-import { splitAt } from '@primitives/array.utils'
-import { notFalsy } from '@primitives/objects.utils'
+import { splitAt, zip } from '@primitives/array.utils'
 import { useQueries, type UseQueryResult } from '@tanstack/react-query'
 import { t } from '@ui-kit/lib/i18n'
 import { getTokenUsdRateQueryOptions } from '@ui-kit/lib/model/entities/token-usd-rate'
 import { combineQueriesMeta } from '@ui-kit/lib/queries/combine'
 import { type QueryOptionsData } from '@ui-kit/lib/queries/types'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import type { Query } from '@ui-kit/types/util'
+import { mapQuery, type Query } from '@ui-kit/types/util'
 import { requireChainId } from '@ui-kit/utils'
 
 export type UserPositionSummaryMetric = { label: string; metric: Query<number> }
@@ -24,12 +21,10 @@ export type UserPositionSummaryMetric = { label: string; metric: Query<number> }
 type StatsQueryOptions =
   | ReturnType<typeof getUserLendingVaultStatsOptions>
   | ReturnType<typeof getUserMintMarketsStatsOptions>
-type EarningsQueryOptions = ReturnType<typeof getUserLendingVaultEarningsOptions>
 
 type LendBorrowStatsData = QueryOptionsData<ReturnType<typeof getUserLendingVaultStatsOptions>>
 type MintBorrowStatsData = QueryOptionsData<ReturnType<typeof getUserMintMarketsStatsOptions>>
 type BorrowStatsData = LendBorrowStatsData | MintBorrowStatsData
-type SupplyStatsData = QueryOptionsData<EarningsQueryOptions>
 type TokenPriceData = QueryOptionsData<ReturnType<typeof getTokenUsdRateQueryOptions>>
 
 type BorrowPositionQuery = {
@@ -40,73 +35,26 @@ type BorrowPositionQuery = {
   marketType: LlamaMarketType
 }
 
-type SupplyPositionQuery = {
-  query: EarningsQueryOptions
-  blockchainId: LlamaMarket['chain']
-  suppliedTokenAddress: Address
-}
-
 type TokenPriceEntry = { chainId: number; tokenAddress: Address }
-
-type PositionQueryEntry =
-  | { kind: 'borrow'; value: BorrowPositionQuery }
-  | { kind: 'supply'; value: SupplyPositionQuery }
 
 const MISSING_PRICE_RESULT: TokenPriceData = 0
 
-const createMetric = (
-  label: string,
-  data: number,
-  isLoading: boolean,
-  error: Error | null,
-): UserPositionSummaryMetric => ({ label, metric: { data, isLoading, error } })
+const createMetric = (label: string, metric: Query<number>): UserPositionSummaryMetric => ({ label, metric })
 
-const getSupplyEntry = (market: LlamaMarket, userAddress: Address | undefined): PositionQueryEntry | null => {
-  if (!market.userHasPositions?.Supply || !market.vaultAddress) return null
-
-  return {
-    kind: 'supply',
-    value: {
-      query: getUserLendingVaultEarningsOptions({
-        contractAddress: market.vaultAddress,
-        userAddress,
-        blockchainId: market.chain,
-      }),
-      blockchainId: market.chain,
-      suppliedTokenAddress: market.assets.borrowed.address,
-    },
-  }
-}
-
-const getBorrowEntry = (market: LlamaMarket, userAddress: Address | undefined): PositionQueryEntry | null => {
-  if (!market.userHasPositions?.Borrow) return null
-
-  return {
-    kind: 'borrow',
-    value: {
-      query:
-        market.type === LlamaMarketType.Lend
-          ? getUserLendingVaultStatsOptions({
-              contractAddress: market.controllerAddress,
-              userAddress,
-              blockchainId: market.chain,
-            })
-          : getUserMintMarketsStatsOptions({
-              contractAddress: market.controllerAddress,
-              userAddress,
-              blockchainId: market.chain,
-            }),
-      blockchainId: market.chain,
-      debtTokenAddress: market.assets.borrowed.address,
-      collateralTokenAddress: market.assets.collateral.address,
-      marketType: market.type,
-    },
-  }
-}
-
-/** Deduplicate token price lookup entries by chain and address. */
-const collectTokenEntries = <T,>(items: T[], getEntries: (item: T) => TokenPriceEntry[]) =>
-  uniqBy(items.flatMap(getEntries), entry => `${entry.chainId}:${entry.tokenAddress.toLowerCase()}`)
+const getBorrowEntry = (
+  { assets: { borrowed, collateral }, chain, controllerAddress, type }: LlamaMarket,
+  userAddress: Address | undefined,
+): BorrowPositionQuery => ({
+  query: { Lend: getUserLendingVaultStatsOptions, Mint: getUserMintMarketsStatsOptions }[type]({
+    contractAddress: controllerAddress,
+    userAddress,
+    blockchainId: chain,
+  }),
+  blockchainId: chain,
+  debtTokenAddress: borrowed.address,
+  collateralTokenAddress: collateral.address,
+  marketType: type,
+})
 
 const createTokenPriceQueries = (entries: TokenPriceEntry[]) =>
   entries.map(({ chainId, tokenAddress }) => getTokenUsdRateQueryOptions({ chainId, tokenAddress }))
@@ -118,7 +66,8 @@ const buildGetPrice = (entries: TokenPriceEntry[], priceResults: UseQueryResult<
     entries.map(({ chainId, tokenAddress }, index) => [getKey(chainId, tokenAddress), priceResults[index]?.data]),
   ) as Record<string, TokenPriceData | undefined>
 
-  return (chainId: number, address: Address) => tokenMap[getKey(chainId, address)] ?? MISSING_PRICE_RESULT
+  return (blockchainId: Chain, address: Address) =>
+    tokenMap[getKey(requireChainId(blockchainId), address)] ?? MISSING_PRICE_RESULT
 }
 
 const isMintMarketStats = (stats: BorrowStatsData | undefined) => stats && 'stablecoin' in stats
@@ -132,6 +81,91 @@ const getSoftLiquidationBorrowedAmount = (marketType: LlamaMarketType, stats: Bo
       ? ((stats as LendBorrowStatsData)?.borrowed ?? MISSING_PRICE_RESULT)
       : MISSING_PRICE_RESULT
 
+function useSupplySummary(markets: LlamaMarket[]) {
+  // Collect unique token contract addresses to price positions in USD.
+  const tokenPriceEntries = useMemo(
+    () =>
+      markets
+        .filter(({ userHasPositions }) => userHasPositions?.Supply)
+        .map(({ assets: { borrowed }, chain }) => ({ chainId: requireChainId(chain), tokenAddress: borrowed.address })),
+    [markets],
+  )
+
+  return useQueries({
+    queries: createTokenPriceQueries(tokenPriceEntries),
+    combine: priceResults => {
+      const getPrice = buildGetPrice(tokenPriceEntries, priceResults)
+      return {
+        ...combineQueriesMeta(priceResults),
+        data: sum(
+          markets.map(
+            ({ lendingPosition, assets: { borrowed }, chain }) =>
+              // Missing USD prices contribute 0 and surface as summary errors
+              (lendingPosition?.totalCurrentAssets ?? 0) * getPrice(chain, borrowed.address),
+          ),
+        ),
+      }
+    },
+  })
+}
+
+function useBorrowSummary(markets: LlamaMarket[]) {
+  const { address: userAddress } = useConnection()
+  const borrowEntries = useMemo(
+    () =>
+      markets
+        .filter(({ userHasPositions }) => userHasPositions?.Borrow)
+        .map(market => getBorrowEntry(market, userAddress)),
+    [markets, userAddress],
+  )
+
+  // Collect unique token contract addresses to price positions in USD.
+  const tokenPriceEntries = useMemo(
+    () =>
+      markets
+        .filter(({ userHasPositions }) => userHasPositions?.Borrow)
+        .flatMap(({ assets: { borrowed, collateral }, chain }) => [
+          { chainId: requireChainId(chain), tokenAddress: borrowed.address },
+          { chainId: requireChainId(chain), tokenAddress: collateral.address },
+        ]),
+    [markets],
+  )
+
+  return useQueries({
+    queries: [...borrowEntries.map(({ query }) => query), ...createTokenPriceQueries(tokenPriceEntries)],
+    combine: results => {
+      const [positionResults, priceResults] = splitAt(results, borrowEntries?.length ?? 0) as [
+        UseQueryResult<BorrowStatsData>[],
+        UseQueryResult<TokenPriceData>[],
+      ]
+
+      const getPrice = buildGetPrice(tokenPriceEntries, priceResults)
+
+      // Missing USD prices contribute 0 and surface as summary errors.
+      const data = {
+        totalCollateralValue: sum(
+          zip(positionResults, borrowEntries).map(
+            ([{ data: position }, { blockchainId, collateralTokenAddress, debtTokenAddress, marketType }]) => {
+              const collateralValue = (position?.collateral ?? 0) * getPrice(blockchainId, collateralTokenAddress)
+              // part of the collateral is converted in the borrowed token when in soft liquidation
+              const borrowedAmount = getSoftLiquidationBorrowedAmount(marketType, position)
+              const borrowedValue = borrowedAmount * getPrice(blockchainId, debtTokenAddress)
+              return collateralValue + borrowedValue
+            },
+          ),
+        ),
+        totalBorrowedValue: sum(
+          zip(positionResults, borrowEntries).map(
+            ([{ data: stat }, { blockchainId, debtTokenAddress }]) =>
+              (stat?.debt ?? 0) * getPrice(blockchainId, debtTokenAddress),
+          ),
+        ),
+      }
+      return { ...combineQueriesMeta(results), data }
+    },
+  })
+}
+
 /**
  * Summarize user positions into USD totals combining position and price queries together.
  * It separates the borrow/supply query sets, fetches token prices and positions, and aggregates totals.
@@ -142,143 +176,17 @@ export const useUserPositionsSummary = ({
 }: {
   markets: LlamaMarket[] | undefined
 }): UserPositionSummaryMetric[] => {
-  const { address: userAddress } = useConnection()
-
-  const userPositionQueries = useMemo(() => {
-    if (!markets) return { borrow: [], supply: [] }
-
-    const positionEntries = markets.flatMap(market => {
-      const isSupply = market.userHasPositions?.Supply
-      if (!market.userHasPositions || (isSupply && !market.vaultAddress)) return []
-
-      return notFalsy<PositionQueryEntry>(getSupplyEntry(market, userAddress), getBorrowEntry(market, userAddress))
-    })
-
-    const [borrow, supply] = partition(positionEntries, entry => entry.kind === 'borrow').map(entries =>
-      entries.map(entry => entry.value),
-    ) as [BorrowPositionQuery[], SupplyPositionQuery[]]
-
-    return { borrow, supply }
-  }, [markets, userAddress])
-
-  // Collect unique token contract addresses to price positions in USD.
-  const tokenPriceEntries = useMemo(
-    () => ({
-      borrow: collectTokenEntries(
-        userPositionQueries.borrow,
-        ({ blockchainId, debtTokenAddress, collateralTokenAddress }) => [
-          { chainId: requireChainId(blockchainId), tokenAddress: debtTokenAddress },
-          { chainId: requireChainId(blockchainId), tokenAddress: collateralTokenAddress },
-        ],
-      ),
-      supply: collectTokenEntries(userPositionQueries.supply, ({ blockchainId, suppliedTokenAddress }) => [
-        { chainId: requireChainId(blockchainId), tokenAddress: suppliedTokenAddress },
-      ]),
-    }),
-    [userPositionQueries],
-  )
-
-  /** Keep price queries in the same useQueries call as position queries and derive totals in combine.
-   * This avoids useMemo deps on proxy query results. */
-  const borrowSummary = useQueries({
-    queries: [
-      ...userPositionQueries.borrow.map(({ query }) => query),
-      ...createTokenPriceQueries(tokenPriceEntries.borrow),
-    ],
-    combine: results => {
-      const [positionResults, priceResults] = splitAt(results, userPositionQueries.borrow.length) as [
-        UseQueryResult<BorrowStatsData>[],
-        UseQueryResult<TokenPriceData>[],
-      ]
-
-      const getPrice = buildGetPrice(tokenPriceEntries.borrow, priceResults)
-
-      // Missing USD prices contribute 0 and surface as summary errors.
-      const totalCollateralValue = sum(
-        positionResults.map((stat, index) => {
-          const borrowMeta = userPositionQueries.borrow[index]
-          const chainId = requireChainId(borrowMeta.blockchainId)
-          const collateralTokenPrice = getPrice(chainId, borrowMeta.collateralTokenAddress)
-          const borrowedTokenPrice = getPrice(chainId, borrowMeta.debtTokenAddress)
-
-          const collateralValue = (stat.data?.collateral ?? 0) * collateralTokenPrice
-          // part of the collateral is converted in the borrowed token when in soft liquidation
-          const borrowedAmount = getSoftLiquidationBorrowedAmount(borrowMeta.marketType, stat.data)
-          const borrowedValue = borrowedAmount * borrowedTokenPrice
-
-          return collateralValue + borrowedValue
-        }),
-      )
-
-      const totalBorrowedValue = sum(
-        positionResults.map((stat, index) => {
-          const borrowMeta = userPositionQueries.borrow[index]
-          const chainId = requireChainId(borrowMeta.blockchainId)
-          const debtPrice = getPrice(chainId, borrowMeta.debtTokenAddress)
-
-          return (stat.data?.debt ?? 0) * debtPrice
-        }),
-      )
-      const data = {
-        totalCollateralValue,
-        totalBorrowedValue,
-      }
-
-      return { ...combineQueriesMeta(results), data }
-    },
-  })
-
-  /** Keep price queries in the same useQueries call as position queries and derive totals in combine.
-   * This avoids useMemo deps on proxy query results. */
-  const supplySummary = useQueries({
-    queries: [
-      ...userPositionQueries.supply.map(({ query }) => query),
-      ...createTokenPriceQueries(tokenPriceEntries.supply),
-    ],
-    combine: results => {
-      const [positionResults, priceResults] = splitAt(results, userPositionQueries.supply.length) as [
-        UseQueryResult<SupplyStatsData>[],
-        UseQueryResult<TokenPriceData>[],
-      ]
-
-      const getPrice = buildGetPrice(tokenPriceEntries.supply, priceResults)
-
-      // Missing USD prices contribute 0 and surface as summary errors.
-      const totalSuppliedValue = sum(
-        positionResults.map((stat, index) => {
-          const supplyMeta = userPositionQueries.supply[index]
-          const chainId = requireChainId(supplyMeta.blockchainId)
-          const suppliedPrice = getPrice(chainId, supplyMeta.suppliedTokenAddress)
-
-          return (stat.data?.totalCurrentAssets ?? 0) * suppliedPrice
-        }),
-      )
-      const data = {
-        totalSuppliedValue,
-      }
-
-      return { ...combineQueriesMeta(results), data }
-    },
-  })
-
+  const borrowSummary = useBorrowSummary(markets ?? [])
+  const supplySummary = useSupplySummary(markets ?? [])
   return [
     createMetric(
       t`Total Collateral`,
-      borrowSummary.data.totalCollateralValue,
-      borrowSummary.isLoading,
-      borrowSummary.error,
+      mapQuery(borrowSummary, d => d.totalCollateralValue),
     ),
     createMetric(
       t`Total Borrowed`,
-      borrowSummary.data.totalBorrowedValue,
-      borrowSummary.isLoading,
-      borrowSummary.error,
+      mapQuery(borrowSummary, d => d.totalBorrowedValue),
     ),
-    createMetric(
-      t`Total Supplied`,
-      supplySummary.data.totalSuppliedValue,
-      supplySummary.isLoading,
-      supplySummary.error,
-    ),
+    createMetric(t`Total Supplied`, supplySummary),
   ]
 }

--- a/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useUserPositionsSummary.tsx
@@ -27,6 +27,8 @@ type TokenPrice = number
 type TokenPriceEntry = { chainId: number; tokenAddress: Address }
 
 const MISSING_PRICE_RESULT: TokenPrice = 0
+const getTokenPriceEntryKey = ({ chainId, tokenAddress }: TokenPriceEntry) => `${chainId}:${tokenAddress.toLowerCase()}`
+const createUniqueTokenPriceEntries = (entries: TokenPriceEntry[]) => uniqBy(entries, getTokenPriceEntryKey)
 
 const createMetric = <T extends Amount>(label: string, metric: Query<T>): UserPositionSummaryMetric => ({
   label,
@@ -34,18 +36,21 @@ const createMetric = <T extends Amount>(label: string, metric: Query<T>): UserPo
 })
 
 const createTokenPriceQueries = (entries: TokenPriceEntry[]) =>
-  uniqBy(entries, e => `${e.chainId}:${e.tokenAddress}`).map(({ chainId, tokenAddress }) =>
+  createUniqueTokenPriceEntries(entries).map(({ chainId, tokenAddress }) =>
     getTokenUsdRateQueryOptions({ chainId, tokenAddress }),
   )
 
 /** Build a token price lookup that hides key formatting. */
 const buildGetPrice = (entries: TokenPriceEntry[], priceResults: UseQueryResult<TokenPrice>[]) => {
-  const getKey = (chainId: number, address: Address) => `${chainId}:${address.toLowerCase()}`
   const tokenMap = Object.fromEntries(
-    entries.map(({ chainId, tokenAddress }, index) => [getKey(chainId, tokenAddress), priceResults[index]?.data]),
+    createUniqueTokenPriceEntries(entries).map((entry, index) => [
+      getTokenPriceEntryKey(entry),
+      priceResults[index]?.data,
+    ]),
   ) as Record<string, TokenPrice | undefined>
   return (blockchainId: Chain, address: Address) =>
-    tokenMap[getKey(requireChainId(blockchainId), address)] ?? MISSING_PRICE_RESULT
+    tokenMap[getTokenPriceEntryKey({ chainId: requireChainId(blockchainId), tokenAddress: address })] ??
+    MISSING_PRICE_RESULT
 }
 
 const isMintMarketStats = (stats: BorrowStatsData | undefined) => stats && 'stablecoin' in stats

--- a/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
+++ b/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
@@ -3,7 +3,6 @@ import {
   getAllMarkets,
   getAllUserLendingPositions,
   getAllUserMarkets,
-  getUserMarketEarnings,
   getUserMarketStats,
   Market,
   type UserMarketStats,
@@ -32,7 +31,7 @@ export const { getQueryOptions: getLendingVaultsOptions, invalidate: invalidateL
 })
 
 const {
-  getQueryOptions: getUserLendingVaultsQueryOptions,
+  getQueryOptions: getUserLendingVaultsOptions,
   getQueryData: getCurrentUserLendingVaults,
   invalidate: invalidateUserLendingVaults,
 } = queryFactory({
@@ -49,27 +48,14 @@ const {
 })
 
 const {
-  getQueryOptions: getUserLendingVaultStatsQueryOptions,
-  useQuery: useUserLendingVaultStatsQuery,
+  getQueryOptions: getUserLendingVaultStatsOptions,
+  useQuery: useUserLendingVaultStats,
   invalidate: invalidateUserLendingVaultStats,
 } = queryFactory({
   queryKey: ({ userAddress, contractAddress, blockchainId }: UserContractParams) =>
     ['user-lending-vault', 'stats', { blockchainId }, { contractAddress }, { userAddress }, 'v1'] as const,
   queryFn: async ({ userAddress, contractAddress, blockchainId }: UserContractQuery): Promise<UserMarketStats> =>
     getUserMarketStats(userAddress, blockchainId, contractAddress),
-  category: 'llamalend.user',
-  validationSuite: userContractValidationSuite,
-})
-
-const {
-  useQuery: useUserLendingVaultEarningsQuery,
-  getQueryOptions: getUserLendingVaultEarningsQueryOptions,
-  invalidate: invalidateUserLendingVaultEarnings,
-} = queryFactory({
-  queryKey: ({ userAddress, contractAddress, blockchainId }: UserContractParams) =>
-    ['user-lending-vault', 'earnings', { blockchainId }, { contractAddress }, { userAddress }, 'v1'] as const,
-  queryFn: ({ userAddress, contractAddress, blockchainId }: UserContractQuery) =>
-    getUserMarketEarnings(userAddress, blockchainId, contractAddress),
   category: 'llamalend.user',
   validationSuite: userContractValidationSuite,
 })
@@ -90,47 +76,42 @@ export async function invalidateAllUserLendingVaults(userAddress: Address | null
   await Promise.all(invalidateContracts)
 }
 
+export type LendingPosition = {
+  currentShares: number
+  totalCurrentAssets: number
+  earnings: number
+  boostMultiplier: number | null
+}
+
 /**
  * Fetches the user's lending supplies across all chains.
  */
-const {
-  getQueryOptions: getUserLendingSuppliesQueryOptions,
-  getQueryData: getCurrentUserLendingSupplies,
-  invalidate: invalidateUserLendingSupplies,
-} = queryFactory({
-  queryKey: ({ userAddress }: UserParams) => ['user-lending-supplies', { userAddress }, 'v4'] as const,
+const { getQueryOptions: getUserLendingSuppliesOptions, invalidate: invalidateUserLendingSupplies } = queryFactory({
+  queryKey: ({ userAddress }: UserParams) => ['user-lending-supplies', { userAddress }, 'v5'] as const,
   category: 'llamalend.user',
-  queryFn: async ({ userAddress }: UserQuery): Promise<Record<ChainName, Address[]>> => {
+  queryFn: async ({ userAddress }: UserQuery): Promise<Record<ChainName, Record<Address, LendingPosition>>> => {
     const positions = await getAllUserLendingPositions(userAddress)
     return fromEntries(
       recordEntries(positions).map(([chain, positions]) => [
         chain,
-        positions.filter(p => p.currentShares || p.currentSharesInGauge).map(position => position.vaultAddress),
+        fromEntries(
+          positions
+            .filter(p => p.currentShares || p.currentSharesInGauge || p.totalCurrentAssets)
+            .map(({ vaultAddress, currentShares, totalCurrentAssets, earnings, boostMultiplier }) => [
+              vaultAddress,
+              { currentShares, totalCurrentAssets: totalCurrentAssets + currentShares, earnings, boostMultiplier },
+            ]),
+        ),
       ]),
     )
   },
   validationSuite: userAddressValidationSuite,
 })
 
-export async function invalidateAllUserLendingSupplies(userAddress: Address | null | undefined) {
-  await invalidateUserLendingSupplies({ userAddress })
-
-  const invalidateContracts = recordEntries(getCurrentUserLendingSupplies({ userAddress }) ?? {}).flatMap(
-    ([blockchainId, positions]) =>
-      positions.map(contractAddress =>
-        invalidateUserLendingVaultEarnings({
-          userAddress,
-          blockchainId,
-          contractAddress,
-        }),
-      ),
-  )
-  await Promise.all(invalidateContracts)
+export {
+  getUserLendingSuppliesOptions,
+  getUserLendingVaultsOptions,
+  getUserLendingVaultStatsOptions,
+  useUserLendingVaultStats,
+  invalidateUserLendingSupplies,
 }
-
-export const getUserLendingSuppliesOptions = getUserLendingSuppliesQueryOptions
-export const getUserLendingVaultEarningsOptions = getUserLendingVaultEarningsQueryOptions
-export const useUserLendingVaultEarnings = useUserLendingVaultEarningsQuery
-export const getUserLendingVaultsOptions = getUserLendingVaultsQueryOptions
-export const getUserLendingVaultStatsOptions = getUserLendingVaultStatsQueryOptions
-export const useUserLendingVaultStats = useUserLendingVaultStatsQuery

--- a/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
+++ b/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
@@ -77,8 +77,7 @@ export async function invalidateAllUserLendingVaults(userAddress: Address | null
 }
 
 export type LendingPosition = {
-  currentShares: number
-  totalCurrentAssets: number
+  supplied: number
   earnings: number
   boostMultiplier: number | null
 }
@@ -96,10 +95,10 @@ const { getQueryOptions: getUserLendingSuppliesOptions, invalidate: invalidateUs
         chain,
         fromEntries(
           positions
-            .filter(p => p.currentShares || p.currentSharesInGauge || p.totalCurrentAssets)
-            .map(({ vaultAddress, currentShares, totalCurrentAssets, earnings, boostMultiplier }) => [
+            .filter(p => p.totalCurrentAssets > 0)
+            .map(({ vaultAddress, totalCurrentAssets, earnings, boostMultiplier }) => [
               vaultAddress,
-              { currentShares, totalCurrentAssets: totalCurrentAssets + currentShares, earnings, boostMultiplier },
+              { supplied: totalCurrentAssets, earnings, boostMultiplier },
             ]),
         ),
       ]),

--- a/apps/main/src/llamalend/queries/market-list/llama-market-stats.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-market-stats.ts
@@ -1,7 +1,7 @@
 import { useConnection } from 'wagmi'
 import { LlamaMarketColumnId } from '@/llamalend/features/market-list/columns'
 import { calculateLtv, getDisplayHealth, getLiquidationStatus, isBelowRange } from '@/llamalend/llama.utils'
-import { useUserLendingVaultEarnings, useUserLendingVaultStats } from '@/llamalend/queries/market-list/lending-vaults'
+import { useUserLendingVaultStats } from '@/llamalend/queries/market-list/lending-vaults'
 import { type LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { useUserMintMarketStats } from '@/llamalend/queries/market-list/mint-markets'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -15,35 +15,28 @@ const statsColumns = [
   LlamaMarketColumnId.UserCollateral,
   LlamaMarketColumnId.UserLtv,
 ]
-const earningsColumns = [
-  LlamaMarketColumnId.UserEarnings,
-  LlamaMarketColumnId.UserDeposited,
-  LlamaMarketColumnId.UserBoostMultiplier,
-]
 
 /**
  * Hook that fetches the user's stats for a given market.
  * Depending on the column and market type, it fetches the stats from different endpoints.
  * It returns the stats data and an error if any.
- * @param market - The market to fetch stats for
- * @param column - The column to fetch stats for
  * @returns The stats data and an error if any
  */
-export function useUserMarketStats(market: LlamaMarket, column?: LlamaMarketColumnId) {
-  const { type, userHasPositions, controllerAddress, vaultAddress, chain } = market
+export function useUserMarketStats(
+  { assets, type, userHasPositions, controllerAddress, chain }: LlamaMarket,
+  column?: LlamaMarketColumnId,
+) {
   const { address: userAddress } = useConnection()
   const { data: collateralUsdRate, isLoading: collateralUsdRateLoading } = useTokenUsdRate({
-    chainId: requireChainId(market.chain),
-    tokenAddress: market.assets.collateral.address,
+    chainId: requireChainId(chain),
+    tokenAddress: assets.collateral.address,
   })
   const { data: borrowedUsdRate, isLoading: borrowedUsdRateLoading } = useTokenUsdRate({
-    chainId: requireChainId(market.chain),
-    tokenAddress: market.assets.borrowed.address,
+    chainId: requireChainId(chain),
+    tokenAddress: assets.borrowed.address,
   })
 
   const enableStats = !!userHasPositions?.Borrow && (!column || statsColumns.includes(column))
-  const enableEarnings = !!userHasPositions?.Supply && column != null && earningsColumns.includes(column)
-
   const enableLendingStats = enableStats && type === LlamaMarketType.Lend
   const enableMintStats = enableStats && type === LlamaMarketType.Mint
 
@@ -55,20 +48,13 @@ export function useUserMarketStats(market: LlamaMarket, column?: LlamaMarketColu
     isLoading: loadingLend,
   } = useUserLendingVaultStats(params, enableLendingStats)
 
-  // The API endpoint for user earnings is an exception in that it relies on the vault address instead of controller address.
-  const {
-    data: earnData,
-    error: earnError,
-    isLoading: loadingEarn,
-  } = useUserLendingVaultEarnings({ ...params, contractAddress: vaultAddress }, enableEarnings)
-
   const { data: mintData, error: mintError, isLoading: loadingMint } = useUserMintMarketStats(params, enableMintStats)
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation before enabling this rule.
   const stats = (enableLendingStats && lendData) || (enableMintStats && mintData)
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation before enabling this rule.
-  const error = (enableLendingStats && lendError) || (enableMintStats && mintError) || (enableEarnings && earnError)
-  const isLoading = loadingLend || loadingEarn || loadingMint || collateralUsdRateLoading || borrowedUsdRateLoading
+  const error = (enableLendingStats && lendError) || (enableMintStats && mintError)
+  const isLoading = loadingLend || loadingMint || collateralUsdRateLoading || borrowedUsdRateLoading
 
   const borrowedAmount = stats ? ('borrowed' in stats ? stats.borrowed : stats.stablecoin) : 0
 
@@ -86,8 +72,8 @@ export function useUserMarketStats(market: LlamaMarket, column?: LlamaMarketColu
         borrowed: stats.debt,
         collateral: {
           amount: stats.collateral,
-          address: market?.assets?.collateral?.address,
-          symbol: market?.assets?.collateral?.symbol,
+          address: assets?.collateral?.address,
+          symbol: assets?.collateral?.symbol,
           usdRate: collateralUsdRate,
         },
         /**
@@ -96,8 +82,8 @@ export function useUserMarketStats(market: LlamaMarket, column?: LlamaMarketColu
          */
         borrowToken: {
           amount: borrowedAmount,
-          address: market?.assets?.borrowed?.address,
-          symbol: market?.assets?.borrowed?.symbol,
+          address: assets?.borrowed?.address,
+          symbol: assets?.borrowed?.symbol,
           usdRate: borrowedUsdRate,
         },
         ltv: calculateLtv(stats.debt, stats.collateral, borrowedAmount, borrowedUsdRate, collateralUsdRate),
@@ -109,8 +95,9 @@ export function useUserMarketStats(market: LlamaMarket, column?: LlamaMarketColu
         },
       },
     }),
-    ...(enableEarnings && { data: { earnings: earnData } }),
     ...(error && { error }),
     isLoading,
   }
 }
+
+export type MarketStats = ReturnType<typeof useUserMarketStats>['data']

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -192,7 +192,7 @@ const convertLendingVault = (
           }))
         : [],
     },
-    lendingPosition: lendingPosition && { ...lendingPosition, boostMultiplier: 10 },
+    lendingPosition,
     type: marketType,
     url: getInternalUrl('lend', chain, `${LEND_ROUTES.PAGE_MARKETS}/${controller}`),
     deprecatedMessage:

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -376,7 +376,9 @@ export const useLlamaMarkets = (
         const favoriteMarketsSet = new Set(favoriteMarkets.data)
         const userBorrows = new Set(recordValues(userLendingVaults.data ?? {}).flat())
         const userMints = new Set(recordValues(userMintMarkets.data ?? {}).flat())
-        const hasSupplied = recordValues(userSuppliedMarkets.data ?? {}).some(c => c)
+        const hasSupplied = recordValues(userSuppliedMarkets.data ?? {}).some(
+          positions => recordValues(positions).length,
+        )
         const countMarket = createCountMarket(mintMarkets.data)
         const campaigns = combineCampaigns([externalCampaigns.data, merklCampaigns.data])
         const getLendMarketBadDebt = createGetBadDebtMarket(badDebtLendMarkets.data)

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -23,6 +23,7 @@ import {
   getLendingVaultsOptions,
   getUserLendingSuppliesOptions,
   getUserLendingVaultsOptions,
+  type LendingPosition,
   LendingVault,
 } from './lending-vaults'
 import { getMintMarketOptions, getUserMintMarketsOptions, MintMarket } from './mint-markets'
@@ -71,6 +72,7 @@ export type LlamaMarket = {
     // extra lending incentives, like OP rewards (so non CRV)
     incentives: ExtraIncentive[]
   }
+  lendingPosition?: LendingPosition
   type: LlamaMarketType
   url: string
   rewards: CampaignRewards[]
@@ -122,12 +124,11 @@ const convertLendingVault = (
   favoriteMarkets: Set<Address>,
   campaigns: Record<string, CampaignRewards[]> = {},
   userBorrows: Set<Address>,
-  userSupplied: Set<Address>,
+  lendingPosition: LendingPosition | undefined,
   badDebtUsd?: number,
 ): LlamaMarket => {
   const marketType = LlamaMarketType.Lend
   const hasBorrowed = userBorrows.has(controller)
-  const hasSupplied = userSupplied.has(vault)
   const totalExtraRewardApy =
     // sumBy returns 0 for empty arrays
     extraRewardApr.length ? sumBy(extraRewardApr, reward => aprToApy(reward.rate)!) : null
@@ -191,6 +192,7 @@ const convertLendingVault = (
           }))
         : [],
     },
+    lendingPosition: lendingPosition && { ...lendingPosition, boostMultiplier: 10 },
     type: marketType,
     url: getInternalUrl('lend', chain, `${LEND_ROUTES.PAGE_MARKETS}/${controller}`),
     deprecatedMessage:
@@ -199,11 +201,8 @@ const convertLendingVault = (
     rewards: [...(campaigns[vault.toLowerCase()] ?? []), ...(campaigns[controller.toLowerCase()] ?? [])],
     leverage: NO_LEVERAGE_LEND[chain]?.includes(controller) ? null : leverage,
     userHasPositions:
-      hasBorrowed || hasSupplied
-        ? {
-            [MarketRateType.Borrow]: hasBorrowed,
-            [MarketRateType.Supply]: hasSupplied,
-          }
+      hasBorrowed || lendingPosition
+        ? { [MarketRateType.Borrow]: hasBorrowed, [MarketRateType.Supply]: !!lendingPosition }
         : null,
     createdAt: new Date(createdAt).getTime(),
     favoriteKey: vault,
@@ -377,7 +376,7 @@ export const useLlamaMarkets = (
         const favoriteMarketsSet = new Set(favoriteMarkets.data)
         const userBorrows = new Set(recordValues(userLendingVaults.data ?? {}).flat())
         const userMints = new Set(recordValues(userMintMarkets.data ?? {}).flat())
-        const userSupplied = new Set(recordValues(userSuppliedMarkets.data ?? {}).flat())
+        const hasSupplied = recordValues(userSuppliedMarkets.data ?? {}).some(c => c)
         const countMarket = createCountMarket(mintMarkets.data)
         const campaigns = combineCampaigns([externalCampaigns.data, merklCampaigns.data])
         const getLendMarketBadDebt = createGetBadDebtMarket(badDebtLendMarkets.data)
@@ -391,7 +390,7 @@ export const useLlamaMarkets = (
         const data: LlamaMarketsResult | undefined = isReady
           ? {
               userHasPositions:
-                userBorrows.size > 0 || userMints.size > 0 || userSupplied.size > 0
+                userBorrows.size > 0 || userMints.size > 0 || hasSupplied
                   ? {
                       [LlamaMarketType.Mint]: {
                         [MarketRateType.Borrow]: userMints.size > 0,
@@ -399,7 +398,7 @@ export const useLlamaMarkets = (
                       },
                       [LlamaMarketType.Lend]: {
                         [MarketRateType.Borrow]: userBorrows.size > 0,
-                        [MarketRateType.Supply]: userSupplied.size > 0,
+                        [MarketRateType.Supply]: hasSupplied,
                       },
                     }
                   : null,
@@ -411,7 +410,7 @@ export const useLlamaMarkets = (
                     favoriteMarketsSet,
                     campaigns,
                     userBorrows,
-                    userSupplied,
+                    userSuppliedMarkets.data?.[vault.chain]?.[vault.vault],
                     getLendMarketBadDebt(vault.chain, vault.controller),
                   ),
                 ),

--- a/apps/main/src/llamalend/queries/user/invalidation.ts
+++ b/apps/main/src/llamalend/queries/user/invalidation.ts
@@ -4,7 +4,7 @@ import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { queryClient } from '@ui-kit/lib/api/query-client'
 import { rootKeys, type UserContractQuery, type UserMarketQuery } from '@ui-kit/lib/model'
-import { invalidateAllUserLendingSupplies, invalidateAllUserLendingVaults } from '../market-list/lending-vaults'
+import { invalidateUserLendingSupplies, invalidateAllUserLendingVaults } from '../market-list/lending-vaults'
 import { invalidateAllUserMintMarkets } from '../market-list/mint-markets'
 
 /**
@@ -24,6 +24,6 @@ export const invalidateAllUserMarketDetails = ({
     invalidateUserCollateralEvents({ userAddress, contractAddress, blockchainId }),
     invalidateAllUserMintMarkets(userAddress),
     invalidateAllUserLendingVaults(userAddress),
-    invalidateAllUserLendingSupplies(userAddress),
+    invalidateUserLendingSupplies({ userAddress }),
   ])
 }

--- a/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
@@ -15,7 +15,7 @@ const format = (value: number) => formatNumber(value, 'usd.notional')
 const TITLE = { Lend: t`Total supplied`, Mint: t`Debt ceiling` }
 const TOOLTIP = {
   Lend: t`Total unborrowed supply available for new loans or withdrawals.`,
-  Mint: `Remaining borrowing capacity under the DAO-set debt ceiling.`,
+  Mint: t`Remaining borrowing capacity under the DAO-set debt ceiling.`,
 }
 
 export const LiquidityUsdTooltipContent = ({

--- a/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
@@ -6,11 +6,17 @@ import {
   TooltipWrapper,
 } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import Stack from '@mui/material/Stack'
+import { maybe } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { LlamaMarketType } from '@ui-kit/types/market'
 import { formatNumber } from '@ui-kit/utils'
 
 const format = (value: number) => formatNumber(value, 'usd.notional')
+
+const TITLE = { Lend: t`Total supplied`, Mint: t`Debt ceiling` }
+const TOOLTIP = {
+  Lend: t`Total unborrowed supply available for new loans or withdrawals.`,
+  Mint: `Remaining borrowing capacity under the DAO-set debt ceiling.`,
+}
 
 export const LiquidityUsdTooltipContent = ({
   market: {
@@ -26,16 +32,12 @@ export const LiquidityUsdTooltipContent = ({
   market: LlamaMarket
 }) => (
   <TooltipWrapper>
-    {type === LlamaMarketType.Lend ? (
-      <TooltipDescription text={t`Total unborrowed supply available for new loans or withdrawals.`} />
-    ) : (
-      <TooltipDescription text={t`Remaining borrowing capacity under the DAO-set debt ceiling.`} />
-    )}
+    <TooltipDescription text={TOOLTIP[type]} />
     <Stack>
       <TooltipItems secondary>
-        {type === LlamaMarketType.Lend
-          ? balanceUsd != null && <TooltipItem title={t`Total supplied`}>{format(balanceUsd)}</TooltipItem>
-          : debtCeiling != null && <TooltipItem title={t`Debt ceiling`}>{format(debtCeiling)}</TooltipItem>}
+        {maybe({ Lend: balanceUsd, Mint: debtCeiling }[type], usd => (
+          <TooltipItem title={TITLE[type]}>{format(usd)}</TooltipItem>
+        ))}
         <TooltipItem title={t`Total borrowed`}>-{format(totalDebtUsd)}</TooltipItem>
       </TooltipItems>
       <TooltipItems>

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -218,7 +218,7 @@ const NUMBER_FORMAT_CATEGORIES = {
   },
 } as const satisfies Record<string, NumberFormatOptions & { fallback: string }>
 
-type NumberFormatCategory = keyof typeof NUMBER_FORMAT_CATEGORIES
+export type NumberFormatCategory = keyof typeof NUMBER_FORMAT_CATEGORIES
 
 /**
  * Decomposes a number into its formatted parts including prefix, main value, suffix, and scale suffix.

--- a/packages/prices-api/src/llamalend/schema.ts
+++ b/packages/prices-api/src/llamalend/schema.ts
@@ -171,7 +171,7 @@ const userLendingPosition = z
     current_shares: z.string(),
     current_shares_in_gauge: z.string(),
     boost_multiplier: z.number().nullable(),
-    current_shares_in_convex: z.string().nullable(),
+    current_shares_in_convex: z.string().optional(),
     earnings: z.string(),
     total_current_assets: z.string(),
   })

--- a/packages/prices-api/src/llamalend/schema.ts
+++ b/packages/prices-api/src/llamalend/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/v4'
-import { fromEntries, recordEntries } from '@primitives/objects.utils'
+import { fromEntries, maybe, recordEntries } from '@primitives/objects.utils'
 import type { Chain } from '..'
 import { address, camelizeKeys, chain, timestamp } from '../schemas'
 
@@ -171,13 +171,21 @@ const userLendingPosition = z
     current_shares: z.string(),
     current_shares_in_gauge: z.string(),
     boost_multiplier: z.number().nullable(),
+    current_shares_in_convex: z.string().nullable(),
+    earnings: z.string(),
+    total_current_assets: z.string(),
   })
   .transform(camelizeKeys)
-  .transform(({ currentShares, currentSharesInGauge, ...data }) => ({
-    ...data,
-    currentShares: parseFloat(currentShares),
-    currentSharesInGauge: parseFloat(currentSharesInGauge),
-  }))
+  .transform(
+    ({ currentShares, currentSharesInGauge, currentSharesInConvex, earnings, totalCurrentAssets, ...data }) => ({
+      ...data,
+      currentShares: parseFloat(currentShares),
+      currentSharesInGauge: parseFloat(currentSharesInGauge),
+      currentSharesInConvex: maybe(currentSharesInConvex, s => parseFloat(s)),
+      earnings: parseFloat(earnings),
+      totalCurrentAssets: parseFloat(totalCurrentAssets),
+    }),
+  )
 
 const userMarketStats = z
   .object({

--- a/packages/primitives/src/array.utils.ts
+++ b/packages/primitives/src/array.utils.ts
@@ -56,3 +56,5 @@ export const median = (values: number[]) => {
   const middle = Math.floor(sorted.length / 2)
   return sorted.length % 2 === 0 ? sorted[middle - 1] : sorted[middle]
 }
+
+export const zip = <T, U>(a: T[], b: U[]): [T, U][] => a.map((k, i) => [k, b[i]] as const)

--- a/packages/primitives/src/array.utils.ts
+++ b/packages/primitives/src/array.utils.ts
@@ -57,4 +57,13 @@ export const median = (values: number[]) => {
   return sorted.length % 2 === 0 ? sorted[middle - 1] : sorted[middle]
 }
 
-export const zip = <T, U>(a: T[], b: U[]): [T, U][] => a.map((k, i) => [k, b[i]] as const)
+export const zip = <T extends readonly unknown[][]>(
+  ...arrays: T
+): { [K in keyof T]: T[K] extends readonly (infer U)[] ? U : never }[] => {
+  if (arrays.some(array => array.length !== arrays[0].length)) {
+    throw new Error('Cannot zip arrays with different lengths')
+  }
+  return arrays[0].map((_, i) => arrays.map(array => array[i])) as {
+    [K in keyof T]: T[K] extends readonly (infer U)[] ? U : never
+  }[]
+}

--- a/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
@@ -44,10 +44,17 @@ export const mockEmptyLlamaMarketBadDebt = () =>
     cy.intercept({ method: 'GET', pathname, query: { fetch_on_chain: 'true' } }, { body: { data: [] } }),
   )
 
+const mockEmptyCrvUsdAmms = () =>
+  cy.intercept(
+    { method: 'GET', pathname: '/api/getVolumes/ethereum/crvusd-amms' },
+    { body: { success: true, data: { amms: [], totalVolume: 0 }, generatedTimeMs: Date.now() } },
+  )
+
 export function setupLlamalendListMocks(vaultData = createLendingVaultChainsResponse()) {
   blockUnmockedLlamaMarketApis()
   mockEmptyLlamaMarketUserData()
   mockEmptyLlamaMarketBadDebt()
+  mockEmptyCrvUsdAmms()
   mockTokenPrices()
   const lendingVaults = mockLendingVaults(vaultData)
   mockLendingSnapshots().as('lend-snapshots')


### PR DESCRIPTION
- stop calling the earnings endpoint
- Make the lending data available at the market level
- cleanup usages and remove unused stuff