### PR TITLE
fix: setup borrow cap for collateral test

### DIFF
--- a/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
@@ -1,5 +1,6 @@
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { getActionValue } from '@cy/support/helpers/llamalend/action-info.helpers'
+import { setupLlv2BorrowingLiquidity } from '@cy/support/helpers/llamalend/borrow-cap.helpers'
 import {
   checkCurrentCollateral,
   getCollateralInput,
@@ -11,6 +12,7 @@ import { LOAN_TEST_MARKETS, oneLoanTestMarket } from '@cy/support/helpers/llamal
 import { LlammalendTestCase } from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import { setupTenderlyLoan } from '@cy/support/helpers/llamalend/loan-setup.helpers'
 import { createVirtualTestnet } from '@cy/support/helpers/tenderly'
+import { getRpcUrls } from '@cy/support/helpers/tenderly/vnet'
 import { skipTestsAfterFailure } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
 import { objectKeys } from '@primitives/objects.utils'
@@ -24,6 +26,8 @@ describe('Collateral forms', () => {
   testCases.forEach(
     ({
       borrow,
+      borrowedAddress,
+      borrowedDecimals,
       chainId,
       collateral,
       collateralAddress,
@@ -41,6 +45,7 @@ describe('Collateral forms', () => {
         const getVirtualNetwork = createVirtualTestnet(uuid => ({
           slug: `collateral-integration-${uuid}`,
           display_name: `CollateralIntegration (${uuid})`,
+          chain_id: chainId,
           fork_config: { block_number: 'latest' },
         }))
 
@@ -63,17 +68,28 @@ describe('Collateral forms', () => {
           />
         )
 
-        before(() =>
+        before(() => {
+          const vnet = getVirtualNetwork()
+          const { adminRpcUrl, publicRpcUrl } = getRpcUrls(vnet)
+
+          setupLlv2BorrowingLiquidity({
+            adminRpcUrl,
+            publicRpcUrl,
+            chainId,
+            controllerAddress,
+            borrowedAddress,
+            borrowedDecimals,
+          })
           setupTenderlyLoan({
-            vnet: getVirtualNetwork(),
+            vnet,
             userAddress: address,
             collateralAddress,
             controllerAddress,
             collateral,
             collateralDecimals,
             borrow,
-          }),
-        )
+          })
+        })
 
         beforeEach(() => {
           onPricesUpdated = cy.stub().as('onPricesUpdated')

--- a/tests/cypress/component/llamalend/loan.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/loan.rpc.cy.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { BigNumber } from 'bignumber.js'
-import { parseUnits } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { checkCurrentDebt, checkDebt } from '@cy/support/helpers/llamalend/action-info.helpers'
-import { setControllerBorrowCap } from '@cy/support/helpers/llamalend/borrow-cap.helpers'
+import { setupLlv2BorrowingLiquidity } from '@cy/support/helpers/llamalend/borrow-cap.helpers'
 import {
   checkBorrowMoreDetailsLoaded,
   submitBorrowMoreForm,
@@ -38,7 +37,6 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { recordValues } from '@primitives/objects.utils'
 import { getLib } from '@ui-kit/features/connect-wallet'
 import { LlamaMarketType } from '@ui-kit/types/market'
-import { Chain } from '@ui-kit/utils'
 import { waitFor } from '@ui-kit/utils/time.utils'
 
 const testCases = recordValues(LlamaMarketType).map(marketType => oneLoanTestMarket(marketType))
@@ -107,26 +105,14 @@ testCases.forEach(
         const vnet = getVirtualNetwork()
         const { adminRpcUrl: nextAdminRpcUrl, publicRpcUrl } = getRpcUrls(vnet)
         adminRpcUrl = nextAdminRpcUrl
-        if (chainId === Chain.Optimism) {
-          const borrowedLiquidity = '10' as const
-          // keep the borrow cap above existing fork debt, otherwise LLv2 max_borrowable returns 0.
-          const borrowCap = '1000' as const
-
-          setControllerBorrowCap({
-            adminRpcUrl,
-            publicRpcUrl,
-            controllerAddress,
-            borrowCap,
-            availableBalance: borrowedLiquidity,
-            borrowedDecimals,
-          })
-          fundErc20({
-            adminRpcUrl,
-            amountWei: `0x${parseUnits(borrowedLiquidity, borrowedDecimals).toString(16)}`,
-            tokenAddress: borrowedAddress,
-            recipientAddresses: [controllerAddress],
-          })
-        }
+        setupLlv2BorrowingLiquidity({
+          adminRpcUrl,
+          publicRpcUrl,
+          chainId,
+          controllerAddress,
+          borrowedAddress,
+          borrowedDecimals,
+        })
       })
 
       beforeEach(() => {

--- a/tests/cypress/support/helpers/llamalend/borrow-cap.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/borrow-cap.helpers.ts
@@ -2,7 +2,8 @@ import { type Address, createPublicClient, encodeFunctionData, http, parseAbi, p
 import { sendAdminTransaction } from '@cy/support/helpers/tenderly/vnet-tx'
 import { LOAD_TIMEOUT } from '@cy/support/ui'
 import type { Decimal } from '@primitives/decimal.utils'
-import { fundEth } from '../tenderly/vnet-fund'
+import { Chain } from '@ui-kit/utils'
+import { fundErc20, fundEth } from '../tenderly/vnet-fund'
 
 const CONTROLLER_V2_ABI = parseAbi([
   'function configurator() view returns (address)',
@@ -78,4 +79,40 @@ export const setControllerBorrowCap = ({
         }),
       ),
   )
+}
+
+export const setupLlv2BorrowingLiquidity = ({
+  adminRpcUrl,
+  publicRpcUrl,
+  chainId,
+  controllerAddress,
+  borrowedAddress,
+  borrowedDecimals,
+}: {
+  adminRpcUrl: string
+  publicRpcUrl: string
+  chainId: Chain
+  controllerAddress: Address
+  borrowedAddress: Address
+  borrowedDecimals: number
+}) => {
+  if (chainId !== Chain.Optimism) return
+
+  const borrowedLiquidity = '10' as const
+  const borrowCap = '1000' as const
+
+  setControllerBorrowCap({
+    adminRpcUrl,
+    publicRpcUrl,
+    controllerAddress,
+    borrowCap,
+    availableBalance: borrowedLiquidity,
+    borrowedDecimals,
+  })
+  fundErc20({
+    adminRpcUrl,
+    amountWei: `0x${parseUnits(borrowedLiquidity, borrowedDecimals).toString(16)}`,
+    tokenAddress: borrowedAddress,
+    recipientAddresses: [controllerAddress],
+  })
 }


### PR DESCRIPTION
- the collateral test [breaks](https://github.com/curvefi/curve-frontend/actions/runs/27952530947) for llv2 due to lack of borrow cap
- extracted the necessary code from loan test into shared helper, and reused it