### PR TITLE
fix: flaky test issues

### DIFF
--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -49,9 +49,10 @@ const testCases = [
 ]
 
 describe('BorrowMoreForm (mocked)', () => {
-  beforeEach(() => mockMintSnapshots({ limit: 1 }))
-
-  afterEach(() => resetLlamaTestContext())
+  beforeEach(() => {
+    resetLlamaTestContext()
+    mockMintSnapshots({ limit: 1 })
+  })
 
   testCases.forEach(({ approved, title, withCollateral, buttonText }) => {
     const hasLeverageManagement = false

--- a/tests/cypress/support/helpers/data-table.helpers.ts
+++ b/tests/cypress/support/helpers/data-table.helpers.ts
@@ -35,8 +35,18 @@ export function closeDrawer(breakpoint: Breakpoint) {
   }
 }
 
+function waitForFiltersPopover() {
+  cy.get('[data-testid="table-filters-popover"]')
+    .should('be.visible')
+    .closest('.MuiPopover-paper')
+    .should('have.css', 'transform', 'none')
+}
+
 export function withFilters<T>(breakpoint: Breakpoint, callback: () => Cypress.Chainable<T>) {
   cy.get(`[data-testid="btn-open-filters"]`).click({ waitForAnimations: true })
+  if (breakpoint !== 'mobile') {
+    waitForFiltersPopover()
+  }
   return callback().then(result => {
     if (breakpoint === 'mobile') {
       closeDrawer(breakpoint)


### PR DESCRIPTION
- afterEach might run while the next test already started
- popover can change places when we click on it, due to the page changing size. Wait for the animation