### PR TITLE
fix: pegkeeper simulation without wallet

### DIFF
--- a/apps/main/src/loan/components/PagePegKeepers/hooks/usePegkeeper.ts
+++ b/apps/main/src/loan/components/PagePegKeepers/hooks/usePegkeeper.ts
@@ -1,5 +1,5 @@
 import { formatEther } from 'viem'
-import { useReadContract, useSimulateContract, useWriteContract } from 'wagmi'
+import { useConnection, useReadContract, useSimulateContract, useWriteContract } from 'wagmi'
 import type { Decimal } from '@primitives/decimal.utils'
 import { fallbackQ, mapQuery } from '@ui-kit/types/util'
 import { abi as pegkeeperAbi } from '../abi/pegkeeper'
@@ -11,6 +11,8 @@ import type { PegKeeper } from '../types'
 const formatWei = (value: bigint) => formatEther(value) as Decimal
 
 export function usePegkeeper({ address, pool: { address: poolAddress } }: PegKeeper) {
+  const { isConnected } = useConnection()
+
   const debt = useReadContract({
     abi: pegkeeperAbi,
     address,
@@ -23,14 +25,14 @@ export function usePegkeeper({ address, pool: { address: poolAddress } }: PegKee
     abi: pegkeeperAbi,
     address,
     functionName: 'update',
-    query: { retry: false }, // If it fails it's most likely because the profit is actually zero
+    query: { enabled: isConnected, retry: false }, // If it fails it's most likely because the profit is actually zero
   })
 
   const estCallerProfitFallback = useReadContract({
     abi: pegkeeperAbi,
     address,
     functionName: 'estimate_caller_profit',
-    query: { enabled: !!estCallerProfit.error },
+    query: { enabled: !isConnected || !!estCallerProfit.error },
   })
 
   const debtCeiling = useReadContract({
@@ -72,7 +74,7 @@ export function usePegkeeper({ address, pool: { address: poolAddress } }: PegKee
     rate: fallbackQ(mapQuery(priceOracle, formatWei), mapQuery(priceOracleFallback, formatWei)),
     debt: mapQuery(debt, formatWei),
     estCallerProfit: fallbackQ(
-      mapQuery(estCallerProfit, p => formatWei(p.result)),
+      isConnected && mapQuery(estCallerProfit, p => formatWei(p.result)),
       mapQuery(estCallerProfitFallback, formatWei),
     ),
     debtCeiling: mapQuery(debtCeiling, formatWei),

--- a/packages/curve-ui-kit/src/types/util.ts
+++ b/packages/curve-ui-kit/src/types/util.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { maybe } from '@primitives/objects.utils'
+import { type Falsy, maybe } from '@primitives/objects.utils'
 import type { UseQueryResult } from '@tanstack/react-query'
 
 export type Range<T> = [T, T]
@@ -75,9 +75,10 @@ export const q = <T>({ data, isLoading, error }: Query<T>) =>
 
 type QueryData<TQuery> = TQuery extends Query<infer TData> ? TData : never
 
-export const fallbackQ = <const TQueries extends readonly [Query<unknown>, ...Query<unknown>[]]>(
-  ...queries: TQueries
-) => q(queries.find(q => !q.error) ?? queries[0]) as QueryProp<QueryData<TQueries[number]>>
+export const fallbackQ = <const TQueries extends readonly (Query<unknown> | Falsy)[]>(...queries: TQueries) => {
+  const filtered = queries.filter((x): x is Query<unknown> => !!x)
+  return q(filtered.find(q => !q.error) ?? filtered[0]) as QueryProp<QueryData<TQueries[number]>>
+}
 
 /**
  * Maps a Query type to extract partial data from it.


### PR DESCRIPTION
- #2703 broke the RPC tests due to Pegkeeper simulation not working without a wallet
- this PR fixes that issue by checking the `isConnected` property
- update `fallbackQ` to support such a case in a generic way