### PR TITLE
styling: disable skeleton growth for market composition table

### DIFF
--- a/apps/main/src/dex/features/advanced-details/components/market-composition/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/market-composition/index.tsx
@@ -2,6 +2,7 @@ import type { ChainId, PoolDataCacheOrApi } from '@/dex/types/main.types'
 import type { Pool as PricesApiPool } from '@curvefi/prices-api/pools'
 import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
+import { DEFAULT_INCREASING_LENGTH } from '@ui-kit/hooks/useIncreasingLength'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
@@ -41,6 +42,7 @@ export const MarketComposition = ({
         size="small"
         isLoading={isLoading}
         disableStickyHeader
+        increasingLengthOptions={{ ...DEFAULT_INCREASING_LENGTH, maxLength: DEFAULT_INCREASING_LENGTH.initialLength }}
         emptyState={<EmptyStateRow table={table} size="sm">{t`No market composition found.`}</EmptyStateRow>}
         footerRow={rows.length > 0 && <FooterRow isLoading={isLoading} totalUsd={totalUsd} />}
       />

--- a/apps/main/src/dex/features/advanced-details/components/market-composition/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/market-composition/index.tsx
@@ -4,8 +4,8 @@ import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
-import { LegacyDataTable } from '@ui-kit/shared/ui/DataTable/LegacyDataTable'
 import { useMarketComposition } from '../../hooks/useMarketComposition'
 import { MARKET_COMPOSITION_COLUMNS, type MarketCompositionRow } from './columns/columns.definitions'
 import { FooterRow } from './FooterRow'
@@ -36,10 +36,10 @@ export const MarketComposition = ({
   return (
     <Stack>
       <CardHeader title={t`Market Composition`} size="small" />
-      <LegacyDataTable<MarketCompositionRow>
+      <DataTable<MarketCompositionRow>
         table={table}
         size="small"
-        loading={isLoading}
+        isLoading={isLoading}
         disableStickyHeader
         emptyState={<EmptyStateRow table={table} size="sm">{t`No market composition found.`}</EmptyStateRow>}
         footerRow={rows.length > 0 && <FooterRow isLoading={isLoading} totalUsd={totalUsd} />}

--- a/apps/main/src/dex/features/advanced-details/components/points-campaigns/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/points-campaigns/index.tsx
@@ -3,8 +3,8 @@ import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
-import { LegacyDataTable } from '@ui-kit/shared/ui/DataTable/LegacyDataTable'
 import { usePointsCampaigns } from '../../hooks/usePointsCampaigns'
 import { POINTS_CAMPAIGNS_COLUMNS, type PointsCampaignsRow } from './columns/columns.definitions'
 
@@ -29,10 +29,10 @@ export const PointsCampaigns = ({
     rows.length > 0 && (
       <Stack>
         <CardHeader title={t`Points Campaigns`} size="small" />
-        <LegacyDataTable<PointsCampaignsRow>
+        <DataTable<PointsCampaignsRow>
           table={table}
           size="small"
-          loading={false}
+          isLoading={false}
           disableStickyHeader
           emptyState={<EmptyStateRow table={table} size="sm">{t`No points campaigns found.`}</EmptyStateRow>}
         />

--- a/apps/main/src/dex/features/advanced-details/components/yield-breakdown/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/yield-breakdown/index.tsx
@@ -3,8 +3,8 @@ import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
-import { LegacyDataTable } from '@ui-kit/shared/ui/DataTable/LegacyDataTable'
 import { useYieldBreakdown } from '../../hooks/useYieldBreakdown'
 import { YIELD_BREAKDOWN_COLUMNS, type YieldBreakdownRow } from './columns/columns.definitions'
 import { FooterRow } from './FooterRow'
@@ -33,10 +33,10 @@ export const YieldBreakdown = ({
     rows.length > 0 && (
       <Stack>
         <CardHeader title={t`Yield Breakdown`} size="small" />
-        <LegacyDataTable<YieldBreakdownRow>
+        <DataTable<YieldBreakdownRow>
           table={table}
           size="small"
-          loading={false}
+          isLoading={false}
           disableStickyHeader
           emptyState={<EmptyStateRow table={table} size="sm">{t`No yield breakdown found.`}</EmptyStateRow>}
           footerRow={total && <FooterRow baseTotal={baseTotal} total={total} />}

--- a/packages/curve-ui-kit/src/hooks/useIncreasingLength.ts
+++ b/packages/curve-ui-kit/src/hooks/useIncreasingLength.ts
@@ -7,14 +7,20 @@ export type IncreasingLengthOptions = {
   maxLength?: number
 }
 
+export const DEFAULT_INCREASING_LENGTH: Required<IncreasingLengthOptions> = {
+  initialLength: 3,
+  increaseEveryMs: 5000,
+  maxLength: 10,
+}
+
 /**
  * Returns a length value that starts at `initialLength` and increases by one every `increaseEveryMs` until it reaches
  * `maxLength`.
  */
 export const useIncreasingLength = ({
-  initialLength = 3,
-  increaseEveryMs = 5000,
-  maxLength = 10,
+  initialLength = DEFAULT_INCREASING_LENGTH.initialLength,
+  increaseEveryMs = DEFAULT_INCREASING_LENGTH.increaseEveryMs,
+  maxLength = DEFAULT_INCREASING_LENGTH.maxLength,
 }: IncreasingLengthOptions = {}) => {
   const [length, setLength] = useState(initialLength)
 


### PR DESCRIPTION
This should prevent the table for growing endlessly like in pic below

<img width="1067" height="982" alt="image" src="https://github.com/user-attachments/assets/12135ccb-8494-495f-b2a2-6920199d65c5" />
