### PR TITLE
fix: surface level fixes for market campaigns

### DIFF
--- a/apps/main/src/lend/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsBanner.tsx
@@ -4,7 +4,7 @@ import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { CampaignBannerComp } from '@ui/CampaignRewards/CampaignBannerComp'
-import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
+import { extraRewardType, useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 
 type CampaignRewardsBannerProps = {
@@ -23,17 +23,25 @@ export const CampaignRewardsBanner = ({ chainId, market }: CampaignRewardsBanner
     address: market?.addresses.controller as Address | undefined,
   })
 
+  const action =
+    supplyCampaigns.length && borrowCampaigns.length
+      ? t`Suppling and borrowing`
+      : supplyCampaigns.length
+        ? t`Supplying`
+        : borrowCampaigns.length
+          ? t`Borrowing`
+          : ''
+
+  const rewardTypes = supplyCampaigns.concat(borrowCampaigns).map(campaign => extraRewardType(campaign))
+  const hasApr = rewardTypes.includes('apr')
+  const hasPoints = rewardTypes.includes('points') || rewardTypes.includes('symbol')
+  const rewardType = hasApr && hasPoints ? t`yield / points` : hasApr ? t`yield` : hasPoints ? t`points` : ''
+
   return (
     supplyCampaigns.length + borrowCampaigns.length > 0 && (
       <CampaignBannerComp
         campaignRewards={[...supplyCampaigns, ...borrowCampaigns]}
-        message={
-          supplyCampaigns.length && borrowCampaigns.length
-            ? t`Supplying and borrowing in this pool earns points!`
-            : supplyCampaigns
-              ? t`Supplying in this pool earns points!`
-              : t`Borrowing in this pool earns points!`
-        }
+        message={t`${action} in this market earns ${rewardType}`}
       />
     )
   )

--- a/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
@@ -70,7 +70,7 @@ export const MarketSupplyRateTooltipContent = ({
         {hasIncentives && (
           <TooltipItems secondary>
             <RewardsTooltipItems
-              title={t`Lending incentives APY*`}
+              title={t`Supplying incentives`}
               tooltipType="supply"
               extraRewards={extraRewards}
               extraIncentives={extraIncentives}

--- a/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
@@ -1,7 +1,7 @@
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import { Stack } from '@mui/material'
 import Link from '@mui/material/Link'
-import { CampaignRewards } from '@ui-kit/entities/campaigns'
+import { CampaignRewards, extraRewardType } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -43,11 +43,18 @@ export const RewardsTooltipItems = ({
           {formatNumber(percentage, 'percent.rate')}
         </TooltipItem>
       ))}
-      {extraRewards.map(
-        (r, i) =>
+      {extraRewards.map((r, i) => {
+        const rewardType = extraRewardType(r)
+
+        return (
           r.action === tooltipType && (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- Existing violation before enabling this rule.
-            <TooltipItem variant="subItem" key={i} title={t`Points`} imageId={r.platformImageId}>
+            <TooltipItem
+              variant="subItem"
+              key={i}
+              title={rewardType === 'apr' ? t`APR` : t`Points`}
+              imageId={r.platformImageId}
+            >
               <Stack
                 component={Link}
                 href={r.dashboardLink}
@@ -63,12 +70,13 @@ export const RewardsTooltipItems = ({
                 }}
               >
                 {r.multiplier}
-                {typeof r.multiplier === 'number' ? 'x' : ''}
+                {rewardType === 'points' ? 'x' : ''}
                 <ArrowOutwardIcon />
               </Stack>
             </TooltipItem>
-          ),
-      )}
+          )
+        )
+      })}
     </>
   )
 }

--- a/packages/curve-ui-kit/src/entities/campaigns/index.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/index.ts
@@ -1,2 +1,3 @@
 export { useCampaignsByAddress, combineCampaigns } from './campaigns'
 export type { CampaignRewards } from './types'
+export { extraRewardType } from './util'

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -58,6 +58,9 @@ const ACTIONS: Record<MerklAction, RewardsAction> = {
   LEND: 'supply',
 }
 
+/** New campaigns / markets might temporarily have a huge APR as things are being bootstrapped. This number has been copied from Merkl's own website. */
+const MAX_APR = 10000
+
 const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] => {
   const network = opp.chain.name.toLocaleLowerCase()
 
@@ -78,7 +81,9 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] 
         lock: false, // Merkl doesn't offer 'locked' rewards.
 
         // Merkl campaigns don't have a multiplier, just a token. And APR is only available for the whole opportunity.
-        multiplier: opp.apr ? formatNumber(opp.apr, 'percent.rate') : token.symbol,
+        multiplier: opp.apr
+          ? `${opp.apr > MAX_APR ? '>' : ''} ${formatNumber(Math.min(opp.apr, MAX_APR), 'percent.rate')}`
+          : token.symbol,
 
         tags: ['tokens'], // Merkl rewards are tokens only as far as I know; no points.
         action: ACTIONS[opp.action],

--- a/packages/curve-ui-kit/src/entities/campaigns/types.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/types.ts
@@ -5,7 +5,8 @@ export type CampaignRewards = Pick<Campaign, 'campaignName' | 'platform' | 'plat
     description: CampaignPool['description'] | null
     steps?: string[]
     lock: boolean
-    multiplier?: number | string // Can be 5 as parsed from "5x", or just the token like "FXN". Kept as number for sorting.
+    /** Can be 5 as parsed from "5x", or just the token like "FXN". Kept as number for sorting. Could also be an APR if it ends with % */
+    multiplier?: number | string
     period?: readonly [Date, Date]
   }
 

--- a/packages/curve-ui-kit/src/entities/campaigns/util.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/util.ts
@@ -1,0 +1,4 @@
+import type { CampaignRewards } from './types'
+
+export const extraRewardType = (r: CampaignRewards) =>
+  typeof r.multiplier === 'number' ? 'points' : r.multiplier?.endsWith('%') ? 'apr' : 'symbol'


### PR DESCRIPTION
Fixes a few surface level issues with the new Merkl market campaigns. It's ugly code, because the front-end campaigns infra wasn't made in mind with campaigns that can be either points, token symbols and now also yield rates.

Will immediately work on a follow up PR to refactor it properly, but don't want it to block the glaring issues.

1. Renames `Lending incentives APY*` to just `Supplying incentives`.
2. Renames 'Points' to just 'APR' in the rows of these incentives. Should be token symbol but can't do that rn.
3. Caps market campaign APRs to >10k%, just like Merkl does on their website.
4. Fixes incorrent labels in campaign banners talking about points when it's about yield, and also fixes the incorrect action.

The Merkl campaign yields also don't count towards net total apy yet.