### PR TITLE
fix: invalid value for prop `render` passed to `<button>`

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Tabs/TabsSwitcher.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Tabs/TabsSwitcher.tsx
@@ -134,15 +134,17 @@ export const TabsSwitcher = <T extends string | number>({
               endAdornment,
               suffix,
               sx: tabSx,
+              disabled,
+              icon,
               // avoids passing the alwaysInKebab prop to the DOM element
               alwaysInKebab: _alwaysInKebab,
-
-              ...props
             }) => (
               <Tab
                 data-testid={`${testIdPrefix}-${val}`}
                 key={val}
                 value={val}
+                disabled={disabled}
+                icon={icon}
                 label={
                   <TabLabel
                     label={label}
@@ -158,7 +160,6 @@ export const TabsSwitcher = <T extends string | number>({
                     hiddenValues.has(val) && { visibility: 'hidden', position: 'absolute', pointerEvents: 'none' }),
                 }}
                 {...(href && { href, component: Link })}
-                {...props}
               />
             ),
           )}

--- a/packages/curve-ui-kit/src/shared/ui/Tabs/tabs-kebab.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Tabs/tabs-kebab.tsx
@@ -113,13 +113,16 @@ export const KebabMenu = <T extends string | number>({
             startAdornment,
             endAdornment,
             suffix,
+            disabled,
+            icon,
             // avoids passing the alwaysInKebab prop to the DOM element
             alwaysInKebab: _alwaysInKebab,
-            ...props
           }) => (
             <Tab
               key={val}
               value={val}
+              disabled={disabled}
+              icon={icon}
               label={
                 <TabLabel
                   label={label}
@@ -130,7 +133,6 @@ export const KebabMenu = <T extends string | number>({
                 />
               }
               {...(href && { href, component: Link })}
-              {...props}
             />
           ),
         )}


### PR DESCRIPTION
- PositionDetailsTabOption extends TabOption, and TabsSwitcher currently forwards any leftover option fields straight into MUI Tab, which then leaks them to the `<button>`