### PR TITLE
fix: denominate util breakdown with correct tokens

### DIFF
--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -60,7 +60,8 @@ const UtilizationTooltipContent = ({
         <TooltipItem variant="primary" title={t`Utilization breakdown`} />
         {type === LlamaMarketType.Lend && (
           <TooltipItem title={t`Total supplied`}>
-            <Currency {...collateral} />
+            {/* The supplied token is the same as the token people borrow, even though we use the collateral balance in this case */}
+            <Currency {...borrowed} balance={collateral.balance} />
           </TooltipItem>
         )}
         <TooltipItem title={t`Total borrowed`}>

--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -15,8 +15,6 @@ import { formatNumber } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
-const isUsd = (symbol: string) => symbol === 'USD' || symbol === 'crvUSD' // show crvUSD as USD
-
 const Currency = ({
   balance,
   symbol,
@@ -28,21 +26,9 @@ const Currency = ({
   balance: number | null
   chain: Chain
 }) => (
-  <Stack
-    direction="row"
-    component="span"
-    sx={{
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      gap: 1,
-      display: 'inline-flex',
-    }}
-  >
+  <Stack direction="row" sx={{ gap: Spacing.xs, alignItems: 'center' }}>
+    {formatNumber(balance, 'token.compact')}
     <TokenIcon blockchainId={chain} address={address} tooltip={symbol} size="mui-sm" />
-    <span>
-      {formatNumber(balance, { unit: isUsd(symbol) ? 'dollar' : undefined, abbreviate: true, fallback: '-' })}
-      {!isUsd(symbol) && ` ${symbol}`}
-    </span>
   </Stack>
 )
 

--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -66,9 +66,12 @@ const UtilizationTooltipContent = ({
         <TooltipItem title={t`Total borrowed`}>
           <Currency {...borrowed} />
         </TooltipItem>
-        <TooltipItem title={t`Available to borrow`}>
-          <Currency {...borrowed} balance={liquidityUsd} />
-        </TooltipItem>
+        {/** liquidityUsd is as the name says, in usd, but we want it denominated in the borrow token, and we have enough info to deduce the borrow token price directly (if both are > 0) */}
+        {borrowed.balance && borrowed.balanceUsd && (
+          <TooltipItem title={t`Available to borrow`}>
+            <Currency {...borrowed} balance={liquidityUsd * (borrowed.balance / borrowed.balanceUsd)} />
+          </TooltipItem>
+        )}
         {debtCeiling != null && (
           <TooltipItem title={t`Debt ceiling`}>
             {/** Only mint markets have a debt ceiling which is in crvUSD */}

--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -11,7 +11,7 @@ import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { formatNumber } from '@ui-kit/utils'
+import { CRVUSD, formatNumber } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -71,7 +71,8 @@ const UtilizationTooltipContent = ({
         </TooltipItem>
         {debtCeiling != null && (
           <TooltipItem title={t`Debt ceiling`}>
-            <Currency {...borrowed} balance={debtCeiling} />
+            {/** Only mint markets have a debt ceiling which is in crvUSD */}
+            <Currency {...CRVUSD} balance={debtCeiling} />
           </TooltipItem>
         )}
       </TooltipItems>

--- a/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/UtilizationCell.tsx
@@ -60,8 +60,7 @@ const UtilizationTooltipContent = ({
         <TooltipItem variant="primary" title={t`Utilization breakdown`} />
         {type === LlamaMarketType.Lend && (
           <TooltipItem title={t`Total supplied`}>
-            {/* as we are displaying the utilization breakdown, display everything as borrowed token */}
-            <Currency {...borrowed} balance={collateral.balanceUsd} />
+            <Currency {...collateral} />
           </TooltipItem>
         )}
         <TooltipItem title={t`Total borrowed`}>


### PR DESCRIPTION
1. Total supplied shold be denominated in collateral token
2. Available to borrow should be denominated in borrow token
3. Debt ceiling should be pinned to crvUSD as it's only applicable to mint markets

No dollar values allowed!

I also put the token icon on the right for better alignment

**Old and incorrect**
<img width="1526" height="345" alt="image" src="https://github.com/user-attachments/assets/796fae3d-a18a-4688-854b-0946505846fb" />

**New and correct**
<img width="1525" height="352" alt="image" src="https://github.com/user-attachments/assets/c6d3f346-a3ee-4a00-a139-75deadc80b26" />

EDIT: reverted back to borrowed token for supplied amount
<img width="467" height="252" alt="image" src="https://github.com/user-attachments/assets/193f3cc7-cd2b-46db-9b25-44e885bb183a" />
