### PR TITLE
fix: missing amm fee denominator for prices api in pool advanced details

### DIFF
--- a/apps/main/src/dex/features/advanced-details/components/Parameters.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/Parameters.tsx
@@ -65,7 +65,7 @@ export const Parameters = ({
           <ActionInfo
             label={t`AMM fee`}
             loading={isLoadingParameters}
-            value={formatNumber(amount(fee ?? snapshotData?.fee), {
+            value={formatNumber(amount(fee ?? maybe(snapshotData?.fee, fee => fee / 10 ** 8)), {
               maximumFractionDigits: 4,
               unit: 'percentage',
               abbreviate: false,


### PR DESCRIPTION
With no connected wallet the AMM fee falls back to prices api, but it was lacking a division by its denominator.

Pool: `0x00836fe54625be242bcfa286207795405ca4fd10`
<img width="634" height="322" alt="image" src="https://github.com/user-attachments/assets/8158e7e4-bbb5-4dd9-a9e7-4b1b2a128d2d" />