### PR TITLE
fix: admin fee for v2 markets

### DIFF
--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -13,11 +13,11 @@ import { getUserMarketCollateralEvents as getLendUserMarketCollateralEvents } fr
 import type { BadDebt } from '@curvefi/prices-api/liquidations'
 import { type Address, Hex } from '@primitives/address.utils'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
-import { maybe, notFalsy, objectKeys } from '@primitives/objects.utils'
+import { assert, maybe, notFalsy, objectKeys } from '@primitives/objects.utils'
 import { getLib, requireLib, type Wallet } from '@ui-kit/features/connect-wallet'
 import { isZapV2Enabled } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
-import { LlamaMarketType } from '@ui-kit/types/market'
+import { LlamaMarketType, LlamaMarketVersion } from '@ui-kit/types/market'
 import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
 import { SOLVENCY_THRESHOLDS } from './llama-markets.constants'
 
@@ -102,6 +102,12 @@ export const hasGauge = (market: LlamaMarketTemplate) =>
 
 export const getMarketType = (market: LlamaMarketTemplate | null | undefined) =>
   market ? (market instanceof LendMarketTemplate ? LlamaMarketType.Lend : LlamaMarketType.Mint) : undefined
+
+export const getLendMarketVersion = (market: LendMarketTemplate): LlamaMarketVersion =>
+  assert(
+    { v1: LlamaMarketVersion.v1, v2: LlamaMarketVersion.v2 }[market.version],
+    `Unsupported LlamaLend market version: ${market.version}`,
+  )
 
 const getBorrowSymbol = (market: LlamaMarketTemplate) =>
   market instanceof MintMarketTemplate ? CRVUSD.symbol : market.borrowed_token.symbol

--- a/apps/main/src/llamalend/queries/market/market-parameters.query.ts
+++ b/apps/main/src/llamalend/queries/market/market-parameters.query.ts
@@ -3,8 +3,9 @@ import { queryFactory } from '@ui-kit/lib/model/query'
 import { marketIdValidationSuite } from '@ui-kit/lib/model/query/market-id-validation'
 import { rootKeys } from '@ui-kit/lib/model/query/root-keys'
 import type { MarketQuery, MarketParams } from '@ui-kit/lib/model/query/root-keys'
+import { LlamaMarketVersion } from '@ui-kit/types/market'
 import { decimal } from '@ui-kit/utils'
-import { getLlamaMarket } from '../../llama.utils'
+import { getLendMarketVersion, getLlamaMarket } from '../../llama.utils'
 import { convertRates } from '../../rates.utils'
 
 export const { useQuery: useMarketParameters } = queryFactory({
@@ -24,13 +25,12 @@ export const { useQuery: useMarketParameters } = queryFactory({
         A: market.A,
       }
     }
-    const [{ admin_fee, base_price, fee, liquidation_discount, loan_discount }, a] = await Promise.all([
-      market.stats.parameters(),
-      market.prices.A(),
-    ])
+    const [{ admin_fee, base_price, fee, liquidation_discount, loan_discount }, a, adminPercentage] = await Promise.all(
+      [market.stats.parameters(), market.prices.A(), market.stats.adminPercentage()],
+    )
     return {
       fee: decimal(fee),
-      admin_fee: decimal(admin_fee),
+      admin_fee: getLendMarketVersion(market) === LlamaMarketVersion.v2 ? decimal(adminPercentage) : decimal(admin_fee),
       liquidation_discount: decimal(liquidation_discount),
       loan_discount: decimal(loan_discount),
       base_price: decimal(base_price),


### PR DESCRIPTION
- for the lend V2 markets only, we display the `admin_percentage` as admin Fee
<img width="521" height="195" alt="Screenshot 2026-06-18 at 19 50 22" src="https://github.com/user-attachments/assets/be1acd8c-9776-4b0d-8bbd-b4691c67eac6" />
