### PR TITLE
fix: hide vecrv boost on sidechains

### DIFF
--- a/apps/main/src/dex/features/user-position/liquidity-details/components/Metrics.tsx
+++ b/apps/main/src/dex/features/user-position/liquidity-details/components/Metrics.tsx
@@ -1,9 +1,10 @@
+import type { ChainId } from '@/dex/types/main.types'
 import Grid from '@mui/material/Grid'
 import { maybe } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { amount, formatNumber } from '@ui-kit/utils'
+import { amount, Chain, formatNumber } from '@ui-kit/utils'
 import type { LiquidityDetailsData } from '../hooks/useLiquidityDetails'
 
 const { Spacing } = SizesAndSpaces
@@ -11,8 +12,10 @@ const { Spacing } = SizesAndSpaces
 const METRIC_GRID_SIZE = { mobile: 6, desktop: 3 } as const
 
 export const Metrics = ({
+  chainId,
   metrics: { boost, lpTokenTotal, positionValue },
 }: {
+  chainId: ChainId
   metrics: LiquidityDetailsData['metrics']
 }) => (
   <Grid container spacing={Spacing.md}>
@@ -27,12 +30,15 @@ export const Metrics = ({
     </Grid>
 
     <Grid size={METRIC_GRID_SIZE}>
-      <Metric
-        size="medium"
-        label={t`veCRV Boost`}
-        value={boost}
-        valueOptions={{ unit: 'multiplier', abbreviate: false }}
-      />
+      {/** There's a ticket to support boost values on sidechains; for now we hide it explicitly instead of showing N/A */}
+      {chainId === Number(Chain.Ethereum) && (
+        <Metric
+          size="medium"
+          label={t`veCRV Boost`}
+          value={boost}
+          valueOptions={{ unit: 'multiplier', abbreviate: false }}
+        />
+      )}
     </Grid>
   </Grid>
 )

--- a/apps/main/src/dex/features/user-position/liquidity-details/index.tsx
+++ b/apps/main/src/dex/features/user-position/liquidity-details/index.tsx
@@ -15,7 +15,7 @@ export const LiquidityDetails = ({ blockchainId, ...params }: { blockchainId: st
 
   return (
     <Stack sx={{ gap: Spacing.md, padding: Spacing.sm }}>
-      <Metrics metrics={metrics} />
+      <Metrics chainId={params.chainId} metrics={metrics} />
 
       <Grid container spacing={Spacing.md}>
         <Grid size={CARD_GRID_SIZE}>


### PR DESCRIPTION
Hides the veCRV boost metric in the liquidity details card for anything but mainnet. There's a ticket to add support for sidechains and bring it back.

<img width="690" height="482" alt="image" src="https://github.com/user-attachments/assets/95c70b01-41ca-40c4-a6d2-4084ba05715b" />
