### PR TITLE
fix: non-multiplier campaigns didn't show token symbol

### DIFF
--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -13,7 +13,7 @@ type CampaignRewardsCompProps = {
 }
 
 export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: CampaignRewardsCompProps) => {
-  const { platform, reward, platformImageId, action } = rewardsPool
+  const { platform, reward, platformImageId, action, symbol } = rewardsPool
 
   return (
     <Tooltip
@@ -28,9 +28,11 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
         {reward && (
           <Multiplier highContrast={highContrast}>
             {action != 'lp' && `${action} `}
-            {reward.type === 'apr'
-              ? formatNumber(action === 'supply' ? aprToApy(reward.value) : reward.value, 'percent.rate')
-              : formatNumber(reward.value, 'multiplier')}
+            {reward.value
+              ? reward.type === 'apr'
+                ? formatNumber(action === 'supply' ? aprToApy(reward.value) : reward.value, 'percent.rate')
+                : formatNumber(reward.value, 'multiplier')
+              : symbol}
           </Multiplier>
         )}
         {rewardsPool.lock && <StyledIcon size={16} name="Locked" $highContrast={highContrast} />}

--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -25,10 +25,10 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
     >
       <Container highContrast={highContrast}>
         <TokenIcon src={platformImageId} alt={platform} width={16} height={16} />
-        {reward && (
+        {(reward != null || symbol) && (
           <Multiplier highContrast={highContrast}>
             {action != 'lp' && `${action} `}
-            {reward.value
+            {reward?.value
               ? reward.type === 'apr'
                 ? formatNumber(action === 'supply' ? aprToApy(reward.value) : reward.value, 'percent.rate')
                 : formatNumber(reward.value, 'multiplier')


### PR DESCRIPTION
Guess who's back, back again

<img width="237" height="133" alt="image" src="https://github.com/user-attachments/assets/194df435-7429-4ae4-8533-45e3900a08aa" />
<img width="206" height="131" alt="image" src="https://github.com/user-attachments/assets/42dc8d52-4f4c-43c4-8ff3-adfa2d60686d" />
