### PR TITLE
refactor: cleanup market params

### DIFF
--- a/apps/main/src/lend/components/ChartAndActivityComp/index.tsx
+++ b/apps/main/src/lend/components/ChartAndActivityComp/index.tsx
@@ -1,27 +1,34 @@
 import { useOhlcChartState } from '@/lend/hooks/useOhlcChartState'
 import { networks } from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
-import { getBandsChartToken } from '@/llamalend/features/bands-chart/bands-chart.utils'
 import { useBandsData } from '@/llamalend/features/bands-chart/hooks/useBandsData'
-import { getAmmAddress } from '@/llamalend/llama.utils'
 import { ChartAndActivityLayout } from '@/llamalend/widgets/ChartAndActivityLayout'
-import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { getBlockchainId } from '@curvefi/prices-api'
-import type { Token } from '@primitives/address.utils'
+import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useBandsChartVisible } from '@ui-kit/hooks/useLocalStorage'
 import type { Range } from '@ui-kit/types/util'
 
 type ChartAndActivityCompProps = {
   rChainId: ChainId
-  market: LendMarketTemplate | undefined
+  marketId: string | undefined
   previewPrices: Range<Decimal> | undefined
+  collateralToken: { address: Address; symbol: string } | undefined
+  borrowToken: { address: Address; symbol: string } | undefined
+  ammAddress: Address | undefined
+  controllerAddress: Address | undefined
 }
 
-export const ChartAndActivityComp = ({ rChainId, market, previewPrices }: ChartAndActivityCompProps) => {
+export const ChartAndActivityComp = ({
+  rChainId,
+  marketId,
+  previewPrices,
+  collateralToken,
+  borrowToken,
+  ammAddress,
+  controllerAddress,
+}: ChartAndActivityCompProps) => {
   const [isBandsVisible] = useBandsChartVisible()
-  const collateralTokenAddress = market?.collateral_token.address
-  const borrowedTokenAddress = market?.borrowed_token.address
   const networkConfig = networks[rChainId]
   const {
     isLoading: isChartLoading,
@@ -29,7 +36,13 @@ export const ChartAndActivityComp = ({ rChainId, market, previewPrices }: ChartA
     setTimeOption,
     legendSets,
     ohlcChartProps,
-  } = useOhlcChartState({ rChainId, market, previewPrices })
+  } = useOhlcChartState({
+    rChainId,
+    marketId,
+    previewPrices,
+    controllerAddress,
+    ammAddress,
+  })
 
   const {
     chartData,
@@ -37,12 +50,11 @@ export const ChartAndActivityComp = ({ rChainId, market, previewPrices }: ChartA
     oraclePrice,
     isLoading: isBandsLoading,
     error: bandsError,
-  } = useBandsData({ chainId: rChainId, marketId: market?.id, enabled: isBandsVisible })
-
-  const collateralToken = getBandsChartToken(collateralTokenAddress, market?.collateral_token.symbol) as
-    | Token
-    | undefined
-  const borrowToken = getBandsChartToken(borrowedTokenAddress, market?.borrowed_token.symbol) as Token | undefined
+  } = useBandsData({
+    chainId: rChainId,
+    marketId,
+    enabled: isBandsVisible,
+  })
 
   return (
     <ChartAndActivityLayout
@@ -64,7 +76,7 @@ export const ChartAndActivityComp = ({ rChainId, market, previewPrices }: ChartA
       }}
       activity={{
         network: getBlockchainId(networkConfig?.id),
-        ammAddress: getAmmAddress(market),
+        ammAddress,
         collateralToken,
         borrowToken,
         endpoint: 'lending',

--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -3,9 +3,10 @@ import { networks } from '@/lend/networks'
 import { PageContentProps } from '@/lend/types/lend.types'
 import { AdvancedDetails, MarketInfoLayout } from '@/llamalend/features/market-advanced-information'
 import { MarketFaq } from '@/llamalend/features/market-faq'
+import { getAmmAddress, getControllerAddress, getTokens } from '@/llamalend/llama.utils'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { MarketRateCurveChart } from '@/llamalend/widgets/MarketRateCurveChart'
-import type { Chain } from '@curvefi/prices-api'
+import { getBlockchainId } from '@curvefi/prices-api'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
@@ -26,34 +27,53 @@ type MarketInformationCompProps = {
  * Reusable component for OHLC charts, Bands (if applicable), and market parameters, used in market and vault pages.
  */
 export const MarketInformationComposite = ({ pageProps, rateType, previewPrices }: MarketInformationCompProps) => {
-  const { rChainId, marketId, market } = pageProps
-  const isBorrow = rateType === MarketRateType.Borrow
-  const blockchainId = networks[rChainId].id as Chain
-
+  const { rChainId, market } = pageProps
+  const blockchainId = getBlockchainId(networks[rChainId].id)
+  const controllerAddress = getControllerAddress(market)
+  const { collateralToken, borrowToken } = getTokens(market) ?? {}
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
-      {isBorrow && <ChartAndActivityComp rChainId={rChainId} market={market} previewPrices={previewPrices} />}
-      {isBorrow && (
-        <MarketHistoricalRatesChart
-          market={market}
-          blockchainId={blockchainId}
-          chainId={rChainId}
-          marketId={marketId}
-          rateMode={MarketRateType.Borrow}
-        />
+      {rateType === MarketRateType.Borrow && (
+        <>
+          <ChartAndActivityComp
+            rChainId={rChainId}
+            marketId={market?.id}
+            previewPrices={previewPrices}
+            controllerAddress={controllerAddress}
+            ammAddress={getAmmAddress(market)}
+            borrowToken={borrowToken}
+            collateralToken={collateralToken}
+          />
+          <MarketHistoricalRatesChart
+            marketType={LlamaMarketType.Lend}
+            controllerAddress={controllerAddress}
+            blockchainId={blockchainId}
+            chainId={rChainId}
+            marketId={market?.id}
+            rateMode={MarketRateType.Borrow}
+          />
+        </>
       )}
       <MarketHistoricalRatesChart
-        market={market}
+        marketType={LlamaMarketType.Lend}
+        controllerAddress={controllerAddress}
         blockchainId={blockchainId}
         chainId={rChainId}
-        marketId={marketId}
+        marketId={market?.id}
         rateMode={MarketRateType.Supply}
       />
-      <MarketRateCurveChart market={market} blockchainId={blockchainId} chainId={rChainId} marketId={marketId} />
+      <MarketRateCurveChart
+        collateralToken={collateralToken}
+        borrowToken={borrowToken}
+        controllerAddress={controllerAddress}
+        blockchainId={blockchainId}
+        chainId={rChainId}
+        marketId={market?.id}
+      />
       <Card size="small">
         <CardHeader title={t`Advanced Details`} />
         <CardContent component={Stack}>
-          <AdvancedDetails chainId={rChainId} marketId={marketId} market={market} marketType={LlamaMarketType.Lend} />
+          <AdvancedDetails chainId={rChainId} marketId={market?.id} market={market} marketType={LlamaMarketType.Lend} />
           <MarketInfoLayout
             chainId={rChainId}
             marketType={LlamaMarketType.Lend}

--- a/apps/main/src/lend/components/PageLendMarket/CreateLoanTabs.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/CreateLoanTabs.tsx
@@ -3,6 +3,7 @@ import { type MarketUrlParams, type PageContentProps } from '@/lend/types/lend.t
 import { CreateLoanForm } from '@/llamalend/features/borrow/components/CreateLoanForm'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import type { Range } from '@ui-kit/types/util'
 import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
 
@@ -15,7 +16,13 @@ const menu = [
     value: 'create',
     label: t`Borrow`,
     component: ({ market, rChainId, onPricesUpdated }: CreateLoanProps) => (
-      <CreateLoanForm networks={networks} chainId={rChainId} market={market} onPricesUpdated={onPricesUpdated} />
+      <CreateLoanForm
+        networks={networks}
+        chainId={rChainId}
+        market={market}
+        onPricesUpdated={onPricesUpdated}
+        marketType={LlamaMarketType.Lend}
+      />
     ),
   },
 ] satisfies FormTab<CreateLoanProps>[]

--- a/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
@@ -15,7 +15,7 @@ import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { getBlockchainId } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useCurve } from '@ui-kit/features/connect-wallet'
+import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -65,7 +65,7 @@ export const LendMarketPage = () => {
   const error = marketError
   return error ? (
     <ErrorPage title={t`Error`} subtitle={error.message} continueUrl={getCollateralListPathname(params)} />
-  ) : (
+  ) : userAddress ? (
     <DetailPageLayout
       formTabs={
         !!market &&
@@ -103,5 +103,7 @@ export const LendMarketPage = () => {
         previewPrices={previewPrices}
       />
     </DetailPageLayout>
+  ) : (
+    <ConnectWalletPrompt description={t`Connect your wallet to view market`} testId="btn-connect-prompt" />
   )
 }

--- a/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketInformationComposite } from '@/lend/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/lend/components/PageLendMarket/CreateLoanTabs'
-import { ManageLoanTabs } from '@/lend/components/PageLendMarket/ManageLoanTabs'
+import { type LendManageLoanProps, ManageLoanTabs } from '@/lend/components/PageLendMarket/ManageLoanTabs'
 import { useLendPageTitle } from '@/lend/hooks/useLendPageTitle'
 import { networks } from '@/lend/networks'
 import { type MarketUrlParams } from '@/lend/types/lend.types'
@@ -15,7 +15,7 @@ import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { getBlockchainId } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
-import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
+import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -28,56 +28,47 @@ import { CampaignRewardsBanner } from '../CampaignRewardsBanner'
 export const LendMarketPage = () => {
   const params = useParams<MarketUrlParams>()
   const { rMarket, rChainId: chainId } = parseMarketParams(params)
-  const { data: market, isLoading: isMarketLoading, isSuccess } = useLendMarket(chainId, rMarket)
-  const { isHydrated, llamaApi: api = null, provider } = useCurve()
-  const marketId = market?.id ?? '' // todo: use market?.id directly everywhere since we pass the market too!
+  const { data: market, isLoading: isMarketLoading, error: marketError } = useLendMarket({ chainId, rMarket })
+  const { llamaApi: api = null, isInitialized } = useCurve()
   const { address: userAddress } = useConnection()
   useLendPageTitle(market?.collateral_token?.symbol ?? rMarket, t`Lend`)
 
   const network = networks[chainId]
-  const tokens = useMemo(() => getTokens(market) ?? {}, [market])
-  const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists(
-    {
-      chainId,
-      marketId,
-      userAddress,
-    },
-    !!market, // enable query as soon as market is defined, the validation suite isn't able to detect it otherwise
-  )
+  const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists({
+    chainId,
+    marketId: market?.id,
+    userAddress,
+  })
 
-  // eslint-disable-next-line @eslint-react/use-state -- Existing violation before enabling this rule.
-  const [previewPrices, onPricesUpdated] = useState<Range<Decimal> | undefined>(undefined)
-  const controllerAddress = getControllerAddress(market)
+  const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
+  const isLoading = !isInitialized || isMarketLoading
+
+  const tokens = useMemo(() => getTokens(market) ?? {}, [market])
   const collateralEvents = useUserCollateralEvents({
     app: LlamaMarketType.Lend,
     chain: getBlockchainId(network.id),
-    controllerAddress,
+    controllerAddress: getControllerAddress(market),
     userAddress,
     tokens,
     network,
   })
 
-  const pageProps = {
+  const pageProps: Omit<LendManageLoanProps, 'collateralEvents'> = {
     params,
     rChainId: chainId,
-    marketId,
     userAddress,
-    isLoaded: !!market,
     api,
     market,
-    onPricesUpdated,
+    onPricesUpdated: setPreviewPrices,
   }
 
-  return isSuccess && !market ? (
-    <ErrorPage
-      title="404"
-      subtitle={`${t`Market`} ${rMarket} ${t`Not Found`}`}
-      continueUrl={getCollateralListPathname(params)}
-    />
-  ) : provider ? (
+  const error = marketError
+  return error ? (
+    <ErrorPage title={t`Error`} subtitle={error.message} continueUrl={getCollateralListPathname(params)} />
+  ) : (
     <DetailPageLayout
       formTabs={
-        market &&
+        !!market &&
         !isLoanExistsLoading &&
         (loanExists ? (
           <ManageLoanTabs {...pageProps} collateralEvents={collateralEvents} />
@@ -89,8 +80,7 @@ export const LendMarketPage = () => {
         <MarketPageHeader
           blockchainId={network.id}
           chainId={chainId}
-          marketId={marketId}
-          isLoading={!isHydrated || isMarketLoading}
+          isLoading={isLoading}
           market={market}
           marketType={LlamaMarketType.Lend}
         />
@@ -105,7 +95,7 @@ export const LendMarketPage = () => {
         hasPosition={loanExists}
         events={collateralEvents}
         tokens={tokens}
-        params={{ chainId, marketId, userAddress }}
+        params={{ chainId, marketId: market?.id, userAddress }}
       />
       <MarketInformationComposite
         pageProps={pageProps}
@@ -113,7 +103,5 @@ export const LendMarketPage = () => {
         previewPrices={previewPrices}
       />
     </DetailPageLayout>
-  ) : (
-    <ConnectWalletPrompt description={t`Connect your wallet to view market`} />
   )
 }

--- a/apps/main/src/lend/components/PageLendMarket/ManageLoanTabs.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/ManageLoanTabs.tsx
@@ -11,10 +11,13 @@ import type { UserCollateralEvents } from '@/llamalend/features/user-position-hi
 import { Decimal } from '@primitives/decimal.utils'
 import { useLoanImplementationKey } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import type { QueryProp, Range } from '@ui-kit/types/util'
 import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
 
-type ManageLoanProps = PageContentProps<MarketUrlParams> & {
+const { Lend } = LlamaMarketType
+
+export type LendManageLoanProps = PageContentProps<MarketUrlParams> & {
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
   collateralEvents: QueryProp<UserCollateralEvents>
 }
@@ -23,15 +26,15 @@ const LendManageMenu = [
   {
     value: 'loan-increase',
     label: t`Borrow`,
-    component: ({ rChainId: chainId, ...props }: ManageLoanProps) => (
-      <BorrowMoreForm chainId={chainId} networks={networks} {...props} />
+    component: ({ rChainId: chainId, ...props }: LendManageLoanProps) => (
+      <BorrowMoreForm chainId={chainId} networks={networks} marketType={Lend} {...props} />
     ),
   },
   {
     value: 'loan-decrease',
     label: t`Repay`,
-    component: ({ rChainId: chainId, ...props }: ManageLoanProps) => (
-      <RepayForm chainId={chainId} networks={networks} {...props} />
+    component: ({ rChainId: chainId, ...props }: LendManageLoanProps) => (
+      <RepayForm chainId={chainId} networks={networks} marketType={Lend} {...props} />
     ),
   },
   {
@@ -41,20 +44,20 @@ const LendManageMenu = [
       {
         value: 'add',
         label: t`Add`,
-        component: ({ rChainId: chainId, ...props }: ManageLoanProps) => (
-          <AddCollateralForm networks={networks} chainId={chainId} {...props} />
+        component: ({ rChainId: chainId, ...props }: LendManageLoanProps) => (
+          <AddCollateralForm networks={networks} chainId={chainId} marketType={Lend} {...props} />
         ),
       },
       {
         value: 'remove',
         label: t`Remove`,
-        component: ({ rChainId: chainId, ...props }: ManageLoanProps) => (
-          <RemoveCollateralForm networks={networks} chainId={chainId} {...props} />
+        component: ({ rChainId: chainId, ...props }: LendManageLoanProps) => (
+          <RemoveCollateralForm networks={networks} chainId={chainId} marketType={Lend} {...props} />
         ),
       },
     ],
   },
-] satisfies FormTab<ManageLoanProps>[]
+] satisfies FormTab<LendManageLoanProps>[]
 
 const LendManageSoftLiquidationMenu = [
   {
@@ -64,25 +67,25 @@ const LendManageSoftLiquidationMenu = [
       {
         value: 'improve-health',
         label: t`Improve health`,
-        component: ({ rChainId: chainId, ...props }: ManageLoanProps) => (
-          <ImproveHealthForm chainId={chainId} networks={networks} {...props} />
+        component: ({ rChainId: chainId, ...props }: LendManageLoanProps) => (
+          <ImproveHealthForm chainId={chainId} networks={networks} marketType={Lend} {...props} />
         ),
       },
       {
         value: 'close-position',
         label: t`Close`,
-        component: ({ rChainId: chainId, market }: ManageLoanProps) => (
+        component: ({ rChainId: chainId, market }: LendManageLoanProps) => (
           <ClosePositionForm chainId={chainId} networks={networks} market={market} />
         ),
       },
     ],
   },
-] satisfies FormTab<ManageLoanProps>[]
+] satisfies FormTab<LendManageLoanProps>[]
 
-export const ManageLoanTabs = (params: ManageLoanProps) => {
+export const ManageLoanTabs = (params: LendManageLoanProps) => {
   const { data: status } = useLiquidationStatus({
     chainId: params.rChainId,
-    marketId: params.marketId,
+    marketId: params.market?.id,
     userAddress: params.userAddress,
   })
   const isSoftLiquidation = ['softLiquidation', 'hardLiquidation'].includes(status ?? '')

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -9,7 +9,7 @@ import { SupplyPositionDetails } from '@/llamalend/features/market-position-deta
 import { useUserShares } from '@/llamalend/queries/user/user-balances.query'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
-import { useCurve } from '@ui-kit/features/connect-wallet'
+import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -41,7 +41,7 @@ export const Page = () => {
       error={error}
       continueUrl={getCollateralListPathname(params)}
     />
-  ) : (
+  ) : userAddress ? (
     <DetailPageLayout
       formTabs={market && <VaultTabs {...pageProps} params={params} />}
       header={
@@ -69,5 +69,7 @@ export const Page = () => {
       )}
       <MarketInformationComposite pageProps={pageProps} rateType={MarketRateType.Supply} />
     </DetailPageLayout>
+  ) : (
+    <ConnectWalletPrompt description={t`Connect your wallet to view market`} testId="btn-connect-prompt" />
   )
 }

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -9,7 +9,7 @@ import { SupplyPositionDetails } from '@/llamalend/features/market-position-deta
 import { useUserShares } from '@/llamalend/queries/user/user-balances.query'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
-import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
+import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -21,39 +21,34 @@ import { CampaignRewardsBanner } from '../CampaignRewardsBanner'
 export const Page = () => {
   const params = useParams<MarketUrlParams>()
   const { rMarket, rChainId: chainId } = parseMarketParams(params)
-  const { llamaApi: api = null, provider, isHydrated } = useCurve()
-  const { data: market, isLoading: isMarketLoading, isSuccess } = useLendMarket(chainId, rMarket)
+  const { llamaApi: api = null, isInitialized } = useCurve()
+  const { data: market, isLoading: isMarketLoading, error: marketError } = useLendMarket({ chainId, rMarket })
   const network = networks[chainId]
   const { address: userAddress } = useConnection()
 
   useLendPageTitle(market?.collateral_token?.symbol, t`Supply`)
 
-  const pageProps: PageContentProps = {
-    params,
-    rChainId: chainId,
-    marketId: market?.id ?? '',
-    userAddress,
-    api,
-    market,
-  }
+  const isLoading = !isInitialized || isMarketLoading
+  const pageProps: PageContentProps = { params, rChainId: chainId, userAddress, api, market }
 
   const supplied = +(useUserShares({ marketId: market?.id, chainId, userAddress }).data?.value ?? 0)
 
-  return isSuccess && !market ? (
+  const error = marketError
+  return error ? (
     <ErrorPage
-      title="404"
-      subtitle={`${t`Market`} ${rMarket} ${t`Not Found`}`}
+      title={t`Error`}
+      subtitle={error.message}
+      error={error}
       continueUrl={getCollateralListPathname(params)}
     />
-  ) : provider ? (
+  ) : (
     <DetailPageLayout
-      formTabs={chainId && <VaultTabs {...pageProps} params={params} />}
+      formTabs={market && <VaultTabs {...pageProps} params={params} />}
       header={
         <MarketPageHeader
           blockchainId={network.id}
           chainId={chainId}
-          marketId={market?.id}
-          isLoading={!isHydrated || isMarketLoading}
+          isLoading={isLoading}
           market={market}
           marketType={LlamaMarketType.Lend}
         />
@@ -74,7 +69,5 @@ export const Page = () => {
       )}
       <MarketInformationComposite pageProps={pageProps} rateType={MarketRateType.Supply} />
     </DetailPageLayout>
-  ) : (
-    <ConnectWalletPrompt description={t`Connect your wallet to view market`} />
   )
 }

--- a/apps/main/src/lend/hooks/useLendMarket.ts
+++ b/apps/main/src/lend/hooks/useLendMarket.ts
@@ -1,29 +1,28 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useLLv2 } from '@ui-kit/hooks/useFeatureFlags'
+import { t } from '@ui-kit/lib/i18n'
 import { useMappedQuery } from '@ui-kit/types/util'
 import { useLendMarkets } from '../queries/lend-markets.query'
 import { ChainId } from '../types/lend.types'
 
-export function useLendMarketData(chainId: ChainId, rMarket: string, enabled?: boolean) {
+export function useLendMarketData(chainId: ChainId, marketId: string, enabled?: boolean) {
   const lendMarkets = useLendMarkets({ chainId, enableLLv2: useLLv2() }, enabled)
-  return {
-    ...useMappedQuery(
-      lendMarkets,
-      useCallback(data => data?.[rMarket], [rMarket]),
-    ),
-    isSuccess: lendMarkets.isSuccess,
-  }
+  const lendMarket = useMappedQuery(
+    lendMarkets,
+    useCallback(data => data?.[marketId], [marketId]),
+  )
+  const error = useMemo(
+    () => lendMarkets.data && !lendMarket.data && new Error(`${t`Market`} ${marketId} ${t`Not Found`}`),
+    [lendMarket.data, lendMarkets.data, marketId],
+  )
+  return { ...lendMarket, ...(error && { error }) }
 }
 
-export const useLendMarket = (chainId: ChainId, rMarket: string, enabled?: boolean) => {
+export const useLendMarket = ({ rMarket, chainId }: { chainId: ChainId; rMarket: string }, enabled?: boolean) => {
   const { llamaApi: api } = useCurve()
-  const lendMarketData = useLendMarketData(chainId, rMarket, enabled)
-  return {
-    ...useMappedQuery(
-      lendMarketData,
-      useCallback(data => api && data && api.getLendMarketByData(data.id, data), [api]),
-    ),
-    isSuccess: lendMarketData.isSuccess && !!api,
-  }
+  return useMappedQuery(
+    useLendMarketData(chainId, rMarket, enabled),
+    useCallback(data => api && data && api.getLendMarketByData(data.id, data), [api]),
+  )
 }

--- a/apps/main/src/lend/hooks/useOhlcChartState.ts
+++ b/apps/main/src/lend/hooks/useOhlcChartState.ts
@@ -2,37 +2,41 @@ import { useConnection } from 'wagmi'
 import { networks } from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
 import { useLlammaOhlcChartStateModel } from '@/llamalend/hooks/useLlammaOhlcChartStateModel'
-import { getAmmAddress, getControllerAddress } from '@/llamalend/llama.utils'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useUserPrices } from '@/llamalend/queries/user'
-import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
-import { getBlockchainId } from '@curvefi/prices-api'
+import { isPricesApiChain } from '@curvefi/prices-api'
+import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { Range } from '@ui-kit/types/util'
 
 type UseOhlcChartStateProps = {
   rChainId: ChainId
-  market: LendMarketTemplate | undefined
+  marketId: string | undefined
   previewPrices: Range<Decimal> | undefined
+  controllerAddress: Address | undefined
+  ammAddress: Address | undefined
 }
 
-export const useOhlcChartState = ({ rChainId, market, previewPrices }: UseOhlcChartStateProps) => {
+export const useOhlcChartState = ({
+  rChainId,
+  marketId,
+  previewPrices,
+  ammAddress,
+  controllerAddress,
+}: UseOhlcChartStateProps) => {
   const { address: userAddress } = useConnection()
-  const { data: userPrices } = useUserPrices({
-    chainId: rChainId,
-    marketId: market?.id,
-    userAddress,
-  })
-  const { data: oraclePrice } = useMarketOraclePrice({ chainId: rChainId, marketId: market?.id })
+  const { data: userPrices } = useUserPrices({ chainId: rChainId, marketId, userAddress })
+  const { data: oraclePrice } = useMarketOraclePrice({ chainId: rChainId, marketId })
+  const networkId = networks[rChainId].id.toLowerCase()
+  const network = isPricesApiChain(networkId) ? networkId : undefined
   return useLlammaOhlcChartStateModel({
     endpoint: 'lending',
     chainKey: rChainId,
-    marketId: market?.id,
-    network: getBlockchainId(networks[rChainId].id),
-    controllerAddress: getControllerAddress(market),
-    llammaAddress: getAmmAddress(market),
+    marketId,
+    network,
+    controllerAddress,
+    llammaAddress: ammAddress,
     oraclePrice,
-    enabled: !!market,
     userPrices,
     previewPrices,
   })

--- a/apps/main/src/lend/types/lend.types.ts
+++ b/apps/main/src/lend/types/lend.types.ts
@@ -30,7 +30,6 @@ export type NetworkConfig<TId extends string = string, TChainId extends number =
 export type PageContentProps<T = UrlParams> = {
   params: T
   rChainId: ChainId
-  marketId: string
   userAddress: Address | undefined
   api: LlamaApi | null
   market: LendMarketTemplate | undefined

--- a/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
@@ -1,5 +1,6 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
+import { getControllerAddress } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { useBorrowMoreExpectedCollateral } from '@/llamalend/queries/borrow-more/borrow-more-expected-collateral.query'
 import { useBorrowMoreFutureLeverage } from '@/llamalend/queries/borrow-more/borrow-more-future-leverage.query'
@@ -19,6 +20,7 @@ import { type Token } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { UseFormReturn } from '@ui-kit/features/forms'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { mapQuery, q } from '@ui-kit/types/util'
 import { decimalSum } from '@ui-kit/utils'
 import { getLeverageInfoFields } from '../../../widgets/action-card/hooks/getLeverageInfoFields'
@@ -32,6 +34,7 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   leverageEnabled,
   form,
   market,
+  marketType,
   routes,
 }: {
   params: BorrowMoreParams<ChainId>
@@ -39,6 +42,7 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
   networks: NetworkDict<ChainId>
   market: LlamaMarketTemplate | undefined
+  marketType: LlamaMarketType
   onSlippageChange: (newSlippage: Decimal) => void
   leverageEnabled: boolean | undefined
   form: UseFormReturn<BorrowMoreForm>
@@ -90,7 +94,10 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
         priceImpact: useBorrowMorePriceImpact(params, isOpen),
         collateralDelta,
       })}
-      {...useBorrowRates({ params, market, debtDelta: debt }, isOpen)}
+      {...useBorrowRates(
+        { params, marketType, controllerAddress: getControllerAddress(market), debtDelta: debt },
+        isOpen,
+      )}
       {...prevLoanState}
     />
   )

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -1,6 +1,7 @@
 import { type ChangeEvent, useCallback } from 'react'
+import { useConnection } from 'wagmi'
 import { LoanPreset, LEVERAGE } from '@/llamalend/constants'
-import { hasLeverage } from '@/llamalend/llama.utils'
+import { getControllerAddress, hasLeverage } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
@@ -10,11 +11,13 @@ import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { joinButtonText } from '@primitives/string.utils'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { useCreateLoanPreset } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { AlertDisableForm } from '@ui-kit/shared/ui/AlertDisableForm'
 import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type Range } from '@ui-kit/types/util'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts, HighPriceImpactAlert } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
@@ -38,12 +41,15 @@ export const CreateLoanForm = <ChainId extends IChainId>({
   networks,
   chainId,
   onPricesUpdated,
+  marketType,
 }: {
   market: LlamaMarketTemplate | undefined
   networks: NetworkDict<ChainId>
   chainId: ChainId
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
+  marketType: LlamaMarketType
 }) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
   const [preset, setPreset] = useCreateLoanPreset<LoanPreset>(LoanPreset.Safe)
   const {
@@ -87,7 +93,8 @@ export const CreateLoanForm = <ChainId extends IChainId>({
       onSubmit={onSubmit}
       footer={
         <CreateLoanInfoList
-          market={market}
+          marketType={marketType}
+          controllerAddress={getControllerAddress(market)}
           form={form}
           params={params}
           values={values}
@@ -128,7 +135,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
               tooltip={t`Max borrow`}
               symbol={borrowToken?.symbol}
               balance={maxDebt.data}
-              loading={maxDebt.isLoading}
+              loading={isConnected && maxDebt.isLoading} // TODO: maxDebt.isLoading is always true when !market even without wallet.
               onClick={useCallback(() => updateForm({ debt: values.maxDebt }), [updateForm, values.maxDebt])}
               buttonTestId="borrow-set-debt-to-max"
             />
@@ -158,12 +165,16 @@ export const CreateLoanForm = <ChainId extends IChainId>({
       </LoanPresetSelector>
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(maxLeverage)} slippageType={LEVERAGE} />
       <HighLiquidationRiskAlert isHighLiquidationRisk={isHighLiquidationRisk} />
-      {disabledAlert ? (
-        <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+      {isConnected ? (
+        disabledAlert ? (
+          <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+        ) : (
+          <Button type="submit" loading={isLoading} disabled={isDisabled} data-testid="create-loan-submit-button">
+            {isPending ? t`Processing...` : joinButtonText(isApproved?.data === false && t`Approve`, t`Borrow`)}
+          </Button>
+        )
       ) : (
-        <Button type="submit" loading={isLoading} disabled={isDisabled} data-testid="create-loan-submit-button">
-          {isPending ? t`Processing...` : joinButtonText(isApproved?.data === false && t`Approve`, t`Borrow`)}
-        </Button>
+        <ConnectWalletButton />
       )}
       <LowSolvencyActionModal
         action="borrow"

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
@@ -1,11 +1,12 @@
 import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
-import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
+import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useCreateLoanIsApproved } from '@/llamalend/queries/create-loan/create-loan-approved.query'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { type Token } from '@primitives/address.utils'
+import { type Address, type Token } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { UseFormReturn } from '@ui-kit/features/forms'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ, mapQuery, q } from '@ui-kit/types/util'
 import { useCreateLoanEstimateGas } from '../../../queries/create-loan/create-loan-estimate-gas.query'
 import { useCreateLoanExpectedCollateral } from '../../../queries/create-loan/create-loan-expected-collateral.query'
@@ -19,7 +20,8 @@ import { useLoanToValue } from '../hooks/useLoanToValue'
 import { type CreateLoanForm, type CreateLoanFormQueryParams } from '../types'
 
 export const CreateLoanInfoList = <ChainId extends IChainId>({
-  market,
+  marketType,
+  controllerAddress,
   params,
   values: { slippage, leverageEnabled, userCollateral, debt },
   collateralToken,
@@ -29,7 +31,8 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
   onSlippageChange,
   form,
 }: {
-  market: LlamaMarketTemplate | undefined
+  marketType: LlamaMarketType
+  controllerAddress: Address | undefined
   params: CreateLoanFormQueryParams<ChainId>
   values: CreateLoanForm
   collateralToken: Token | undefined
@@ -71,7 +74,7 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
         leverageTotalCollateral: mapQuery(expectedCollateral, data => data.totalCollateral),
         expected: expectedCollateral,
       })}
-      {...useBorrowRates({ params, market, debtDelta: debt }, isOpen)}
+      {...useBorrowRates({ params, marketType, controllerAddress, debtDelta: debt }, isOpen)}
     />
   )
 }

--- a/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
 import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
-import { calculateReturnToWallet } from '@/llamalend/llama.utils'
+import { calculateReturnToWallet, getControllerAddress } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useRepayExpectedBorrowed } from '@/llamalend/queries/repay/repay-expected-borrowed.query'
@@ -22,6 +22,7 @@ import { type Token } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { UseFormReturn } from '@ui-kit/features/forms'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ, mapQuery, q, type Query, type QueryProp, type Range } from '@ui-kit/types/util'
 import { decimal, decimalMinus, decimalNegate } from '@ui-kit/utils'
 import { getLeverageInfoFields } from '../../../widgets/action-card/hooks/getLeverageInfoFields'
@@ -83,6 +84,7 @@ function useReturnToWallet(
 
 export function RepayLoanInfoList<ChainId extends IChainId>({
   market,
+  marketType,
   params,
   values: { slippage, stateCollateral, userCollateral, userBorrowed, isFull },
   tokens: { collateralToken, borrowToken },
@@ -95,6 +97,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   prevPrices,
 }: {
   market: LlamaMarketTemplate | undefined
+  marketType: LlamaMarketType
   params: RepayParams
   values: RepayFormData
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
@@ -164,7 +167,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
         priceImpact: useRepayPriceImpact(params, isOpen),
         collateralDelta: userCollateral,
       })}
-      {...useBorrowRates({ params, market, debtDelta }, isOpen)}
+      {...useBorrowRates({ params, marketType, controllerAddress: getControllerAddress(market), debtDelta }, isOpen)}
       {...prevLoanState}
     />
   )

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
@@ -8,64 +8,51 @@ import {
   useManualPagination,
   DEFAULT_PAGE_SIZE,
 } from '@ui-kit/features/activity-table'
+import { combineQueries } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { mapQuery, q } from '@ui-kit/types/util'
+import { fakeLoadingQ } from '@ui-kit/types/util'
 import { getPageCount } from '@ui-kit/utils'
 import { LlammaActivityProps } from '..'
 
 export const useLlammaActivityEventsConfig = ({
-  network,
+  network: chain,
   collateralToken,
   borrowToken,
-  ammAddress,
+  ammAddress: llamma,
   endpoint,
   networkConfig,
 }: LlammaActivityProps) => {
   const { eventsColumnVisibility } = useLlammaActivityVisibility()
-  const { pagination, onPaginationChange, apiPage } = useManualPagination()
+  const { pagination, onPaginationChange, apiPage: page } = useManualPagination()
 
-  const eventsQuery = useLlammaEvents({
-    chain: network,
-    llamma: ammAddress,
-    endpoint,
-    page: apiPage,
-    perPage: DEFAULT_PAGE_SIZE,
-  })
-
-  const pageCount = getPageCount(eventsQuery.data?.count, DEFAULT_PAGE_SIZE)
+  const eventsQuery = useLlammaEvents({ chain, llamma, endpoint, page, perPage: DEFAULT_PAGE_SIZE })
 
   // Transform events data with block explorer URLs
-  const eventsWithUrlsQuery = mapQuery(
-    eventsQuery,
+  const query = combineQueries(
+    [eventsQuery, fakeLoadingQ(llamma)],
     ({ events }) =>
-      network &&
+      chain &&
       events.map((event: LlammaEvent) => ({
         ...event,
         providerUrl: scanAddressPath(networkConfig, event.provider),
         txUrl: scanTxPath(networkConfig, event.txHash),
-        network,
+        network: chain,
         collateralToken,
         borrowToken,
       })),
   )
 
-  const table = useTable({
-    query: q({
-      data: eventsWithUrlsQuery.data,
-      isLoading: eventsWithUrlsQuery.isLoading || !ammAddress,
-      error: ammAddress ? eventsWithUrlsQuery.error : null,
-    }),
-    columns: LLAMMA_EVENTS_COLUMNS,
-    state: { columnVisibility: eventsColumnVisibility, pagination },
-    manualPagination: true,
-    pageCount,
-    onPaginationChange,
-    ...getTableOptions<LlammaEventRow>(eventsWithUrlsQuery.data),
-  })
-
   return {
-    table,
+    table: useTable({
+      query,
+      columns: LLAMMA_EVENTS_COLUMNS,
+      state: { columnVisibility: eventsColumnVisibility, pagination },
+      manualPagination: true,
+      pageCount: getPageCount(eventsQuery.data?.count, DEFAULT_PAGE_SIZE),
+      onPaginationChange,
+      ...getTableOptions<LlammaEventRow>(query.data),
+    }),
     emptyMessage: t`No activity data found.`,
     errorMessage: t`Could not load activity data.`,
   }

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityEventsConfig.ts
@@ -68,7 +68,7 @@ export const useLlammaActivityEventsConfig = ({
   return {
     table,
     isLoading: isEventsLoading || !ammAddress,
-    isError: isEventsError,
+    isError: isEventsError && !!ammAddress,
     emptyMessage: t`No activity data found.`,
     errorMessage: t`Could not load activity data.`,
   }

--- a/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
+++ b/apps/main/src/llamalend/features/llamma-activity/hooks/useLlammaActivityTradesConfig.ts
@@ -64,7 +64,7 @@ export const useLlammaActivityTradesConfig = ({
   return {
     table,
     isLoading: isTradesLoading || !ammAddress,
-    isError: isTradesError,
+    isError: isTradesError && !!ammAddress,
     emptyMessage: t`No swap data found.`,
     errorMessage: t`Could not load swap data.`,
   }

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
@@ -5,6 +5,7 @@ import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type Range } from '@ui-kit/types/util'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
@@ -16,11 +17,13 @@ export const AddCollateralForm = <ChainId extends IChainId>({
   networks,
   chainId,
   onPricesUpdated,
+  marketType,
 }: {
   market: LlamaMarketTemplate | undefined
   networks: NetworkDict<ChainId>
   chainId: ChainId
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
+  marketType: LlamaMarketType
 }) => {
   const network = networks[chainId]
 
@@ -53,6 +56,7 @@ export const AddCollateralForm = <ChainId extends IChainId>({
           borrowToken={borrowToken}
           networks={networks}
           market={market}
+          marketType={marketType}
         />
       }
     >

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralInfoList.tsx
@@ -1,6 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
+import { getControllerAddress } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { useAddCollateralFutureLeverage } from '@/llamalend/queries/add-collateral/add-collateral-future-leverage.query'
 import { useAddCollateralEstimateGas } from '@/llamalend/queries/add-collateral/add-collateral-gas-estimate.query'
@@ -16,6 +17,7 @@ import { LoanActionInfoList } from '@/llamalend/widgets/action-card/LoanActionIn
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { type Token } from '@primitives/address.utils'
 import type { UseFormReturn } from '@ui-kit/features/forms'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { mapQuery, q } from '@ui-kit/types/util'
 import { decimal } from '@ui-kit/utils'
 import { getLeverageInfoFields } from '../../../widgets/action-card/hooks/getLeverageInfoFields'
@@ -28,6 +30,7 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
   networks,
   form,
   market,
+  marketType,
 }: {
   params: CollateralParams<ChainId>
   values: CollateralForm
@@ -36,6 +39,7 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
   networks: NetworkDict<ChainId>
   form: UseFormReturn<CollateralForm>
   market: LlamaMarketTemplate | undefined
+  marketType: LlamaMarketType
 }) {
   const isOpen = form.isTouched('userCollateral')
   const prevLoanState = usePrevLoanState({ params, collateralToken, borrowToken }, isOpen)
@@ -75,7 +79,7 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
         collateralDelta: userCollateral,
       })}
       {...prevLoanState}
-      {...useBorrowRates({ params, market }, isOpen)}
+      {...useBorrowRates({ params, marketType, controllerAddress: getControllerAddress(market) }, isOpen)}
     />
   )
 }

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -17,6 +17,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { AlertDisableForm } from '@ui-kit/shared/ui/AlertDisableForm'
 import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type QueryProp, type Range } from '@ui-kit/types/util'
 import { isDevelopment } from '@ui-kit/utils'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
@@ -31,12 +32,14 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
   chainId,
   onPricesUpdated,
   collateralEvents,
+  marketType,
 }: {
   market: LlamaMarketTemplate | undefined
   networks: NetworkDict<ChainId>
   chainId: ChainId
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
   collateralEvents: QueryProp<UserCollateralEvents>
+  marketType: LlamaMarketType
 }) => {
   const network = networks[chainId]
   const {
@@ -89,6 +92,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           tokens={{ collateralToken, borrowToken }}
           networks={networks}
           routes={routes}
+          marketType={marketType}
           onSlippageChange={value => updateForm({ slippage: value })}
           leverageEnabled={values.leverageEnabled}
         />

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -6,6 +6,7 @@ import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type Range } from '@ui-kit/types/util'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
@@ -17,11 +18,13 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
   networks,
   chainId,
   onPricesUpdated,
+  marketType,
 }: {
   market: LlamaMarketTemplate | undefined
   networks: NetworkDict<ChainId>
   chainId: ChainId
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
+  marketType: LlamaMarketType
 }) => {
   const network = networks[chainId]
 
@@ -54,6 +57,7 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
           borrowToken={borrowToken}
           networks={networks}
           market={market}
+          marketType={marketType}
         />
       }
     >

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralInfoList.tsx
@@ -1,5 +1,6 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
+import { getControllerAddress } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useRemoveCollateralFutureLeverage } from '@/llamalend/queries/remove-collateral/remove-collateral-future-leverage.query'
@@ -15,6 +16,7 @@ import { LoanActionInfoList } from '@/llamalend/widgets/action-card/LoanActionIn
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { type Token } from '@primitives/address.utils'
 import type { UseFormReturn } from '@ui-kit/features/forms'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { mapQuery, q } from '@ui-kit/types/util'
 import { decimalMax, decimalMinus, decimalNegate } from '@ui-kit/utils'
 import { getLeverageInfoFields } from '../../../widgets/action-card/hooks/getLeverageInfoFields'
@@ -27,6 +29,7 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
   networks,
   form,
   market,
+  marketType,
 }: {
   params: CollateralParams<ChainId>
   values: CollateralForm
@@ -35,6 +38,7 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
   networks: NetworkDict<ChainId>
   form: UseFormReturn<CollateralForm>
   market: LlamaMarketTemplate | undefined
+  marketType: LlamaMarketType
 }) {
   const isOpen = form.isTouched('userCollateral')
   const prevLoanState = usePrevLoanState({ params, collateralToken, borrowToken }, isOpen)
@@ -74,7 +78,7 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
         collateralDelta: userCollateral && decimalNegate(userCollateral),
       })}
       {...prevLoanState}
-      {...useBorrowRates({ params, market }, isOpen)}
+      {...useBorrowRates({ params, marketType, controllerAddress: getControllerAddress(market) }, isOpen)}
     />
   )
 }

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -23,6 +23,7 @@ import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
 import { Balance } from '@ui-kit/shared/ui/LargeTokenInput/Balance'
 import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type QueryProp, type Range } from '@ui-kit/types/util'
 import { CRVUSD } from '@ui-kit/utils'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
@@ -69,6 +70,7 @@ export const RepayForm = <ChainId extends IChainId>({
   onPricesUpdated,
   collateralEvents,
   isInSoftLiquidation,
+  marketType,
 }: {
   market: LlamaMarketTemplate | undefined
   networks: NetworkDict<ChainId>
@@ -77,6 +79,7 @@ export const RepayForm = <ChainId extends IChainId>({
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
   collateralEvents: QueryProp<UserCollateralEvents>
   isInSoftLiquidation?: boolean
+  marketType: LlamaMarketType
 }) => {
   const network = networks[chainId]
   const {
@@ -141,6 +144,7 @@ export const RepayForm = <ChainId extends IChainId>({
       footer={
         <RepayLoanInfoList
           market={market}
+          marketType={marketType}
           form={form}
           params={params}
           values={values}

--- a/apps/main/src/llamalend/features/market-position-details/MarketEmptyPosition.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/MarketEmptyPosition.tsx
@@ -24,7 +24,7 @@ const EMPTY_MARKET_CONFIG: Record<NoPositionProps['rateType'], { title: string; 
 export const MarketEmptyPosition = ({ rateType }: NoPositionProps) => {
   const { title, description } = EMPTY_MARKET_CONFIG[rateType]
   return (
-    <Stack sx={{ alignItems: 'center', padding: Spacing.md }}>
+    <Stack sx={{ alignItems: 'center', padding: Spacing.md }} data-testid={`no-position-${rateType.toLowerCase()}`}>
       <EmptyStateCard title={title} description={description} />
     </Stack>
   )

--- a/apps/main/src/llamalend/features/market-position-details/hooks/usePositionDetailsTabs.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/hooks/usePositionDetailsTabs.tsx
@@ -7,6 +7,7 @@ import { notFalsy } from '@primitives/objects.utils'
 import { useTabs } from '@ui-kit/hooks/useTabs'
 import { t } from '@ui-kit/lib/i18n'
 import type { UserMarketParams } from '@ui-kit/lib/model'
+import { EmptyStateCard } from '@ui-kit/shared/ui/EmptyStateCard'
 import { type TabOption } from '@ui-kit/shared/ui/Tabs/TabsSwitcher'
 import { MarketRateType } from '@ui-kit/types/market'
 import type { QueryProp } from '@ui-kit/types/util'
@@ -38,8 +39,14 @@ export const usePositionDetailsTabs = ({
           render: () =>
             hasPosition ? (
               <BorrowPositionDetails tokens={tokens} params={{ chainId, marketId, userAddress }} />
-            ) : (
+            ) : userAddress ? (
               <MarketEmptyPosition rateType={MarketRateType.Borrow} />
+            ) : (
+              <EmptyStateCard
+                title={t`Disconnected`}
+                description={t`Please connect your wallet to view your positions.`}
+                button={{ type: 'connect-wallet', label: t`Connect Wallet`, testId: 'market-disconnected' }}
+              />
             ),
         },
         events?.length && {

--- a/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
+++ b/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
@@ -1,9 +1,11 @@
+import { useConnection } from 'wagmi'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { t } from '@ui-kit/lib/i18n'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -25,6 +27,7 @@ const TEST_ID_PREFIX = 'supply-claim'
 const { Spacing } = SizesAndSpaces
 
 export const ClaimTab = <ChainId extends IChainId>({ market, networks, chainId, enabled }: ClaimTabProps<ChainId>) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
 
   const {
@@ -74,29 +77,33 @@ export const ClaimTab = <ChainId extends IChainId>({ market, networks, chainId, 
             )
           }
         />
-        <Stack sx={{ flexDirection: 'column', gap: Spacing.xs }}>
-          <Button
-            fullWidth
-            type="button"
-            loading={isCrvPending || !market}
-            disabled={isCrvDisabled}
-            data-testid={`${TEST_ID_PREFIX}-crv-rewards-submit-button`}
-            onClick={onSubmitCrv}
-          >
-            {isCrvPending ? t`Processing...` : t`Claim CRV rewards`}
-          </Button>
-          <Button
-            color="secondary"
-            fullWidth
-            type="button"
-            loading={isRewardsPending || !market}
-            disabled={isRewardsDisabled}
-            data-testid={`${TEST_ID_PREFIX}-other-rewards-submit-button`}
-            onClick={onSubmitRewards}
-          >
-            {isRewardsPending ? t`Processing...` : t`Claim other rewards`}
-          </Button>
-        </Stack>
+        {isConnected ? (
+          <Stack sx={{ flexDirection: 'column', gap: Spacing.xs }}>
+            <Button
+              fullWidth
+              type="button"
+              loading={isCrvPending || !market}
+              disabled={isCrvDisabled}
+              data-testid={`${TEST_ID_PREFIX}-crv-rewards-submit-button`}
+              onClick={onSubmitCrv}
+            >
+              {isCrvPending ? t`Processing...` : t`Claim CRV rewards`}
+            </Button>
+            <Button
+              color="secondary"
+              fullWidth
+              type="button"
+              loading={isRewardsPending || !market}
+              disabled={isRewardsDisabled}
+              data-testid={`${TEST_ID_PREFIX}-other-rewards-submit-button`}
+              onClick={onSubmitRewards}
+            >
+              {isRewardsPending ? t`Processing...` : t`Claim other rewards`}
+            </Button>
+          </Stack>
+        ) : (
+          <ConnectWalletButton />
+        )}
 
         <FormAlerts error={errors.find(Boolean) ?? null} formErrors={[]} handledErrors={[]} />
       </FormContent>

--- a/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
@@ -1,9 +1,11 @@
+import { useConnection } from 'wagmi'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import Button from '@mui/material/Button'
 import { notFalsy } from '@primitives/objects.utils'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { t } from '@ui-kit/lib/i18n'
 import { AlertDisableForm } from '@ui-kit/shared/ui/AlertDisableForm'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
@@ -26,6 +28,7 @@ export const DepositForm = <ChainId extends IChainId>({
   chainId,
   enabled,
 }: DepositFormProps<ChainId>) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
 
   const {
@@ -62,12 +65,21 @@ export const DepositForm = <ChainId extends IChainId>({
         network={network}
       />
 
-      {disabledAlert ? (
-        <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+      {isConnected ? (
+        disabledAlert ? (
+          <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+        ) : (
+          <Button
+            type="submit"
+            loading={isLoading}
+            disabled={isDisabled}
+            data-testid={`${TEST_ID_PREFIX}-submit-button`}
+          >
+            {isPending ? t`Processing...` : notFalsy(isApproved.data === false && t`Approve`, t`Deposit`).join(' & ')}
+          </Button>
+        )
       ) : (
-        <Button type="submit" loading={isLoading} disabled={isDisabled} data-testid={`${TEST_ID_PREFIX}-submit-button`}>
-          {isPending ? t`Processing...` : notFalsy(isApproved.data === false && t`Approve`, t`Deposit`).join(' & ')}
-        </Button>
+        <ConnectWalletButton />
       )}
       <LowSolvencyActionModal
         action="deposit"

--- a/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
@@ -1,3 +1,4 @@
+import { useConnection } from 'wagmi'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
@@ -5,6 +6,7 @@ import { StakeTokenLabel } from '@/llamalend/widgets/action-card/StakeTokenLabel
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import Button from '@mui/material/Button'
 import { notFalsy } from '@primitives/objects.utils'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { t } from '@ui-kit/lib/i18n'
 import { AlertDisableForm } from '@ui-kit/shared/ui/AlertDisableForm'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
@@ -28,6 +30,7 @@ export const StakeForm = <ChainId extends IChainId>({
   chainId,
   enabled,
 }: StakeFormProps<ChainId>) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
   const blockchainId = network.id
 
@@ -76,21 +79,25 @@ export const StakeForm = <ChainId extends IChainId>({
         }
       />
 
-      {hasGauge ? (
-        disabledAlert ? (
-          <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+      {isConnected ? (
+        hasGauge ? (
+          disabledAlert ? (
+            <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>
+          ) : (
+            <Button
+              type="submit"
+              loading={isLoading}
+              disabled={isDisabled}
+              data-testid={`${TEST_ID_PREFIX}-submit-button`}
+            >
+              {isPending ? t`Processing...` : notFalsy(isApproved.data === false && t`Approve`, t`Stake`).join(' & ')}
+            </Button>
+          )
         ) : (
-          <Button
-            type="submit"
-            loading={isLoading}
-            disabled={isDisabled}
-            data-testid={`${TEST_ID_PREFIX}-submit-button`}
-          >
-            {isPending ? t`Processing...` : notFalsy(isApproved.data === false && t`Approve`, t`Stake`).join(' & ')}
-          </Button>
+          <AlertNoGauge />
         )
       ) : (
-        <AlertNoGauge />
+        <ConnectWalletButton />
       )}
 
       <LowSolvencyActionModal

--- a/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
@@ -1,8 +1,10 @@
+import { useConnection } from 'wagmi'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { StakeTokenLabel } from '@/llamalend/widgets/action-card/StakeTokenLabel'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import Button from '@mui/material/Button'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { t } from '@ui-kit/lib/i18n'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
@@ -25,6 +27,7 @@ export const UnstakeForm = <ChainId extends IChainId>({
   chainId,
   enabled,
 }: UnstakeFormProps<ChainId>) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
   const blockchainId = network.id
 
@@ -73,14 +76,18 @@ export const UnstakeForm = <ChainId extends IChainId>({
       />
       {Number(max.data) > 0 && <AlertUnstakeOnly />}
 
-      <Button
-        type="submit"
-        loading={isPending || !market}
-        disabled={isDisabled}
-        data-testid={`${TEST_ID_PREFIX}-submit-button`}
-      >
-        {isPending ? t`Processing...` : t`Unstake`}
-      </Button>
+      {isConnected ? (
+        <Button
+          type="submit"
+          loading={isPending || !market}
+          disabled={isDisabled}
+          data-testid={`${TEST_ID_PREFIX}-submit-button`}
+        >
+          {isPending ? t`Processing...` : t`Unstake`}
+        </Button>
+      ) : (
+        <ConnectWalletButton />
+      )}
 
       <FormAlerts error={unstakeError} formErrors={formErrors} handledErrors={['unstakeAmount']} />
     </Form>

--- a/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
@@ -1,8 +1,10 @@
+import { useConnection } from 'wagmi'
 import type { LlamaMarketTemplate, NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import Button from '@mui/material/Button'
 import { notFalsy } from '@primitives/objects.utils'
+import { ConnectWalletButton } from '@ui-kit/features/connect-wallet/ui/ConnectWalletButton'
 import { t } from '@ui-kit/lib/i18n'
 import { Form } from '@ui-kit/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
@@ -25,6 +27,7 @@ export const WithdrawForm = <ChainId extends IChainId>({
   chainId,
   enabled,
 }: WithdrawFormProps<ChainId>) => {
+  const { isConnected } = useConnection()
   const network = networks[chainId]
 
   const {
@@ -67,14 +70,18 @@ export const WithdrawForm = <ChainId extends IChainId>({
         <AlertUnstakeFirst />
       )}
 
-      <Button
-        type="submit"
-        loading={isPending || !market}
-        disabled={isDisabled}
-        data-testid={`${TEST_ID_PREFIX}-submit-button`}
-      >
-        {isPending ? t`Processing...` : notFalsy(t`Withdraw`, isFull.data && t`All`).join(' ')}
-      </Button>
+      {isConnected ? (
+        <Button
+          type="submit"
+          loading={isPending || !market}
+          disabled={isDisabled}
+          data-testid={`${TEST_ID_PREFIX}-submit-button`}
+        >
+          {isPending ? t`Processing...` : notFalsy(t`Withdraw`, isFull.data && t`All`).join(' ')}
+        </Button>
+      ) : (
+        <ConnectWalletButton />
+      )}
 
       <FormAlerts error={withdrawError} formErrors={formErrors} handledErrors={['withdrawAmount']} />
     </Form>

--- a/apps/main/src/llamalend/queries/llamma-snapshots.query.ts
+++ b/apps/main/src/llamalend/queries/llamma-snapshots.query.ts
@@ -1,42 +1,34 @@
-import { getControllerAddress } from '@/llamalend/llama.utils'
-import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
-import { useCrvUsdSnapshots } from '@ui-kit/entities/crvusd-snapshots'
-import { useLendingSnapshots } from '@ui-kit/entities/lending-snapshots'
+import { type CrvUsdSnapshot, useCrvUsdSnapshots } from '@ui-kit/entities/crvusd-snapshots'
+import { type LendingSnapshot, useLendingSnapshots } from '@ui-kit/entities/lending-snapshots'
 import type { SnapshotRange } from '@ui-kit/lib/model/query/time-option-validation'
-import type { LlamaMarketTemplate } from 'main/src/llamalend/llamalend.types'
+import { LlamaMarketType } from '@ui-kit/types/market'
+import type { Query } from '@ui-kit/types/util'
+import type { Address } from 'viem'
 
 export function useLlamaSnapshot({
   blockchainId,
   enabled = true,
-  market,
   range = { kind: 'timeRange', timeOption: '1M' },
+  controllerAddress,
+  marketType,
 }: {
-  market: LlamaMarketTemplate | undefined | null
   blockchainId: Chain | undefined | null
   enabled?: boolean
   range?: SnapshotRange
-}) {
-  const isLendMarket = market instanceof LendMarketTemplate
+  controllerAddress: Address | undefined
+  marketType: LlamaMarketType
+}): Query<LendingSnapshot[] | CrvUsdSnapshot[]> {
   const timeOption = range.kind === 'timeRange' ? range.timeOption : undefined
   const limit = range.kind === 'limit' ? range.limit : undefined
-  const lendingSnapshotsQuery = useLendingSnapshots(
-    {
-      blockchainId,
-      contractAddress: getControllerAddress(market),
-      timeOption,
-      limit,
-    },
-    enabled && isLendMarket,
-  )
-  const crvUsdSnapshotsQuery = useCrvUsdSnapshots(
-    {
-      blockchainId,
-      contractAddress: getControllerAddress(market),
-      timeOption,
-      limit,
-    },
-    enabled && !isLendMarket,
-  )
-  return isLendMarket ? lendingSnapshotsQuery : crvUsdSnapshotsQuery
+  return {
+    Lend: useLendingSnapshots(
+      { blockchainId, contractAddress: controllerAddress, timeOption, limit },
+      enabled && marketType === LlamaMarketType.Lend,
+    ),
+    Mint: useCrvUsdSnapshots(
+      { blockchainId, contractAddress: controllerAddress, timeOption, limit },
+      enabled && marketType === LlamaMarketType.Mint,
+    ),
+  }[marketType]
 }

--- a/apps/main/src/llamalend/queries/llamma-snapshots.query.ts
+++ b/apps/main/src/llamalend/queries/llamma-snapshots.query.ts
@@ -1,10 +1,10 @@
 import type { Chain } from '@curvefi/prices-api'
+import { Address } from '@primitives/address.utils'
 import { type CrvUsdSnapshot, useCrvUsdSnapshots } from '@ui-kit/entities/crvusd-snapshots'
 import { type LendingSnapshot, useLendingSnapshots } from '@ui-kit/entities/lending-snapshots'
 import type { SnapshotRange } from '@ui-kit/lib/model/query/time-option-validation'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import type { Query } from '@ui-kit/types/util'
-import type { Address } from 'viem'
 
 export function useLlamaSnapshot({
   blockchainId,

--- a/apps/main/src/llamalend/queries/market/market-rates.query.ts
+++ b/apps/main/src/llamalend/queries/market/market-rates.query.ts
@@ -18,3 +18,5 @@ export const { useQuery: useMarketRates, invalidate: invalidateMarketRates } = q
   category: 'llamalend.market',
   validationSuite: marketIdValidationSuite,
 })
+
+export type MarketRates = NonNullable<ReturnType<typeof useMarketRates>['data']>

--- a/apps/main/src/llamalend/queries/ohlc-chart.query.ts
+++ b/apps/main/src/llamalend/queries/ohlc-chart.query.ts
@@ -45,16 +45,10 @@ const getOraclePoolTokenPair = (pools: OraclePool[]): Pick<OraclePoolOhlcPage, '
 
   return {
     ...maybe(collateralPool, ({ collateralAddress, collateralSymbol }) => ({
-      collateralToken: {
-        address: collateralAddress,
-        symbol: collateralSymbol,
-      },
+      collateralToken: { address: collateralAddress, symbol: collateralSymbol },
     })),
     ...maybe(borrowedPool, ({ borrowedAddress, borrowedSymbol }) => ({
-      borrowedToken: {
-        address: borrowedAddress,
-        symbol: borrowedSymbol,
-      },
+      borrowedToken: { address: borrowedAddress, symbol: borrowedSymbol },
     })),
   }
 }
@@ -145,7 +139,6 @@ export const useLlammaOhlcQuery = ({
         },
         { signal },
       )
-
       return { oraclePriceData: formatOraclePriceData(ohlc), ...createOhlcPageResult(ohlc) }
     },
   })

--- a/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
+++ b/apps/main/src/llamalend/widgets/CrvUsdPriceChart.tsx
@@ -118,7 +118,7 @@ export const CrvUsdPriceChart = () => {
   )
 
   return (
-    <Card size="small">
+    <Card size="small" data-testid="crvusd-price-chart">
       <CardHeader
         title={t`Historical crvUSD Peg`}
         action={

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -1,8 +1,8 @@
 import { sortBy } from 'lodash'
 import { useCallback, useMemo, useState } from 'react'
-import { type LlamaMarketTemplate } from '@/llamalend/llamalend.types'
+import { Address } from 'viem'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
-import { useMarketRates } from '@/llamalend/queries/market'
+import { type MarketRates, useMarketRates } from '@/llamalend/queries/market'
 import { HistoricalRatesTooltip } from '@/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip'
 import type { Chain } from '@curvefi/prices-api'
 import { CardContent, Stack } from '@mui/material'
@@ -14,7 +14,6 @@ import { maybe, notFalsy } from '@primitives/objects.utils'
 import { formatDate } from '@ui/utils'
 import type { CrvUsdSnapshot } from '@ui-kit/entities/crvusd-snapshots'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
-import { useCombinedQueries } from '@ui-kit/lib'
 import { t } from '@ui-kit/lib/i18n'
 import { type TimeOption, timeOptions } from '@ui-kit/lib/model/query/time-option-validation'
 import {
@@ -30,7 +29,7 @@ import {
 } from '@ui-kit/shared/ui/Chart'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { MarketRateType } from '@ui-kit/types/market'
+import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import { mapQuery, useMappedQuery } from '@ui-kit/types/util'
 import { formatNumber } from '@ui-kit/utils'
 import { calculateAverageRates } from '@ui-kit/utils/averageRates'
@@ -46,15 +45,15 @@ export type RateChartPoint = {
 
 type RateSeriesKey = 'rate' | 'movingAverage' | 'totalAverage'
 
-type MarketRates = NonNullable<ReturnType<typeof useMarketRates>['data']>
 type RateSnapshot = CrvUsdSnapshot | LendingSnapshot
 type RateValue = Amount | null | undefined
 
 type MarketHistoricalRatesChartProps = {
-  market: LlamaMarketTemplate | undefined | null
+  controllerAddress: Address | undefined
+  marketType: LlamaMarketType
   blockchainId: Chain | undefined
   chainId: number
-  marketId: string
+  marketId: string | undefined
   rateMode: MarketRateType
 }
 
@@ -113,7 +112,8 @@ const averageRates = (ratePoints: { rate: number; timestamp: number }[]) =>
   calculateAverageRates(ratePoints, 7, { rate: ({ rate }) => rate })?.rate
 
 export const MarketHistoricalRatesChart = ({
-  market,
+  marketType,
+  controllerAddress,
   blockchainId,
   chainId,
   marketId,
@@ -129,20 +129,25 @@ export const MarketHistoricalRatesChart = ({
 
   const marketRates = useMarketRates({ chainId, marketId })
 
-  const snapshots = useLlamaSnapshot({ market, blockchainId, range: { kind: 'timeRange', timeOption } })
+  const snapshots = useLlamaSnapshot({
+    controllerAddress,
+    marketType,
+    blockchainId,
+    range: { kind: 'timeRange', timeOption },
+  })
 
-  const ratePoints = useCombinedQueries(
-    [snapshots, marketRates],
+  const ratePoints = useMappedQuery(
+    snapshots,
     useCallback(
-      (snapshots, marketRates) => {
-        const currentLiveRate = toRateNumber(modeConfig.getLiveRate(marketRates))
+      snapshots => {
+        const currentLiveRate = toRateNumber(modeConfig.getLiveRate(marketRates.data))
         const snapshotRatePoints = toSnapshotRatePoints(snapshots, modeConfig.getSnapshotRate)
         return sortBy(
           notFalsy(...snapshotRatePoints, currentLiveRate != null && { timestamp: Date.now(), rate: currentLiveRate }),
           item => item.timestamp,
         )
       },
-      [modeConfig],
+      [modeConfig, marketRates.data],
     ),
   )
 
@@ -180,7 +185,7 @@ export const MarketHistoricalRatesChart = ({
   )
 
   return (
-    <Card size="small">
+    <Card size="small" data-testid={`historical-${rateMode.toLowerCase()}-rate-chart`}>
       <CardHeader
         title={modeConfig.chartTitle}
         action={
@@ -188,7 +193,7 @@ export const MarketHistoricalRatesChart = ({
             options={timeOptions}
             activeOption={timeOption}
             setActiveOption={setTimeOption}
-            isLoading={snapshots.isLoading || !market}
+            isLoading={snapshots.isLoading || !controllerAddress}
           />
         }
       />
@@ -215,7 +220,7 @@ export const MarketHistoricalRatesChart = ({
         </Stack>
         <ChartStateWrapper
           height={Height.shortChart}
-          isLoading={snapshots.isLoading || !market}
+          isLoading={snapshots.isLoading || !controllerAddress}
           error={snapshots.error}
           errorMessage={t`Unable to fetch historical rates data.`}
         >

--- a/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketRateCurveChart.tsx
@@ -1,11 +1,10 @@
 import { sortBy } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Address } from 'viem'
-import { getTokens, getUtilizationPercent, tokenMetric } from '@/llamalend/llama.utils'
+import { getUtilizationPercent, tokenMetric } from '@/llamalend/llama.utils'
 import { useMarketCapAndAvailable, useMarketTotalCollateral, useRateCurve } from '@/llamalend/queries/market'
 import { TooltipOptions, TotalCollateralTooltip, UtilizationTooltip } from '@/llamalend/widgets/tooltips'
 import { RateCurveTooltip } from '@/llamalend/widgets/tooltips/chart/RateCurveTooltip'
-import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import { CardContent, Stack } from '@mui/material'
 import Card from '@mui/material/Card'
@@ -75,19 +74,21 @@ const calculateCombinedCollateral = ({
       )
 
 export const MarketRateCurveChart = ({
-  market,
+  collateralToken,
+  borrowToken,
+  controllerAddress,
   blockchainId,
   chainId,
   marketId,
 }: {
-  market: LendMarketTemplate | undefined | null
   blockchainId: Chain | undefined
   chainId: number | undefined
   marketId: string | undefined
+  collateralToken: { address: Address; symbol: string } | undefined
+  borrowToken: { address: Address; symbol: string } | undefined
+  controllerAddress: Address | undefined
 }) => {
   const [visibleSeries, setVisibleSeries] = useState<RateCurveSeriesKey[]>(SERIES_CONFIG.map(({ key }) => key))
-  const controllerAddress = market?.addresses.controller as Address | undefined
-  const { collateralToken, borrowToken } = getTokens(market) ?? {}
   const {
     design: { Color },
   } = useTheme()
@@ -121,6 +122,7 @@ export const MarketRateCurveChart = ({
     ({ collateral, borrowed }, collateralUsdRate, borrowUsdRate) =>
       calculateCombinedCollateral({ collateral, borrowed, collateralUsdRate, borrowUsdRate }),
   )
+
   const collateralUsdValue = combineQueries([collateralTotal, collateralUsdRate], (total, usdRate) => +total * usdRate)
   const borrowedCollateralUsdValue = combineQueries(
     [borrowedCollateralTotal, borrowedUsdRate],
@@ -166,7 +168,7 @@ export const MarketRateCurveChart = ({
   )
 
   return (
-    <Card size="small">
+    <Card size="small" data-testid="interest-rate-utilization-chart">
       <CardHeader title={t`Interest Rate & Utilization`} />
       <CardContent component={Stack} sx={{ gap: Spacing.md }}>
         <Stack

--- a/apps/main/src/llamalend/widgets/action-card/hooks/useBorrowRates.ts
+++ b/apps/main/src/llamalend/widgets/action-card/hooks/useBorrowRates.ts
@@ -1,12 +1,13 @@
-import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
 import { useMarketFutureRates, useMarketRates } from '@/llamalend/queries/market'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
+import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { CrvUsdSnapshot } from '@ui-kit/entities/crvusd-snapshots'
 import { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import type { MarketParams } from '@ui-kit/lib/model'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
+import type { LlamaMarketType } from '@ui-kit/types/market'
 import { q, Query, type QueryProp } from '@ui-kit/types/util'
 import { BlockchainIds, decimal, decimalMinus } from '@ui-kit/utils'
 
@@ -31,15 +32,22 @@ export function useBorrowRates<ChainId extends IChainId>(
   {
     params: { chainId, marketId },
     debtDelta,
-    market,
+    marketType,
+    controllerAddress,
   }: {
     params: MarketParams<ChainId>
-    market: LlamaMarketTemplate | undefined
+    marketType: LlamaMarketType
+    controllerAddress: Address | undefined
     debtDelta?: Decimal | null
   },
   enabled: boolean,
 ) {
-  const snapshots = useLlamaSnapshot({ market, blockchainId: chainId && BlockchainIds[chainId], enabled })
+  const snapshots = useLlamaSnapshot({
+    marketType,
+    controllerAddress,
+    blockchainId: chainId && BlockchainIds[chainId],
+    enabled,
+  })
   // Without `debt`, `rates`/`netBorrowApr` are disabled on purpose. `ActionInfo` shows `prevRates` as current.
   const [rates, netBorrowApr] = addNetApr(useMarketFutureRates({ chainId, marketId, debtDelta }, enabled), snapshots)
   const [prevRates, prevNetBorrowApr] = addNetApr(useMarketRates({ chainId, marketId }, enabled), snapshots)

--- a/apps/main/src/llamalend/widgets/action-card/hooks/useSupplyRates.ts
+++ b/apps/main/src/llamalend/widgets/action-card/hooks/useSupplyRates.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'viem'
+import { getControllerAddress } from '@/llamalend/llama.utils'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
-import { useMarketSupplyFutureRates, useMarketRates, useMarketVaultOnChainRewards } from '@/llamalend/queries/market'
+import { useMarketRates, useMarketSupplyFutureRates, useMarketVaultOnChainRewards } from '@/llamalend/queries/market'
 import { useUserSupplyBoost } from '@/llamalend/queries/user'
 import { requireVault } from '@/llamalend/queries/validation/supply.validation'
 import {
@@ -13,10 +14,11 @@ import {
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Decimal } from '@primitives/decimal.utils'
 import { maybe } from '@primitives/objects.utils'
-import { useCampaignsByAddress, type CampaignRewards } from '@ui-kit/entities/campaigns'
+import { type CampaignRewards, useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import type { UserMarketParams } from '@ui-kit/lib/model'
 import { combineQueryState } from '@ui-kit/lib/queries/combine'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { q, type Query, type QueryProp, type Range } from '@ui-kit/types/util'
 import { BlockchainIds, decimal } from '@ui-kit/utils'
 
@@ -65,7 +67,12 @@ export function useSupplyRates<ChainId extends IChainId>(
 ) {
   const blockchainId = maybe(chainId, chainId => BlockchainIds[chainId])
   const market = marketId ? requireVault(marketId) : undefined
-  const snapshotsQuery = useLlamaSnapshot({ market, blockchainId, enabled })
+  const snapshotsQuery = useLlamaSnapshot({
+    marketType: LlamaMarketType.Lend,
+    controllerAddress: getControllerAddress(market),
+    blockchainId,
+    enabled,
+  })
   const lendingSnapshotsQuery = q({
     ...snapshotsQuery,
     data: snapshotsQuery.data as LendingSnapshot[] | undefined,

--- a/apps/main/src/llamalend/widgets/page-header/MarketPageHeader.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MarketPageHeader.tsx
@@ -25,20 +25,23 @@ const { Spacing } = SizesAndSpaces
 export const MarketPageHeader = ({
   blockchainId,
   chainId,
-  marketId,
   isLoading,
   market,
   marketType,
 }: {
   blockchainId: Chain
   chainId: number
-  marketId: string | undefined
   isLoading: boolean
   market: LlamaMarketTemplate | undefined
   marketType: LlamaMarketType
 }) => {
   const { address: userAddress } = useConnection()
-  const { borrowRate, supplyRate, availableLiquidity } = usePageHeader({ chainId, marketId, market, blockchainId })
+  const { borrowRate, supplyRate, availableLiquidity } = usePageHeader({
+    chainId,
+    market,
+    blockchainId,
+    marketType,
+  })
   const { collateralToken, borrowToken } = getTokens(market) ?? {}
 
   const title =

--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -45,6 +45,7 @@ export const MetricsRow = ({
       {supplyRate && (
         <Metric
           alignment={metricAlignment}
+          testId="market-net-supply-apy"
           label={NET_SUPPLY_RATE_TITLE}
           value={mapQuery(supplyRate, supplyRate => supplyRate.totalMinBoost)}
           valueOptions={{ unit: 'percentage' }}
@@ -80,6 +81,7 @@ export const MetricsRow = ({
       )}
       <Metric
         alignment={metricAlignment}
+        testId="market-available-liquidity"
         label={t`Available liquidity`}
         {...tokenMetric({
           value: mapQuery(availableLiquidity, d => d.value),

--- a/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
+++ b/apps/main/src/llamalend/widgets/page-header/hooks/usePageHeader.ts
@@ -1,8 +1,13 @@
 import { useFilteredRewards } from '@/llamalend/hooks/useFilteredRewards'
-import { getControllerAddress } from '@/llamalend/llama.utils'
+import { getControllerAddress, getTokens, getVaultAddress } from '@/llamalend/llama.utils'
 import type { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import { useLlamaSnapshot } from '@/llamalend/queries/llamma-snapshots.query'
-import { useMarketCapAndAvailable, useMarketRates, useMarketVaultOnChainRewards } from '@/llamalend/queries/market'
+import {
+  type MarketRates,
+  useMarketCapAndAvailable,
+  useMarketRates,
+  useMarketVaultOnChainRewards,
+} from '@/llamalend/queries/market'
 import {
   aprToApy,
   formatSupplyExtraIncentives,
@@ -17,17 +22,17 @@ import {
   sumOnChainExtraIncentivesApy,
   toNumberOrNull,
 } from '@/llamalend/rates.utils'
-import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
-import { notFalsyArray } from '@primitives/objects.utils'
+import { maybes, notFalsyArray } from '@primitives/objects.utils'
 import { type CampaignRewards, useCampaignsByAddress } from '@ui-kit/entities/campaigns'
+import type { CrvUsdSnapshot } from '@ui-kit/entities/crvusd-snapshots'
 import type { LendingSnapshot } from '@ui-kit/entities/lending-snapshots'
 import { combineQueries } from '@ui-kit/lib'
 import { useTokenUsdRate } from '@ui-kit/lib/model/entities/token-usd-rate'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
-import { fakeLoadingQ, Query, type Range } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, type AverageCategory, CRVUSD_ADDRESS } from '@ui-kit/utils'
+import { fakeLoadingQ, q, Query, type QueryProp, type Range } from '@ui-kit/types/util'
+import { AVERAGE_CATEGORIES, type AverageCategory, decimalMultiply } from '@ui-kit/utils'
 
 const RATE_CATEGORY: AverageCategory = 'llamalend.market.rate'
 
@@ -87,83 +92,149 @@ function buildSupplyRate({
   }
 }
 
-export const usePageHeader = ({
+export const useBorrowRate = ({
+  marketRates,
+  marketType,
+  snapshot,
+  marketQuery,
+  campaigns,
+}: {
+  marketRates: QueryProp<MarketRates>
+  marketType: LlamaMarketType
+  marketQuery: QueryProp<LlamaMarketTemplate>
+  snapshot: QueryProp<LendingSnapshot[] | CrvUsdSnapshot[]>
+  campaigns: CampaignRewards[]
+}) => {
+  const borrowCampaigns = useFilteredRewards(campaigns, marketType, MarketRateType.Borrow)
+
+  return combineQueries([marketRates, snapshot, marketQuery], ({ borrowApr }, snapshots) => {
+    const { averageRate, averageRebasingYield, averageTotalRate, rebasingYield, totalRate } = getBorrowRateMetrics({
+      borrowRate: toNumberOrNull(borrowApr),
+      campaignsRate: sumCampaignsApr(borrowCampaigns),
+      snapshots,
+      getBorrowRate: getSnapshotBorrowApr,
+      getRebasingYield: getSnapshotCollateralRebasingYieldApr,
+      daysBack: RATE_WINDOW,
+    })
+    return {
+      rate: toNumberOrNull(borrowApr),
+      averageRate,
+      averageCategory: RATE_CATEGORY,
+      rebasingYield,
+      averageRebasingYield,
+      totalBorrowRate: totalRate,
+      totalAverageBorrowRate: averageTotalRate,
+      extraRewards: borrowCampaigns,
+    }
+  })
+}
+
+export const useSupplyRate = ({
+  marketRates,
+  snapshot,
+  marketQuery,
   chainId,
-  marketId,
-  market,
   blockchainId,
+  marketType,
+  campaigns,
 }: {
   chainId: number
-  marketId: string | undefined
-  market: LlamaMarketTemplate | null | undefined
+  marketRates: QueryProp<MarketRates>
+  snapshot: QueryProp<LendingSnapshot[] | CrvUsdSnapshot[]>
+  marketQuery: QueryProp<LlamaMarketTemplate>
   blockchainId: Chain | undefined
+  marketType: LlamaMarketType
+  campaigns: CampaignRewards[]
 }) => {
-  const isLendMarket = market instanceof LendMarketTemplate
-  const vaultAddress = (isLendMarket ? market.addresses.vault : undefined) as Address | undefined
-  const controllerAddress = getControllerAddress(market)
-  const borrowTokenAddress = (isLendMarket ? market.addresses.borrowed_token : CRVUSD_ADDRESS) as Address | undefined
-  const marketType = isLendMarket ? LlamaMarketType.Lend : LlamaMarketType.Mint
+  const marketId = marketQuery.data?.id
+  const enabled = marketType === LlamaMarketType.Lend
+  const onChainRewards = useMarketVaultOnChainRewards({ chainId, marketId }, enabled)
+  const supplyCampaigns = useFilteredRewards(campaigns, marketType, MarketRateType.Supply)
 
-  const snapshot = useLlamaSnapshot({ market, blockchainId, range: { kind: 'limit', limit: RATE_WINDOW } })
-  const marketRates = useMarketRates({ chainId, marketId })
-  const capAndAvailable = useMarketCapAndAvailable({ chainId, marketId })
+  const onChainSupplyRate = combineQueries(
+    [marketRates, snapshot as Query<LendingSnapshot[]>, onChainRewards, marketQuery],
+    (marketRates, lendingSnapshots, marketOnChainRewards) =>
+      buildSupplyRate({
+        supplyApy: marketRates?.lendApy,
+        rebasingYieldApy: getLatestSnapshotValue(lendingSnapshots, snapshot => snapshot.borrowedToken.rebasingYield),
+        marketOnChainRewards,
+        lendingSnapshots,
+        campaigns: supplyCampaigns,
+        blockchainId,
+        category: RATE_CATEGORY,
+      }),
+  )
+
+  return enabled ? onChainSupplyRate : undefined
+}
+
+export const useAvailableLiquidity = ({
+  chainId,
+  marketQuery: { data: market },
+}: {
+  chainId: number
+  marketQuery: QueryProp<LlamaMarketTemplate>
+}) => {
+  const borrowTokenAddress = getTokens(market)?.borrowToken.address
+  const capAndAvailable = useMarketCapAndAvailable({ chainId, marketId: market?.id })
   const borrowUsdRate = useTokenUsdRate({ chainId, tokenAddress: borrowTokenAddress })
-  const onChainRewards = useMarketVaultOnChainRewards({ chainId, marketId }, isLendMarket)
+  const marketQuery = fakeLoadingQ(market) // todo: use a proper query, see #2729
+  return combineQueries([borrowUsdRate, capAndAvailable, marketQuery], (borrowUsdRate, { available, totalAssets }) => ({
+    value: available,
+    max: totalAssets,
+    usdRate: borrowUsdRate,
+    notional: maybes([available, borrowUsdRate], ([liq, rate]) => decimalMultiply(liq, rate)),
+  }))
+}
 
+function useCampaigns({
+  blockchainId,
+  controllerAddress,
+  vaultAddress,
+  marketType,
+}: {
+  blockchainId: Chain | undefined
+  controllerAddress: Address | undefined
+  vaultAddress: Address | null | undefined
+  marketType: LlamaMarketType
+}) {
   const { data: controllerCampaigns } = useCampaignsByAddress({ blockchainId, address: controllerAddress })
   const { data: vaultCampaigns } = useCampaignsByAddress({ blockchainId, address: vaultAddress })
-  const campaigns = isLendMarket ? [...vaultCampaigns, ...controllerCampaigns] : controllerCampaigns
-  const borrowCampaigns = useFilteredRewards(campaigns, marketType, MarketRateType.Borrow)
-  const supplyCampaigns = useFilteredRewards(campaigns, marketType, MarketRateType.Supply)
-  const marketQuery = fakeLoadingQ(market) // todo: use a proper query, see #2729
+  return marketType === LlamaMarketType.Lend ? [...vaultCampaigns, ...controllerCampaigns] : controllerCampaigns
+}
+
+export const usePageHeader = ({
+  chainId,
+  market,
+  blockchainId,
+  marketType,
+}: {
+  chainId: number
+  market: LlamaMarketTemplate | null | undefined
+  blockchainId: Chain | undefined
+  marketType: LlamaMarketType
+}) => {
+  const vaultAddress = getVaultAddress(market)
+  const controllerAddress = getControllerAddress(market)
+  const snapshot = q(
+    useLlamaSnapshot({ marketType, controllerAddress, blockchainId, range: { kind: 'limit', limit: RATE_WINDOW } }),
+  )
+  const marketRates = q(useMarketRates({ chainId, marketId: market?.id }))
+  const campaigns = useCampaigns({ blockchainId, controllerAddress, vaultAddress, marketType })
+  const marketQuery = fakeLoadingQ(market ?? undefined) // todo: use a proper query, see #2729
 
   return {
-    borrowRate: combineQueries([marketRates, snapshot, marketQuery], ({ borrowApr }, snapshots) => {
-      const { averageRate, averageRebasingYield, averageTotalRate, rebasingYield, totalRate } = getBorrowRateMetrics({
-        borrowRate: toNumberOrNull(borrowApr),
-        campaignsRate: sumCampaignsApr(borrowCampaigns),
-        snapshots,
-        getBorrowRate: getSnapshotBorrowApr,
-        getRebasingYield: getSnapshotCollateralRebasingYieldApr,
-        daysBack: RATE_WINDOW,
-      })
-      return {
-        rate: toNumberOrNull(borrowApr),
-        averageRate,
-        averageCategory: RATE_CATEGORY,
-        rebasingYield,
-        averageRebasingYield,
-        totalBorrowRate: totalRate,
-        totalAverageBorrowRate: averageTotalRate,
-        extraRewards: borrowCampaigns,
-      }
+    borrowRate: useBorrowRate({ marketRates, marketQuery, campaigns, marketType, snapshot }),
+    supplyRate: useSupplyRate({
+      marketRates,
+      marketQuery,
+      snapshot,
+      marketType,
+      chainId,
+      blockchainId,
+      campaigns,
     }),
-    supplyRate: isLendMarket
-      ? combineQueries(
-          [marketRates, snapshot as Query<LendingSnapshot[]>, onChainRewards, marketQuery],
-          (marketRates, lendingSnapshots, marketOnChainRewards) =>
-            buildSupplyRate({
-              supplyApy: marketRates?.lendApy,
-              rebasingYieldApy: getLatestSnapshotValue(
-                lendingSnapshots,
-                snapshot => snapshot.borrowedToken.rebasingYield,
-              ),
-              marketOnChainRewards,
-              lendingSnapshots,
-              campaigns: supplyCampaigns,
-              blockchainId,
-              category: RATE_CATEGORY,
-            }),
-        )
-      : undefined,
-    availableLiquidity: combineQueries(
-      [borrowUsdRate, capAndAvailable, marketQuery],
-      (borrowUsdRate, { available, totalAssets }) => ({
-        value: available,
-        max: totalAssets,
-        usdRate: borrowUsdRate,
-      }),
-    ),
+    availableLiquidity: useAvailableLiquidity({ chainId, marketQuery }),
   }
 }
 

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -5,6 +5,7 @@ import { CrvUsdPriceChart } from '@/llamalend/widgets/CrvUsdPriceChart'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { ChartAndActivityComp } from '@/loan/components/ChartAndActivityComp'
 import type { ChainId, Llamma } from '@/loan/types/loan.types'
+import { getBlockchainId } from '@curvefi/prices-api'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
@@ -13,7 +14,6 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { LlamaMarketType, MarketRateType } from '@ui-kit/types/market'
 import type { Range } from '@ui-kit/types/util'
-import { BlockchainIds, Chain } from '@ui-kit/utils/network'
 import { PAGE_SPACING } from '@ui-kit/widgets/DetailPageLayout/constants'
 import { networks } from '../networks'
 
@@ -30,6 +30,7 @@ export const MarketInformationComposite = ({
   chainId,
   previewPrices,
 }: MarketInformationCompProps) => {
+  const controllerAddress = getControllerAddress(market)
   const { collateralToken, borrowToken } = getTokens(market) ?? {}
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
@@ -37,14 +38,15 @@ export const MarketInformationComposite = ({
         chainId={chainId}
         marketId={marketId}
         previewPrices={previewPrices}
-        controllerAddress={getControllerAddress(market)}
+        controllerAddress={controllerAddress}
         ammAddress={getAmmAddress(market)}
         borrowToken={borrowToken}
         collateralToken={collateralToken}
       />
       <MarketHistoricalRatesChart
-        market={market}
-        blockchainId={BlockchainIds[Chain.Ethereum]}
+        marketType={LlamaMarketType.Mint}
+        controllerAddress={controllerAddress}
+        blockchainId={getBlockchainId(networks[chainId].id)}
         chainId={chainId}
         marketId={marketId}
         rateMode={MarketRateType.Borrow}

--- a/apps/main/src/loan/components/PageMintMarket/CreateLoanTabs.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/CreateLoanTabs.tsx
@@ -2,6 +2,7 @@ import { CreateLoanForm } from '@/llamalend/features/borrow/components/CreateLoa
 import type { LoanTabProps } from '@/loan/components/PageMintMarket/types'
 import { networks } from '@/loan/networks'
 import { t } from '@ui-kit/lib/i18n'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
 
 const menu = [
@@ -9,7 +10,13 @@ const menu = [
     value: 'create',
     label: t`Borrow`,
     component: ({ market, rChainId, onPricesUpdated }: LoanTabProps) => (
-      <CreateLoanForm networks={networks} chainId={rChainId} market={market} onPricesUpdated={onPricesUpdated} />
+      <CreateLoanForm
+        networks={networks}
+        chainId={rChainId}
+        market={market}
+        onPricesUpdated={onPricesUpdated}
+        marketType={LlamaMarketType.Mint}
+      />
     ),
   },
 ] satisfies FormTab<LoanTabProps>[]

--- a/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/ManageLoanTabs.tsx
@@ -12,26 +12,30 @@ import { networks } from '@/loan/networks'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { useLoanImplementationKey } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import type { QueryProp } from '@ui-kit/types/util'
 import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
 
+const { Mint } = LlamaMarketType
+
 // casting the networks for the loan app so we don't need to make the whole form generic
 const softLiqNetworks = networks as unknown as NetworkDict<LlamaChainId>
-type MintManageLoanProps = LoanTabProps & { collateralEvents: QueryProp<UserCollateralEvents> }
+
+export type MintManageLoanProps = LoanTabProps & { collateralEvents: QueryProp<UserCollateralEvents> }
 
 const MintManageMenu = [
   {
     value: 'borrow',
     label: t`Borrow`,
     component: ({ rChainId, ...props }: MintManageLoanProps) => (
-      <BorrowMoreForm networks={networks} chainId={rChainId} {...props} />
+      <BorrowMoreForm networks={networks} chainId={rChainId} marketType={Mint} {...props} />
     ),
   },
   {
     value: 'repay',
     label: t`Repay`,
     component: ({ rChainId, ...props }: MintManageLoanProps) => (
-      <RepayForm networks={networks} chainId={rChainId} {...props} />
+      <RepayForm networks={networks} chainId={rChainId} marketType={Mint} {...props} />
     ),
   },
   {
@@ -42,14 +46,14 @@ const MintManageMenu = [
         value: 'add',
         label: t`Add`,
         component: ({ rChainId, ...props }: MintManageLoanProps) => (
-          <AddCollateralForm networks={networks} chainId={rChainId} {...props} />
+          <AddCollateralForm networks={networks} chainId={rChainId} marketType={Mint} {...props} />
         ),
       },
       {
         value: 'remove',
         label: t`Remove`,
         component: ({ rChainId, ...props }: MintManageLoanProps) => (
-          <RemoveCollateralForm networks={networks} chainId={rChainId} {...props} />
+          <RemoveCollateralForm networks={networks} chainId={rChainId} marketType={Mint} {...props} />
         ),
       },
     ],
@@ -65,7 +69,13 @@ const MintManageSoftLiquidationMenu = [
         value: 'improve-health',
         label: t`Improve health`,
         component: ({ rChainId, ...props }: MintManageLoanProps) => (
-          <ImproveHealthForm chainId={rChainId} networks={softLiqNetworks} {...props} isInSoftLiquidation />
+          <ImproveHealthForm
+            chainId={rChainId}
+            networks={softLiqNetworks}
+            marketType={Mint}
+            {...props}
+            isInSoftLiquidation
+          />
         ),
       },
       {

--- a/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
@@ -8,13 +8,13 @@ import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { MarketInformationComposite } from '@/loan/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/loan/components/PageMintMarket/CreateLoanTabs'
-import { ManageLoanTabs } from '@/loan/components/PageMintMarket/ManageLoanTabs'
+import { ManageLoanTabs, type MintManageLoanProps } from '@/loan/components/PageMintMarket/ManageLoanTabs'
 import { networks } from '@/loan/networks'
 import { type CollateralUrlParams } from '@/loan/types/loan.types'
-import { getCollateralListPathname, getChainId } from '@/loan/utils/utilsRouter'
+import { getChainId, getCollateralListPathname } from '@/loan/utils/utilsRouter'
 import { getBlockchainId } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
-import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
+import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -26,45 +26,56 @@ import { useMintMarket } from '../../hooks/useMintMarket'
 export const MintMarketPage = () => {
   const params = useParams<CollateralUrlParams>()
   const rCollateralId = params.collateralId.toLowerCase()
-  const { llamaApi: curve = null, isHydrated, provider } = useCurve()
-  const rChainId = getChainId(params)
+  const { llamaApi: curve = null, isInitialized } = useCurve()
+  const chainId = getChainId(params)
   const { address } = useConnection()
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
 
-  const { data: market, isLoading: isMarketLoading, isSuccess } = useMintMarket(rChainId, rCollateralId)
-  const userMarketParams = { chainId: rChainId, marketId: market?.id, userAddress: address }
-  const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists(
-    {
-      chainId: rChainId,
-      marketId: market?.id,
-      userAddress: address,
-    },
-    !!market, // enable query as soon as market is defined, the validation suite isn't able to detect it otherwise
-  )
+  const {
+    data: market,
+    isLoading: isMarketLoading,
+    error: marketError,
+  } = useMintMarket({ chainId, rMarket: rCollateralId })
 
-  const network = networks[rChainId]
+  const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists({
+    chainId,
+    marketId: market?.id,
+    userAddress: address,
+  })
+
+  const network = networks[chainId]
+  const isLoading = !isInitialized || isMarketLoading
   const tokens = useMemo(() => getTokens(market) ?? {}, [market])
 
   const collateralEvents = useUserCollateralEvents({
     app: LlamaMarketType.Mint,
     chain: getBlockchainId(network.id),
     controllerAddress: getControllerAddress(market),
-    userAddress: curve?.signerAddress,
+    userAddress: address,
     network,
     tokens,
   })
 
-  const pageProps = { curve, market, rChainId, params, onPricesUpdated: setPreviewPrices }
+  const pageProps: Omit<MintManageLoanProps, 'collateralEvents'> = {
+    curve,
+    market,
+    rChainId: chainId,
+    params,
+    onPricesUpdated: setPreviewPrices,
+  }
 
-  return isSuccess && !market ? (
+  const error = marketError
+  return error ? (
     <ErrorPage
-      title="404"
-      subtitle={`${t`Market`} ${rCollateralId} ${t`Not Found`}`}
+      title={t`Error`}
+      subtitle={error.message}
+      error={error}
       continueUrl={getCollateralListPathname(params)}
     />
-  ) : provider ? (
+  ) : (
     <DetailPageLayout
       formTabs={
+        !!market &&
         !isLoanExistsLoading &&
         (loanExists ? (
           <ManageLoanTabs {...pageProps} collateralEvents={collateralEvents} />
@@ -75,29 +86,26 @@ export const MintMarketPage = () => {
       header={
         <MarketPageHeader
           blockchainId={network.id}
-          chainId={rChainId}
-          marketId={market?.id ?? ''}
-          isLoading={!isHydrated || isMarketLoading}
+          chainId={chainId}
+          isLoading={isLoading}
           market={market}
           marketType={LlamaMarketType.Mint}
         />
       }
     >
-      <MarketBanners chainId={rChainId} market={market} />
+      <MarketBanners chainId={chainId} market={market} />
       <PositionDetailsComposite
         tokens={tokens}
-        params={userMarketParams}
         hasPosition={loanExists}
         events={collateralEvents}
+        params={{ chainId, marketId: market?.id, userAddress: address }}
       />
       <MarketInformationComposite
         market={market ?? null}
         marketId={market?.id ?? ''}
-        chainId={rChainId}
+        chainId={chainId}
         previewPrices={previewPrices}
       />
     </DetailPageLayout>
-  ) : (
-    <ConnectWalletPrompt description={t`Connect your wallet to view market`} />
   )
 }

--- a/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
@@ -14,7 +14,7 @@ import { type CollateralUrlParams } from '@/loan/types/loan.types'
 import { getChainId, getCollateralListPathname } from '@/loan/utils/utilsRouter'
 import { getBlockchainId } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useCurve } from '@ui-kit/features/connect-wallet'
+import { ConnectWalletPrompt, useCurve } from '@ui-kit/features/connect-wallet'
 import { useParams } from '@ui-kit/hooks/router'
 import { t } from '@ui-kit/lib/i18n'
 import { ErrorPage } from '@ui-kit/pages/ErrorPage'
@@ -28,7 +28,7 @@ export const MintMarketPage = () => {
   const rCollateralId = params.collateralId.toLowerCase()
   const { llamaApi: curve = null, isInitialized } = useCurve()
   const chainId = getChainId(params)
-  const { address } = useConnection()
+  const { address: userAddress } = useConnection()
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
 
   const {
@@ -40,7 +40,7 @@ export const MintMarketPage = () => {
   const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists({
     chainId,
     marketId: market?.id,
-    userAddress: address,
+    userAddress,
   })
 
   const network = networks[chainId]
@@ -51,7 +51,7 @@ export const MintMarketPage = () => {
     app: LlamaMarketType.Mint,
     chain: getBlockchainId(network.id),
     controllerAddress: getControllerAddress(market),
-    userAddress: address,
+    userAddress,
     network,
     tokens,
   })
@@ -72,7 +72,7 @@ export const MintMarketPage = () => {
       error={error}
       continueUrl={getCollateralListPathname(params)}
     />
-  ) : (
+  ) : userAddress ? (
     <DetailPageLayout
       formTabs={
         !!market &&
@@ -98,7 +98,7 @@ export const MintMarketPage = () => {
         tokens={tokens}
         hasPosition={loanExists}
         events={collateralEvents}
-        params={{ chainId, marketId: market?.id, userAddress: address }}
+        params={{ chainId, marketId: market?.id, userAddress }}
       />
       <MarketInformationComposite
         market={market ?? null}
@@ -107,5 +107,7 @@ export const MintMarketPage = () => {
         previewPrices={previewPrices}
       />
     </DetailPageLayout>
+  ) : (
+    <ConnectWalletPrompt description={t`Connect your wallet to view market`} testId="btn-connect-prompt" />
   )
 }

--- a/apps/main/src/loan/components/PagePegKeepers/hooks/usePegkeeper.ts
+++ b/apps/main/src/loan/components/PagePegKeepers/hooks/usePegkeeper.ts
@@ -74,7 +74,7 @@ export function usePegkeeper({ address, pool: { address: poolAddress } }: PegKee
     rate: fallbackQ(mapQuery(priceOracle, formatWei), mapQuery(priceOracleFallback, formatWei)),
     debt: mapQuery(debt, formatWei),
     estCallerProfit: fallbackQ(
-      isConnected && mapQuery(estCallerProfit, p => formatWei(p.result)),
+      mapQuery(estCallerProfit, p => formatWei(p.result)),
       mapQuery(estCallerProfitFallback, formatWei),
     ),
     debtCeiling: mapQuery(debtCeiling, formatWei),

--- a/apps/main/src/loan/hooks/useMintMarket.ts
+++ b/apps/main/src/loan/hooks/useMintMarket.ts
@@ -1,28 +1,27 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useCurve } from '@ui-kit/features/connect-wallet'
+import { t } from '@ui-kit/lib/i18n'
 import { useMappedQuery } from '@ui-kit/types/util'
 import { useMintMarkets } from '../entities/mint-markets.query'
 import { ChainId } from '../types/loan.types'
 
-export function useMintMarketData(chainId: ChainId, rMarket: string, enabled?: boolean) {
+function useMintMarketData({ chainId, rMarket }: { chainId: ChainId; rMarket: string }, enabled?: boolean) {
   const mintMarkets = useMintMarkets({ chainId }, enabled)
-  return {
-    ...useMappedQuery(
-      mintMarkets,
-      useCallback(data => data?.[rMarket], [rMarket]),
-    ),
-    isSuccess: mintMarkets.isSuccess,
-  }
+  const mintMarket = useMappedQuery(
+    mintMarkets,
+    useCallback(data => data?.[rMarket], [rMarket]),
+  )
+  const error = useMemo(
+    () => mintMarkets.data && !mintMarket.data && new Error(`${t`Market`} ${rMarket} ${t`Not Found`}`),
+    [mintMarket.data, mintMarkets.data, rMarket],
+  )
+  return { ...mintMarket, ...(error && { error }) }
 }
 
-export const useMintMarket = (chainId: ChainId, rMarket: string, enabled?: boolean) => {
+export const useMintMarket = ({ rMarket, chainId }: { chainId: ChainId; rMarket: string }, enabled?: boolean) => {
   const { llamaApi: api } = useCurve()
-  const mintMarketData = useMintMarketData(chainId, rMarket, enabled)
-  return {
-    ...useMappedQuery(
-      mintMarketData,
-      useCallback(data => api && data && api.getMintMarketByData(data.id, data), [api]),
-    ),
-    isSuccess: mintMarketData.isSuccess && !!api,
-  }
+  return useMappedQuery(
+    useMintMarketData({ chainId, rMarket }, enabled),
+    useCallback(data => api && data && api.getMintMarketByData(data.id, data), [api]),
+  )
 }

--- a/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
@@ -106,7 +106,7 @@ const useCampaigns = ({ blockchainId }: UseCampaignsOptions = {}) =>
 export const useCampaignsByAddress = ({
   address,
   blockchainId,
-}: { address: Address | undefined } & UseCampaignsOptions) => {
+}: { address: Address | null | undefined } & UseCampaignsOptions) => {
   const query = useMappedQuery(
     useCampaigns({ blockchainId, enabled: Boolean(address) }),
     useCallback(campaigns => address && campaigns[address], [address]),

--- a/packages/curve-ui-kit/src/types/util.ts
+++ b/packages/curve-ui-kit/src/types/util.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { type Falsy, maybe } from '@primitives/objects.utils'
+import { maybe } from '@primitives/objects.utils'
 import type { UseQueryResult } from '@tanstack/react-query'
 
 export type Range<T> = [T, T]
@@ -75,10 +75,15 @@ export const q = <T>({ data, isLoading, error }: Query<T>) =>
 
 type QueryData<TQuery> = TQuery extends Query<infer TData> ? TData : never
 
-export const fallbackQ = <const TQueries extends readonly (Query<unknown> | Falsy)[]>(...queries: TQueries) => {
-  const filtered = queries.filter((x): x is Query<unknown> => !!x)
-  return q(filtered.find(q => !q.error) ?? filtered[0]) as QueryProp<QueryData<TQueries[number]>>
-}
+/**
+ * Takes the first query with data, then the first query with an error, then the first query that is loading,
+ * and finally the first query in the list. Use the disabled query property to ignore a query and use the fallback.
+ */
+export const fallbackQ = <const TQueries extends readonly QueryProp<unknown>[]>(...queries: TQueries) =>
+  (queries.find(q => q.data != null) ??
+    queries.find(q => q.error) ??
+    queries.find(q => q.isLoading) ??
+    queries[0]) as QueryProp<QueryData<TQueries[number]>>
 
 /**
  * Maps a Query type to extract partial data from it.

--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -16,6 +16,7 @@ import {
 } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createBorrowMoreScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
 import { mockMintSnapshots } from '@cy/support/helpers/minting-mocks'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ } from '@ui-kit/types/util'
 import { Chain } from '@ui-kit/utils'
 
@@ -75,6 +76,7 @@ describe('BorrowMoreForm (mocked)', () => {
             chainId={chainId}
             onPricesUpdated={onPricesUpdated}
             collateralEvents={constQ(fakeCollateralEvents)}
+            marketType={LlamaMarketType.Mint}
           />
         </MockLoanTestWrapper>,
       )

--- a/tests/cypress/component/llamalend/create-loan.cy.tsx
+++ b/tests/cypress/component/llamalend/create-loan.cy.tsx
@@ -8,6 +8,7 @@ import {
 import { MockLoanTestWrapper } from '@cy/support/helpers/llamalend/MockLoanTestWrapper'
 import { llamaNetworks, setGasInfo, setLlamaApi } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createCreateLoanScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
+import { LlamaMarketType } from '@ui-kit/types/market'
 
 const chainId = 1
 const testCases = [
@@ -35,6 +36,7 @@ describe('CreateLoanForm (mocked)', () => {
             networks={llamaNetworks}
             chainId={chainId}
             onPricesUpdated={onPricesUpdated}
+            marketType={LlamaMarketType.Mint}
           />
         </MockLoanTestWrapper>,
       )

--- a/tests/cypress/component/llamalend/manage-soft-liq.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/manage-soft-liq.rpc.cy.tsx
@@ -8,6 +8,7 @@ import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import { createTenderlyWagmiConfigFromVNet, forkVirtualTestnet } from '@cy/support/helpers/tenderly'
 import Skeleton from '@mui/material/Skeleton'
 import { CurveProvider, useCurve } from '@ui-kit/features/connect-wallet'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ } from '@ui-kit/types/util'
 import { Chain } from '@ui-kit/utils'
 
@@ -35,6 +36,7 @@ describe('Manage soft liquidation', () => {
         chainId={chainId}
         enabled={isHydrated}
         collateralEvents={constQ(undefined)}
+        marketType={LlamaMarketType.Mint}
       />
     )
   }

--- a/tests/cypress/component/llamalend/repay.cy.tsx
+++ b/tests/cypress/component/llamalend/repay.cy.tsx
@@ -16,6 +16,7 @@ import {
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createRepayScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ } from '@ui-kit/types/util'
 import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 
@@ -52,6 +53,7 @@ describe('RepayForm (mocked)', () => {
             chainId={chainId}
             onPricesUpdated={onPricesUpdated}
             collateralEvents={constQ(fakeCollateralEvents)}
+            marketType={LlamaMarketType.Mint}
           />
         </MockLoanTestWrapper>,
       )

--- a/tests/cypress/component/llamalend/soft-liquidation.cy.tsx
+++ b/tests/cypress/component/llamalend/soft-liquidation.cy.tsx
@@ -21,6 +21,7 @@ import {
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createSoftLiquidationScenario } from '@cy/support/helpers/llamalend/test-scenarios.helpers'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { constQ } from '@ui-kit/types/util'
 
 const chainId = 1
@@ -53,6 +54,7 @@ describe('Soft Liquidation Forms (mocked)', () => {
               networks={llamaNetworks}
               chainId={chainId}
               collateralEvents={constQ(undefined)}
+              marketType={LlamaMarketType.Mint}
             />
           </MockLoanTestWrapper>,
         )

--- a/tests/cypress/e2e/all/header.cy.ts
+++ b/tests/cypress/e2e/all/header.cy.ts
@@ -1,3 +1,4 @@
+import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
 import {
   APP_ROUTES,
   AppRoute,
@@ -118,6 +119,7 @@ describe('Header', () => {
       cy.viewport(width, height)
       dismissPhishingWarningBanner()
       route = oneAppRoute()
+      mockMerklCampaigns()
       cy.visitWithoutTestConnector(route)
       waitIsLoaded(route)
     })

--- a/tests/cypress/e2e/lend/basic.cy.ts
+++ b/tests/cypress/e2e/lend/basic.cy.ts
@@ -28,11 +28,21 @@ describe('Basic Access Test', () => {
 
   it('should load lend market details with a wallet', () => {
     cy.visit(`/lend/ethereum/markets/${LEND_MARKET}`)
-    shouldLoadLendBorrowDetails({ hasWallet: true })
+    shouldLoadLendBorrowDetails()
   })
 
   it('should load lend vault details with a wallet', () => {
     cy.visit(`/lend/ethereum/markets/${LEND_MARKET}/vault`)
-    shouldLoadLendVaultDetails({ hasWallet: true })
+    shouldLoadLendVaultDetails()
+  })
+
+  it('should load lend market details without a wallet', () => {
+    cy.visitWithoutTestConnector(`lend/ethereum/markets/${LEND_MARKET}`)
+    cy.get(`[data-testid="btn-connect-prompt"]`).should('be.visible')
+  })
+
+  it('should load lend vault details without a wallet', () => {
+    cy.visitWithoutTestConnector(`lend/ethereum/markets/${LEND_MARKET}/vault`)
+    cy.get(`[data-testid="btn-connect-prompt"]`).should('be.visible')
   })
 })

--- a/tests/cypress/e2e/lend/basic.cy.ts
+++ b/tests/cypress/e2e/lend/basic.cy.ts
@@ -1,6 +1,15 @@
+import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
+import {
+  shouldLoadLendBorrowDetails,
+  shouldLoadLendVaultDetails,
+} from '@cy/support/helpers/llamalend/market-details.helpers'
 import { LOAD_TIMEOUT } from '@cy/support/ui'
 
+const LEND_MARKET = '0x23F5a668A9590130940eF55964ead9787976f2CC'
+
 describe('Basic Access Test', () => {
+  beforeEach(() => mockMerklCampaigns())
+
   it('should open the Lend DApp successfully', () => {
     cy.visit('/lend/')
     cy.url(LOAD_TIMEOUT).should('match', /http:\/\/localhost:\d+\/llamalend\/ethereum\/markets\/?$/)
@@ -17,8 +26,13 @@ describe('Basic Access Test', () => {
     cy.title().should('equal', 'Legal - Curve')
   })
 
-  it('should open a lend market page succesfully', () => {
-    cy.visit('/lend/ethereum/markets/0x23F5a668A9590130940eF55964ead9787976f2CC') // some WETH lend market on ethereum
-    cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
+  it('should load lend market details with a wallet', () => {
+    cy.visit(`/lend/ethereum/markets/${LEND_MARKET}`)
+    shouldLoadLendBorrowDetails({ hasWallet: true })
+  })
+
+  it('should load lend vault details with a wallet', () => {
+    cy.visit(`/lend/ethereum/markets/${LEND_MARKET}/vault`)
+    shouldLoadLendVaultDetails({ hasWallet: true })
   })
 })

--- a/tests/cypress/e2e/loan/basic.cy.ts
+++ b/tests/cypress/e2e/loan/basic.cy.ts
@@ -1,6 +1,12 @@
+import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
+import { shouldLoadMintBorrowDetails } from '@cy/support/helpers/llamalend/market-details.helpers'
 import { LOAD_TIMEOUT } from '@cy/support/ui'
 
+const MINT_MARKET = 'WBTC'
+
 describe('Basic Access Test', () => {
+  beforeEach(() => mockMerklCampaigns())
+
   it('should open the crvUSD DApp successfully', () => {
     cy.visit('/crvusd')
     cy.title(LOAD_TIMEOUT).should('include', 'Markets')
@@ -12,8 +18,8 @@ describe('Basic Access Test', () => {
     cy.url().should('match', /http:\/\/localhost:\d+\/crvusd\/ethereum\/scrvUSD\/?$/)
   })
 
-  it('should open a loan market page succesfully', () => {
-    cy.visit('/crvusd/ethereum/markets/WBTC') // some WBTC mint market on ethereum
-    cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
+  it('should load mint market details with a wallet', () => {
+    cy.visit(`/crvusd/ethereum/markets/${MINT_MARKET}`)
+    shouldLoadMintBorrowDetails({ hasWallet: true })
   })
 })

--- a/tests/cypress/e2e/loan/basic.cy.ts
+++ b/tests/cypress/e2e/loan/basic.cy.ts
@@ -20,6 +20,11 @@ describe('Basic Access Test', () => {
 
   it('should load mint market details with a wallet', () => {
     cy.visit(`/crvusd/ethereum/markets/${MINT_MARKET}`)
-    shouldLoadMintBorrowDetails({ hasWallet: true })
+    shouldLoadMintBorrowDetails()
+  })
+
+  it('should load mint market details without a wallet', () => {
+    cy.visitWithoutTestConnector(`crvusd/ethereum/markets/${MINT_MARKET}`)
+    cy.get(`[data-testid="btn-connect-prompt"]`).should('be.visible')
   })
 })

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -60,9 +60,14 @@ type LlammalendTestProps = UserMarketQuery<LlamaChainId> & {
 function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: LlammalendTestProps) {
   const isLoan = type === 'loan'
   const { marketId, chainId } = props
-  const mintChain = chainId as MintChain
-  const { data: lendMarket, error: lendError } = useLendMarket(chainId, marketId, marketType === LlamaMarketType.Lend)
-  const { data: mintMarket, error: mintError } = useMintMarket(mintChain, marketId, marketType === LlamaMarketType.Mint)
+  const { data: lendMarket, error: lendError } = useLendMarket(
+    { chainId, rMarket: marketId },
+    marketType === LlamaMarketType.Lend,
+  )
+  const { data: mintMarket, error: mintError } = useMintMarket(
+    { chainId: chainId as MintChain, rMarket: marketId },
+    marketType === LlamaMarketType.Mint,
+  )
   const market = lendMarket ?? mintMarket
   const error = lendError ?? mintError
   const { data: loanExists } = useLoanExists(props, isLoan && !!market)
@@ -81,6 +86,7 @@ function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: Ll
       onSuccess={cy.stub()}
       enabled
       collateralEvents={constQ(fakeCollateralEvents)}
+      marketType={marketType}
       {...props}
     />
   ) : market ? (

--- a/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
@@ -1,110 +1,85 @@
 import { DECIMAL_REGEX, getActionValue } from '@cy/support/helpers/llamalend/action-info.helpers'
 import { LOAD_TIMEOUT } from '@cy/support/ui'
 
-type WalletOptions = { hasWallet: boolean }
-
 const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/
 
 const shouldShowCanvas = (testId: string) =>
   cy.get(`[data-testid="${testId}"] canvas`, LOAD_TIMEOUT).should('be.visible')
 
-const shouldLoadMarketContracts = ({
-  hasMonetaryPolicy,
-  hasOracle,
-  hasVault,
-}: {
-  hasMonetaryPolicy: boolean
-  hasOracle: boolean
-  hasVault: boolean
-}) => {
+const shouldLoadMarketContracts = ({ hasVault }: { hasVault: boolean }) => {
   cy.get('[data-testid="market-contracts-section"]', LOAD_TIMEOUT).should('be.visible')
   getActionValue('market-contract-collateral-token').should('match', ADDRESS_PATTERN)
   getActionValue('market-contract-borrow-token').should('match', ADDRESS_PATTERN)
   getActionValue('market-contract-amm').should('match', ADDRESS_PATTERN)
   if (hasVault) getActionValue('market-contract-vault').should('match', ADDRESS_PATTERN)
   getActionValue('market-contract-controller').should('match', ADDRESS_PATTERN)
-  if (hasMonetaryPolicy) getActionValue('market-contract-monetary-policy').should('match', ADDRESS_PATTERN)
-  if (hasOracle) getActionValue('market-contract-oracle').should('match', ADDRESS_PATTERN)
+  getActionValue('market-contract-monetary-policy').should('match', ADDRESS_PATTERN)
+  getActionValue('market-contract-oracle').should('match', ADDRESS_PATTERN)
 }
 
-const shouldLoadMarketParameters = ({
-  hasOnChainParameters,
-  hasOraclePrice,
-  hasPricePerShare,
-}: {
-  hasOnChainParameters: boolean
-  hasOraclePrice: boolean
-  hasPricePerShare: boolean
-}) => {
+const shouldLoadMarketParameters = ({ hasPricePerShare }: { hasPricePerShare: boolean }) => {
   cy.get('[data-testid="market-parameters-section"]', LOAD_TIMEOUT).should('be.visible')
-  if (hasOnChainParameters) {
-    getActionValue('market-param-amm-swap-fee').should('match', DECIMAL_REGEX)
-    getActionValue('market-param-admin-fee').should('match', DECIMAL_REGEX)
-    getActionValue('market-param-band-width-factor').should('match', DECIMAL_REGEX)
-    getActionValue('market-param-loan-discount').should('match', DECIMAL_REGEX)
-    getActionValue('market-param-liquidation-discount').should('match', DECIMAL_REGEX)
-  }
+  getActionValue('market-param-amm-swap-fee').should('match', DECIMAL_REGEX)
+  getActionValue('market-param-admin-fee').should('match', DECIMAL_REGEX)
+  getActionValue('market-param-band-width-factor').should('match', DECIMAL_REGEX)
+  getActionValue('market-param-loan-discount').should('match', DECIMAL_REGEX)
+  getActionValue('market-param-liquidation-discount').should('match', DECIMAL_REGEX)
   getActionValue('market-param-max-ltv').should('match', DECIMAL_REGEX)
 
   cy.get('[data-testid="market-prices-section"]', LOAD_TIMEOUT).should('be.visible')
-  if (hasOraclePrice) getActionValue('market-price-oracle').should('match', DECIMAL_REGEX)
+  getActionValue('market-price-oracle').should('match', DECIMAL_REGEX)
   if (hasPricePerShare) getActionValue('market-price-per-share').should('match', DECIMAL_REGEX)
 
   cy.get('[data-testid="market-id-section"]', LOAD_TIMEOUT).should('be.visible')
   getActionValue('market-id').should('not.equal', '-')
 }
 
-export const shouldLoadMarketDetails = ({ hasWallet }: WalletOptions) => {
+export const shouldLoadMarketDetails = () => {
   cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
-  cy.get('[data-testid="navigation-connect-wallet"]').should(hasWallet ? 'not.exist' : 'be.visible')
+  cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
   getActionValue('market-available-liquidity').should('match', DECIMAL_REGEX)
   cy.get('[data-testid="market-advanced-details"]', LOAD_TIMEOUT).should('be.visible')
   getActionValue('market-total-borrowers').should('match', DECIMAL_REGEX)
   cy.get('[data-testid="llamalend-market-faq"]').should('be.visible')
 }
 
-export const shouldLoadBorrowDetails = ({ hasWallet }: WalletOptions) => {
-  cy.get(`[data-testid="no-position-${hasWallet ? 'borrow' : 'disconnected'}"]`).should('be.visible')
+export const shouldLoadBorrowDetails = () => {
+  cy.get(`[data-testid="no-position-borrow"]`).should('be.visible')
   cy.get('[data-testid="borrow-collateral-input"]').should('be.visible')
   cy.get('[data-testid="borrow-debt-input"]').should('be.visible')
-  cy.get(`[data-testid="${hasWallet ? 'create-loan-submit-button' : 'navigation-connect-wallet'}"]`).should(
-    'be.visible',
-  )
-  if (hasWallet) cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
-  cy.get('[data-testid="create-loan-submit-button"]').should(hasWallet ? 'be.visible' : 'not.exist')
+  cy.get(`[data-testid="create-loan-submit-button"]`).should('be.visible')
+  cy.get('[data-testid="create-loan-submit-button"]').should('be.visible')
   getActionValue('market-net-borrow-apr').should('match', DECIMAL_REGEX)
   shouldShowCanvas('market-chart-and-activity')
   shouldShowCanvas('historical-borrow-rate-chart')
-  shouldLoadMarketDetails({ hasWallet })
+  shouldLoadMarketDetails()
 }
 
-export const shouldLoadLendBorrowDetails = ({ hasWallet }: WalletOptions) => {
-  shouldLoadBorrowDetails({ hasWallet })
+export const shouldLoadLendBorrowDetails = () => {
+  shouldLoadBorrowDetails()
   shouldShowCanvas('historical-supply-rate-chart')
   shouldShowCanvas('interest-rate-utilization-chart')
-  shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
-  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: false })
+  shouldLoadMarketContracts({ hasVault: true })
+  shouldLoadMarketParameters({ hasPricePerShare: false })
 }
 
-export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
-  shouldLoadBorrowDetails({ hasWallet })
+export const shouldLoadMintBorrowDetails = () => {
+  shouldLoadBorrowDetails()
   shouldShowCanvas('crvusd-price-chart')
   getActionValue('market-total-collateral').should('match', DECIMAL_REGEX)
-  shouldLoadMarketContracts({ hasMonetaryPolicy: hasWallet, hasOracle: hasWallet, hasVault: false })
-  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: hasWallet, hasPricePerShare: false })
+  shouldLoadMarketContracts({ hasVault: false })
+  shouldLoadMarketParameters({ hasPricePerShare: false })
 }
 
-export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
+export const shouldLoadLendVaultDetails = () => {
   cy.get('[data-testid="supply-deposit-input"]').should('be.visible')
-  cy.get(`[data-testid="${hasWallet ? 'supply-deposit-submit-button' : 'navigation-connect-wallet'}"]`).should(
-    'be.visible',
-  )
-  if (hasWallet) cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
-  cy.get('[data-testid="supply-deposit-submit-button"]').should(hasWallet ? 'be.visible' : 'not.exist')
+  cy.get(`[data-testid="supply-deposit-submit-button"]`).should('be.visible')
+  cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
+  cy.get('[data-testid="supply-deposit-submit-button"]').should('be.visible')
   getActionValue('market-net-supply-apy').should('match', DECIMAL_REGEX)
   shouldShowCanvas('historical-supply-rate-chart')
   shouldShowCanvas('interest-rate-utilization-chart')
-  shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
-  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: hasWallet })
-  shouldLoadMarketDetails({ hasWallet })
+  shouldLoadMarketContracts({ hasVault: true })
+  shouldLoadMarketParameters({ hasPricePerShare: true })
+  shouldLoadMarketDetails()
 }

--- a/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
@@ -1,0 +1,110 @@
+import { DECIMAL_REGEX, getActionValue } from '@cy/support/helpers/llamalend/action-info.helpers'
+import { LOAD_TIMEOUT } from '@cy/support/ui'
+
+type WalletOptions = { hasWallet: boolean }
+
+const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/
+
+const shouldShowCanvas = (testId: string) =>
+  cy.get(`[data-testid="${testId}"] canvas`, LOAD_TIMEOUT).should('be.visible')
+
+const shouldLoadMarketContracts = ({
+  hasMonetaryPolicy,
+  hasOracle,
+  hasVault,
+}: {
+  hasMonetaryPolicy: boolean
+  hasOracle: boolean
+  hasVault: boolean
+}) => {
+  cy.get('[data-testid="market-contracts-section"]', LOAD_TIMEOUT).should('be.visible')
+  getActionValue('market-contract-collateral-token').should('match', ADDRESS_PATTERN)
+  getActionValue('market-contract-borrow-token').should('match', ADDRESS_PATTERN)
+  getActionValue('market-contract-amm').should('match', ADDRESS_PATTERN)
+  if (hasVault) getActionValue('market-contract-vault').should('match', ADDRESS_PATTERN)
+  getActionValue('market-contract-controller').should('match', ADDRESS_PATTERN)
+  if (hasMonetaryPolicy) getActionValue('market-contract-monetary-policy').should('match', ADDRESS_PATTERN)
+  if (hasOracle) getActionValue('market-contract-oracle').should('match', ADDRESS_PATTERN)
+}
+
+const shouldLoadMarketParameters = ({
+  hasOnChainParameters,
+  hasOraclePrice,
+  hasPricePerShare,
+}: {
+  hasOnChainParameters: boolean
+  hasOraclePrice: boolean
+  hasPricePerShare: boolean
+}) => {
+  cy.get('[data-testid="market-parameters-section"]', LOAD_TIMEOUT).should('be.visible')
+  if (hasOnChainParameters) {
+    getActionValue('market-param-amm-swap-fee').should('match', DECIMAL_REGEX)
+    getActionValue('market-param-admin-fee').should('match', DECIMAL_REGEX)
+    getActionValue('market-param-band-width-factor').should('match', DECIMAL_REGEX)
+    getActionValue('market-param-loan-discount').should('match', DECIMAL_REGEX)
+    getActionValue('market-param-liquidation-discount').should('match', DECIMAL_REGEX)
+  }
+  getActionValue('market-param-max-ltv').should('match', DECIMAL_REGEX)
+
+  cy.get('[data-testid="market-prices-section"]', LOAD_TIMEOUT).should('be.visible')
+  if (hasOraclePrice) getActionValue('market-price-oracle').should('match', DECIMAL_REGEX)
+  if (hasPricePerShare) getActionValue('market-price-per-share').should('match', DECIMAL_REGEX)
+
+  cy.get('[data-testid="market-id-section"]', LOAD_TIMEOUT).should('be.visible')
+  getActionValue('market-id').should('not.equal', '-')
+}
+
+export const shouldLoadMarketDetails = ({ hasWallet }: WalletOptions) => {
+  cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
+  cy.get('[data-testid="navigation-connect-wallet"]').should(hasWallet ? 'not.exist' : 'be.visible')
+  getActionValue('market-available-liquidity').should('match', DECIMAL_REGEX)
+  cy.get('[data-testid="market-advanced-details"]', LOAD_TIMEOUT).should('be.visible')
+  getActionValue('market-total-borrowers').should('match', DECIMAL_REGEX)
+  cy.get('[data-testid="llamalend-market-faq"]').should('be.visible')
+}
+
+export const shouldLoadBorrowDetails = ({ hasWallet }: WalletOptions) => {
+  cy.get(`[data-testid="no-position-${hasWallet ? 'borrow' : 'disconnected'}"]`).should('be.visible')
+  cy.get('[data-testid="borrow-collateral-input"]').should('be.visible')
+  cy.get('[data-testid="borrow-debt-input"]').should('be.visible')
+  cy.get(`[data-testid="${hasWallet ? 'create-loan-submit-button' : 'navigation-connect-wallet'}"]`).should(
+    'be.visible',
+  )
+  if (hasWallet) cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
+  cy.get('[data-testid="create-loan-submit-button"]').should(hasWallet ? 'be.visible' : 'not.exist')
+  getActionValue('market-net-borrow-apr').should('match', DECIMAL_REGEX)
+  shouldShowCanvas('market-chart-and-activity')
+  shouldShowCanvas('historical-borrow-rate-chart')
+  shouldLoadMarketDetails({ hasWallet })
+}
+
+export const shouldLoadLendBorrowDetails = ({ hasWallet }: WalletOptions) => {
+  shouldLoadBorrowDetails({ hasWallet })
+  shouldShowCanvas('historical-supply-rate-chart')
+  shouldShowCanvas('interest-rate-utilization-chart')
+  shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
+  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: false })
+}
+
+export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
+  shouldLoadBorrowDetails({ hasWallet })
+  shouldShowCanvas('crvusd-price-chart')
+  getActionValue('market-total-collateral').should('match', DECIMAL_REGEX)
+  shouldLoadMarketContracts({ hasMonetaryPolicy: hasWallet, hasOracle: hasWallet, hasVault: false })
+  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: hasWallet, hasPricePerShare: false })
+}
+
+export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
+  cy.get('[data-testid="supply-deposit-input"]').should('be.visible')
+  cy.get(`[data-testid="${hasWallet ? 'supply-deposit-submit-button' : 'navigation-connect-wallet'}"]`).should(
+    'be.visible',
+  )
+  if (hasWallet) cy.get('[data-testid="navigation-connect-wallet"]').should('not.exist')
+  cy.get('[data-testid="supply-deposit-submit-button"]').should(hasWallet ? 'be.visible' : 'not.exist')
+  getActionValue('market-net-supply-apy').should('match', DECIMAL_REGEX)
+  shouldShowCanvas('historical-supply-rate-chart')
+  shouldShowCanvas('interest-rate-utilization-chart')
+  shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
+  shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: hasWallet })
+  shouldLoadMarketDetails({ hasWallet })
+}

--- a/tests/cypress/support/routes.ts
+++ b/tests/cypress/support/routes.ts
@@ -12,7 +12,7 @@ import {
   PAGE_LEGAL,
 } from '@ui-kit/shared/routes'
 
-const SDOLA_LEND_POOL = '0xaD444663c6C92B497225c6cE65feE2E7F78BFb86'
+const WBTC_LEND_POOL = '0xcaD85b7fe52B1939DCEebEe9bCf0b2a5Aa0cE617'
 const DEFAULT_NETWORK = 'ethereum'
 
 export const CRVUSD_PAGE_MARKETS_ROUTE = `crvusd/${DEFAULT_NETWORK}${CRVUSD_ROUTES.PAGE_MARKETS}/`
@@ -24,7 +24,7 @@ export const APP_ROUTES = {
       ...recordValues(LEND_ROUTES).map(r =>
         r == LEND_ROUTES.PAGE_MARKETS
           ? // use market detail page, the list page redirects to the llamalend app
-            `${LEND_ROUTES.PAGE_MARKETS}/${SDOLA_LEND_POOL}${oneValueOf(LEND_MARKET_ROUTES)}`
+            `${LEND_ROUTES.PAGE_MARKETS}/${WBTC_LEND_POOL}${oneValueOf(LEND_MARKET_ROUTES)}`
           : r,
       ),
     )}`,


### PR DESCRIPTION
- depends on #2774 
- removes unnecessary marketId parameter
- replace market parameter by addresses & necessary parameters in preparation to #2748 
- add more specific tests to lend/mint market pages
- prepare create loan, claim, deposit, stake forms to show 'connect wallet' button
- refactor usePageHeader hook to separate supply/borrow/liquidity
- update fallbackQ behavior