### PR TITLE
feat: show token icons in column headers for pool liquidity table

### DIFF
--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
@@ -67,7 +67,10 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
     [liquidityData?.events, network, networkConfig, poolTokens],
   )
 
-  const liquidityColumns = useMemo(() => createPoolLiquidityColumns({ poolTokens }), [poolTokens])
+  const liquidityColumns = useMemo(
+    () => createPoolLiquidityColumns({ blockchainId: network, poolTokens }),
+    [network, poolTokens],
+  )
 
   const { error, isLoading } = combineQueryState(poolLiquidityEvents, poolPriceApi)
 

--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
@@ -189,7 +189,10 @@ const generateLlammaEvents = (count: number, collateralToken: Token, borrowToken
 const DexPoolActivityComponent = () => {
   const tradesData = useMemo(() => generatePoolTrades(20), [])
   const liquidityData = useMemo(() => generatePoolLiquidity(15), [])
-  const liquidityColumns = useMemo(() => createPoolLiquidityColumns({ poolTokens: POOL_TOKENS }), [])
+  const liquidityColumns = useMemo(
+    () => createPoolLiquidityColumns({ blockchainId: 'ethereum', poolTokens: POOL_TOKENS }),
+    [],
+  )
 
   const tradesTable = useTable({
     data: tradesData,

--- a/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/columns/pool-liquidity-columns.tsx
@@ -1,12 +1,17 @@
+import Stack from '@mui/material/Stack'
 import { type Token } from '@primitives/address.utils'
 import { createColumnHelper } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { InlineTableCell } from '@ui-kit/shared/ui/DataTable/inline-cells/InlineTableCell'
+import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { TokenInfo } from '@ui-kit/shared/ui/TokenInfo'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber } from '@ui-kit/utils'
 import { AddressCell, TimestampCell } from '../cells'
 import { PoolLiquidityActionCell } from '../cells/PoolLiquidityActionCell'
 import type { PoolLiquidityRow } from '../types'
+
+const { Spacing } = SizesAndSpaces
 
 export enum PoolLiquidityColumnId {
   Action = 'eventType',
@@ -19,10 +24,11 @@ export const getTokenAmountColumnId = (tokenIndex: number): string => `tokenAmou
 const columnHelper = createColumnHelper<PoolLiquidityRow>()
 
 type CreatePoolLiquidityColumnsParams = {
+  blockchainId: string
   poolTokens: Token[]
 }
 
-export const createPoolLiquidityColumns = ({ poolTokens }: CreatePoolLiquidityColumnsParams) => {
+export const createPoolLiquidityColumns = ({ blockchainId, poolTokens }: CreatePoolLiquidityColumnsParams) => {
   const baseColumns = [
     columnHelper.accessor('provider', {
       id: PoolLiquidityColumnId.User,
@@ -40,25 +46,25 @@ export const createPoolLiquidityColumns = ({ poolTokens }: CreatePoolLiquidityCo
   const tokenColumns = poolTokens.map((token, index) =>
     columnHelper.display({
       id: getTokenAmountColumnId(index),
-      header: token.symbol ?? t`Token ${index + 1}`,
+      header: () => (
+        <Stack direction="row" sx={{ gap: Spacing.xs, alignItems: 'center' }}>
+          {token.symbol ?? t`Token ${index + 1}`}
+          <TokenIcon blockchainId={blockchainId} address={token.address} size="mui-md" />
+        </Stack>
+      ),
       cell: ({ row }) => {
-        const { tokenAmounts, network, eventType } = row.original
+        const { tokenAmounts, eventType } = row.original
         const amount = tokenAmounts[index] ?? 0
         const isAdd = eventType === 'AddLiquidity'
         const displayAmount = isAdd ? amount : -amount
 
         return (
           <InlineTableCell sx={{ alignItems: 'end' }}>
-            {amount === 0 ? (
-              '-'
-            ) : (
-              <TokenInfo
-                address={token.address}
-                blockchainId={network}
-                iconPosition="right"
-                primary={formatNumber(displayAmount, { abbreviate: false })}
-              />
-            )}
+            <TokenInfo
+              icon={null}
+              iconPosition="right"
+              primary={amount === 0 ? '-' : formatNumber(displayAmount, 'token.amount')}
+            />
           </InlineTableCell>
         )
       },


### PR DESCRIPTION
Reduces token icon amount by simply putting them in the column headers for pool liquidity events.

I've looked at the pool swaps tables and llamalend swap & activity tables as well, but sadly the columns aren't fixed to a specific token, so we can't reduce the overload there 😞 

<img width="1060" height="561" alt="image" src="https://github.com/user-attachments/assets/36d7bceb-22f7-4025-ac3b-c501d57632b7" />
