### PR TITLE
fix: remove LP action from campaign badge in pool list

### DIFF
--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -27,7 +27,7 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
         <TokenIcon src={platformImageId} alt={platform} width={16} height={16} />
         {reward && (
           <Multiplier highContrast={highContrast}>
-            {action}{' '}
+            {action != 'lp' && `${action} `}
             {reward.type === 'apr'
               ? formatNumber(action === 'supply' ? aprToApy(reward.value) : reward.value, 'percent.rate')
               : formatNumber(reward.value, 'multiplier')}


### PR DESCRIPTION
Removes the LP part in the pool list, while maintaining it for Merkl campaigns for markets

<img width="137" height="53" alt="image" src="https://github.com/user-attachments/assets/98e455bc-738e-409b-a686-59ce5e09d842" />
<img width="422" height="72" alt="image" src="https://github.com/user-attachments/assets/07e9e5db-0067-42f1-b2c0-ae19b338074b" />
