### PR TITLE
feat: add price oracles addresses to contracts in new advanced details

### DIFF
--- a/apps/main/src/dex/features/advanced-details/components/Contracts.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/Contracts.tsx
@@ -1,11 +1,14 @@
 import { isAddressEqual, zeroAddress, type Address } from 'viem'
 import { ChipInactive } from '@/dex/components/ChipInactive'
 import { useNetworkByChain } from '@/dex/entities/networks'
+import { usePoolMetadata } from '@/dex/entities/pool-metadata.query'
 import type { ChainId, PoolDataCacheOrApi } from '@/dex/types/main.types'
+import type { Chain as BlockchainId } from '@curvefi/prices-api'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
+import { notFalsy } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { AddressActionInfo } from '@ui-kit/shared/ui/AddressActionInfo'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -27,33 +30,59 @@ export const Contracts = ({
   const gaugeIsKilled = !!poolDataCacheOrApi.gauge.isKilled
   const isSameAddress = isAddressEqual(poolAddress, lpTokenAddress)
 
+  const chain = network.networkId as BlockchainId
+  const { data: metadata } = usePoolMetadata({ chain, poolAddress })
+  const oracles = notFalsy(
+    ...(metadata?.assetTypes?.map((assetType, index) => {
+      const oracleAddress = metadata.oracles?.[index]?.oracleAddress
+      const symbol = metadata.coins[index]?.symbol
+
+      return (
+        assetType === 1 &&
+        oracleAddress &&
+        !isAddressEqual(oracleAddress, zeroAddress) && {
+          address: oracleAddress,
+          title: symbol ? `${symbol} ${t`Oracle`}` : t`Oracle ${index + 1}`,
+        }
+      )
+    }) ?? []),
+  )
+
   return (
     <Card size="inline">
       <CardHeader title={t`Contracts`} />
-      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm }}>
-        {poolAddress && (
-          <AddressActionInfo
-            network={network}
-            address={poolAddress}
-            title={isSameAddress ? t`Pool / Token` : t`Pool`}
-          />
-        )}
+      <CardContent component={Stack} sx={{ marginBlock: Spacing.sm, gap: Spacing.md }}>
+        <Stack>
+          {poolAddress && (
+            <AddressActionInfo
+              network={network}
+              address={poolAddress}
+              title={isSameAddress ? t`Pool / Token` : t`Pool`}
+            />
+          )}
 
-        {!isSameAddress && lpTokenAddress && (
-          <AddressActionInfo network={network} address={lpTokenAddress} title={t`Token`} />
-        )}
+          {!isSameAddress && lpTokenAddress && (
+            <AddressActionInfo network={network} address={lpTokenAddress} title={t`Token`} />
+          )}
 
-        {!isAddressEqual(gaugeAddress, zeroAddress) && (
-          <AddressActionInfo
-            network={network}
-            address={gaugeAddress}
-            title={
-              <>
-                {t`Gauge`} {gaugeIsKilled && <ChipInactive>Inactive</ChipInactive>}
-              </>
-            }
-          />
-        )}
+          {!isAddressEqual(gaugeAddress, zeroAddress) && (
+            <AddressActionInfo
+              network={network}
+              address={gaugeAddress}
+              title={
+                <>
+                  {t`Gauge`} {gaugeIsKilled && <ChipInactive>Inactive</ChipInactive>}
+                </>
+              }
+            />
+          )}
+        </Stack>
+
+        <Stack sx={{ '&:empty': { display: 'none' } }}>
+          {oracles.map(oracle => (
+            <AddressActionInfo key={oracle.address} network={network} {...oracle} />
+          ))}
+        </Stack>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
When applicable, like for WEETH/WETH-NG, it shows price oracles address in new advanced details.

<img width="368" height="143" alt="image" src="https://github.com/user-attachments/assets/9dc8fe45-45ba-41c8-a1e2-11533daa971d" />
