### PR TITLE
fix: pool composition and balance column

### DIFF
--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/FooterRow.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/FooterRow.tsx
@@ -6,32 +6,32 @@ import { t } from '@ui-kit/lib/i18n'
 import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { amount, formatNumber } from '@ui-kit/utils'
-import type { MarketCompositionRow } from './columns/columns.definitions'
-import { MarketCompositionColumnId } from './columns/columns.enum'
+import type { PoolCompositionRow } from './columns/columns.definitions'
+import { PoolCompositionColumnId } from './columns/columns.enum'
 
 const { Spacing } = SizesAndSpaces
 
 type FooterRowProps = {
-  visibleColumns: Column<MarketCompositionRow, unknown>[]
+  visibleColumns: Column<PoolCompositionRow, unknown>[]
   isLoading: boolean
   totalUsd: string
 }
 
-type FooterCellProps = FooterRowProps & { columnId: MarketCompositionColumnId }
+type FooterCellProps = FooterRowProps & { columnId: PoolCompositionColumnId }
 
-const footerCellByColumnId: Record<MarketCompositionColumnId, (props: FooterCellProps) => ReactNode> = {
-  [MarketCompositionColumnId.Asset]: ({ columnId }: FooterCellProps) => (
+const footerCellByColumnId: Record<PoolCompositionColumnId, (props: FooterCellProps) => ReactNode> = {
+  [PoolCompositionColumnId.Asset]: ({ columnId }: FooterCellProps) => (
     <TableCell key={columnId} sx={{ padding: Spacing.md }}>
       <Typography variant="tableCellMBold">{t`USD Total`}</Typography>
     </TableCell>
   ),
-  [MarketCompositionColumnId.Price]: ({ columnId }: FooterCellProps) => <TableCell key={columnId} />,
-  [MarketCompositionColumnId.MarketShare]: ({ columnId }: FooterCellProps) => (
+  [PoolCompositionColumnId.Price]: ({ columnId }: FooterCellProps) => <TableCell key={columnId} />,
+  [PoolCompositionColumnId.MarketShare]: ({ columnId }: FooterCellProps) => (
     <TableCell key={columnId} sx={{ paddingInline: Spacing.sm, paddingBlock: Spacing.sm, textAlign: 'right' }}>
       <Typography variant="tableCellMBold">100%</Typography>
     </TableCell>
   ),
-  [MarketCompositionColumnId.TokenAmount]: ({ columnId, isLoading, totalUsd }: FooterCellProps) => (
+  [PoolCompositionColumnId.TokenAmount]: ({ columnId, isLoading, totalUsd }: FooterCellProps) => (
     <TableCell key={columnId} sx={{ paddingInline: Spacing.md, paddingBlock: Spacing.sm, textAlign: 'right' }}>
       <WithSkeleton loading={isLoading} sx={{ justifySelf: 'end' }}>
         <Typography variant="tableCellMBold">{formatNumber(amount(totalUsd), 'usd.notional')}</Typography>
@@ -42,5 +42,5 @@ const footerCellByColumnId: Record<MarketCompositionColumnId, (props: FooterCell
 
 export const FooterRow = (props: FooterRowProps) =>
   props.visibleColumns.map(({ id }) =>
-    footerCellByColumnId[id as MarketCompositionColumnId]({ columnId: id as MarketCompositionColumnId, ...props }),
+    footerCellByColumnId[id as PoolCompositionColumnId]({ columnId: id as PoolCompositionColumnId, ...props }),
   )

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/FooterRow.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/FooterRow.tsx
@@ -26,7 +26,7 @@ const footerCellByColumnId: Record<PoolCompositionColumnId, (props: FooterCellPr
     </TableCell>
   ),
   [PoolCompositionColumnId.Price]: ({ columnId }: FooterCellProps) => <TableCell key={columnId} />,
-  [PoolCompositionColumnId.MarketShare]: ({ columnId }: FooterCellProps) => (
+  [PoolCompositionColumnId.Balance]: ({ columnId }: FooterCellProps) => (
     <TableCell key={columnId} sx={{ paddingInline: Spacing.sm, paddingBlock: Spacing.sm, textAlign: 'right' }}>
       <Typography variant="tableCellMBold">100%</Typography>
     </TableCell>

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.definitions.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.definitions.tsx
@@ -25,14 +25,14 @@ const columnHelper = createColumnHelper<PoolCompositionRow>()
 const headers = {
   [PoolCompositionColumnId.Asset]: t`Asset`,
   [PoolCompositionColumnId.Price]: t`Price`,
-  [PoolCompositionColumnId.MarketShare]: t`% of Market`,
+  [PoolCompositionColumnId.Balance]: t`Balance`,
   [PoolCompositionColumnId.TokenAmount]: t`Amount`,
 } as const
 
 export const POOL_COMPOSITION_MOBILE_COLUMN_VISIBILITY = {
   [PoolCompositionColumnId.Asset]: true,
   [PoolCompositionColumnId.Price]: false,
-  [PoolCompositionColumnId.MarketShare]: true,
+  [PoolCompositionColumnId.Balance]: true,
   [PoolCompositionColumnId.TokenAmount]: true,
 } satisfies VisibilityState
 
@@ -55,8 +55,8 @@ export const POOL_COMPOSITION_COLUMNS = [
     meta: { type: 'numeric' },
   }),
   columnHelper.accessor('marketShare', {
-    id: PoolCompositionColumnId.MarketShare,
-    header: headers[PoolCompositionColumnId.MarketShare],
+    id: PoolCompositionColumnId.Balance,
+    header: headers[PoolCompositionColumnId.Balance],
     cell: ({ getValue }) => (
       <InlineTableCell>
         <Typography>{formatNumber(getValue(), 'percent.rate')}</Typography>

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.definitions.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.definitions.tsx
@@ -9,9 +9,9 @@ import { TokenInfo, type TokenInfoTokenIconProps } from '@ui-kit/shared/ui/Token
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { formatNumber } from '@ui-kit/utils'
 import { TokenCell } from '../../TokenCell'
-import { MarketCompositionColumnId } from './columns.enum'
+import { PoolCompositionColumnId } from './columns.enum'
 
-export type MarketCompositionRow = TableItem & {
+export type PoolCompositionRow = TableItem & {
   source: TokenInfoTokenIconProps
   explorerUrl?: string
   marketShare?: number
@@ -20,32 +20,32 @@ export type MarketCompositionRow = TableItem & {
   price?: number
 }
 
-const columnHelper = createColumnHelper<MarketCompositionRow>()
+const columnHelper = createColumnHelper<PoolCompositionRow>()
 
 const headers = {
-  [MarketCompositionColumnId.Asset]: t`Asset`,
-  [MarketCompositionColumnId.Price]: t`Price`,
-  [MarketCompositionColumnId.MarketShare]: t`% of Market`,
-  [MarketCompositionColumnId.TokenAmount]: t`Amount`,
+  [PoolCompositionColumnId.Asset]: t`Asset`,
+  [PoolCompositionColumnId.Price]: t`Price`,
+  [PoolCompositionColumnId.MarketShare]: t`% of Market`,
+  [PoolCompositionColumnId.TokenAmount]: t`Amount`,
 } as const
 
-export const MARKET_COMPOSITION_MOBILE_COLUMN_VISIBILITY = {
-  [MarketCompositionColumnId.Asset]: true,
-  [MarketCompositionColumnId.Price]: false,
-  [MarketCompositionColumnId.MarketShare]: true,
-  [MarketCompositionColumnId.TokenAmount]: true,
+export const POOL_COMPOSITION_MOBILE_COLUMN_VISIBILITY = {
+  [PoolCompositionColumnId.Asset]: true,
+  [PoolCompositionColumnId.Price]: false,
+  [PoolCompositionColumnId.MarketShare]: true,
+  [PoolCompositionColumnId.TokenAmount]: true,
 } satisfies VisibilityState
 
-export const MARKET_COMPOSITION_COLUMNS = [
+export const POOL_COMPOSITION_COLUMNS = [
   columnHelper.accessor('source', {
-    id: MarketCompositionColumnId.Asset,
-    header: headers[MarketCompositionColumnId.Asset],
+    id: PoolCompositionColumnId.Asset,
+    header: headers[PoolCompositionColumnId.Asset],
     cell: ({ getValue, row }) => <TokenCell source={getValue()} explorerUrl={row.original.explorerUrl} />,
     enableSorting: false,
   }),
   columnHelper.accessor('price', {
-    id: MarketCompositionColumnId.Price,
-    header: headers[MarketCompositionColumnId.Price],
+    id: PoolCompositionColumnId.Price,
+    header: headers[PoolCompositionColumnId.Price],
     cell: ({ getValue }) => (
       <InlineTableCell>
         <Typography>{formatNumber(getValue(), 'usd.amount')}</Typography>
@@ -55,8 +55,8 @@ export const MARKET_COMPOSITION_COLUMNS = [
     meta: { type: 'numeric' },
   }),
   columnHelper.accessor('marketShare', {
-    id: MarketCompositionColumnId.MarketShare,
-    header: headers[MarketCompositionColumnId.MarketShare],
+    id: PoolCompositionColumnId.MarketShare,
+    header: headers[PoolCompositionColumnId.MarketShare],
     cell: ({ getValue }) => (
       <InlineTableCell>
         <Typography>{formatNumber(getValue(), 'percent.rate')}</Typography>
@@ -66,8 +66,8 @@ export const MARKET_COMPOSITION_COLUMNS = [
     meta: { type: 'numeric' },
   }),
   columnHelper.accessor('amount', {
-    id: MarketCompositionColumnId.TokenAmount,
-    header: headers[MarketCompositionColumnId.TokenAmount],
+    id: PoolCompositionColumnId.TokenAmount,
+    header: headers[PoolCompositionColumnId.TokenAmount],
     cell: ({ getValue, row }) => {
       const symbol = row.original.source.primary
 

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.enum.ts
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.enum.ts
@@ -1,4 +1,4 @@
-export enum MarketCompositionColumnId {
+export enum PoolCompositionColumnId {
   Asset = 'asset',
   Price = 'price',
   MarketShare = 'marketShare',

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.enum.ts
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/columns/columns.enum.ts
@@ -1,6 +1,6 @@
 export enum PoolCompositionColumnId {
   Asset = 'asset',
   Price = 'price',
-  MarketShare = 'marketShare',
+  Balance = 'balance',
   TokenAmount = 'tokenAmount',
 }

--- a/apps/main/src/dex/features/advanced-details/components/pool-composition/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/components/pool-composition/index.tsx
@@ -7,15 +7,15 @@ import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
-import { useMarketComposition } from '../../hooks/useMarketComposition'
+import { usePoolComposition } from '../../hooks/usePoolComposition'
 import {
-  MARKET_COMPOSITION_COLUMNS,
-  MARKET_COMPOSITION_MOBILE_COLUMN_VISIBILITY,
-  type MarketCompositionRow,
+  POOL_COMPOSITION_COLUMNS,
+  POOL_COMPOSITION_MOBILE_COLUMN_VISIBILITY,
+  type PoolCompositionRow,
 } from './columns/columns.definitions'
 import { FooterRow } from './FooterRow'
 
-export const MarketComposition = ({
+export const PoolComposition = ({
   chainId,
   poolDataCacheOrApi,
   poolId,
@@ -27,7 +27,7 @@ export const MarketComposition = ({
   pricesApiPoolData?: PricesApiPool
 }) => {
   const isMobile = useIsMobile()
-  const { isLoading, rows, totalUsd } = useMarketComposition({
+  const { isLoading, rows, totalUsd } = usePoolComposition({
     chainId,
     poolDataCacheOrApi,
     poolId,
@@ -35,15 +35,15 @@ export const MarketComposition = ({
   })
   const table = useTable({
     data: rows,
-    columns: MARKET_COMPOSITION_COLUMNS,
-    state: { columnVisibility: isMobile ? MARKET_COMPOSITION_MOBILE_COLUMN_VISIBILITY : undefined },
+    columns: POOL_COMPOSITION_COLUMNS,
+    state: { columnVisibility: isMobile ? POOL_COMPOSITION_MOBILE_COLUMN_VISIBILITY : undefined },
     ...getTableOptions(rows),
   })
 
   return (
     <Stack>
-      <CardHeader title={t`Market Composition`} size="small" />
-      <DataTable<MarketCompositionRow>
+      <CardHeader title={t`Pool Composition`} size="small" />
+      <DataTable<PoolCompositionRow>
         table={table}
         isLoading={isLoading}
         disableStickyHeader

--- a/apps/main/src/dex/features/advanced-details/hooks/usePoolComposition.ts
+++ b/apps/main/src/dex/features/advanced-details/hooks/usePoolComposition.ts
@@ -6,9 +6,9 @@ import { getChainPoolIdActiveKey } from '@/dex/utils'
 import type { Pool as PricesApiPool } from '@curvefi/prices-api/pools'
 import { maybe } from '@primitives/objects.utils'
 import { scanTokenPath } from '@ui/utils'
-import type { MarketCompositionRow } from '../components/market-composition/columns/columns.definitions'
+import type { PoolCompositionRow } from '../components/pool-composition/columns/columns.definitions'
 
-export const useMarketComposition = ({
+export const usePoolComposition = ({
   chainId,
   poolDataCacheOrApi,
   poolId,
@@ -42,7 +42,7 @@ export const useMarketComposition = ({
       })
     : currencyReserves?.tokens
 
-  const rows: MarketCompositionRow[] = poolDataCacheOrApi.tokens
+  const rows: PoolCompositionRow[] = poolDataCacheOrApi.tokens
     .map((symbol, index) => {
       const tokenAddress = poolDataCacheOrApi.tokenAddresses[index]
       const reserve = reserves?.find(token => token.tokenAddress.toLowerCase() === tokenAddress.toLowerCase())

--- a/apps/main/src/dex/features/advanced-details/index.tsx
+++ b/apps/main/src/dex/features/advanced-details/index.tsx
@@ -19,10 +19,10 @@ import { cardContentSmallStyles } from '@ui-kit/themes/components/card-content'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { Alerts } from './components/Alerts'
 import { Contracts } from './components/Contracts'
-import { MarketComposition } from './components/market-composition'
 import { Metrics } from './components/Metrics'
 import { Parameters } from './components/Parameters'
 import { PointsCampaigns } from './components/points-campaigns'
+import { PoolComposition } from './components/pool-composition'
 import { YieldBreakdown } from './components/yield-breakdown'
 
 const { Spacing } = SizesAndSpaces
@@ -76,7 +76,7 @@ export const AdvancedDetails = ({
               poolId={resolvedPoolId}
               pricesApiPoolData={pricesApiPoolData}
             />
-            <MarketComposition
+            <PoolComposition
               chainId={chainId}
               poolDataCacheOrApi={poolDataCacheOrApi}
               poolId={resolvedPoolId}


### PR DESCRIPTION
1. Renames 'market composition' to 'pool composition' to prevent confusion with lending markets.
2. Renames '% of market' column to just 'balance'.