### PR TITLE
fix: show LlamaLend market metrics in token units

### DIFF
--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -176,7 +176,7 @@ export const MarketRateCurveChart = ({
             label={t`Total collateral`}
             value={collateralTotal}
             valueOptions={{
-              unit: collateralToken?.symbol ? { symbol: ` ${collateralToken.symbol}`, position: 'suffix' } : undefined,
+              unit: maybe(collateralToken?.symbol, symbol => ({ symbol, position: 'suffix' })),
               abbreviate: true,
             }}
             notional={maybe(combinedCollateralUsdValue.data, val => formatNumber(val, 'usd.notional'))}

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Address } from 'viem'
-import { formatCollateralNotional, getTokens, getUtilizationPercent } from '@/llamalend/llama.utils'
+import { getTokens, getUtilizationPercent } from '@/llamalend/llama.utils'
 import { useMarketCapAndAvailable, useMarketTotalCollateral, useRateCurve } from '@/llamalend/queries/market'
 import { TooltipOptions, TotalCollateralTooltip, UtilizationTooltip } from '@/llamalend/widgets/tooltips'
 import { RateCurveTooltip } from '@/llamalend/widgets/tooltips/chart/RateCurveTooltip'
@@ -28,7 +28,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { fallbackQ, mapQuery, useMappedQuery } from '@ui-kit/types/util'
-import { decimal, decimalMax, decimalMinus, formatNumber } from '@ui-kit/utils'
+import { decimalMax, decimalMinus, formatNumber } from '@ui-kit/utils'
 
 const { Spacing, Height } = SizesAndSpaces
 
@@ -174,14 +174,12 @@ export const MarketRateCurveChart = ({
           <Metric
             size="medium"
             label={t`Total collateral`}
-            value={combinedCollateralUsdValue}
-            valueOptions={{ unit: 'dollar' }}
-            notional={maybe(totalCollateral.data, ({ collateral, borrowed }) =>
-              formatCollateralNotional(
-                { value: decimal(collateral), symbol: collateralToken?.symbol },
-                { value: decimal(borrowed), symbol: borrowToken?.symbol },
-              ),
-            )}
+            value={collateralTotal}
+            valueOptions={{
+              unit: collateralToken?.symbol ? { symbol: ` ${collateralToken.symbol}`, position: 'suffix' } : undefined,
+              abbreviate: true,
+            }}
+            notional={maybe(combinedCollateralUsdValue.data, val => formatNumber(val, 'usd.notional'))}
             valueTooltip={{
               title: t`Total Collateral`,
               body: (

--- a/apps/main/src/llamalend/widgets/page-header/MarketPageHeader.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MarketPageHeader.tsx
@@ -104,6 +104,7 @@ export const MarketPageHeader = ({
           availableLiquidity={availableLiquidity}
           marketType={marketType}
           collateral={collateralToken}
+          borrowToken={borrowToken}
         />
       }
     />

--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -20,12 +20,14 @@ export const MetricsRow = ({
   availableLiquidity,
   marketType,
   collateral,
+  borrowToken,
 }: {
   borrowRate: QueryProp<BorrowRate>
   supplyRate?: QueryProp<SupplyRate>
   availableLiquidity: QueryProp<AvailableLiquidity>
   marketType: LlamaMarketType
   collateral: { symbol: string } | undefined
+  borrowToken: { symbol: string } | undefined
 }) => {
   const isMobile = useIsMobile()
   const metricAlignment = isMobile ? 'start' : 'end'
@@ -79,7 +81,9 @@ export const MetricsRow = ({
         alignment={metricAlignment}
         label={t`Available liquidity`}
         value={mapQuery(availableLiquidity, availableLiquidity => availableLiquidity.value)}
-        valueOptions={{ unit: 'none' }} // We could've shown the supply token symbol, but it's a bit ugly and it's implicit anyway
+        valueOptions={{
+          unit: borrowToken?.symbol ? { symbol: ` ${borrowToken.symbol}`, position: 'suffix' } : undefined,
+        }}
         valueTooltip={{
           title: t`Available Liquidity ${MarketTypeSuffix[marketType]}`,
           body: <AvailableLiquidityTooltip marketType={marketType} />,

--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -82,7 +82,7 @@ export const MetricsRow = ({
         label={t`Available liquidity`}
         value={mapQuery(availableLiquidity, availableLiquidity => availableLiquidity.value)}
         valueOptions={{
-          unit: borrowToken?.symbol ? { symbol: ` ${borrowToken.symbol}`, position: 'suffix' } : undefined,
+          unit: maybe(borrowToken?.symbol, symbol => ({ symbol, position: 'suffix' })),
         }}
         valueTooltip={{
           title: t`Available Liquidity ${MarketTypeSuffix[marketType]}`,


### PR DESCRIPTION
## Summary

- Show the collateral-token amount and symbol as the primary Total collateral metric.
- Show the combined collateral USD value as the smaller notional.
- Show Available liquidity with the borrow-token symbol in the market page header.
- Preserve the existing collateral tooltip breakdown for soft-liquidation conversions.

## Root cause

The Total collateral metric reversed the intended token/USD hierarchy, while Available liquidity suppressed its borrow-token unit despite already being denominated in that token.

## Validation

- Prettier passes for all touched files.
- Targeted ESLint passes for the page-header changes; the collateral chart is clean apart from existing unresolved MUI theme-type rules on unchanged lines.
- Full main-app typecheck remains blocked by unrelated existing workspace type errors on main.
- PR payload verified as three source files with no local filesystem or screenshot paths.