### PR TITLE
feat: denominate bands in borrow token

### DIFF
--- a/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
+++ b/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
@@ -5,12 +5,11 @@ import { t } from '@ui-kit/lib/i18n'
 import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { LegendBox } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { decimalDiv, decimalGreaterThan, decimalMultiply, formatNumber } from '@ui-kit/utils'
+import { decimalDiv, decimalGreaterThan, decimalMultiply, formatNumber, ZERO } from '@ui-kit/utils'
 import { useBandsChartPalette } from './hooks/useBandsChartPalette'
 import type { BandsChartToken, ChartDataPoint } from './types'
 
 const { Spacing } = SizesAndSpaces
-const ZERO: Decimal = '0'
 
 type TooltipContentProps = {
   data: ChartDataPoint

--- a/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
+++ b/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
@@ -26,10 +26,14 @@ const calculateBandShare = (numerator: Decimal | undefined, denominator: Decimal
     : '?'
 
 const formatAbbreviatedNumber = (value: Decimal | undefined): string =>
-  value != null ? `${formatNumber(value, { abbreviate: true })}` : '?'
+  formatNumber(value, { abbreviate: true, fallback: '?' })
 
-const formatBorrowTokenValue = (value: Decimal | undefined, borrowTokenSuffix: string): string =>
-  value != null ? `${formatNumber(value, { abbreviate: true })}${borrowTokenSuffix}` : '?'
+const formatBorrowTokenValue = (value: Decimal | undefined, borrowTokenSymbol: string | undefined): string =>
+  formatNumber(value, {
+    abbreviate: true,
+    fallback: '?',
+    unit: { symbol: borrowTokenSymbol ? ` ${borrowTokenSymbol}` : '', position: 'suffix' },
+  })
 
 export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipContentProps) => {
   const palette = useBandsChartPalette()
@@ -72,7 +76,7 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Your band liquidity`}>
-              {formatBorrowTokenValue(data.userBandTotalValue, borrowTokenSuffix)}
+              {formatBorrowTokenValue(data.userBandTotalValue, borrowToken?.symbol)}
             </TooltipItem>
           </Stack>
         )}
@@ -93,7 +97,7 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Band liquidity`}>
-              {formatBorrowTokenValue(data.bandTotalValue, borrowTokenSuffix)}
+              {formatBorrowTokenValue(data.bandTotalValue, borrowToken?.symbol)}
             </TooltipItem>
           </>
         )}

--- a/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
+++ b/apps/main/src/llamalend/features/bands-chart/TooltipContent.tsx
@@ -1,14 +1,16 @@
 import { TooltipItem, TooltipItems, TooltipWrapper } from '@/llamalend/widgets/tooltips/TooltipComponents'
 import { Box, Stack, Typography } from '@mui/material'
+import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { LegendBox } from '@ui-kit/shared/ui/Chart/LegendSet'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { formatNumber } from '@ui-kit/utils'
+import { decimalDiv, decimalGreaterThan, decimalMultiply, formatNumber } from '@ui-kit/utils'
 import { useBandsChartPalette } from './hooks/useBandsChartPalette'
-import { BandsChartToken, ChartDataPoint } from './types'
+import type { BandsChartToken, ChartDataPoint } from './types'
 
 const { Spacing } = SizesAndSpaces
+const ZERO: Decimal = '0'
 
 type TooltipContentProps = {
   data: ChartDataPoint
@@ -16,25 +18,25 @@ type TooltipContentProps = {
   borrowToken: BandsChartToken
 }
 
-const calculateBandShare = (numerator: number | undefined, denominator: number | undefined): string =>
-  typeof denominator === 'number' && denominator > 0 && typeof numerator === 'number'
-    ? `${formatNumber((numerator / denominator) * 100, 'percent.rate')}`
+const isPositiveDecimal = (value: Decimal | undefined): boolean => value != null && decimalGreaterThan(value, ZERO)
+
+const calculateBandShare = (numerator: Decimal | undefined, denominator: Decimal | undefined): string =>
+  numerator != null && denominator != null && decimalGreaterThan(denominator, ZERO)
+    ? `${formatNumber(decimalMultiply(decimalDiv(numerator, denominator), '100'), 'percent.rate')}`
     : '?'
 
-const formatAbbreviatedNumber = (value: number | undefined): string =>
-  typeof value === 'number' ? `${formatNumber(value, { abbreviate: true })}` : '?'
+const formatAbbreviatedNumber = (value: Decimal | undefined): string =>
+  value != null ? `${formatNumber(value, { abbreviate: true })}` : '?'
 
-const formatUsdNotional = (value: number | undefined): string =>
-  typeof value === 'number' ? formatNumber(value, 'usd.notional') : '?'
-const formatBandPrice = (value: number): string =>
-  formatChartAxisNumber(value, { unit: 'dollar', abbreviateFrom: false })
+const formatBorrowTokenValue = (value: Decimal | undefined, borrowTokenSuffix: string): string =>
+  value != null ? `${formatNumber(value, { abbreviate: true })}${borrowTokenSuffix}` : '?'
 
 export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipContentProps) => {
   const palette = useBandsChartPalette()
-  const hasMarketData =
-    (typeof data.bandCollateralAmount === 'number' && data.bandCollateralAmount > 0) ||
-    (typeof data.bandBorrowedAmount === 'number' && data.bandBorrowedAmount > 0)
-  const hasUserData = !!(data.userBandCollateralValueUsd || data.userBandBorrowedValueUsd)
+  const hasMarketData = isPositiveDecimal(data.bandTotalValue)
+  const hasUserData = isPositiveDecimal(data.userBandTotalValue)
+  const borrowTokenSuffix = borrowToken?.symbol ? ` ${borrowToken.symbol}` : ''
+  const bandRange = `${formatChartAxisNumber(data.p_down, { abbreviateFrom: false })} - ${formatChartAxisNumber(data.p_up, { abbreviateFrom: false })}${borrowTokenSuffix}`
 
   return (
     <Box sx={{ padding: Spacing.md, backgroundColor: t => t.design.Layer[1].Fill }} onClick={e => e.stopPropagation()}>
@@ -49,18 +51,17 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
           <Stack sx={{ gap: Spacing.sm, marginBottom: Spacing.sm }}>
             <TooltipItems secondary>
               <TooltipItem title={t`Your share of band`} sx={{ marginBottom: Spacing.sm }}>
-                {calculateBandShare(data.userBandTotalCollateralValueUsd, data.bandTotalCollateralValueUsd)}
+                {calculateBandShare(data.userBandTotalValue, data.bandTotalValue)}
               </TooltipItem>
               <TooltipItem
                 title={t`Your position balances`}
-              >{`${calculateBandShare(data.userBandCollateralValueUsd, data.userBandTotalCollateralValueUsd)} / ${calculateBandShare(data.userBandBorrowedValueUsd, data.userBandTotalCollateralValueUsd)}`}</TooltipItem>
+              >{`${calculateBandShare(data.userBandCollateralValue, data.userBandTotalValue)} / ${calculateBandShare(data.userBandBorrowedAmount, data.userBandTotalValue)}`}</TooltipItem>
               <TooltipItem
                 variant="subItem"
                 title={collateralToken?.symbol}
                 titleAdornment={<LegendBox outline="none" fill={palette.userCollateralShareColor} />}
               >
                 {formatAbbreviatedNumber(data.userBandCollateralAmount)}
-                {formatUsdNotional(data.userBandCollateralValueUsd)}
               </TooltipItem>
               <TooltipItem
                 variant="subItem"
@@ -68,11 +69,10 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
                 titleAdornment={<LegendBox outline="none" fill={palette.userBorrowedShareColor} />}
               >
                 {formatAbbreviatedNumber(data.userBandBorrowedAmount)}
-                {formatUsdNotional(data.userBandBorrowedValueUsd)}
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Your band liquidity`}>
-              {formatUsdNotional(data.userBandTotalCollateralValueUsd)}
+              {formatBorrowTokenValue(data.userBandTotalValue, borrowTokenSuffix)}
             </TooltipItem>
           </Stack>
         )}
@@ -80,24 +80,20 @@ export const TooltipContent = ({ data, collateralToken, borrowToken }: TooltipCo
           <>
             <TooltipItems secondary>
               <TooltipItem title={t`Band range`} sx={{ marginBottom: Spacing.sm }}>
-                {typeof data.p_down === 'number' && typeof data.p_up === 'number'
-                  ? `${formatBandPrice(data.p_down)} - ${formatBandPrice(data.p_up)}`
-                  : '?'}
+                {bandRange}
               </TooltipItem>
               <TooltipItem
                 title={t`Band balances`}
-              >{`${calculateBandShare(data.bandCollateralValueUsd, data.bandTotalCollateralValueUsd)} / ${calculateBandShare(data.bandBorrowedValueUsd, data.bandTotalCollateralValueUsd)}`}</TooltipItem>
+              >{`${calculateBandShare(data.bandCollateralValue, data.bandTotalValue)} / ${calculateBandShare(data.bandBorrowedAmount, data.bandTotalValue)}`}</TooltipItem>
               <TooltipItem variant="subItem" title={collateralToken?.symbol}>
                 {formatAbbreviatedNumber(data.bandCollateralAmount)}
-                {formatUsdNotional(data.bandCollateralValueUsd)}
               </TooltipItem>
               <TooltipItem variant="subItem" title={borrowToken?.symbol}>
                 {formatAbbreviatedNumber(data.bandBorrowedAmount)}
-                {formatUsdNotional(data.bandBorrowedValueUsd)}
               </TooltipItem>
             </TooltipItems>
             <TooltipItem variant="primary" title={t`Band liquidity`}>
-              {formatUsdNotional(data.bandTotalCollateralValueUsd)}
+              {formatBorrowTokenValue(data.bandTotalValue, borrowTokenSuffix)}
             </TooltipItem>
           </>
         )}

--- a/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
+++ b/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
@@ -1,4 +1,3 @@
-import { sum, zip } from 'lodash'
 import { formatChartAxisNumber } from '@ui-kit/shared/ui/Chart'
 import { Duration } from '@ui-kit/themes/design/0_primitives'
 import { generateOracleReferenceLines, generateRangeBoundaryLines, type HorizontalLine } from './horizontalLines'
@@ -316,10 +315,10 @@ export const getChartOptions = (
   const priceMin = getPriceMin(chartData, oraclePrice, rangeOverlays)
   const priceMax = getPriceMax(chartData, oraclePrice, rangeOverlays)
 
-  // Calculate x-axis extent for horizontal lines (max endX value across all series)
+  // Calculate x-axis extent for horizontal lines (max endX value across all bands)
   // data format: [median, startX, widthX, pDown, pUp, isLiq, endX]
-  // endX is at index 6, and for the full extent we need marketWidth + userWidth
-  const xEnd = Math.max(...zip(derived.marketData, derived.userCollateralData, derived.userBorrowedData).map(sum))
+  // endX is at index 6 and spans the total band value.
+  const xEnd = Math.max(...derived.bandTotalData)
   const xStart = 0
 
   return {
@@ -409,10 +408,9 @@ export const getChartOptions = (
         const pDown = d.p_down
         const pUp = d.p_up
         const isLiq = derived.isLiquidation[i] ? 1 : 0
-        const marketWidth = derived.marketData[i] ?? 0
         const userCollateralWidth = derived.userCollateralData[i] ?? 0
         const userBorrowedWidth = derived.userBorrowedData[i] ?? 0
-        const totalWidth = marketWidth + userCollateralWidth + userBorrowedWidth
+        const totalWidth = derived.bandTotalData[i] ?? 0
         marketSeriesData.push([median, 0, totalWidth, pDown, pUp, isLiq, totalWidth])
         userCollateralSeriesData.push([median, 0, userCollateralWidth, pDown, pUp, isLiq, userCollateralWidth])
         userBorrowedSeriesData.push([

--- a/apps/main/src/llamalend/features/bands-chart/hooks/useBandsChartZoom.ts
+++ b/apps/main/src/llamalend/features/bands-chart/hooks/useBandsChartZoom.ts
@@ -1,4 +1,3 @@
-import { sum, zip } from 'lodash'
 import { useMemo } from 'react'
 import { PRICE_SCALE_MARGINS } from '@ui-kit/features/candle-chart'
 import { BANDS_CHART_SERIES_TYPE } from '../types'
@@ -68,9 +67,8 @@ export const useBandsChartZoom = ({ option, priceRange, chartData, derived }: Pa
     const yMin = priceRange.min - PRICE_SCALE_MARGINS.bottom * fullSpan
     const yMax = priceRange.max + PRICE_SCALE_MARGINS.top * fullSpan
 
-    const totals = zip(derived.marketData, derived.userCollateralData, derived.userBorrowedData).map(sum)
     const visibleMax = chartData.reduce(
-      (max, d, i) => (d.p_up >= yMin && d.p_down <= yMax ? Math.max(max, totals[i]) : max),
+      (max, d, i) => (d.p_up >= yMin && d.p_down <= yMax ? Math.max(max, derived.bandTotalData[i] ?? 0) : max),
       0,
     )
     const xMax = visibleMax > 0 ? visibleMax * CHART_PADDING_MULTIPLIER : undefined

--- a/apps/main/src/llamalend/features/bands-chart/hooks/useDerivedChartData.ts
+++ b/apps/main/src/llamalend/features/bands-chart/hooks/useDerivedChartData.ts
@@ -1,13 +1,18 @@
 import { useMemo } from 'react'
-import { ChartDataPoint, DerivedChartData } from '../types'
+import type { Decimal } from '@primitives/decimal.utils'
+import { decimalSum } from '@ui-kit/utils/decimal'
+import type { ChartDataPoint, DerivedChartData } from '../types'
+
+const ZERO: Decimal = '0'
+const toNumber = (value: Decimal | undefined): number => Number(value ?? ZERO)
 
 /**
  * Derives chart-specific data from raw band data
  *
  * Transforms the raw chart data into arrays optimized for ECharts rendering:
  * - yAxisData: Price values for the y-axis (median of band price range)
- * - marketData: Total market value per band
- * - userData: User's current position value per band
+ * - userData: User's current position value per band, denominated in the borrow token
+ * - bandTotalData: Total band value per band, denominated in the borrow token
  * - isLiquidation: Flags indicating if a band is in soft liquidation
  *
  * @param chartData - Raw chart data points
@@ -16,25 +21,24 @@ import { ChartDataPoint, DerivedChartData } from '../types'
 export const useDerivedChartData = (chartData: ChartDataPoint[]): DerivedChartData =>
   useMemo(() => {
     const yAxisData: number[] = []
-    const marketData: number[] = []
     const userCollateralData: number[] = []
     const userBorrowedData: number[] = []
+    const bandTotalData: number[] = []
     const isLiquidation: boolean[] = []
 
     for (const d of chartData) {
       // Use median price for y-axis labels
       yAxisData.push(d.pUpDownMedian)
 
-      const totalBandValue = (d.bandCollateralValueUsd ?? 0) + (d.bandBorrowedValueUsd ?? 0)
-      const userCollateralValue = d.userBandCollateralValueUsd ?? 0
-      const userBorrowedValue = d.userBandBorrowedValueUsd ?? 0
-      const marketBandValue = totalBandValue - userCollateralValue - userBorrowedValue
+      const userCollateralValue = d.userBandCollateralValue ?? ZERO
+      const userBorrowedValue = d.userBandBorrowedAmount ?? ZERO
+      const totalBandValue = d.bandTotalValue ?? decimalSum(userCollateralValue, userBorrowedValue)
 
-      marketData.push(marketBandValue)
-      userCollateralData.push(userCollateralValue)
-      userBorrowedData.push(userBorrowedValue)
+      userCollateralData.push(toNumber(userCollateralValue))
+      userBorrowedData.push(toNumber(userBorrowedValue))
+      bandTotalData.push(toNumber(totalBandValue))
       isLiquidation.push(d.isLiquidationBand)
     }
 
-    return { yAxisData, marketData, userCollateralData, userBorrowedData, isLiquidation }
+    return { yAxisData, userCollateralData, userBorrowedData, bandTotalData, isLiquidation }
   }, [chartData])

--- a/apps/main/src/llamalend/features/bands-chart/hooks/useDerivedChartData.ts
+++ b/apps/main/src/llamalend/features/bands-chart/hooks/useDerivedChartData.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react'
 import type { Decimal } from '@primitives/decimal.utils'
-import { decimalSum } from '@ui-kit/utils/decimal'
+import { decimalSum, ZERO } from '@ui-kit/utils/decimal'
 import type { ChartDataPoint, DerivedChartData } from '../types'
 
-const ZERO: Decimal = '0'
 const toNumber = (value: Decimal | undefined): number => Number(value ?? ZERO)
 
 /**
@@ -30,8 +29,8 @@ export const useDerivedChartData = (chartData: ChartDataPoint[]): DerivedChartDa
       // Use median price for y-axis labels
       yAxisData.push(d.pUpDownMedian)
 
-      const userCollateralValue = d.userBandCollateralValue ?? ZERO
-      const userBorrowedValue = d.userBandBorrowedAmount ?? ZERO
+      const userCollateralValue = d.userBandCollateralValue
+      const userBorrowedValue = d.userBandBorrowedAmount
       const totalBandValue = d.bandTotalValue ?? decimalSum(userCollateralValue, userBorrowedValue)
 
       userCollateralData.push(toNumber(userCollateralValue))

--- a/apps/main/src/llamalend/features/bands-chart/hooks/useProcessedBandsData.ts
+++ b/apps/main/src/llamalend/features/bands-chart/hooks/useProcessedBandsData.ts
@@ -11,60 +11,37 @@ export const useProcessedBandsData = ({ marketBandsBalances, userBandsBalances }
   useMemo(() => {
     if (!marketBandsBalances) return []
 
-    const marketBands = marketBandsBalances ?? []
     const userBands = userBandsBalances ?? []
 
-    const getBandValues = (band: FetchedBandsBalances) => ({
-      collateralAmount: +band.collateral,
-      borrowedAmount: +band.borrowed,
-      collateralValueUsd: band.collateralUsd,
-      borrowedValueUsd: band.collateralBorrowedUsd - band.collateralUsd,
-    })
+    const marketTuples: [number, ChartDataPoint][] = marketBandsBalances.map(band => [
+      band.n,
+      {
+        n: band.n,
+        pUpDownMedian: Number(band.pUpDownMedian),
+        p_up: Number(band.p_up),
+        p_down: Number(band.p_down),
+        bandCollateralAmount: band.collateral,
+        bandCollateralValue: band.collateralValue,
+        bandBorrowedAmount: band.borrowed,
+        bandTotalValue: band.totalValue,
+        isLiquidationBand: band.isLiquidationBand,
+      },
+    ])
 
-    const marketTuples: [number, ChartDataPoint][] = marketBands.map(band => {
-      const { collateralAmount, borrowedAmount, collateralValueUsd, borrowedValueUsd } = getBandValues(band)
-
-      return [
-        band.n,
-        {
-          n: band.n,
-          pUpDownMedian: band.pUpDownMedian,
-          p_up: band.p_up,
-          p_down: band.p_down,
-          bandCollateralAmount: collateralAmount,
-          bandCollateralValueUsd: collateralValueUsd,
-          bandBorrowedAmount: borrowedAmount,
-          bandBorrowedValueUsd: borrowedValueUsd,
-          bandTotalCollateralValueUsd:
-            typeof collateralValueUsd === 'number' && typeof borrowedValueUsd === 'number'
-              ? collateralValueUsd + borrowedValueUsd
-              : undefined,
-          isLiquidationBand: band.isLiquidationBand,
-        },
-      ]
-    })
-
-    const userTuples: [number, ChartDataPoint][] = userBands.map(band => {
-      const { collateralAmount, borrowedAmount, collateralValueUsd, borrowedValueUsd } = getBandValues(band)
-      return [
-        band.n,
-        {
-          n: band.n,
-          pUpDownMedian: band.pUpDownMedian,
-          p_up: band.p_up,
-          p_down: band.p_down,
-          userBandCollateralAmount: collateralAmount,
-          userBandCollateralValueUsd: collateralValueUsd,
-          userBandBorrowedAmount: borrowedAmount,
-          userBandBorrowedValueUsd: borrowedValueUsd,
-          userBandTotalCollateralValueUsd:
-            typeof collateralValueUsd === 'number' && typeof borrowedValueUsd === 'number'
-              ? collateralValueUsd + borrowedValueUsd
-              : undefined,
-          isLiquidationBand: band.isLiquidationBand,
-        },
-      ]
-    })
+    const userTuples: [number, ChartDataPoint][] = userBands.map(band => [
+      band.n,
+      {
+        n: band.n,
+        pUpDownMedian: Number(band.pUpDownMedian),
+        p_up: Number(band.p_up),
+        p_down: Number(band.p_down),
+        userBandCollateralAmount: band.collateral,
+        userBandCollateralValue: band.collateralValue,
+        userBandBorrowedAmount: band.borrowed,
+        userBandTotalValue: band.totalValue,
+        isLiquidationBand: band.isLiquidationBand,
+      },
+    ])
 
     const bandsMap = new Map<number, ChartDataPoint>(marketTuples)
 

--- a/apps/main/src/llamalend/features/bands-chart/types.ts
+++ b/apps/main/src/llamalend/features/bands-chart/types.ts
@@ -1,23 +1,28 @@
 import type { EChartsOption } from 'echarts-for-react'
 import type { Decimal } from '@primitives/decimal.utils'
 
+export type { FetchedBandsBalances } from '@/llamalend/queries/bands/types'
+
 export type BandsChartToken = { symbol: string; address: string } | undefined
 
+/**
+ * `*Value` fields are denominated in the market borrow token.
+ * Collateral values use the band price to convert collateral amount into borrow-token notional.
+ * Borrowed amounts are already in the borrow token and are used directly as borrowed values.
+ */
 export type ChartDataPoint = {
   n: number
   pUpDownMedian: number
   p_up: number
   p_down: number
-  bandCollateralAmount?: number
-  bandCollateralValueUsd?: number
-  bandBorrowedAmount?: number
-  bandBorrowedValueUsd?: number
-  bandTotalCollateralValueUsd?: number
-  userBandCollateralAmount?: number
-  userBandCollateralValueUsd?: number
-  userBandBorrowedAmount?: number
-  userBandBorrowedValueUsd?: number
-  userBandTotalCollateralValueUsd?: number
+  bandCollateralAmount?: Decimal
+  bandCollateralValue?: Decimal
+  bandBorrowedAmount?: Decimal
+  bandTotalValue?: Decimal
+  userBandCollateralAmount?: Decimal
+  userBandCollateralValue?: Decimal
+  userBandBorrowedAmount?: Decimal
+  userBandTotalValue?: Decimal
   isLiquidationBand: boolean
 }
 
@@ -59,9 +64,9 @@ export type UserBandsPriceRange = {
 
 export type DerivedChartData = {
   yAxisData: number[]
-  marketData: number[]
   userCollateralData: number[]
   userBorrowedData: number[]
+  bandTotalData: number[]
   isLiquidation: boolean[]
 }
 
@@ -120,16 +125,4 @@ export type BandsChartSeries =
 
 export type BandsChartOption = Omit<EChartsOption, 'series'> & {
   series?: BandsChartSeries[]
-}
-
-export type FetchedBandsBalances = {
-  borrowed: Decimal
-  collateral: Decimal
-  collateralUsd: number
-  collateralBorrowedUsd: number
-  isLiquidationBand: boolean
-  n: number
-  p_up: number
-  p_down: number
-  pUpDownMedian: number
 }

--- a/apps/main/src/llamalend/queries/bands/bands-balances.query-helpers.ts
+++ b/apps/main/src/llamalend/queries/bands/bands-balances.query-helpers.ts
@@ -2,6 +2,7 @@ import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import type { FetchedBandsBalances, SortedBandBalance } from '@/llamalend/queries/bands/types'
 import { getPricesImplementation } from '@/llamalend/queries/market/market.query-helpers'
 import { sortBy } from '@primitives/array.utils'
+import { recordEntries } from '@primitives/objects.utils'
 import PromisePool from '@supercharge/promise-pool'
 import {
   decimal,
@@ -16,7 +17,7 @@ type BandsBalances = Record<number, { borrowed: string; collateral: string }>
 
 export const sortBands = (bandsBalances: BandsBalances): SortedBandBalance[] =>
   sortBy(
-    Object.entries(bandsBalances).map(([band, { borrowed, collateral }]) => ({
+    recordEntries(bandsBalances).map(([band, { borrowed, collateral }]) => ({
       borrowed: decimal(borrowed)!,
       collateral: decimal(collateral)!,
       band: Number(band),

--- a/apps/main/src/llamalend/queries/bands/bands-balances.query-helpers.ts
+++ b/apps/main/src/llamalend/queries/bands/bands-balances.query-helpers.ts
@@ -1,55 +1,58 @@
-import { BigNumber } from 'bignumber.js'
-import lodash from 'lodash'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
+import type { FetchedBandsBalances, SortedBandBalance } from '@/llamalend/queries/bands/types'
 import { getPricesImplementation } from '@/llamalend/queries/market/market.query-helpers'
-import type { Decimal } from '@primitives/decimal.utils'
+import { sortBy } from '@primitives/array.utils'
 import PromisePool from '@supercharge/promise-pool'
-import { decimal } from '@ui-kit/utils/decimal'
+import {
+  decimal,
+  decimalDiv,
+  decimalGreaterThan,
+  decimalMultiply,
+  decimalSqrt,
+  decimalSum,
+} from '@ui-kit/utils/decimal'
 
 type BandsBalances = Record<number, { borrowed: string; collateral: string }>
-type BandsBalancesArr = { borrowed: string; collateral: string; band: number }[]
-type FetchedBandsBalances = {
-  borrowed: Decimal
-  collateral: Decimal
-  collateralUsd: number
-  collateralBorrowedUsd: number
-  isLiquidationBand: boolean
-  n: number
-  p_up: number
-  p_down: number
-  pUpDownMedian: number
-}
 
-export const sortBands = (bandsBalances: BandsBalances) => ({
-  bandsBalancesArr: lodash.sortBy(Object.keys(bandsBalances), k => +k).map(k => ({ ...bandsBalances[+k], band: +k })),
-  bandsBalances,
-})
+export const sortBands = (bandsBalances: BandsBalances): SortedBandBalance[] =>
+  sortBy(
+    Object.entries(bandsBalances).map(([band, { borrowed, collateral }]) => ({
+      borrowed: decimal(borrowed)!,
+      collateral: decimal(collateral)!,
+      band: Number(band),
+    })),
+    ({ band }) => band,
+  )
 
 export async function fetchChartBandBalancesData(
-  { bandsBalancesArr }: { bandsBalances: BandsBalances; bandsBalancesArr: BandsBalancesArr },
+  bandsBalancesArr: SortedBandBalance[],
   liquidationBand: number | null,
   market: LlamaMarketTemplate,
   isMarket: boolean,
 ) {
-  const bands = isMarket ? bandsBalancesArr.filter(b => +b.borrowed > 0 || +b.collateral > 0) : bandsBalancesArr
+  const bands = isMarket
+    ? bandsBalancesArr.filter(b => decimalGreaterThan(b.borrowed, '0') || decimalGreaterThan(b.collateral, '0'))
+    : bandsBalancesArr
 
   const { results }: { results: FetchedBandsBalances[] } = await PromisePool.for(bands).process(async b => {
     const { collateral, borrowed, band: n } = b
-    const [p_up, p_down] = await getPricesImplementation(market).calcBandPrices(n)
-    const sqrt = new BigNumber(p_up).multipliedBy(p_down).squareRoot()
-    const pUpDownMedian = new BigNumber(p_up).plus(p_down).dividedBy(2).toFixed()
-    const collateralUsd = new BigNumber(collateral).multipliedBy(sqrt)
+    const [pUp, pDown] = await getPricesImplementation(market).calcBandPrices(n)
+    const p_up = decimal(pUp)!
+    const p_down = decimal(pDown)!
+    const sqrtPrice = decimalSqrt(decimalMultiply(p_up, p_down))
+    const pUpDownMedian = decimalDiv(decimalSum(p_up, p_down), '2')
+    const collateralValue = decimalMultiply(collateral, sqrtPrice)
 
     return {
-      borrowed: decimal(borrowed)!,
-      collateral: decimal(collateral)!,
-      collateralUsd: collateralUsd.toNumber(),
-      collateralBorrowedUsd: collateralUsd.plus(borrowed).toNumber(),
-      isLiquidationBand: liquidationBand === +n,
+      borrowed,
+      collateral,
+      collateralValue,
+      totalValue: decimalSum(collateralValue, borrowed),
+      isLiquidationBand: liquidationBand === n,
       n,
-      p_up: +p_up,
-      p_down: +p_down,
-      pUpDownMedian: +pUpDownMedian,
+      p_up,
+      p_down,
+      pUpDownMedian,
     }
   })
 

--- a/apps/main/src/llamalend/queries/bands/index.ts
+++ b/apps/main/src/llamalend/queries/bands/index.ts
@@ -1,2 +1,3 @@
+export * from './types'
 export * from './user-bands-balances.query'
 export * from './market-bands-balances.query'

--- a/apps/main/src/llamalend/queries/bands/types.ts
+++ b/apps/main/src/llamalend/queries/bands/types.ts
@@ -1,0 +1,22 @@
+import type { Decimal } from '@primitives/decimal.utils'
+
+export type SortedBandBalance = {
+  borrowed: Decimal
+  collateral: Decimal
+  band: number
+}
+
+/**
+ * `*Value` fields are denominated in the market borrow token, not USD.
+ */
+export type FetchedBandsBalances = {
+  borrowed: Decimal
+  collateral: Decimal
+  collateralValue: Decimal
+  totalValue: Decimal
+  isLiquidationBand: boolean
+  n: number
+  p_up: Decimal
+  p_down: Decimal
+  pUpDownMedian: Decimal
+}

--- a/packages/curve-ui-kit/src/utils/decimal.spec.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.spec.ts
@@ -84,4 +84,8 @@ describe('decimalSqrt', () => {
     expect(decimalSqrt('2.25')).toBe('1.5')
     expect(decimalSqrt('0.000000000000000001')).toBe('0.000000001')
   })
+
+  it('rejects negative numbers', () => {
+    expect(() => decimalSqrt('-1')).toThrow('Cannot calculate square root of a negative Decimal: -1')
+  })
 })

--- a/packages/curve-ui-kit/src/utils/decimal.spec.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.spec.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { describe, expect, it } from 'vitest'
-import { amount, decimal } from './decimal'
+import { amount, decimal, decimalSqrt } from './decimal'
 
 describe('decimal', () => {
   it('handles basic, normal numbers', () => {
@@ -76,4 +76,12 @@ describe('amount', () => {
       expect(amount(invalidValue)).toBe(undefined)
     },
   )
+})
+
+describe('decimalSqrt', () => {
+  it('returns square roots as Decimal strings', () => {
+    expect(decimalSqrt('4')).toBe('2')
+    expect(decimalSqrt('2.25')).toBe('1.5')
+    expect(decimalSqrt('0.000000000000000001')).toBe('0.000000001')
+  })
 })

--- a/packages/curve-ui-kit/src/utils/decimal.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.ts
@@ -56,6 +56,8 @@ export const decimalGreaterThan = (first: Decimal, second: Decimal) => BigNumber
 export const decimalMultiply = (first: Decimal, ...items: Amount[]) =>
   items.reduce((p, c) => p.multipliedBy(c), new BigNumber(first)).toFixed() as Decimal
 
+export const decimalSqrt = (value: Decimal): Decimal => new BigNumber(value).squareRoot().toFixed() as Decimal
+
 /** Divides the 1st by the 2nd decimal. Does NOT guard for division-by-zero! */
 export const decimalDiv = (first: Decimal, second: Decimal) =>
   new BigNumber(first).dividedBy(second).toFixed() as Decimal

--- a/packages/curve-ui-kit/src/utils/decimal.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.ts
@@ -3,6 +3,8 @@ import { formatUnits, parseUnits } from 'viem'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
 import { maybe } from '@primitives/objects.utils'
 
+export const ZERO: Decimal = '0'
+
 /** Converts loose numeric input to an Amount for formatting, returning undefined for empty or non-numeric values. */
 export const amount = (value: number | string | BigNumber | bigint | null | undefined): Amount | undefined =>
   value == null || value === '' || Number.isNaN(value) ? undefined : typeof value === 'number' ? value : decimal(value)
@@ -56,7 +58,11 @@ export const decimalGreaterThan = (first: Decimal, second: Decimal) => BigNumber
 export const decimalMultiply = (first: Decimal, ...items: Amount[]) =>
   items.reduce((p, c) => p.multipliedBy(c), new BigNumber(first)).toFixed() as Decimal
 
-export const decimalSqrt = (value: Decimal): Decimal => new BigNumber(value).squareRoot().toFixed() as Decimal
+export const decimalSqrt = (value: Decimal): Decimal => {
+  const decimalValue = new BigNumber(value)
+  if (decimalValue.isNegative()) throw new Error(`Cannot calculate square root of a negative Decimal: ${value}`)
+  return decimalValue.squareRoot().toFixed() as Decimal
+}
 
 /** Divides the 1st by the 2nd decimal. Does NOT guard for division-by-zero! */
 export const decimalDiv = (first: Decimal, second: Decimal) =>


### PR DESCRIPTION
Updates the LlamaLend bands chart to denominate band liquidity, shares, and tooltip values in the market borrow token instead of USD, while simplifying the chart data flow around total band values.

Changes:
- Calculate collateral value, total band liquidity, and user liquidity in borrow-token terms.
- Use precomputed band totals for chart sizing, zoom bounds, and tooltip percentages.
- Replace USD notional tooltip values with borrow-token liquidity formatting.
- Simplify band balance processing with Decimal values and shared query types.
- Add decimalSqrt utility with unit coverage.