### PR TITLE
feat: bump llamalend to 2.2.4

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.2.3",
+    "@curvefi/llamalend-api": "2.2.4",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.170.11",
     "@tanstack/react-router-devtools": "1.167.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,15 +495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.2.3":
-  version: 2.2.3
-  resolution: "@curvefi/llamalend-api@npm:2.2.3"
+"@curvefi/llamalend-api@npm:2.2.4":
+  version: 2.2.4
+  resolution: "@curvefi/llamalend-api@npm:2.2.4"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.16"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.15.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/dd6db1c408507e46ea912a37c74f66e3712d2bcdef3fe36e67458e19a0f5ed9df0b9e9c9a4e9f5115193983c589b32fd1faa1650b290f910ff9aec061c2180f6
+  checksum: 10c0/5c37b84bf1cf6deea90a1a97cd6a66d6dcfa2a019732d66595a693c713adc4dddf459bba892093ce15684d29a3af07b9daa893a37230dcd814de51bb659def4f
   languageName: node
   linkType: hard
 
@@ -10712,7 +10712,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.2.3"
+    "@curvefi/llamalend-api": "npm:2.2.4"
     "@sentry/vite-plugin": "npm:5.3.0"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.170.11"


### PR DESCRIPTION
- bump llamalend to 2.2.4 https://github.com/curvefi/curve-llamalend.js/pull/113

fixes the net supply apy for v2 markets:
<img width="274" height="135" alt="Screenshot 2026-06-17 at 13 38 22" src="https://github.com/user-attachments/assets/bbb42cd3-2c4e-4b5c-b431-3fbe9e53b23a" />
