### PR TITLE
chore: add missing MERKL_API_KEY to e2e github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,6 +200,8 @@ jobs:
       - name: Start merkl api server
         run: yarn dev 2>&1 | tee ../../e2e-api-${{ matrix.browser }}-${{ matrix.count }}.log &
         working-directory: apps/merkl-api
+        env:
+          MERKL_API_KEY: ${{ secrets.MERKL_API_KEY }}
 
       - name: e2e tests
         working-directory: tests

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -6,6 +6,14 @@ type ApiServerEnv = Partial<
 
 type DevServerEnv = Partial<Record<'HOST' | 'PORT', string | undefined>>
 
+const loadEnvFile = (path?: string) => {
+  try {
+    process.loadEnvFile(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
 export const createApiServer = ({ serviceName, env = process.env }: { serviceName: string; env?: ApiServerEnv }) => {
   const { LOG_LEVEL, NODE_ENV, SERVICE_NAME, npm_package_version } = env
 
@@ -39,7 +47,8 @@ export async function startDevServer({
   failureMessage: string
   env?: DevServerEnv
 }): Promise<void> {
-  process.loadEnvFile()
+  loadEnvFile('.env.local')
+  loadEnvFile()
 
   const server = createServer()
 


### PR DESCRIPTION
Also had to add support for `.env.local` in case you want to use the Merkl API key without having to commit to production `.env`