### PR TITLE
fix: flaky tests

### DIFF
--- a/tests/cypress/e2e/dex/pool-page.cy.ts
+++ b/tests/cypress/e2e/dex/pool-page.cy.ts
@@ -9,7 +9,7 @@ describe('Pool page', () => {
     'ethereum/pools/factory-tricrypto-0',
     'ethereum/pools/factory-stable-ng-561',
     'arbitrum/pools/2pool',
-    'plasma/pools/0x1e8d78e9b3f0152d54d32904b7933f1cfe439df1/deposit',
+    'plasma/pools/0x1e8d78e9b3f0152d54d32904b7933f1cfe439df1',
   )}/deposit`
   const slippageType: SlippageType = path.includes('tricrypto') ? 'crypto' : 'stable'
   const slippageConfig = SLIPPAGE[slippageType]

--- a/tests/cypress/e2e/dex/refuel.cy.ts
+++ b/tests/cypress/e2e/dex/refuel.cy.ts
@@ -63,7 +63,10 @@ describe('Refuel page', () => {
     getTestById('daily-refuels-chart').contains('Refuel count').should('be.visible')
 
     getTestById('recent-refuels').should('be.visible')
-    getTestById('recent-refuels').find('[data-testid="data-table"]').should('be.visible')
-    getTestById('recent-refuels').find('[data-testid^="data-table-row-"]').its('length').should('be.greaterThan', 0)
+    getTestById('recent-refuels').find('[data-testid="data-table"]', API_LOAD_TIMEOUT).should('be.visible')
+    getTestById('recent-refuels')
+      .find('[data-testid^="data-table-row-"]', API_LOAD_TIMEOUT)
+      .its('length')
+      .should('be.greaterThan', 0)
   })
 })


### PR DESCRIPTION
- the test appends /deposit so we shouldn't add that to the list
- the refuel can fail with a timeout when the backend is slow