### PR TITLE
chore: avoid checking css props in tests

### DIFF
--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from 'react'
+import { useState, type RefObject } from 'react'
 import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
@@ -42,6 +42,7 @@ export const LlamaTableFiltersOverlay = ({
   ...filterProps
 }: LlamaTableFiltersOverlayProps) => {
   const isMobile = useIsMobile()
+  const [testId, setTestId] = useState<string | null>(null)
   const content = <LendingMarketsFilters table={table} marketsQuery={marketsQuery} {...filterProps} />
   const resetButton = (
     <Button
@@ -71,9 +72,10 @@ export const LlamaTableFiltersOverlay = ({
         paper: {
           sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
         },
+        transition: { onEntered: () => setTestId('table-filters-popover'), onExit: () => setTestId(null) },
       }}
     >
-      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} data-testid="table-filters-popover">
+      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} data-testid={testId}>
         <Stack
           direction="row"
           sx={{

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
@@ -72,6 +72,7 @@ export const LlamaTableFiltersOverlay = ({
         paper: {
           sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
         },
+        // set the testid once transition is ready to avoid flaky tests trying to click during transition
         transition: { onEntered: () => setTestId('table-filters-popover'), onExit: () => setTestId(null) },
       }}
     >

--- a/tests/cypress/support/helpers/data-table.helpers.ts
+++ b/tests/cypress/support/helpers/data-table.helpers.ts
@@ -35,17 +35,10 @@ export function closeDrawer(breakpoint: Breakpoint) {
   }
 }
 
-function waitForFiltersPopover() {
-  cy.get('[data-testid="table-filters-popover"]')
-    .should('be.visible')
-    .closest('.MuiPopover-paper')
-    .should('have.css', 'transform', 'none')
-}
-
 export function withFilters<T>(breakpoint: Breakpoint, callback: () => Cypress.Chainable<T>) {
   cy.get(`[data-testid="btn-open-filters"]`).click({ waitForAnimations: true })
   if (breakpoint !== 'mobile') {
-    waitForFiltersPopover()
+    cy.get('[data-testid="table-filters-popover"]').should('be.visible')
   }
   return callback().then(result => {
     if (breakpoint === 'mobile') {


### PR DESCRIPTION
- Firefox can (sometimes?) report the `none` transform as `matrix(1, 0, 0, 1, 0, 0)` - which is equivalent.
- Instead of checking css properties, we should just make the testId depend on the transition state. That should be always correct.