### PR TITLE
chore: replace defunct corn for plasma in tests

### DIFF
--- a/apps/router-api/test/integration/routes.test.ts
+++ b/apps/router-api/test/integration/routes.test.ts
@@ -16,11 +16,12 @@ const CHAIN_ID_ARBITRUM = '42161'
 const ARBITRUM_USDC = '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
 const ARBITRUM_USDT = '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'
 
-const CHAIN_ID_CORN = '21000000'
-const CORN = '0x44f49ff0da2498bcb1d3dc7c0f999578f67fd8c6'
-const CORN_WBTCN = '0xda5ddd7270381a7c2717ad10d1c0ecb19e3cdfb2'
-const BTC_DECIMALS = 18
+const CHAIN_ID_PLASMA = '9745'
+const CORN_USDT0 = '0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb'
+const CORN_SUSDE = '0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2'
+
 const USD_DECIMALS = 6
+const USDT0_DECIMALS = 6
 
 type QueryString = { [P in keyof RoutesQuery]?: string | string[] }
 type SuccessCase = { query: QueryString; expectedRoutes?: number }
@@ -48,8 +49,13 @@ const successCasesByProvider: PartialRecord<RouteProvider, Record<string, Succes
         amountOut: [toWei('1000', USD_DECIMALS)],
       },
     },
-    'corn amountIn': {
-      query: { chainId: CHAIN_ID_CORN, tokenIn: [CORN], tokenOut: [CORN_WBTCN], amountIn: [toWei('10', BTC_DECIMALS)] },
+    'plasma amountIn': {
+      query: {
+        chainId: CHAIN_ID_PLASMA,
+        tokenIn: [CORN_USDT0],
+        tokenOut: [CORN_SUSDE],
+        amountIn: [toWei('10', USDT0_DECIMALS)],
+      },
     },
   },
   enso: {

--- a/tests/cypress/e2e/dex/basic.cy.ts
+++ b/tests/cypress/e2e/dex/basic.cy.ts
@@ -40,7 +40,7 @@ describe('Basic Access Test', () => {
     cy.visitWithoutTestConnector('dex/plasma/pools')
     cy.title(LOAD_TIMEOUT).should('equal', 'Pools - Curve')
     cy.url().should('include', '/dex/plasma/pools')
-    cy.contains(/USDT0\/wsUSDe/i, API_LOAD_TIMEOUT).should('be.visible')
+    cy.contains(/USDT0\/sUSDe/i, API_LOAD_TIMEOUT).should('be.visible')
   })
 
   it('shows 404 on /dex/:network/pools/404', () => {

--- a/tests/cypress/e2e/dex/basic.cy.ts
+++ b/tests/cypress/e2e/dex/basic.cy.ts
@@ -6,7 +6,7 @@ describe('Basic Access Test', () => {
 
   it('should support default networks if the lite API is offline', () => {
     cy.intercept(`https://api-core.curve.finance/v1/getPlatforms`, { status: 500 }).as('error')
-    cy.visit('/dex/corn/pools')
+    cy.visit('/dex/plasma/pools')
     cy.wait('@error', LOAD_TIMEOUT)
     cy.title(LOAD_TIMEOUT).should('equal', 'Pools - Curve')
     cy.get('[data-testid="error-title"]').should('not.exist')
@@ -37,10 +37,10 @@ describe('Basic Access Test', () => {
   })
 
   it('should load for lite networks', () => {
-    cy.visitWithoutTestConnector('dex/corn/pools')
+    cy.visitWithoutTestConnector('dex/plasma/pools')
     cy.title(LOAD_TIMEOUT).should('equal', 'Pools - Curve')
-    cy.url().should('include', '/dex/corn/pools')
-    cy.contains(/LBTC\/wBTCN/i, API_LOAD_TIMEOUT).should('be.visible')
+    cy.url().should('include', '/dex/plasma/pools')
+    cy.contains(/USDT0\/wsUSDe/i, API_LOAD_TIMEOUT).should('be.visible')
   })
 
   it('shows 404 on /dex/:network/pools/404', () => {

--- a/tests/cypress/e2e/dex/pool-page.cy.ts
+++ b/tests/cypress/e2e/dex/pool-page.cy.ts
@@ -9,7 +9,7 @@ describe('Pool page', () => {
     'ethereum/pools/factory-tricrypto-0',
     'ethereum/pools/factory-stable-ng-561',
     'arbitrum/pools/2pool',
-    'corn/pools/factory-stable-ng-0',
+    'plasma/pools/0x1e8d78e9b3f0152d54d32904b7933f1cfe439df1/deposit',
   )}/deposit`
   const slippageType: SlippageType = path.includes('tricrypto') ? 'crypto' : 'stable'
   const slippageConfig = SLIPPAGE[slippageType]


### PR DESCRIPTION
Corn will go defunct and might be the cause of some tests failing, so let's try Plasma, which is also a lite network