### PR TITLE
feat: support merkle campaigns in borrow rates

### DIFF
--- a/apps/main/src/dex/features/advanced-details/hooks/usePointsCampaigns.tsx
+++ b/apps/main/src/dex/features/advanced-details/hooks/usePointsCampaigns.tsx
@@ -6,7 +6,7 @@ import type { Chain as BlockchainId } from '@curvefi/prices-api'
 import Box from '@mui/material/Box'
 import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { decimal, formatNumber } from '@ui-kit/utils'
+import { formatNumber } from '@ui-kit/utils'
 import type { PointsCampaignsRow } from '../components/points-campaigns/columns/columns.definitions'
 
 const { IconSize } = SizesAndSpaces
@@ -28,9 +28,9 @@ export const usePointsCampaigns = ({
   const rows = useMemo(
     () =>
       campaigns
-        .filter(({ tags }) => tags.includes('points'))
+        .filter(({ reward }) => reward?.type === 'points')
         .map(
-          ({ dashboardLink, multiplier, platform, platformImageId }): PointsCampaignsRow => ({
+          ({ dashboardLink, reward, platform, platformImageId }): PointsCampaignsRow => ({
             source: {
               icon: (
                 <Box
@@ -43,7 +43,7 @@ export const usePointsCampaigns = ({
               iconPosition: 'left',
               primary: platform,
             },
-            points: formatNumber(decimal(multiplier), 'multiplier'),
+            points: formatNumber(reward?.value, 'multiplier'),
             campaignUrl: dashboardLink,
           }),
         ),

--- a/apps/main/src/dex/features/advanced-details/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/advanced-details/hooks/useYieldBreakdown.tsx
@@ -92,8 +92,8 @@ export const useYieldBreakdown = ({
     })
 
     campaigns
-      .filter(({ tags }) => !tags.includes('points'))
-      .forEach(({ address, multiplier, platform, platformImageId }) => {
+      .filter(({ reward }) => reward?.type === 'apr')
+      .forEach(({ address, reward, platform, platformImageId }) => {
         rows.push({
           source: {
             icon: (
@@ -109,7 +109,7 @@ export const useYieldBreakdown = ({
           },
           address,
           explorerUrl: scanAddressPath(network, address),
-          apy: aprToApy(Number(multiplier), COMPOUND_WINDOW) ?? undefined,
+          apy: aprToApy(reward?.value, COMPOUND_WINDOW) ?? undefined,
         })
       })
 

--- a/apps/main/src/lend/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/lend/components/CampaignRewardsBanner.tsx
@@ -3,8 +3,9 @@ import { ChainId } from '@/lend/types/lend.types'
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
+import { notFalsy } from '@primitives/objects.utils'
 import { CampaignBannerComp } from '@ui/CampaignRewards/CampaignBannerComp'
-import { extraRewardType, useCampaignsByAddress } from '@ui-kit/entities/campaigns'
+import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 
 type CampaignRewardsBannerProps = {
@@ -32,9 +33,9 @@ export const CampaignRewardsBanner = ({ chainId, market }: CampaignRewardsBanner
           ? t`Borrowing`
           : ''
 
-  const rewardTypes = supplyCampaigns.concat(borrowCampaigns).map(campaign => extraRewardType(campaign))
+  const rewardTypes = notFalsy(...supplyCampaigns.concat(borrowCampaigns).map(campaign => campaign.reward?.type))
   const hasApr = rewardTypes.includes('apr')
-  const hasPoints = rewardTypes.includes('points') || rewardTypes.includes('symbol')
+  const hasPoints = rewardTypes.includes('points')
   const rewardType = hasApr && hasPoints ? t`yield / points` : hasApr ? t`yield` : hasPoints ? t`points` : ''
 
   return (

--- a/apps/main/src/llamalend/features/market-list/columns/column.options.tsx
+++ b/apps/main/src/llamalend/features/market-list/columns/column.options.tsx
@@ -85,13 +85,13 @@ const createLlamaMarketsColumnOptions = ({
       {
         label: t`Net borrow APR`,
         columns: [LlamaMarketColumnId.NetBorrowRate],
-        active: false,
+        active: onlyPositions != MarketRateType.Supply,
         enabled: true,
       },
       {
         label: t`Borrow APR`,
         columns: [LlamaMarketColumnId.BorrowRate],
-        active: onlyPositions != MarketRateType.Supply,
+        active: false,
         enabled: true,
       },
       {

--- a/apps/main/src/llamalend/features/market-list/hooks/useLlamaTableVisibility.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useLlamaTableVisibility.tsx
@@ -43,7 +43,7 @@ export const getLlamaMarketsColumnVariant = (
     : 'hasPositions' // show the general market table, for users with positions
 
 const migration: MigrationOptions<Record<LlamaColumnVariant, VisibilityGroup<LlamaMarketColumnId>[]>> = {
-  version: 5,
+  version: 6,
   migrate: (oldValue, initialValue) =>
     mapRecord(initialValue, (variant, initialGroups) => mergeVisibilityGroups(oldValue[variant], initialGroups)),
 }

--- a/apps/main/src/llamalend/features/market-list/hooks/useLlamaTableVisibility.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useLlamaTableVisibility.tsx
@@ -27,10 +27,15 @@ const mergeVisibilityGroups = (
     return oldGroup
       ? {
           ...initialGroup,
-          options: initialGroup.options.map(
-            initialOption =>
-              oldGroup.options.find(oldOption => isEqual(oldOption.columns, initialOption.columns)) ?? initialOption,
-          ),
+          options: initialGroup.options.map(initialOption => {
+            const oldOption =
+              oldGroup.options.find(oldOption => isEqual(oldOption.columns, initialOption.columns)) ?? initialOption
+            return isEqual(initialOption.columns, [LlamaMarketColumnId.NetBorrowRate])
+              ? { ...oldOption, active: initialOption.active }
+              : isEqual(initialOption.columns, [LlamaMarketColumnId.BorrowRate])
+                ? { ...oldOption, active: false }
+                : oldOption
+          }),
         }
       : initialGroup
   })

--- a/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
@@ -11,6 +11,7 @@ import {
   getLatestSnapshotValue,
   getSupplyApyAverageMetrics,
   getSupplyApyMetrics,
+  sumCampaignsApy,
   sumOnChainExtraIncentivesApy,
   toNumberOrNull,
 } from '@/llamalend/rates.utils'
@@ -86,6 +87,7 @@ export const SupplyPositionDetails = ({ chainId, market, userAddress, blockchain
         rebasingYieldApy: rebasingYield,
         crvBoostApr: crvRates,
         extraIncentivesApy: sumOnChainExtraIncentivesApy(rewardsApr),
+        campaignsApy: sumCampaignsApy(campaigns),
         userSupplyBoost,
       }),
   )

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -3,7 +3,13 @@ import { useCallback, useMemo } from 'react'
 import { ethAddress } from 'viem'
 import { LLAMMALEND_V2_DATE } from '@/llamalend/constants'
 import { calculateMarketSolvency, createGetBadDebtMarket, lowSolvencyDeprecatedMessage } from '@/llamalend/llama.utils'
-import { aprToApy, computeTotalRate, getSupplyApyMetrics } from '@/llamalend/rates.utils'
+import {
+  aprToApy,
+  computeTotalRate,
+  getSupplyApyMetrics,
+  sumCampaignsApr,
+  sumCampaignsApy,
+} from '@/llamalend/rates.utils'
 import { type Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { assert, recordValues } from '@primitives/objects.utils'
@@ -132,11 +138,16 @@ const convertLendingVault = (
   const totalExtraRewardApy =
     // sumBy returns 0 for empty arrays
     extraRewardApr.length ? sumBy(extraRewardApr, reward => aprToApy(reward.rate)!) : null
+  const rewards = [...(campaigns[vault.toLowerCase()] ?? []), ...(campaigns[controller.toLowerCase()] ?? [])]
+  const borrowCampaignsApr = sumCampaignsApr(rewards.filter(r => r.action === 'borrow'))
+  const borrowCampaignsApy = sumCampaignsApy(rewards.filter(r => r.action === 'borrow'))
+  const supplyCampaignsApy = sumCampaignsApy(rewards.filter(r => r.action === 'supply'))
   const { totalMinBoost, totalMaxBoost } = getSupplyApyMetrics({
     supplyApy: lendApy,
     crvBoostApr: [lendCrvAprUnboosted, lendCrvAprBoosted],
     rebasingYieldApy: borrowedToken?.rebasingYield,
     extraIncentivesApy: totalExtraRewardApy,
+    campaignsApy: supplyCampaignsApy,
   })
   const solvencyPercent = calculateMarketSolvency({ totalAssetsUsd, badDebtUsd })
 
@@ -180,9 +191,9 @@ const convertLendingVault = (
       lendTotalApyMinBoosted: totalMinBoost,
       lendTotalApyMaxBoosted: totalMaxBoost,
       borrowApy,
-      borrowTotalApy: computeTotalRate(borrowApy, collateralToken.rebasingYield ?? 0),
+      borrowTotalApy: computeTotalRate(borrowApy, collateralToken.rebasingYield ?? 0, borrowCampaignsApy ?? 0),
       borrowApr,
-      borrowTotalApr: computeTotalRate(borrowApr, collateralToken.rebasingYieldApr ?? 0),
+      borrowTotalApr: computeTotalRate(borrowApr, collateralToken.rebasingYieldApr ?? 0, borrowCampaignsApr ?? 0),
       incentives: extraRewardApr
         ? extraRewardApr.map(({ address, symbol, rate }) => ({
             title: symbol,
@@ -198,7 +209,7 @@ const convertLendingVault = (
     deprecatedMessage:
       DEPRECATED_LLAMAS[marketType][chain]?.[controller]?.message ?? lowSolvencyDeprecatedMessage(solvencyPercent),
     isFavorite: favoriteMarkets.has(vault),
-    rewards: [...(campaigns[vault.toLowerCase()] ?? []), ...(campaigns[controller.toLowerCase()] ?? [])],
+    rewards,
     leverage: NO_LEVERAGE_LEND[chain]?.includes(controller) ? null : leverage,
     userHasPositions:
       hasBorrowed || lendingPosition
@@ -242,6 +253,10 @@ const convertMintMarket = (
   const hasBorrow = userMintMarkets.has(address)
   const [collateralSymbol, collateralAddress] = getCollateral(collateralToken)
   const name = collateralIndex > 1 ? `${collateralSymbol}${collateralIndex}` : collateralSymbol
+  const rewards = [...(campaigns[address.toLowerCase()] ?? []), ...(campaigns[llamma.toLowerCase()] ?? [])]
+  const borrowCampaignsApr = sumCampaignsApr(rewards.filter(r => r.action === 'borrow'))
+  const borrowCampaignsApy = sumCampaignsApy(rewards.filter(r => r.action === 'borrow'))
+
   return {
     chain,
     controllerAddress: address,
@@ -288,16 +303,16 @@ const convertMintMarket = (
       lendTotalApyMinBoosted: null,
       lendTotalApyMaxBoosted: null,
       borrowApy,
-      borrowTotalApy: computeTotalRate(borrowApy, collateralToken.rebasingYield ?? 0),
+      borrowTotalApy: computeTotalRate(borrowApy, collateralToken.rebasingYield ?? 0, borrowCampaignsApy ?? 0),
       borrowApr,
-      borrowTotalApr: computeTotalRate(borrowApr, collateralToken.rebasingYieldApr ?? 0),
+      borrowTotalApr: computeTotalRate(borrowApr, collateralToken.rebasingYieldApr ?? 0, borrowCampaignsApr ?? 0),
       incentives: [],
     },
     type: marketType,
     deprecatedMessage: DEPRECATED_LLAMAS[marketType][chain]?.[address]?.message ?? null,
     url: getInternalUrl('crvusd', chain, `${CRVUSD_ROUTES.PAGE_MARKETS}/${name}`),
     isFavorite: favoriteMarkets.has(llamma),
-    rewards: [...(campaigns[address.toLowerCase()] ?? []), ...(campaigns[llamma.toLowerCase()] ?? [])],
+    rewards,
     leverage,
     userHasPositions: hasBorrow ? { [MarketRateType.Borrow]: hasBorrow, [MarketRateType.Supply]: false } : null,
     createdAt: new Date(createdAt).getTime(),

--- a/apps/main/src/llamalend/rates.utils.ts
+++ b/apps/main/src/llamalend/rates.utils.ts
@@ -1,6 +1,7 @@
 import { sumBy } from 'lodash'
 import type { Decimal } from '@primitives/decimal.utils'
 import { maybe, maybes, notFalsy } from '@primitives/objects.utils'
+import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 import type { CrvUsdSnapshot } from '@ui-kit/entities/crvusd-snapshots'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import type { ExtraIncentive } from '@ui-kit/types/market'
@@ -13,13 +14,15 @@ export { aprToApy } from '@ui-kit/utils/rates'
 
 type BorrowRateMetricsParams<TSnapshot extends WithTimestamp = WithTimestamp> = {
   borrowRate: number | null | undefined
+  campaignsRate: number | null | undefined
   snapshots: TSnapshot[] | undefined
   getBorrowRate: (snapshot: TSnapshot) => number | null | undefined
   getRebasingYield: (snapshot: TSnapshot) => number | null | undefined
   daysBack: number
 }
 
-export const computeTotalRate = (rate: number, rebasingYield: number) => rate - rebasingYield
+export const computeTotalRate = (rate: number, rebasingYield: number, campaignsRate: number) =>
+  rate - rebasingYield - campaignsRate
 
 export const getSnapshotBorrowApr = ({ borrowApr }: LendingSnapshot | CrvUsdSnapshot) => borrowApr
 export const getSnapshotCollateralRebasingYieldApr = <
@@ -40,13 +43,15 @@ export const getLatestSnapshotValue = <TSnapshot extends WithTimestamp, TValue>(
  */
 export const getBorrowRateMetrics = <TSnapshot extends WithTimestamp = WithTimestamp>({
   borrowRate,
+  campaignsRate,
   snapshots,
   getBorrowRate,
   getRebasingYield,
   daysBack,
 }: BorrowRateMetricsParams<TSnapshot>) => {
   const rebasingYield = getLatestSnapshotValue(snapshots, getRebasingYield)
-  const totalRate = maybe(borrowRate, borrowRate => computeTotalRate(borrowRate, rebasingYield ?? 0)) ?? null
+  const totalRate =
+    maybe(borrowRate, borrowRate => computeTotalRate(borrowRate, rebasingYield ?? 0, campaignsRate ?? 0)) ?? null
 
   const averages = calculateAverageRates(snapshots, daysBack, {
     rate: getBorrowRate,
@@ -61,7 +66,7 @@ export const getBorrowRateMetrics = <TSnapshot extends WithTimestamp = WithTimes
     averageRate,
     averageRebasingYield,
     averageTotalRate:
-      maybe(averageRate, averageRate => computeTotalRate(averageRate, averageRebasingYield ?? 0)) ?? null,
+      maybe(averageRate, averageRate => computeTotalRate(averageRate, averageRebasingYield ?? 0, 0)) ?? null,
   }
 }
 
@@ -76,6 +81,22 @@ type OnChainSupplyRewardApr = { apy: number; symbol: string; tokenAddress: strin
 
 export const sumOnChainExtraIncentivesApy = (rewardsApr: OnChainSupplyRewardApr[] | undefined) =>
   rewardsApr && rewardsApr.length > 0 ? sumBy(rewardsApr, reward => aprToApy(reward.apy)!) : null
+
+export const sumCampaignsApr = (campaigns: CampaignRewards[] | undefined) =>
+  campaigns && campaigns.length > 0
+    ? sumBy(
+        campaigns.filter(c => c.reward?.type === 'apr'),
+        c => c.reward?.value ?? 0,
+      )
+    : null
+
+export const sumCampaignsApy = (campaigns: CampaignRewards[] | undefined) =>
+  campaigns && campaigns.length > 0
+    ? sumBy(
+        campaigns.filter(c => c.reward?.type === 'apr'),
+        c => aprToApy(c.reward?.value ?? 0)!,
+      )
+    : null
 
 export const formatSupplyExtraIncentives = ({
   incentives,
@@ -110,6 +131,7 @@ type SupplyRateMetricsParams = {
   crvBoostApr: Range<number> | null | undefined
   rebasingYieldApy: number | null | undefined
   extraIncentivesApy: number | null | undefined
+  campaignsApy: number | null | undefined
   userSupplyBoost?: Decimal | null | undefined
 }
 
@@ -122,6 +144,7 @@ export const getSupplyApyMetrics = ({
   crvBoostApr,
   rebasingYieldApy,
   extraIncentivesApy,
+  campaignsApy,
   userSupplyBoost,
 }: SupplyRateMetricsParams) => {
   rebasingYieldApy = rebasingYieldApy ?? null
@@ -133,7 +156,7 @@ export const getSupplyApyMetrics = ({
   const crvMaxBoostApy = aprToApy(crvMaxBoostApr)
   const userBoostApy = maybes([crvMinBoostApr, userSupplyBoost], ([apr, boost]) => aprToApy(apr * +boost)) ?? null
 
-  const totalWithoutBoost = sumRates(supplyApy, rebasingYieldApy, extraIncentivesApy)
+  const totalWithoutBoost = sumRates(supplyApy, rebasingYieldApy, extraIncentivesApy, campaignsApy)
 
   return {
     supplyApy,

--- a/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
+++ b/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
@@ -37,8 +37,8 @@ export const BorrowAprMetric = ({ marketType, borrowRate, collateralSymbol, alig
     <Metric
       size="medium"
       alignment={alignment}
-      label={t`Borrow APR`}
-      value={mapQuery(borrowRate, borrowRate => borrowRate.rate)}
+      label={t`Net Borrow APR`}
+      value={mapQuery(borrowRate, borrowRate => borrowRate.totalBorrowRate)}
       valueOptions={{ unit: 'percentage' }}
       notional={maybe(borrowRate.data?.averageRate, data => ({
         value: data,

--- a/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
+++ b/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
@@ -40,7 +40,7 @@ export const BorrowAprMetric = ({ marketType, borrowRate, collateralSymbol, alig
       label={t`Net Borrow APR`}
       value={mapQuery(borrowRate, borrowRate => borrowRate.totalBorrowRate)}
       valueOptions={{ unit: 'percentage' }}
-      notional={maybe(borrowRate.data?.averageRate, data => ({
+      notional={maybe(borrowRate.data?.totalAverageBorrowRate, data => ({
         value: data,
         unit: { symbol: `% ${averageRatePeriod} Avg`, position: 'suffix' },
       }))}

--- a/apps/main/src/llamalend/widgets/action-card/hooks/useSupplyRates.ts
+++ b/apps/main/src/llamalend/widgets/action-card/hooks/useSupplyRates.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'viem'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
 import { useMarketSupplyFutureRates, useMarketRates, useMarketVaultOnChainRewards } from '@/llamalend/queries/market'
 import { useUserSupplyBoost } from '@/llamalend/queries/user'
@@ -5,12 +6,14 @@ import { requireVault } from '@/llamalend/queries/validation/supply.validation'
 import {
   getLatestSnapshotValue,
   getSupplyApyMetrics,
+  sumCampaignsApy,
   sumOnChainExtraIncentivesApy,
   toNumberOrNull,
 } from '@/llamalend/rates.utils'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Decimal } from '@primitives/decimal.utils'
 import { maybe } from '@primitives/objects.utils'
+import { useCampaignsByAddress, type CampaignRewards } from '@ui-kit/entities/campaigns'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import type { UserMarketParams } from '@ui-kit/lib/model'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
@@ -29,6 +32,7 @@ const addNetApy = <T extends { lendApy?: Decimal }>(
   rates: Query<T>,
   snapshotsQuery: Query<LendingSnapshot[] | undefined>,
   marketOnChainRewardsQuery: Query<SupplyRewards | undefined>,
+  campaignsQuery: Query<CampaignRewards[] | undefined>,
   userSupplyBoostQuery: Query<Decimal | null>,
 ) => {
   const rebasingYieldApy = getLatestSnapshotValue(snapshotsQuery.data, snapshot => snapshot.borrowedToken.rebasingYield)
@@ -38,6 +42,7 @@ const addNetApy = <T extends { lendApy?: Decimal }>(
     crvBoostApr: marketOnChainRewardsQuery.data?.crvRates,
     rebasingYieldApy: rebasingYieldApy ?? 0,
     extraIncentivesApy: sumOnChainExtraIncentivesApy(marketOnChainRewardsQuery.data?.rewardsApr),
+    campaignsApy: sumCampaignsApy(campaignsQuery.data),
     userSupplyBoost: userSupplyBoostQuery.data,
   })
   const netSupplyApy = q({
@@ -67,18 +72,21 @@ export function useSupplyRates<ChainId extends IChainId>(
   })
   const marketOnChainRewardsQuery = useMarketVaultOnChainRewards({ chainId, marketId }, enabled)
   const userSupplyBoostQuery = useUserSupplyBoost({ chainId, marketId, userAddress }, enabled)
+  const campaignsQuery = useCampaignsByAddress({ blockchainId, address: market?.addresses.controller as Address })
 
   // Without `reservesDelta`, `rates`/`netSupplyApy` are disabled on purpose. `ActionInfo` shows `prevRates` as current.
   const [rates, netSupplyApy] = addNetApy(
     useMarketSupplyFutureRates({ chainId, marketId, reserves: reservesDelta }, enabled),
     lendingSnapshotsQuery,
     marketOnChainRewardsQuery,
+    campaignsQuery,
     userSupplyBoostQuery,
   )
   const [prevRates, prevNetSupplyApy] = addNetApy(
     useMarketRates({ chainId, marketId }, enabled),
     lendingSnapshotsQuery,
     marketOnChainRewardsQuery,
+    campaignsQuery,
     userSupplyBoostQuery,
   )
 

--- a/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
+++ b/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
@@ -12,6 +12,8 @@ import {
   getSnapshotCollateralRebasingYieldApr,
   getSupplyApyAverageMetrics,
   getSupplyApyMetrics,
+  sumCampaignsApr,
+  sumCampaignsApy,
   sumOnChainExtraIncentivesApy,
   toNumberOrNull,
 } from '@/llamalend/rates.utils'
@@ -56,6 +58,7 @@ function buildSupplyRate({
     rebasingYieldApy: toNumberOrNull(rebasingYieldApy),
     crvBoostApr: marketOnChainRewards?.crvRates,
     extraIncentivesApy: sumOnChainExtraIncentivesApy(marketOnChainRewards?.rewardsApr),
+    campaignsApy: sumCampaignsApy(campaigns),
   })
   const supplyAverageMetrics = getSupplyApyAverageMetrics({
     snapshots: lendingSnapshots,
@@ -118,6 +121,7 @@ export const usePageHeader = ({
     borrowRate: combineQueries([marketRates, snapshot, marketQuery], ({ borrowApr }, snapshots) => {
       const { averageRate, averageRebasingYield, averageTotalRate, rebasingYield, totalRate } = getBorrowRateMetrics({
         borrowRate: toNumberOrNull(borrowApr),
+        campaignsRate: sumCampaignsApr(borrowCampaigns),
         snapshots,
         getBorrowRate: getSnapshotBorrowApr,
         getRebasingYield: getSnapshotCollateralRebasingYieldApr,

--- a/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
@@ -1,12 +1,12 @@
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import { Stack } from '@mui/material'
 import Link from '@mui/material/Link'
-import { CampaignRewards, extraRewardType } from '@ui-kit/entities/campaigns'
+import { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { TransitionFunction } from '@ui-kit/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { ExtraIncentive } from '@ui-kit/types/market'
-import { formatNumber } from '@ui-kit/utils'
+import { aprToApy, formatNumber } from '@ui-kit/utils'
 import type { RewardsAction } from '@external-rewards'
 import { TooltipItem } from './TooltipComponents'
 
@@ -43,16 +43,14 @@ export const RewardsTooltipItems = ({
           {formatNumber(percentage, 'percent.rate')}
         </TooltipItem>
       ))}
-      {extraRewards.map((r, i) => {
-        const rewardType = extraRewardType(r)
-
-        return (
+      {extraRewards.map(
+        (r, i) =>
           r.action === tooltipType && (
-            // eslint-disable-next-line @eslint-react/no-array-index-key -- Existing violation before enabling this rule.
             <TooltipItem
               variant="subItem"
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- Existing violation before enabling this rule.
               key={i}
-              title={rewardType === 'apr' ? t`APR` : t`Points`}
+              title={r.reward?.type === 'apr' ? r.symbol || '' : t`Points`}
               imageId={r.platformImageId}
             >
               <Stack
@@ -69,14 +67,14 @@ export const RewardsTooltipItems = ({
                   '&:hover svg': { fontSize: 20 },
                 }}
               >
-                {r.multiplier}
-                {rewardType === 'points' ? 'x' : ''}
+                {r.reward?.type === 'apr'
+                  ? formatNumber(aprToApy(r.reward.value), 'percent.rate')
+                  : formatNumber(r.reward?.value, 'multiplier')}
                 <ArrowOutwardIcon />
               </Stack>
             </TooltipItem>
-          )
-        )
-      })}
+          ),
+      )}
     </>
   )
 }

--- a/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/RewardTooltipItems.tsx
@@ -68,7 +68,7 @@ export const RewardsTooltipItems = ({
                 }}
               >
                 {r.reward?.type === 'apr'
-                  ? formatNumber(aprToApy(r.reward.value), 'percent.rate')
+                  ? `${tooltipType === 'supply' ? '+' : ''}${formatNumber(tooltipType === 'supply' ? aprToApy(r.reward.value) : -r.reward.value, 'percent.rate')}`
                   : formatNumber(r.reward?.value, 'multiplier')}
                 <ArrowOutwardIcon />
               </Stack>

--- a/packages/curve-ui-kit/src/entities/campaigns/campaigns-external.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/campaigns-external.ts
@@ -1,15 +1,15 @@
 import { groupBy, inRange } from 'lodash'
-import type { Address } from '@primitives/address.utils'
 import { mapRecord } from '@primitives/objects.utils'
 import { CURVE_ASSETS_URL } from '@ui/utils'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model'
 import { campaigns } from '@external-rewards'
+import type { CampaignRewards } from './types'
 
 const REWARDS = groupBy(
   // Can't use Object.groupBy until we support ES2024
   campaigns.flatMap(campaign =>
-    campaign.pools.map(pool => ({
+    campaign.pools.map<CampaignRewards>(pool => ({
       // Campaign specific properties
       campaignName: campaign.campaignName,
       platform: campaign.platform,
@@ -18,15 +18,15 @@ const REWARDS = groupBy(
 
       // Pool specific properties
       ...pool,
-      address: pool.address.toLocaleLowerCase() as Address,
+      address: pool.address.toLocaleLowerCase(),
       description: pool.description !== 'null' ? pool.description : campaign.description,
       lock: pool.lock === 'true',
-      // Remove possible 'x' suffix and convert to number if numeric, otherwise keep as string
-      multiplier: (() => {
+      // Remove possible 'x' suffix and convert to number if numeric, otherwise keep as symbol string
+      ...(() => {
         if (!pool.multiplier || pool.multiplier.trim() === '') return undefined
         const withoutSuffix = pool.multiplier.replace(/x$/i, '')
         const numericValue = Number(withoutSuffix)
-        return isNaN(numericValue) ? pool.multiplier : numericValue
+        return isNaN(numericValue) ? { symbol: pool.multiplier } : { reward: { type: 'points', value: numericValue } }
       })(),
       ...(+pool.campaignStart &&
         +pool.campaignEnd && {

--- a/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
@@ -1,10 +1,11 @@
 import memoizee from 'memoizee'
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { fromEntries, notFalsy, objectKeys } from '@primitives/objects.utils'
 import { type QueriesResults, useQueries } from '@tanstack/react-query'
 import { combineQueriesMeta } from '@ui-kit/lib'
+import { useMappedQuery } from '@ui-kit/types/util'
 import { getCampaignsExternalOptions } from './campaigns-external'
 import { getCampaignsMarketsMerklOptions } from './campaigns-markets-merkl'
 import { getCampaignsPoolsMerklOptions } from './campaigns-pools-merkl'
@@ -106,7 +107,14 @@ export const useCampaignsByAddress = ({
   address,
   blockchainId,
 }: { address: Address | undefined } & UseCampaignsOptions) => {
-  const { data } = useCampaigns({ blockchainId, enabled: Boolean(address) })
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Existing violation before enabling this rule.
-  return { data: useMemo(() => (address && data[address]) || [], [address, data]) }
+  const query = useMappedQuery(
+    useCampaigns({ blockchainId, enabled: Boolean(address) }),
+    useCallback(campaigns => address && campaigns[address], [address]),
+  )
+
+  // TODO: Temporarily map undefined data to [], needs a proper fix
+  return {
+    ...query,
+    data: query.data ?? [],
+  }
 }

--- a/packages/curve-ui-kit/src/entities/campaigns/index.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/index.ts
@@ -1,3 +1,2 @@
 export { useCampaignsByAddress, combineCampaigns } from './campaigns'
 export type { CampaignRewards } from './types'
-export { extraRewardType } from './util'

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -2,7 +2,6 @@ import { capitalize, groupBy } from 'lodash'
 import type { Address } from 'viem'
 import { paginate } from '@curvefi/prices-api/paginate'
 import { addQueryString, FetchError } from '@primitives/fetch.utils'
-import { formatNumber } from '@ui-kit/utils'
 import type { RewardsAction } from '@external-rewards'
 import type { CampaignRewards } from './types'
 
@@ -61,7 +60,7 @@ const ACTIONS: Record<MerklAction, RewardsAction> = {
 /** New campaigns / markets might temporarily have a huge APR as things are being bootstrapped. This number has been copied from Merkl's own website. */
 const MAX_APR = 10000
 
-const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] => {
+const opportunityToCampaignRewards = (opp: MerklOpportunity) => {
   const network = opp.chain.name.toLocaleLowerCase()
 
   return (
@@ -69,21 +68,20 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity): CampaignRewards[] 
       // Filter rewards with a value of 0. Maybe campaign devs are testing something, as such campaigns exist in real life data.
       .filter(({ value }) => value > 0)
       // Convert actual token reward data into the more generic data type we use all across the app.
-      .map(({ token }) => ({
+      .map<CampaignRewards>(({ token }) => ({
         campaignName: opp.name,
         platform: opp.tags.map(tag => capitalize(tag)).join(', '),
         platformImageId: token.icon,
         dashboardLink: `https://app.merkl.xyz/opportunities/${network}/${opp.type}/${opp.identifier}`,
 
-        address: opp.explorerAddress.toLocaleLowerCase() as Address,
+        address: opp.explorerAddress.toLocaleLowerCase(),
         description: opp.description,
         steps: opp.howToSteps,
         lock: false, // Merkl doesn't offer 'locked' rewards.
 
         // Merkl campaigns don't have a multiplier, just a token. And APR is only available for the whole opportunity.
-        multiplier: opp.apr
-          ? `${opp.apr > MAX_APR ? '>' : ''} ${formatNumber(Math.min(opp.apr, MAX_APR), 'percent.rate')}`
-          : token.symbol,
+        reward: { type: 'apr', value: Math.min(opp.apr, MAX_APR) },
+        symbol: token.symbol,
 
         tags: ['tokens'], // Merkl rewards are tokens only as far as I know; no points.
         action: ACTIONS[opp.action],

--- a/packages/curve-ui-kit/src/entities/campaigns/types.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/types.ts
@@ -1,12 +1,14 @@
 import type { Campaign, CampaignPool } from '@external-rewards'
 
+export type CampaignReward = { type: 'apr'; value: number } | { type: 'points'; value: number }
+
 export type CampaignRewards = Pick<Campaign, 'campaignName' | 'platform' | 'platformImageId' | 'dashboardLink'> &
   Pick<CampaignPool, 'action' | 'tags' | 'address' | 'network'> & {
     description: CampaignPool['description'] | null
     steps?: string[]
     lock: boolean
-    /** Can be 5 as parsed from "5x", or just the token like "FXN". Kept as number for sorting. Could also be an APR if it ends with % */
-    multiplier?: number | string
+    reward?: CampaignReward
+    symbol?: string
     period?: readonly [Date, Date]
   }
 

--- a/packages/curve-ui-kit/src/entities/campaigns/util.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/util.ts
@@ -1,4 +1,0 @@
-import type { CampaignRewards } from './types'
-
-export const extraRewardType = (r: CampaignRewards) =>
-  typeof r.multiplier === 'number' ? 'points' : r.multiplier?.endsWith('%') ? 'apr' : 'symbol'

--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -3,6 +3,7 @@ import { TooltipMessage } from '@ui/CampaignRewards/TooltipMessage'
 import { Icon } from '@ui/Icon'
 import { TooltipButton as Tooltip } from '@ui/Tooltip/TooltipButton'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
+import { aprToApy, formatNumber } from '@ui-kit/utils'
 
 type CampaignRewardsCompProps = {
   rewardsPool: CampaignRewards
@@ -12,7 +13,7 @@ type CampaignRewardsCompProps = {
 }
 
 export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: CampaignRewardsCompProps) => {
-  const { platform, multiplier, platformImageId } = rewardsPool
+  const { platform, reward, platformImageId } = rewardsPool
 
   return (
     <Tooltip
@@ -24,10 +25,11 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
     >
       <Container highContrast={highContrast}>
         <TokenIcon src={platformImageId} alt={platform} width={16} height={16} />
-        {multiplier && (
+        {reward && (
           <Multiplier highContrast={highContrast}>
-            {multiplier}
-            {typeof multiplier === 'number' ? 'x' : ''}
+            {reward.type === 'apr'
+              ? formatNumber(aprToApy(reward.value), 'percent.rate')
+              : formatNumber(reward.value, 'multiplier')}
           </Multiplier>
         )}
         {rewardsPool.lock && <StyledIcon size={16} name="Locked" $highContrast={highContrast} />}

--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -29,7 +29,7 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
           <Multiplier highContrast={highContrast}>
             {action}{' '}
             {reward.type === 'apr'
-              ? formatNumber(aprToApy(reward.value), 'percent.rate')
+              ? formatNumber(action === 'supply' ? aprToApy(reward.value) : reward.value, 'percent.rate')
               : formatNumber(reward.value, 'multiplier')}
           </Multiplier>
         )}

--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -13,7 +13,7 @@ type CampaignRewardsCompProps = {
 }
 
 export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: CampaignRewardsCompProps) => {
-  const { platform, reward, platformImageId } = rewardsPool
+  const { platform, reward, platformImageId, action } = rewardsPool
 
   return (
     <Tooltip
@@ -27,6 +27,7 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
         <TokenIcon src={platformImageId} alt={platform} width={16} height={16} />
         {reward && (
           <Multiplier highContrast={highContrast}>
+            {action}{' '}
             {reward.type === 'apr'
               ? formatNumber(aprToApy(reward.value), 'percent.rate')
               : formatNumber(reward.value, 'multiplier')}

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -112,8 +112,8 @@ testCases.forEach(([width, height, breakpoint]) => {
       cy.get(`[data-testid="${element}"]`).should('not.exist')
     })
 
-    it('should display Borrow APR by default', () => {
-      const borrowColumnId = LlamaMarketColumnId.BorrowRate
+    it('should display Net Borrow APR by default', () => {
+      const borrowColumnId = LlamaMarketColumnId.NetBorrowRate
 
       if (breakpoint === 'mobile') {
         // On mobile, expand the first row and check the metric is visible in the expanded panel
@@ -152,7 +152,7 @@ testCases.forEach(([width, height, breakpoint]) => {
         // note: not possible currently to sort ascending
         return cy.get(`[data-testid="metric-${utilizationColumnId}"]`).contains('99%', LOAD_TIMEOUT)
       } else {
-        cy.get(`[data-testid="data-table-cell-${LlamaMarketColumnId.BorrowRate}"]`).first().contains('%')
+        cy.get(`[data-testid="data-table-cell-${LlamaMarketColumnId.NetBorrowRate}"]`).first().contains('%')
         cy.get(`[data-testid="data-table-header-${utilizationColumnId}"]`).click()
         cy.get(`[data-testid="data-table-cell-${utilizationColumnId}"]`).first().contains('99%', LOAD_TIMEOUT)
         cy.get(`[data-testid="data-table-header-${utilizationColumnId}"]`).click()


### PR DESCRIPTION
This adds merkl campaign support merkl rates in the borrow and supply data for markets.

Instead of a `multiplier` property, there's now a proper union type for different kind of rewards in `CampaignRewards`.