### PR TITLE
fix: use percent rate category in quorum

### DIFF
--- a/apps/main/src/dao/components/ProposalVoteStatusBox/index.tsx
+++ b/apps/main/src/dao/components/ProposalVoteStatusBox/index.tsx
@@ -31,16 +31,9 @@ export const ProposalVoteStatusBox = ({ proposalData, className }: ProposalVoteS
             <HighlightedData>{t`Quorum`} </HighlightedData>
           </Box>
           <Box flex flexGap="var(--spacing-1)" flexAlignItems="flex-end">
-            <HighlightedData>
-              {formatNumber(currentQuorumPercentage, {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-                abbreviate: false,
-              })}
-              %
-            </HighlightedData>{' '}
+            <HighlightedData>{formatNumber(currentQuorumPercentage, 'percent.rate')}</HighlightedData>{' '}
             <Data>
-              ({formatNumber(minAcceptQuorumPercent, { abbreviate: true })}% {t`needed`})
+              ({formatNumber(minAcceptQuorumPercent, 'percent.rate')} {t`needed`})
             </Data>
             <TooltipIcon>{t`The minimum share of For votes required to reach quorum is ${minAcceptQuorumPercent}% for this proposal.`}</TooltipIcon>
           </Box>


### PR DESCRIPTION
Fixes this case

<img width="339" height="119" alt="image" src="https://github.com/user-attachments/assets/4680d200-6737-4a69-83f2-56c13c2a0ead" />

With fix
<img width="323" height="153" alt="image" src="https://github.com/user-attachments/assets/563e27f2-b6d7-45fd-9b0c-11741730f01f" />
