### PR TITLE
fix: pagination tests

### DIFF
--- a/packages/curve-ui-kit/src/hooks/router.ts
+++ b/packages/curve-ui-kit/src/hooks/router.ts
@@ -54,9 +54,8 @@ export function useSearchNavigate(searchParams: URLSearchParams) {
   const navigate = useNavigate()
   const pathname = usePathname()
   return useCallback(
-    (update: SearchParamsUpdate, options?: NavigateOptions) => {
-      navigate(pathname + getSearchString(update, searchParams), options)
-    },
+    (update: SearchParamsUpdate, options?: NavigateOptions) =>
+      navigate(pathname + getSearchString(update, searchParams), options),
     [navigate, pathname, searchParams],
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataTable.tsx
@@ -33,10 +33,13 @@ function useResetPageOnResultChange<T extends TableItem>(table: TanstackTable<T>
   const onPaginationChangeEvent = useEffectEvent(table.setPagination)
   const lastResultCountRef = useRef<number>(resultCount)
   useEffect(() => {
-    // Skip for manual pagination - data is expected to change on page change
-    if (isManualPagination) return
-    // Reset to first page, but only if result amount wasn't 0 (links must keep working while data might still be loading)
-    if (lastResultCountRef.current && resultCount) onPaginationChangeEvent(prev => ({ ...prev, pageIndex: 0 }))
+    const last = resultCount && lastResultCountRef.current
+    if (
+      !isManualPagination && // Skip for manual pagination - data is expected to change on page change
+      last && // when 0 don't reset the page, data might be loading
+      resultCount !== last // // in strict mode the effect can trigger even when the count didn't change
+    )
+      onPaginationChangeEvent(prev => ({ ...prev, pageIndex: 0 }))
     lastResultCountRef.current = resultCount
   }, [resultCount, isManualPagination])
 }

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -2,6 +2,7 @@
 import { orderBy } from 'lodash'
 import { oneOf } from '@cy/support/generators'
 import { getHiddenCount, withFilterChips } from '@cy/support/helpers/data-table.helpers'
+import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
 import { API_LOAD_TIMEOUT, type Breakpoint, LOAD_TIMEOUT, oneViewport } from '@cy/support/ui'
 import { assert } from '@primitives/objects.utils'
 
@@ -56,6 +57,7 @@ describe('DEX Pools', () => {
   let width: number, height: number
 
   beforeEach(() => {
+    mockMerklCampaigns()
     ;[width, height, breakpoint] = oneViewport()
   })
 
@@ -164,8 +166,8 @@ describe('DEX Pools', () => {
   })
 
   it('paginates', () => {
-    const getPages = ($buttons: JQuery) =>
-      Cypress.$.makeArray($buttons).map(el => el.dataset.testid?.replace('btn-page-', ''))
+    const getPages = (...$buttons: JQuery[]) =>
+      $buttons.flatMap(el => Cypress.$.makeArray(el)).map(e => e.dataset.testid?.replace('btn-page-', ''))
 
     // open page 5 (1-based)
     visitAndWait(width, height, { query: { page: '5' } })
@@ -173,7 +175,7 @@ describe('DEX Pools', () => {
     // Current page selected
     cy.get('[data-testid="btn-page-5"]').should('have.class', 'Mui-selected')
     cy.get('[data-testid^="btn-page-"]').then($buttons => {
-      const [prevLastPage, lastPage] = [$buttons.length - 1, $buttons.length]
+      const [prevLastPage, lastPage] = getPages($buttons.eq($buttons.length - 3), $buttons.eq($buttons.length - 2))
       expect(getPages($buttons)).to.deep.equal([
         'prev',
         '1',

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -175,6 +175,7 @@ describe('DEX Pools', () => {
     // Current page selected
     cy.get('[data-testid="btn-page-5"]').should('have.class', 'Mui-selected')
     cy.get('[data-testid^="btn-page-"]').then($buttons => {
+      // last page is displayed in index -2, since the last item (-1) is 'next'. The one before the last is index -3.
       const [prevLastPage, lastPage] = getPages($buttons.eq($buttons.length - 3), $buttons.eq($buttons.length - 2))
       expect(getPages($buttons)).to.deep.equal([
         'prev',


### PR DESCRIPTION
- the dex pagination test was only working by coincidence. We always have 11 buttons, but that doesn't say anything about the last page count.
- we actually have to read the page index to be able to determine the index of the last page