### PR TITLE
fix: campaign tooltip fixed position

### DIFF
--- a/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
+++ b/packages/ui/src/CampaignRewards/CampaignRewardsComp.tsx
@@ -20,7 +20,7 @@ export const RewardsCompSmall = ({ rewardsPool, highContrast, mobile, banner }: 
       clickable
       tooltip={<TooltipMessage rewardsPool={rewardsPool} />}
       minWidth="400px"
-      placement={mobile ? 'top' : 'auto'}
+      placement={mobile ? 'top' : banner ? 'left' : 'auto'}
       increaseZIndex={banner}
     >
       <Container highContrast={highContrast}>


### PR DESCRIPTION
This fixes the bug where the tooltip in the campaign banner jumps around on hover. It is now fixed to the left