### PR TITLE
fix: dex pools paginates test

### DIFF
--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -173,7 +173,7 @@ describe('DEX Pools', () => {
     // Current page selected
     cy.get('[data-testid="btn-page-5"]').should('have.class', 'Mui-selected')
     cy.get('[data-testid^="btn-page-"]').then($buttons => {
-      const [prevLastPage, lastPage] = [$buttons.length - 1, $buttons.length]
+      const [prevLastPage, lastPage] = [$buttons.length - 2, $buttons.length - 1]
       expect(getPages($buttons)).to.deep.equal([
         'prev',
         '1',


### PR DESCRIPTION
- fixed dex pools paginates test by getting the correct last 2 pages buttons

it seems that it worked by accident before because the number of element rendered in the pagination, was the same as the number of pages. But now there are less market on Arbitrum so we got from 11 pages to 10.