### PR TITLE
fix: points campaigns mixup in new advanced details tables

### DIFF
--- a/apps/main/src/dex/features/advanced-details/components/yield-breakdown/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/yield-breakdown/index.tsx
@@ -45,7 +45,11 @@ export const YieldBreakdown = ({
           table={table}
           disableStickyHeader
           emptyState={<EmptyStateRow table={table} size="sm">{t`No yield breakdown found.`}</EmptyStateRow>}
-          footerRow={<FooterRow visibleColumns={table.getVisibleLeafColumns()} baseTotal={baseTotal} total={total} />}
+          footerRow={
+            rows.length > 1 && (
+              <FooterRow visibleColumns={table.getVisibleLeafColumns()} baseTotal={baseTotal} total={total} />
+            )
+          }
         />
       </Stack>
     )

--- a/apps/main/src/dex/features/advanced-details/hooks/usePointsCampaigns.tsx
+++ b/apps/main/src/dex/features/advanced-details/hooks/usePointsCampaigns.tsx
@@ -28,9 +28,9 @@ export const usePointsCampaigns = ({
   const rows = useMemo(
     () =>
       campaigns
-        .filter(({ reward }) => reward?.type === 'points')
+        .filter(({ reward, symbol }) => reward?.type === 'points' || (!reward?.type && symbol))
         .map(
-          ({ dashboardLink, reward, platform, platformImageId }): PointsCampaignsRow => ({
+          ({ dashboardLink, reward, platform, platformImageId, symbol }): PointsCampaignsRow => ({
             source: {
               icon: (
                 <Box
@@ -43,7 +43,7 @@ export const usePointsCampaigns = ({
               iconPosition: 'left',
               primary: platform,
             },
-            multiplier: formatNumber(reward?.value, 'multiplier'),
+            multiplier: reward?.value != null || symbol == null ? formatNumber(reward?.value, 'multiplier') : symbol,
             campaignUrl: dashboardLink,
           }),
         ),

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -79,8 +79,8 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity) => {
         steps: opp.howToSteps,
         lock: false, // Merkl doesn't offer 'locked' rewards.
 
-        // Merkl campaigns don't have a multiplier, just a token. And APR is only available for the whole opportunity.
-        reward: { type: 'apr', value: Math.min(opp.apr, MAX_APR) },
+        // Merkl campaigns might be a points campaign or just a token, but those campaigns report an APR of 0 as their only distinction
+        reward: opp.apr ? { type: 'apr', value: Math.min(opp.apr, MAX_APR) } : undefined,
         symbol: token.symbol,
 
         tags: ['tokens'], // Merkl rewards are tokens only as far as I know; no points.


### PR DESCRIPTION
Fixes two bugs:

1. Merkl points campaigns would show up in the yield breakdown, as Merkl points campaigns have an APR of 0 as its only distinction. Very annoying.
2. Points campaigns would not show non-multiplier Merkl campaigns. I know the column is called 'Multiplier' and it doesn't make sense for non-multipliers, but these are edge cases and I don't want to rename the column again.

As a bonus it also removes the aggregation footer row in yield breakdown if there's only 1 row, making aggregation useless.

`0x317837aed98bea887074d1f97fd3c83ebca6905b`
<img width="712" height="676" alt="image" src="https://github.com/user-attachments/assets/735e9791-0e6f-4291-9b30-3c10ecbe595e" />

`0xf4d0cf32908b2c7f1021339c43df0f77f06896d7`
<img width="728" height="590" alt="image" src="https://github.com/user-attachments/assets/b197aa10-9caa-4e98-a25d-9cc694d00c92" />

`0xefc6516323fbd28e80b85a497b65a86243a54b3e`
<img width="727" height="732" alt="image" src="https://github.com/user-attachments/assets/76bafbf8-66bd-4eb6-a8d1-de02e42969c4" />
