### PR TITLE
fix: token symbol and notional metrics

### DIFF
--- a/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/AdvancedDetails.tsx
@@ -1,4 +1,4 @@
-import { formatCollateralNotional } from '@/llamalend/llama.utils'
+import { formatCollateralNotional, tokenMetric } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import {
   MaxLeverageTooltip,
@@ -26,7 +26,7 @@ type AdvancedDetailsProps = {
 }
 
 export const AdvancedDetails = ({ chainId, marketId, market, marketType }: AdvancedDetailsProps) => {
-  const { collateral, availableLiquidity, maxLeverage, solvency, totalBorrowers, averageHealth } =
+  const { borrowedUsdRate, collateral, availableLiquidity, maxLeverage, solvency, totalBorrowers, averageHealth } =
     useAdvancedDetailsData({
       chainId,
       market,
@@ -47,8 +47,11 @@ export const AdvancedDetails = ({ chainId, marketId, market, marketType }: Advan
         <Metric
           size="medium"
           label={t`Borrow cap`}
-          value={mapQuery(availableLiquidity, ({ borrowCap }) => borrowCap)}
-          valueOptions={{ abbreviate: true }}
+          {...tokenMetric({
+            value: mapQuery(availableLiquidity, d => d.borrowCap),
+            symbol: availableLiquidity.data?.borrowSymbol,
+            usdRate: borrowedUsdRate,
+          })}
         />
       )}
       <Metric

--- a/apps/main/src/llamalend/features/market-advanced-information/hooks/useAdvancedDetailsData.ts
+++ b/apps/main/src/llamalend/features/market-advanced-information/hooks/useAdvancedDetailsData.ts
@@ -14,7 +14,7 @@ import { combineQueries } from '@ui-kit/lib'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import type { MarketParams } from '@ui-kit/lib/model/query/root-keys'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { mapQuery } from '@ui-kit/types/util'
+import { mapQuery, q } from '@ui-kit/types/util'
 import { requireBlockchainId } from '@ui-kit/utils/network'
 
 const endpointFromMarketType: Record<LlamaMarketType, Endpoint> = {
@@ -82,10 +82,12 @@ export const useAdvancedDetailsData = ({
       }),
     ),
     maxLeverage: mapQuery(maxLeverage, value => ({ value })),
+    borrowedUsdRate: q(borrowedUsdRate),
     availableLiquidity: mapQuery(capAndAvailable, ({ available, totalAssets, borrowCap }) => ({
       available,
       totalAssets,
       borrowCap,
+      borrowSymbol: borrowToken?.symbol,
     })),
     totalBorrowers: mapQuery(marketUsers, ({ count }) => ({ value: count })),
     averageHealth: mapQuery(liquidationHealthDistribution, distribution => ({

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -13,12 +13,13 @@ import { getUserMarketCollateralEvents as getLendUserMarketCollateralEvents } fr
 import type { BadDebt } from '@curvefi/prices-api/liquidations'
 import { type Address, Hex } from '@primitives/address.utils'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
-import { assert, maybe, notFalsy, objectKeys } from '@primitives/objects.utils'
+import { assert, maybe, maybes, notFalsy, objectKeys } from '@primitives/objects.utils'
 import { getLib, requireLib, type Wallet } from '@ui-kit/features/connect-wallet'
-import { isZapV2Enabled } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
+import { MetricProps } from '@ui-kit/shared/ui/Metric'
 import { LlamaMarketType, LlamaMarketVersion } from '@ui-kit/types/market'
-import { CRVUSD, decimalMinus, decimalSum, formatNumber } from '@ui-kit/utils'
+import { QueryProp } from '@ui-kit/types/util'
+import { CRVUSD, decimal, decimalMinus, decimalMultiply, decimalSum, formatNumber } from '@ui-kit/utils'
 import { SOLVENCY_THRESHOLDS } from './llama-markets.constants'
 
 /**
@@ -438,3 +439,51 @@ export const lowSolvencyDeprecatedMessage = (solvencyPercent: number | null) =>
     : null
 
 export const getZapAddress = (market: LlamaMarketTemplate) => market.getZapAddress() as Address
+
+/**
+ * Returns the total collateral expressed in collateral-token units.
+ * The borrowed-token portion can appear in collateral after soft liquidation, so it must be converted through USD rates
+ * before being added to the native collateral amount.
+ *
+ * Example: 10 WETH collateral + 4,000 crvUSD borrowed collateral, with WETH at $2,000 and crvUSD at $1,
+ * becomes 12 WETH: 10 + (4,000 * 1 / 2,000).
+ */
+export const calculateCombinedCollateral = ({
+  collateral,
+  borrowed,
+  collateralUsdRate,
+  borrowUsdRate,
+}: {
+  collateral: Decimal | undefined
+  borrowed: Decimal | undefined
+  collateralUsdRate: number
+  borrowUsdRate: number
+}) =>
+  collateralUsdRate === 0
+    ? undefined
+    : maybes([collateral, borrowed], ([collateral, borrowed]) =>
+        decimalSum(collateral, decimalMultiply(borrowed, borrowUsdRate / collateralUsdRate)),
+      )
+
+/** Builds Metric props for a token-denominated value with the matching USD notional shown below it. */
+export const tokenMetric = ({
+  value,
+  symbol,
+  usdRate,
+}: {
+  value: MetricProps['value']
+  symbol: string | null | undefined
+  usdRate: QueryProp<Amount | null | undefined>
+}) => {
+  const notionalValue = maybes([decimal(value.data), usdRate.data], ([value, usdRate]) =>
+    decimalMultiply(value, usdRate),
+  )
+  return {
+    value,
+    valueOptions: {
+      abbreviate: true,
+      unit: maybe(symbol, symbol => ({ symbol, position: 'suffix' as const })),
+    },
+    notional: maybe(notionalValue, value => ({ value, unit: 'dollar' as const })),
+  } satisfies Pick<MetricProps, 'value' | 'valueOptions' | 'notional'>
+}

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -440,31 +440,6 @@ export const lowSolvencyDeprecatedMessage = (solvencyPercent: number | null) =>
 
 export const getZapAddress = (market: LlamaMarketTemplate) => market.getZapAddress() as Address
 
-/**
- * Returns the total collateral expressed in collateral-token units.
- * The borrowed-token portion can appear in collateral after soft liquidation, so it must be converted through USD rates
- * before being added to the native collateral amount.
- *
- * Example: 10 WETH collateral + 4,000 crvUSD borrowed collateral, with WETH at $2,000 and crvUSD at $1,
- * becomes 12 WETH: 10 + (4,000 * 1 / 2,000).
- */
-export const calculateCombinedCollateral = ({
-  collateral,
-  borrowed,
-  collateralUsdRate,
-  borrowUsdRate,
-}: {
-  collateral: Decimal | undefined
-  borrowed: Decimal | undefined
-  collateralUsdRate: number
-  borrowUsdRate: number
-}) =>
-  collateralUsdRate === 0
-    ? undefined
-    : maybes([collateral, borrowed], ([collateral, borrowed]) =>
-        decimalSum(collateral, decimalMultiply(borrowed, borrowUsdRate / collateralUsdRate)),
-      )
-
 /** Builds Metric props for a token-denominated value with the matching USD notional shown below it. */
 export const tokenMetric = ({
   value,
@@ -473,17 +448,16 @@ export const tokenMetric = ({
 }: {
   value: MetricProps['value']
   symbol: string | null | undefined
-  usdRate: QueryProp<Amount | null | undefined>
-}) => {
-  const notionalValue = maybes([decimal(value.data), usdRate.data], ([value, usdRate]) =>
-    decimalMultiply(value, usdRate),
-  )
-  return {
+  usdRate: QueryProp<Amount>
+}) =>
+  ({
     value,
     valueOptions: {
       abbreviate: true,
       unit: maybe(symbol, symbol => ({ symbol, position: 'suffix' as const })),
     },
-    notional: maybe(notionalValue, value => ({ value, unit: 'dollar' as const })),
-  } satisfies Pick<MetricProps, 'value' | 'valueOptions' | 'notional'>
-}
+    notional: maybes([decimal(value.data), usdRate.data], ([value, usdRate]) => ({
+      value: decimalMultiply(value, usdRate),
+      unit: 'dollar' as const,
+    })),
+  }) satisfies Pick<MetricProps, 'value' | 'valueOptions' | 'notional'>

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Address } from 'viem'
-import { getTokens, getUtilizationPercent } from '@/llamalend/llama.utils'
+import { calculateCombinedCollateral, getTokens, getUtilizationPercent, tokenMetric } from '@/llamalend/llama.utils'
 import { useMarketCapAndAvailable, useMarketTotalCollateral, useRateCurve } from '@/llamalend/queries/market'
 import { TooltipOptions, TotalCollateralTooltip, UtilizationTooltip } from '@/llamalend/widgets/tooltips'
 import { RateCurveTooltip } from '@/llamalend/widgets/tooltips/chart/RateCurveTooltip'
@@ -11,7 +11,7 @@ import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
-import { maybe, maybes, notFalsy } from '@primitives/objects.utils'
+import { maybes, notFalsy } from '@primitives/objects.utils'
 import { combineQueries } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
@@ -27,7 +27,7 @@ import {
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { fallbackQ, mapQuery, useMappedQuery } from '@ui-kit/types/util'
+import { fallbackQ, mapQuery, q, useMappedQuery } from '@ui-kit/types/util'
 import { decimalMax, decimalMinus, formatNumber } from '@ui-kit/utils'
 
 const { Spacing, Height } = SizesAndSpaces
@@ -80,10 +80,6 @@ export const MarketRateCurveChart = ({
       decimalMax(decimalMinus(totalAssets, available), '0'),
     ),
   )
-  const totalBorrowedUsdValue = combineQueries(
-    [totalBorrowed, borrowedUsdRate],
-    (totalBorrowed, borrowedUsdRate) => Number(totalBorrowed) * borrowedUsdRate,
-  )
   const utilizationBreakdown = combineQueries(
     [totalBorrowed, capAndAvailable],
     (borrow, { totalAssets }) =>
@@ -94,6 +90,11 @@ export const MarketRateCurveChart = ({
 
   const collateralTotal = mapQuery(totalCollateral, totalCollateral => totalCollateral.collateral)
   const borrowedCollateralTotal = mapQuery(totalCollateral, totalCollateral => totalCollateral.borrowed)
+  const combinedCollateral = combineQueries(
+    [totalCollateral, collateralUsdRate, borrowedUsdRate],
+    ({ collateral, borrowed }, collateralUsdRate, borrowUsdRate) =>
+      calculateCombinedCollateral({ collateral, borrowed, collateralUsdRate, borrowUsdRate }),
+  )
   const collateralUsdValue = combineQueries([collateralTotal, collateralUsdRate], (total, usdRate) => +total * usdRate)
   const borrowedCollateralUsdValue = combineQueries(
     [borrowedCollateralTotal, borrowedUsdRate],
@@ -164,22 +165,20 @@ export const MarketRateCurveChart = ({
           <Metric
             size="medium"
             label={t`Total borrowed`}
-            value={totalBorrowed}
-            valueOptions={{
-              unit: borrowToken?.symbol ? { symbol: ` ${borrowToken.symbol}`, position: 'suffix' } : undefined,
-              abbreviate: true,
-            }}
-            notional={maybe(totalBorrowedUsdValue.data, val => formatNumber(val, 'usd.notional'))}
+            {...tokenMetric({
+              value: totalBorrowed,
+              symbol: borrowToken?.symbol,
+              usdRate: q(borrowedUsdRate),
+            })}
           />
           <Metric
             size="medium"
             label={t`Total collateral`}
-            value={collateralTotal}
-            valueOptions={{
-              unit: maybe(collateralToken?.symbol, symbol => ({ symbol, position: 'suffix' })),
-              abbreviate: true,
-            }}
-            notional={maybe(combinedCollateralUsdValue.data, val => formatNumber(val, 'usd.notional'))}
+            {...tokenMetric({
+              value: combinedCollateral,
+              symbol: collateralToken?.symbol,
+              usdRate: q(collateralUsdRate),
+            })}
             valueTooltip={{
               title: t`Total Collateral`,
               body: (

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -1,7 +1,7 @@
 import { sortBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Address } from 'viem'
-import { calculateCombinedCollateral, getTokens, getUtilizationPercent, tokenMetric } from '@/llamalend/llama.utils'
+import { getTokens, getUtilizationPercent, tokenMetric } from '@/llamalend/llama.utils'
 import { useMarketCapAndAvailable, useMarketTotalCollateral, useRateCurve } from '@/llamalend/queries/market'
 import { TooltipOptions, TotalCollateralTooltip, UtilizationTooltip } from '@/llamalend/widgets/tooltips'
 import { RateCurveTooltip } from '@/llamalend/widgets/tooltips/chart/RateCurveTooltip'
@@ -11,6 +11,7 @@ import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader'
 import { useTheme } from '@mui/material/styles'
+import { Decimal } from '@primitives/decimal.utils'
 import { maybes, notFalsy } from '@primitives/objects.utils'
 import { combineQueries } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
@@ -28,7 +29,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { fallbackQ, mapQuery, q, useMappedQuery } from '@ui-kit/types/util'
-import { decimalMax, decimalMinus, formatNumber } from '@ui-kit/utils'
+import { decimalMax, decimalMinus, decimalMultiply, decimalSum, formatNumber } from '@ui-kit/utils'
 
 const { Spacing, Height } = SizesAndSpaces
 
@@ -47,6 +48,31 @@ const SERIES_CONFIG: { key: RateCurveSeriesKey; label: string; dash?: ChartLineD
 
 const transform = ({ rates = [] }: { rates: RateCurveChartPoint[] | undefined }): RateCurveChartPoint[] =>
   sortBy(rates, 'utilization')
+
+/**
+ * Returns the total collateral expressed in collateral-token units.
+ * The borrowed-token portion can appear in collateral after soft liquidation, so it must be converted through USD rates
+ * before being added to the native collateral amount.
+ *
+ * Example: 10 WETH collateral + 4,000 crvUSD borrowed collateral, with WETH at $2,000 and crvUSD at $1,
+ * becomes 12 WETH: 10 + (4,000 * 1 / 2,000).
+ */
+const calculateCombinedCollateral = ({
+  collateral,
+  borrowed,
+  collateralUsdRate,
+  borrowUsdRate,
+}: {
+  collateral: Decimal | undefined
+  borrowed: Decimal | undefined
+  collateralUsdRate: number
+  borrowUsdRate: number
+}) =>
+  collateralUsdRate === 0
+    ? undefined
+    : maybes([collateral, borrowed], ([collateral, borrowed]) =>
+        decimalSum(collateral, decimalMultiply(borrowed, borrowUsdRate / collateralUsdRate)),
+      )
 
 export const MarketRateCurveChart = ({
   market,

--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -1,4 +1,5 @@
 import { MarketTypeSuffix, NET_SUPPLY_RATE_TITLE } from '@/llamalend/constants'
+import { tokenMetric } from '@/llamalend/llama.utils'
 import { BorrowAprMetric } from '@/llamalend/widgets/BorrowAprMetric'
 import { MarketSupplyRateTooltipContent, AvailableLiquidityTooltip, TooltipOptions } from '@/llamalend/widgets/tooltips'
 import Stack from '@mui/material/Stack'
@@ -80,16 +81,16 @@ export const MetricsRow = ({
       <Metric
         alignment={metricAlignment}
         label={t`Available liquidity`}
-        value={mapQuery(availableLiquidity, availableLiquidity => availableLiquidity.value)}
-        valueOptions={{
-          unit: maybe(borrowToken?.symbol, symbol => ({ symbol, position: 'suffix' })),
-        }}
+        {...tokenMetric({
+          value: mapQuery(availableLiquidity, d => d.value),
+          symbol: borrowToken?.symbol,
+          usdRate: mapQuery(availableLiquidity, d => d.usdRate),
+        })}
         valueTooltip={{
           title: t`Available Liquidity ${MarketTypeSuffix[marketType]}`,
           body: <AvailableLiquidityTooltip marketType={marketType} />,
           ...TooltipOptions,
         }}
-        notional={maybe(availableLiquidity.data?.notional, x => ({ value: x, unit: 'dollar' }))}
       />
     </Stack>
   )

--- a/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
+++ b/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
@@ -20,14 +20,14 @@ import {
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
-import { maybes, notFalsyArray } from '@primitives/objects.utils'
+import { notFalsyArray } from '@primitives/objects.utils'
 import { type CampaignRewards, useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import { combineQueries } from '@ui-kit/lib'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import { fakeLoadingQ, Query, type Range } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, type AverageCategory, CRVUSD_ADDRESS, decimalMultiply } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, type AverageCategory, CRVUSD_ADDRESS } from '@ui-kit/utils'
 
 const RATE_CATEGORY: AverageCategory = 'llamalend.market.rate'
 
@@ -161,7 +161,7 @@ export const usePageHeader = ({
       (borrowUsdRate, { available, totalAssets }) => ({
         value: available,
         max: totalAssets,
-        notional: maybes([available, borrowUsdRate], ([liq, rate]) => decimalMultiply(liq, rate)),
+        usdRate: borrowUsdRate,
       }),
     ),
   }

--- a/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
@@ -39,7 +39,7 @@ export const TotalCollateralTooltip = ({
   return (
     <TooltipWrapper>
       <TooltipDescription
-        text={t`The total collateral deposited and converted in this market, shown in the collateral token.`}
+        text={t`The total collateral deposited and converted in this market, all denominated in the collateral token.`}
       />
       <TooltipDescription text={t`Used as backing for borrowed or minted debt (e.g., crvUSD).`} />
       <TooltipDescription

--- a/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/TotalCollateralTooltip.tsx
@@ -38,7 +38,9 @@ export const TotalCollateralTooltip = ({
 
   return (
     <TooltipWrapper>
-      <TooltipDescription text={t`The total USD value of all collateral assets deposited in this market.`} />
+      <TooltipDescription
+        text={t`The total collateral deposited and converted in this market, shown in the collateral token.`}
+      />
       <TooltipDescription text={t`Used as backing for borrowed or minted debt (e.g., crvUSD).`} />
       <TooltipDescription
         text={t`This includes both active positions and collateral currently in the liquidation band (being gradually converted).`}


### PR DESCRIPTION
- created an helper to have consistent token symbol and notional value for a metric
- fixed market page's borow cap and total collateral metrics

<img width="185" height="76" alt="Screenshot 2026-06-19 at 19 10 31" src="https://github.com/user-attachments/assets/2b81fb30-0210-48ec-acd0-be151060dd2a" />
<img width="371" height="333" alt="Screenshot 2026-06-19 at 19 10 54" src="https://github.com/user-attachments/assets/f72f1efa-f3a7-42b0-9070-08f65fc815d4" />
