### PR TITLE
refactor: extract reusable table filter controls

### DIFF
--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
@@ -10,6 +10,7 @@ import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-tabl
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
 import { TableFilters } from '@ui-kit/shared/ui/DataTable/TableFilters'
+import { TableFiltersChip } from '@ui-kit/shared/ui/DataTable/TableFiltersChip'
 import { TableHeader } from '@ui-kit/shared/ui/DataTable/TableHeader'
 import { mapQuery, type QueryProp } from '@ui-kit/types/util'
 import { LlamaListChips } from './chips/LlamaListChips'
@@ -17,7 +18,6 @@ import { DEFAULT_SORT, LLAMA_MARKET_COLUMNS, LlamaMarketColumnId } from './colum
 import { MarketSortDrawer } from './drawers/MarketSortDrawer'
 import { getLlamaFacetedRowModel } from './filters/llamaFaceting'
 import { useLlamaGlobalFilterFn } from './filters/llamaGlobalFilter'
-import { LlamaTableFiltersChip } from './filters/LlamaTableFiltersChip'
 import { LlamaTableFiltersCollapsible } from './filters/LlamaTableFiltersCollapsible'
 import { LlamaTableFiltersOverlay } from './filters/LlamaTableFiltersOverlay'
 import { getLlamaMarketsColumnVariant, useLlamaTableVisibility } from './hooks/useLlamaTableVisibility'
@@ -101,7 +101,12 @@ export const LlamaMarketsTable = ({
             hasActiveFilters,
           }}
           filterChip={
-            <LlamaTableFiltersChip popoverFilterChipRef={filterChipRef} open={filtersOpen} setOpen={setFiltersOpen} />
+            <TableFiltersChip
+              popoverFilterChipRef={filterChipRef}
+              open={filtersOpen}
+              setOpen={setFiltersOpen}
+              testId="btn-open-filters"
+            />
           }
           sortChip={isMobile && <MarketSortDrawer onSortingChange={onSortingChange} sortField={sortField} />}
           chips={<LlamaListChips hasFavorites={hasFavorites} {...filterProps} />}

--- a/apps/main/src/llamalend/features/market-list/drawers/MarketSortDrawer.tsx
+++ b/apps/main/src/llamalend/features/market-list/drawers/MarketSortDrawer.tsx
@@ -1,21 +1,7 @@
-import { useCallback, useMemo, useRef } from 'react'
-import { MenuItem, MenuList } from '@mui/material'
-import Typography from '@mui/material/Typography'
 import { OnChangeFn, SortingState } from '@tanstack/react-table'
-import { useSwitch } from '@ui-kit/hooks/useSwitch'
-import { t } from '@ui-kit/lib/i18n'
-import { CaretSortIcon } from '@ui-kit/shared/icons/CaretSort'
-import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
-import { InvertOnHover } from '@ui-kit/shared/ui/InvertOnHover'
-import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
-import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
-import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
-import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { TableSortDrawer } from '@ui-kit/shared/ui/DataTable/TableSortDrawer'
 import { LlamaMarketColumnId } from '../columns'
 import { useLlamaMarketSortOptions } from '../hooks/useLlamaMarketSortOptions'
-
-const { Spacing, ButtonSize } = SizesAndSpaces
 
 type Props = {
   onSortingChange: OnChangeFn<SortingState>
@@ -23,56 +9,15 @@ type Props = {
 }
 
 export const MarketSortDrawer = ({ onSortingChange, sortField }: Props) => {
-  const [open, , closeDrawer, toggleDrawer] = useSwitch(false)
   const sortOptions = useLlamaMarketSortOptions()
-  const menuRef = useRef<HTMLLIElement | null>(null)
-
-  const selectedOption = useMemo(() => sortOptions.find(option => option.id === sortField), [sortOptions, sortField])
-
-  const handleSort = useCallback(
-    (id: LlamaMarketColumnId) => {
-      onSortingChange([{ id, desc: true }])
-      closeDrawer()
-    },
-    [onSortingChange, closeDrawer],
-  )
 
   return (
-    <SwipeableDrawer
-      paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }}
-      button={
-        <SelectableChip
-          size="medium"
-          selected={open}
-          icon={<CaretSortIcon />}
-          toggle={toggleDrawer}
-          data-testid="btn-drawer-sort-lamalend-markets"
-        />
-      }
-      open={open}
-      setOpen={closeDrawer}
-    >
-      <DrawerHeader title={t`Sort by`} />
-      <DrawerItems data-testid="drawer-sort-menu-lamalend-markets">
-        <MenuList disablePadding sx={{ display: 'flex', flexDirection: 'column', gap: Spacing.sm }}>
-          {sortOptions.map(({ id, label }) => (
-            <InvertOnHover hoverRef={menuRef} key={id}>
-              <MenuItem
-                ref={menuRef}
-                value={id}
-                selected={selectedOption?.id === id}
-                onClick={() => handleSort(id)}
-                sx={{ justifyContent: 'space-between', minHeight: ButtonSize.sm }}
-              >
-                <Typography component="span" variant="bodyMBold">
-                  {label}
-                </Typography>
-                {selectedOption?.id === id && <CheckIcon sx={{ marginLeft: Spacing.sm }} />}
-              </MenuItem>
-            </InvertOnHover>
-          ))}
-        </MenuList>
-      </DrawerItems>
-    </SwipeableDrawer>
+    <TableSortDrawer
+      buttonTestId="btn-drawer-sort-lamalend-markets"
+      drawerTestId="drawer-sort-menu-lamalend-markets"
+      onSortingChange={onSortingChange}
+      options={sortOptions}
+      sortField={sortField}
+    />
   )
 }

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaMarketsFilters.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaMarketsFilters.tsx
@@ -1,6 +1,7 @@
 import { noop, type Dictionary } from 'lodash'
 import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
+import { TableFilterButtonGroup } from '@ui-kit/shared/ui/DataTable/TableFilterButtonGroup'
 import { TableFilterItem } from '@ui-kit/shared/ui/DataTable/TableFilterItem'
 import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
 import { TokenLabel } from '@ui-kit/shared/ui/TokenLabel'
@@ -9,10 +10,9 @@ import { type AssetDetails } from '../../../queries/market-list/llama-markets'
 import { LlamaChainFilterChips } from '../chips/LlamaChainFilterChips'
 import { LLAMA_MARKET_TITLES, LlamaMarketColumnId } from '../columns'
 import { type LlamaMarketsFiltersProps, useLlamaMarketsFilters } from './hooks/useLlamaMarketsFilters'
+import { LlamaTableRangeFilter } from './LlamaTableRangeFilter'
 import { MultiSelectFilter } from './MultiSelectFilter'
-import { RangeFilter } from './RangeFilter'
 import { RangeSliderRowFilter } from './RangeSliderRowFilter'
-import { TableFilterButtonGroup } from './TableFilterButtonGroup'
 
 const { Spacing } = SizesAndSpaces
 
@@ -82,7 +82,7 @@ export const LlamaMarketsFilters = (props: LlamaMarketsFiltersProps) => {
         />
       </TableFilterItem>
       <TableFilterItem title={LLAMA_MARKET_TITLES[LlamaMarketColumnId.BorrowRate]}>
-        <RangeFilter
+        <LlamaTableRangeFilter
           id={LlamaMarketColumnId.BorrowRate}
           min={borrowRateRange.min}
           max={borrowRateRange.max}
@@ -92,7 +92,7 @@ export const LlamaMarketsFilters = (props: LlamaMarketsFiltersProps) => {
         />
       </TableFilterItem>
       <TableFilterItem title={LLAMA_MARKET_TITLES[LlamaMarketColumnId.Tvl]}>
-        <RangeFilter
+        <LlamaTableRangeFilter
           id={LlamaMarketColumnId.Tvl}
           min={tvlRange.min}
           max={tvlRange.max}
@@ -102,7 +102,7 @@ export const LlamaMarketsFilters = (props: LlamaMarketsFiltersProps) => {
         />
       </TableFilterItem>
       <TableFilterItem title={LLAMA_MARKET_TITLES[LlamaMarketColumnId.LiquidityUsd]}>
-        <RangeFilter
+        <LlamaTableRangeFilter
           id={LlamaMarketColumnId.LiquidityUsd}
           min={liquidityRange.min}
           max={liquidityRange.max}
@@ -112,7 +112,7 @@ export const LlamaMarketsFilters = (props: LlamaMarketsFiltersProps) => {
         />
       </TableFilterItem>
       <TableFilterItem title={LLAMA_MARKET_TITLES[LlamaMarketColumnId.UtilizationPercent]}>
-        <RangeFilter
+        <LlamaTableRangeFilter
           id={LlamaMarketColumnId.UtilizationPercent}
           min={utilizationRange.min}
           max={utilizationRange.max}

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableActiveFiltersChip.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableActiveFiltersChip.tsx
@@ -1,6 +1,5 @@
 import { capitalize } from 'lodash'
 import { useMemo } from 'react'
-import Stack from '@mui/material/Stack'
 import { toArray } from '@primitives/array.utils'
 import { assert, notFalsy } from '@primitives/objects.utils'
 import { ChainFilterChips } from '@ui-kit/shared/ui/DataTable/chips/ChainFilterChips'
@@ -12,15 +11,15 @@ import {
   rangeFilterFn,
   serializeListFilter,
 } from '@ui-kit/shared/ui/DataTable/filters'
+import { HiddenInlinedItems } from '@ui-kit/shared/ui/DataTable/HiddenInlinedItems'
+import { getInlinedItemsVisibility } from '@ui-kit/shared/ui/DataTable/HiddenInlinedItems.utils'
 import { TableActiveFilterChip } from '@ui-kit/shared/ui/DataTable/TableActiveFilterChip'
-import { TableSelectedFilterChips } from '@ui-kit/shared/ui/DataTable/TableSelectedFilterChips'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import {
+  TableActiveFilterGroups,
+  type TableActiveFilterGroup,
+} from '@ui-kit/shared/ui/DataTable/TableActiveFilterGroups'
 import { constQ } from '@ui-kit/types/util'
 import { LLAMA_MARKET_COLUMNS, LLAMA_MARKET_TITLES, LlamaMarketColumnId } from '../columns'
-import { HiddenInlinedItems } from './HiddenInlinedItems'
-import { getInlinedItemsVisibility } from './utils'
-
-const { Spacing } = SizesAndSpaces
 
 const LLAMA_MARKET_COLUMN_ORDER = new Map(LLAMA_MARKET_COLUMNS.map((column, index) => [column.id, index]))
 
@@ -55,57 +54,56 @@ export const LlamaTableActiveFiltersChip = <T extends TableItem>({
   )
 
   return (
-    <Stack direction="row" sx={{ gap: Spacing.sm, flexWrap: 'wrap' }}>
-      {sortedFiltersState.map(({ id, value }) => {
-        const column = assert(table.getColumn(id), `no column with id ${id}`)
-        const isRangeFilterFn = column.getFilterFn() === rangeFilterFn
-        const labels = isRangeFilterFn
-          ? notFalsy(getRangeLabel(value, column.columnDef.meta?.unit))
-          : parseListFilter(value)
-        const [visibleLabels, hiddenLabels] = getInlinedItemsVisibility(labels)
+    <TableActiveFilterGroups
+      groups={notFalsy(
+        ...sortedFiltersState.map(({ id, value }): TableActiveFilterGroup | false => {
+          const column = assert(table.getColumn(id), `no column with id ${id}`)
+          const isRangeFilterFn = column.getFilterFn() === rangeFilterFn
+          const labels = isRangeFilterFn
+            ? notFalsy(getRangeLabel(value, column.columnDef.meta?.unit))
+            : parseListFilter(value)
+          const [visibleLabels, hiddenLabels] = getInlinedItemsVisibility(labels)
 
-        const removeClickedValue = (clickedValue: string | string[]) => {
-          const activeValues = parseListFilter(value)
-          const removedValues = new Set(toArray(clickedValue))
-          const remainingValues = activeValues?.filter(v => !removedValues.has(v))
-          setColumnFilter(id, serializeListFilter(remainingValues))
-        }
+          const removeClickedValue = (clickedValue: string | string[]) => {
+            const activeValues = parseListFilter(value)
+            const removedValues = new Set(toArray(clickedValue))
+            const remainingValues = activeValues?.filter(v => !removedValues.has(v))
+            setColumnFilter(id, serializeListFilter(remainingValues))
+          }
 
-        return (
-          !!labels?.length && (
-            <TableSelectedFilterChips
-              key={`selected-chip-${id}`}
-              title={LLAMA_MARKET_TITLES[id]}
-              testId={`${testIdPrefix}-active-filter-${id}`}
-            >
-              {/* Special chip for the chains filter */}
-              {id === LlamaMarketColumnId.Chain ? (
-                <ChainFilterChips
-                  chainsQuery={constQ(labels)}
-                  selectedChains={labels}
-                  toggleChain={removeClickedValue}
-                />
-              ) : (
-                <>
-                  {visibleLabels.map(label => (
-                    <TableActiveFilterChip
-                      key={`${label}-${id}`}
-                      label={formatLabel(label, id)}
-                      toggle={isRangeFilterFn ? () => setColumnFilter(id, null) : () => removeClickedValue(label)}
-                    />
-                  ))}
-                  <HiddenInlinedItems
-                    hiddenSelectedItemsLength={hiddenLabels.length}
-                    renderItem={label => (
-                      <TableActiveFilterChip label={label} toggle={() => removeClickedValue(hiddenLabels)} />
-                    )}
+          return (
+            !!labels?.length && {
+              chips:
+                id === LlamaMarketColumnId.Chain ? (
+                  <ChainFilterChips
+                    chainsQuery={constQ(labels)}
+                    selectedChains={labels}
+                    toggleChain={removeClickedValue}
                   />
-                </>
-              )}
-            </TableSelectedFilterChips>
+                ) : (
+                  <>
+                    {visibleLabels.map(label => (
+                      <TableActiveFilterChip
+                        key={`${label}-${id}`}
+                        label={formatLabel(label, id)}
+                        toggle={isRangeFilterFn ? () => setColumnFilter(id, null) : () => removeClickedValue(label)}
+                      />
+                    ))}
+                    <HiddenInlinedItems
+                      hiddenSelectedItemsLength={hiddenLabels.length}
+                      renderItem={label => (
+                        <TableActiveFilterChip label={label} toggle={() => removeClickedValue(hiddenLabels)} />
+                      )}
+                    />
+                  </>
+                ),
+              key: `selected-chip-${id}`,
+              title: LLAMA_MARKET_TITLES[id],
+              testId: `${testIdPrefix}-active-filter-${id}`,
+            }
           )
-        )
-      })}
-    </Stack>
+        }),
+      )}
+    />
   )
 }

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableActiveFiltersChip.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableActiveFiltersChip.tsx
@@ -6,27 +6,23 @@ import { assert, notFalsy } from '@primitives/objects.utils'
 import { ChainFilterChips } from '@ui-kit/shared/ui/DataTable/chips/ChainFilterChips'
 import type { ColumnMeta, FilterProps, TableItem, TanstackTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import {
+  getRangeFilterLabel,
   parseListFilter,
   parseRangeFilter,
   rangeFilterFn,
   serializeListFilter,
 } from '@ui-kit/shared/ui/DataTable/filters'
-import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+import { TableActiveFilterChip } from '@ui-kit/shared/ui/DataTable/TableActiveFilterChip'
+import { TableSelectedFilterChips } from '@ui-kit/shared/ui/DataTable/TableSelectedFilterChips'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { constQ } from '@ui-kit/types/util'
-import { formatNumber } from '@ui-kit/utils'
-import { type Unit } from '@ui-kit/utils/units'
 import { LLAMA_MARKET_COLUMNS, LLAMA_MARKET_TITLES, LlamaMarketColumnId } from '../columns'
 import { HiddenInlinedItems } from './HiddenInlinedItems'
-import { SelectedFilterChips } from './SelectedFilterChips'
 import { getInlinedItemsVisibility } from './utils'
 
 const { Spacing } = SizesAndSpaces
 
 const LLAMA_MARKET_COLUMN_ORDER = new Map(LLAMA_MARKET_COLUMNS.map((column, index) => [column.id, index]))
-
-const formatRangeValue = (value: number, unit?: Unit) =>
-  formatNumber(value, { abbreviate: true, ...(unit && { unit }) })
 
 // capitalize all labels except columns containing tokens symbols
 const formatLabel = (label: string, id: LlamaMarketColumnId) =>
@@ -34,18 +30,9 @@ const formatLabel = (label: string, id: LlamaMarketColumnId) =>
 
 // Convert a serialized range filter (`min~max`) into a single chip label
 const getRangeLabel = (serializedRange: string | undefined, unit?: ColumnMeta['unit']) => {
-  const [min, max] = parseRangeFilter(serializedRange) ?? []
-
-  if ((min == null || min === 0) && max != null) return `<${formatRangeValue(max, unit)}`
-  if (min != null && max == null) return `>${formatRangeValue(min, unit)}`
-  if (min != null && max != null) return `${formatRangeValue(min, unit)} - ${formatRangeValue(max, unit)}`
-
-  return null
+  const range = parseRangeFilter(serializedRange)
+  return range ? getRangeFilterLabel(range, unit) : null
 }
-
-const ActiveFilterChip = ({ label, toggle }: { label: string; toggle: () => void }) => (
-  <SelectableChip selected toggle={toggle} label={label} aria-label={label} />
-)
 
 export const LlamaTableActiveFiltersChip = <T extends TableItem>({
   table,
@@ -86,7 +73,7 @@ export const LlamaTableActiveFiltersChip = <T extends TableItem>({
 
         return (
           !!labels?.length && (
-            <SelectedFilterChips
+            <TableSelectedFilterChips
               key={`selected-chip-${id}`}
               title={LLAMA_MARKET_TITLES[id]}
               testId={`${testIdPrefix}-active-filter-${id}`}
@@ -101,7 +88,7 @@ export const LlamaTableActiveFiltersChip = <T extends TableItem>({
               ) : (
                 <>
                   {visibleLabels.map(label => (
-                    <ActiveFilterChip
+                    <TableActiveFilterChip
                       key={`${label}-${id}`}
                       label={formatLabel(label, id)}
                       toggle={isRangeFilterFn ? () => setColumnFilter(id, null) : () => removeClickedValue(label)}
@@ -110,12 +97,12 @@ export const LlamaTableActiveFiltersChip = <T extends TableItem>({
                   <HiddenInlinedItems
                     hiddenSelectedItemsLength={hiddenLabels.length}
                     renderItem={label => (
-                      <ActiveFilterChip label={label} toggle={() => removeClickedValue(hiddenLabels)} />
+                      <TableActiveFilterChip label={label} toggle={() => removeClickedValue(hiddenLabels)} />
                     )}
                   />
                 </>
               )}
-            </SelectedFilterChips>
+            </TableSelectedFilterChips>
           )
         )
       })}

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersCollapsible.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersCollapsible.tsx
@@ -1,17 +1,11 @@
-import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
-import Stack from '@mui/material/Stack'
 import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
-import { t } from '@ui-kit/lib/i18n'
 import { FavoriteHeartIcon } from '@ui-kit/shared/icons/HeartIcon'
 import type { FilterProps, TableItem, TanstackTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { borderStyle } from '@ui-kit/utils'
+import { TableActiveFiltersBar } from '@ui-kit/shared/ui/DataTable/TableActiveFiltersBar'
 import { LlamaMarketColumnId } from '../columns'
 import { useToggleFilter } from '../hooks/useToggleFilter'
 import { LlamaTableActiveFiltersChip } from './LlamaTableActiveFiltersChip'
-
-const { Spacing } = SizesAndSpaces
 
 const TEST_ID = 'table-filters-collapsible'
 
@@ -34,39 +28,22 @@ export const LlamaTableFiltersCollapsible = <T extends TableItem>({
     setColumnFilter,
   })
 
+  const favoriteChip = isMobile && (
+    <IconButton size="small" onClick={toggleFavorites} disabled={!hasFavorites} data-testid={`chip-favorites`}>
+      <FavoriteHeartIcon isFavorite={favorites} />
+    </IconButton>
+  )
+
   return (
-    <Stack
-      direction="row"
-      sx={{
-        paddingBlock: Spacing.xs,
-        paddingInline: Spacing.sm,
-        alignItems: 'end',
-        gap: Spacing.sm,
-        justifyContent: 'space-between',
-        borderTop: borderStyle,
-      }}
-      data-testid={TEST_ID}
+    <TableActiveFiltersBar
+      hasActiveFilters={hasActiveFilters}
+      resetFilters={resetFilters}
+      testId={TEST_ID}
+      endSlot={favoriteChip}
     >
       {!isMobile && (
         <LlamaTableActiveFiltersChip table={table} setColumnFilter={setColumnFilter} testIdPrefix={TEST_ID} />
       )}
-
-      <Button
-        color="ghost"
-        size="extraSmall"
-        onClick={resetFilters}
-        disabled={!hasActiveFilters}
-        sx={{ flexShrink: 0 }}
-        data-testid={`${TEST_ID}-reset-btn`}
-      >
-        {t`Reset filters`}
-      </Button>
-
-      {isMobile && (
-        <IconButton size="small" onClick={toggleFavorites} disabled={!hasFavorites} data-testid={`chip-favorites`}>
-          <FavoriteHeartIcon isFavorite={favorites} />
-        </IconButton>
-      )}
-    </Stack>
+    </TableActiveFiltersBar>
   )
 }

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableFiltersOverlay.tsx
@@ -1,24 +1,11 @@
-import { useState, type RefObject } from 'react'
+import { type RefObject } from 'react'
 import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
-import Button from '@mui/material/Button'
-import IconButton from '@mui/material/IconButton'
-import Popover from '@mui/material/Popover'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
-import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
-import { Cross2Icon } from '@ui-kit/shared/icons/Cross2Icon'
 import { FilterProps, TanstackTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
-import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
-import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
-import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { TableFiltersOverlay } from '@ui-kit/shared/ui/DataTable/TableFiltersOverlay'
 import type { QueryProp } from '@ui-kit/types/util'
-import { borderStyle, directChildrenAfterFirst } from '@ui-kit/utils'
 import { LlamaMarketColumnId } from '../columns'
 import { LlamaMarketsFilters } from './LlamaMarketsFilters'
-
-const { Spacing, Width, MinHeight } = SizesAndSpaces
 
 type LlamaTableFiltersOverlayProps = {
   table: TanstackTable<LlamaMarket>
@@ -30,7 +17,6 @@ type LlamaTableFiltersOverlayProps = {
   hasActiveFilters: boolean
 } & FilterProps<LlamaMarketColumnId>
 
-/** Llama market list table filters. Renders a drawer for mobile or a popover with the table filters. */
 export const LlamaTableFiltersOverlay = ({
   table,
   open,
@@ -40,65 +26,16 @@ export const LlamaTableFiltersOverlay = ({
   resetFilters,
   hasActiveFilters,
   ...filterProps
-}: LlamaTableFiltersOverlayProps) => {
-  const isMobile = useIsMobile()
-  const [testId, setTestId] = useState<string | null>(null)
-  const content = <LlamaMarketsFilters table={table} marketsQuery={marketsQuery} {...filterProps} />
-  const resetButton = (
-    <Button
-      color="ghost"
-      size="extraSmall"
-      onClick={resetFilters}
-      disabled={!hasActiveFilters}
-      data-testid="btn-reset-filters"
-    >
-      {t`Reset filters`}
-    </Button>
-  )
-  return isMobile ? (
-    <SwipeableDrawer paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }} open={open} setOpen={setOpen}>
-      <DrawerHeader title={t`Filter markets`}>
-        <Stack>{resetButton}</Stack>
-      </DrawerHeader>
-      <DrawerItems data-testid="drawer-filter-menu-lamalend-markets">{content}</DrawerItems>
-    </SwipeableDrawer>
-  ) : (
-    <Popover
-      open={open}
-      onClose={() => setOpen(false)}
-      anchorEl={() => anchorRef.current}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      slotProps={{
-        paper: {
-          sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
-        },
-        // set the testid once transition is ready to avoid flaky tests trying to click during transition
-        transition: { onEntered: () => setTestId('table-filters-popover'), onExit: () => setTestId(null) },
-      }}
-    >
-      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} data-testid={testId}>
-        <Stack
-          direction="row"
-          sx={{
-            gap: Spacing.sm,
-            paddingInlineStart: Spacing.sm,
-            minHeight: MinHeight.popoverHeader,
-            justifyContent: 'space-between',
-            alignItems: 'flex-end',
-          }}
-        >
-          <Typography variant="headingXsBold" color="textSecondary" sx={{ paddingBlockEnd: Spacing.xs }}>
-            {t`Filter markets`}
-          </Typography>
-          <IconButton size="extraSmall" onClick={() => setOpen(false)} data-testid="btn-close-filters">
-            <Cross2Icon />
-          </IconButton>
-        </Stack>
-        {content}
-        <Stack direction="row" sx={{ padding: Spacing.sm }}>
-          {resetButton}
-        </Stack>
-      </Stack>
-    </Popover>
-  )
-}
+}: LlamaTableFiltersOverlayProps) => (
+  <TableFiltersOverlay
+    anchorRef={anchorRef}
+    drawerTestId="drawer-filter-menu-lamalend-markets"
+    hasActiveFilters={hasActiveFilters}
+    open={open}
+    resetFilters={resetFilters}
+    setOpen={setOpen}
+    title={t`Filter markets`}
+  >
+    <LlamaMarketsFilters table={table} marketsQuery={marketsQuery} {...filterProps} />
+  </TableFiltersOverlay>
+)

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableRangeFilter.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableRangeFilter.tsx
@@ -27,7 +27,7 @@ export const LlamaTableRangeFilter = <TColumnId extends string>({
       range={range}
       setRange={setRange}
       adornment={adornment}
-      disabled={isLoading}
+      isLoading={isLoading}
       min={min}
       max={max}
     />

--- a/apps/main/src/llamalend/features/market-list/filters/LlamaTableRangeFilter.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/LlamaTableRangeFilter.tsx
@@ -1,0 +1,35 @@
+import { type FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { useRangeFilter } from '@ui-kit/shared/ui/DataTable/hooks/useRangeFilter'
+import { RangeFilter } from '@ui-kit/shared/ui/DataTable/RangeFilter'
+import { type NumericTextFieldProps } from '@ui-kit/shared/ui/NumericTextField'
+
+type LlamaTableRangeFilterProps<TColumnId extends string> = FilterProps<TColumnId> & {
+  id: TColumnId
+  adornment?: NumericTextFieldProps['adornment']
+  isLoading?: boolean
+  min?: number
+  max?: number
+}
+
+export const LlamaTableRangeFilter = <TColumnId extends string>({
+  id,
+  adornment,
+  isLoading = false,
+  min,
+  max,
+  ...filterProps
+}: LlamaTableRangeFilterProps<TColumnId>) => {
+  const [range, setRange] = useRangeFilter({ isLoading, id, min, max, ...filterProps })
+
+  return (
+    <RangeFilter
+      id={id}
+      range={range}
+      setRange={setRange}
+      adornment={adornment}
+      disabled={isLoading}
+      min={min}
+      max={max}
+    />
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/filters/MultiSelectFilter.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/MultiSelectFilter.tsx
@@ -11,11 +11,11 @@ import { t } from '@ui-kit/lib/i18n'
 import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
 import { type FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { parseListFilter, serializeListFilter } from '@ui-kit/shared/ui/DataTable/filters'
+import { HiddenInlinedItems } from '@ui-kit/shared/ui/DataTable/HiddenInlinedItems'
+import { getInlinedItemsVisibility } from '@ui-kit/shared/ui/DataTable/HiddenInlinedItems.utils'
 import { InvertOnHover } from '@ui-kit/shared/ui/InvertOnHover'
 import { Select } from '@ui-kit/shared/ui/Select'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { HiddenInlinedItems } from './HiddenInlinedItems'
-import { getInlinedItemsVisibility } from './utils'
 
 const { Spacing } = SizesAndSpaces
 

--- a/apps/main/src/llamalend/features/market-list/filters/RangeSliderRowFilter.tsx
+++ b/apps/main/src/llamalend/features/market-list/filters/RangeSliderRowFilter.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from 'react'
 import { type FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { useRangeFilter } from '@ui-kit/shared/ui/DataTable/hooks/useRangeFilter'
 import { type NumericTextFieldProps } from '@ui-kit/shared/ui/NumericTextField'
 import { type DecimalRangeValue, SliderInput } from '@ui-kit/shared/ui/SliderInput'
 import { Range } from '@ui-kit/types/util'
 import { decimal, formatNumber } from '@ui-kit/utils'
-import { useRangeFilter } from './RangeSliderFilter/useRangeFilter'
 
 type RangeSliderRowFilterProps<TColumnId extends string> = FilterProps<TColumnId> & {
   id: TColumnId

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
-/** Renders the overflow indicator for items hidden behind a max visibility limit.  */
+/** Renders the overflow indicator for items hidden behind a max visibility limit. */
 export const HiddenInlinedItems = ({
   hiddenSelectedItemsLength,
   renderItem,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.utils.ts
@@ -5,7 +5,7 @@ const MAX_VISIBLE_INLINED_ITEMS = 4
 
 /**
  * Split an array between visible and hidden items to maintain inline compaction.
- * Any remaining items are collapsed into a single "+N" item.
+ * Any remaining items are collapsed into a single "+N" item, , if more than 1 item is hidden
  */
 export const getInlinedItemsVisibility = (
   selectedItems: string[] | undefined,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/HiddenInlinedItems.utils.ts
@@ -5,7 +5,7 @@ const MAX_VISIBLE_INLINED_ITEMS = 4
 
 /**
  * Split an array between visible and hidden items to maintain inline compaction.
- * Any remaining items are collapsed into a single "+N" item, if more than 1 item is hidden
+ * Any remaining items are collapsed into a single "+N" item.
  */
 export const getInlinedItemsVisibility = (
   selectedItems: string[] | undefined,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/RangeFilter.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/RangeFilter.tsx
@@ -3,35 +3,26 @@ import { useCallback } from 'react'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { t } from '@ui-kit/lib/i18n'
-import { type FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { NumericTextField, type NumericTextFieldProps } from '@ui-kit/shared/ui/NumericTextField'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { Range } from '@ui-kit/types/util'
 import { amount, decimal, formatNumber } from '@ui-kit/utils'
-import { useRangeFilter } from './RangeSliderFilter/useRangeFilter'
 
 const { Spacing } = SizesAndSpaces
 
-type RangeFilterProps<TColumnId extends string> = FilterProps<TColumnId> & {
-  id: TColumnId
+type InputIndex = 0 | 1
+
+type RangeFilterProps = {
+  id: string
+  range: Range<number | null>
+  setRange: (range: Range<number | null>) => void
   adornment?: NumericTextFieldProps['adornment']
-  isLoading?: boolean
+  disabled?: boolean
   min?: number
   max?: number
 }
 
-type InputIndex = 0 | 1
-
-export const RangeFilter = <TColumnId extends string>({
-  id,
-  adornment,
-  isLoading = false,
-  min,
-  max,
-  ...filterProps
-}: RangeFilterProps<TColumnId>) => {
-  const [range, setRange] = useRangeFilter({ isLoading, id, min, max, ...filterProps })
-
+export const RangeFilter = ({ id, range, setRange, adornment, disabled = false, min, max }: RangeFilterProps) => {
   const handleInputChange = useCallback(
     (index: InputIndex) => (newValue: string | undefined) => {
       const nextFirst = index === 0 ? (amount(newValue) as number) : range[0]
@@ -78,7 +69,7 @@ export const RangeFilter = <TColumnId extends string>({
       max={decimal(max)}
       onChange={handleInputChange(index)}
       onBlur={handleInputBlur(index)}
-      disabled={isLoading}
+      disabled={disabled}
       adornment={adornment}
       format={value => (value == null ? '' : formatNumber(value, { abbreviate: true }))}
       placeholder={placeholder}
@@ -89,16 +80,8 @@ export const RangeFilter = <TColumnId extends string>({
 
   return (
     <Stack direction="row" sx={{ gap: Spacing.sm }}>
-      {renderInputField({
-        index: 0,
-        placeholder: t`Min`,
-        testId: 'min',
-      })}
-      {renderInputField({
-        index: 1,
-        placeholder: t`Max`,
-        testId: 'max',
-      })}
+      {renderInputField({ index: 0, placeholder: t`Min`, testId: 'min' })}
+      {renderInputField({ index: 1, placeholder: t`Max`, testId: 'max' })}
     </Stack>
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/RangeFilter.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/RangeFilter.tsx
@@ -17,12 +17,12 @@ type RangeFilterProps = {
   range: Range<number | null>
   setRange: (range: Range<number | null>) => void
   adornment?: NumericTextFieldProps['adornment']
-  disabled?: boolean
+  isLoading?: boolean
   min?: number
   max?: number
 }
 
-export const RangeFilter = ({ id, range, setRange, adornment, disabled = false, min, max }: RangeFilterProps) => {
+export const RangeFilter = ({ id, range, setRange, adornment, isLoading = false, min, max }: RangeFilterProps) => {
   const handleInputChange = useCallback(
     (index: InputIndex) => (newValue: string | undefined) => {
       const nextFirst = index === 0 ? (amount(newValue) as number) : range[0]
@@ -69,7 +69,7 @@ export const RangeFilter = ({ id, range, setRange, adornment, disabled = false, 
       max={decimal(max)}
       onChange={handleInputChange(index)}
       onBlur={handleInputBlur(index)}
-      disabled={disabled}
+      disabled={isLoading}
       adornment={adornment}
       format={value => (value == null ? '' : formatNumber(value, { abbreviate: true }))}
       placeholder={placeholder}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFilterChip.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFilterChip.tsx
@@ -1,0 +1,11 @@
+import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+
+type TableActiveFilterChipProps = {
+  label: string
+  testId?: string
+  toggle: () => void
+}
+
+export const TableActiveFilterChip = ({ label, testId, toggle }: TableActiveFilterChipProps) => (
+  <SelectableChip selected toggle={toggle} label={label} aria-label={label} data-testid={testId} />
+)

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFilterGroups.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFilterGroups.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+import Stack from '@mui/material/Stack'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { TableSelectedFilterChips } from './TableSelectedFilterChips'
+
+const { Spacing } = SizesAndSpaces
+
+export type TableActiveFilterGroup = {
+  chips: ReactNode
+  key: string
+  testId?: string
+  title: ReactNode
+}
+
+/** Renders active filters grouped under category labels. */
+export const TableActiveFilterGroups = ({ groups }: { groups: readonly TableActiveFilterGroup[] }) => (
+  <Stack direction="row" sx={{ gap: Spacing.sm, flexWrap: 'wrap' }}>
+    {groups.map(({ chips, key, testId, title }) => (
+      <TableSelectedFilterChips key={key} title={title} testId={testId}>
+        {chips}
+      </TableSelectedFilterChips>
+    ))}
+  </Stack>
+)

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFiltersBar.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFiltersBar.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react'
+import Button from '@mui/material/Button'
+import Stack from '@mui/material/Stack'
+import { t } from '@ui-kit/lib/i18n'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { borderStyle } from '@ui-kit/utils'
+
+const { Spacing } = SizesAndSpaces
+
+type TableActiveFiltersBarProps = {
+  children: ReactNode
+  endSlot?: ReactNode
+  hasActiveFilters: boolean
+  resetFilters: () => void
+  testId: string
+}
+
+/** Collapsible active-filter row for DataTable screens. Extracted from the LlamaLend markets list. */
+export const TableActiveFiltersBar = ({
+  children,
+  endSlot,
+  hasActiveFilters,
+  resetFilters,
+  testId,
+}: TableActiveFiltersBarProps) => (
+  <Stack
+    direction="row"
+    sx={{
+      paddingBlock: Spacing.xs,
+      paddingInline: Spacing.sm,
+      alignItems: 'end',
+      gap: Spacing.sm,
+      justifyContent: 'space-between',
+      borderTop: borderStyle,
+    }}
+    data-testid={testId}
+  >
+    {children}
+
+    <Button
+      color="ghost"
+      size="extraSmall"
+      onClick={resetFilters}
+      disabled={!hasActiveFilters}
+      sx={{ flexShrink: 0 }}
+      data-testid={`${testId}-reset-btn`}
+    >
+      {t`Reset filters`}
+    </Button>
+
+    {endSlot}
+  </Stack>
+)

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFiltersBar.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableActiveFiltersBar.tsx
@@ -15,7 +15,7 @@ type TableActiveFiltersBarProps = {
   testId: string
 }
 
-/** Collapsible active-filter row for DataTable screens. Extracted from the LlamaLend markets list. */
+/** Collapsible active-filter row for DataTable. */
 export const TableActiveFiltersBar = ({
   children,
   endSlot,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilterButtonGroup.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilterButtonGroup.tsx
@@ -3,7 +3,7 @@ import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import { notFalsy } from '@primitives/objects.utils'
 import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
-import { TableFilterItem } from '@ui-kit/shared/ui/DataTable/TableFilterItem'
+import { TableFilterItem } from './TableFilterItem'
 
 export type TableFilterButtonOption<T extends string> = {
   value: T

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFilters.tsx
@@ -32,8 +32,7 @@ export const TableFilters = <ColumnIds extends string>({
   testIdPrefix: string
   visibilityGroups: VisibilityGroup<ColumnIds>[]
   toggleVisibility?: (columns: string[]) => void
-  filtersOverlay?: ReactNode // filters shown in the filter overlay (popover or drawer for mobile)
-  // collabsible bar that displays the active filters
+  // collapsible bar that displays the active filters
   collapsibleFilters?: { collapsible: ReactNode; hasActiveFilters?: boolean | undefined }
   chips?: ReactNode // buttons that are part of the collapsible (on mobile) or always visible (on larger screens)
   filterChip?: ReactNode // buttons responsible for filtering

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersChip.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersChip.tsx
@@ -2,30 +2,23 @@ import type { RefObject } from 'react'
 import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
 import { FilterIcon } from '@ui-kit/shared/icons/FilterIcon'
-import { GridChip } from '@ui-kit/shared/ui/DataTable/chips/GridChip'
 import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+import { GridChip } from './chips/GridChip'
 
-const OPEN_FILTERS_TEST_ID = 'btn-open-filters'
-
-type LlamaTableFiltersChipProps = {
+type TableFiltersChipProps = {
   open: boolean
-  setOpen: (open: boolean) => void
   popoverFilterChipRef: RefObject<HTMLDivElement | null>
+  setOpen: (open: boolean) => void
+  testId: string
 }
 
-/** Button that opens the Llama market filters drawer or popover. */
-export const LlamaTableFiltersChip = ({ open, setOpen, popoverFilterChipRef }: LlamaTableFiltersChipProps) => {
+/** Button that opens table filters in a drawer or popover. */
+export const TableFiltersChip = ({ open, popoverFilterChipRef, setOpen, testId }: TableFiltersChipProps) => {
   const isMobile = useIsMobile()
   const openFilters = () => setOpen(true)
 
   return isMobile ? (
-    <SelectableChip
-      size="medium"
-      selected={open}
-      icon={<FilterIcon />}
-      toggle={openFilters}
-      data-testid={OPEN_FILTERS_TEST_ID}
-    />
+    <SelectableChip size="medium" selected={open} icon={<FilterIcon />} toggle={openFilters} data-testid={testId} />
   ) : (
     <GridChip
       ref={popoverFilterChipRef}
@@ -34,7 +27,7 @@ export const LlamaTableFiltersChip = ({ open, setOpen, popoverFilterChipRef }: L
       selected={open}
       icon={<FilterIcon />}
       toggle={openFilters}
-      data-testid={OPEN_FILTERS_TEST_ID}
+      data-testid={testId}
     />
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
@@ -1,0 +1,100 @@
+import { useState, type ReactNode, type RefObject } from 'react'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import Popover from '@mui/material/Popover'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { useIsMobile } from '@ui-kit/hooks/useBreakpoints'
+import { t } from '@ui-kit/lib/i18n'
+import { Cross2Icon } from '@ui-kit/shared/icons/Cross2Icon'
+import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
+import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
+import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { borderStyle, directChildrenAfterFirst } from '@ui-kit/utils'
+
+const { Spacing, Width, MinHeight } = SizesAndSpaces
+
+type TableFiltersOverlayProps = {
+  anchorRef: RefObject<HTMLDivElement | null>
+  children: ReactNode
+  drawerTestId: string
+  hasActiveFilters: boolean
+  open: boolean
+  resetFilters: () => void
+  setOpen: (open: boolean) => void
+  title: string
+}
+
+/** Renders table filters in a mobile drawer or desktop popover. */
+export const TableFiltersOverlay = ({
+  anchorRef,
+  children,
+  drawerTestId,
+  hasActiveFilters,
+  open,
+  resetFilters,
+  setOpen,
+  title,
+}: TableFiltersOverlayProps) => {
+  const isMobile = useIsMobile()
+  const [testId, setTestId] = useState<string | null>(null)
+  const resetButton = (
+    <Button
+      color="ghost"
+      size="extraSmall"
+      onClick={resetFilters}
+      disabled={!hasActiveFilters}
+      data-testid="btn-reset-filters"
+    >
+      {t`Reset filters`}
+    </Button>
+  )
+
+  return isMobile ? (
+    <SwipeableDrawer paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }} open={open} setOpen={setOpen}>
+      <DrawerHeader title={title}>
+        <Stack>{resetButton}</Stack>
+      </DrawerHeader>
+      <DrawerItems data-testid={drawerTestId}>{children}</DrawerItems>
+    </SwipeableDrawer>
+  ) : (
+    <Popover
+      open={open}
+      onClose={() => setOpen(false)}
+      anchorEl={() => anchorRef.current}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      slotProps={{
+        paper: {
+          sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
+        },
+        // Set the test ID once transition is ready to avoid flaky tests clicking during transition.
+        transition: { onEntered: () => setTestId('table-filters-popover'), onExit: () => setTestId(null) },
+      }}
+    >
+      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} data-testid={testId}>
+        <Stack
+          direction="row"
+          sx={{
+            gap: Spacing.sm,
+            paddingInlineStart: Spacing.sm,
+            minHeight: MinHeight.popoverHeader,
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+          }}
+        >
+          <Typography variant="headingXsBold" color="textSecondary" sx={{ paddingBlockEnd: Spacing.xs }}>
+            {title}
+          </Typography>
+          <IconButton size="extraSmall" onClick={() => setOpen(false)} data-testid="btn-close-filters">
+            <Cross2Icon />
+          </IconButton>
+        </Stack>
+        {children}
+        <Stack direction="row" sx={{ padding: Spacing.sm }}>
+          {resetButton}
+        </Stack>
+      </Stack>
+    </Popover>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableSelectedFilterChips.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableSelectedFilterChips.tsx
@@ -5,7 +5,7 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { Spacing } = SizesAndSpaces
 
-export const SelectedFilterChips = ({
+export const TableSelectedFilterChips = ({
   title,
   children,
   testId,

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableSortDrawer.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableSortDrawer.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { MenuItem, MenuList } from '@mui/material'
+import Typography from '@mui/material/Typography'
+import type { OnChangeFn, SortingState } from '@tanstack/react-table'
+import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { t } from '@ui-kit/lib/i18n'
+import { CaretSortIcon } from '@ui-kit/shared/icons/CaretSort'
+import { CheckIcon } from '@ui-kit/shared/icons/CheckIcon'
+import { InvertOnHover } from '@ui-kit/shared/ui/InvertOnHover'
+import { SelectableChip } from '@ui-kit/shared/ui/SelectableChip'
+import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
+import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
+import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+
+const { Spacing, ButtonSize } = SizesAndSpaces
+
+export type TableSortDrawerOption<TSortId extends string> = {
+  id: TSortId
+  label: string
+}
+
+type TableSortDrawerProps<TSortId extends string> = {
+  buttonTestId: string
+  drawerTestId: string
+  onSortingChange: OnChangeFn<SortingState>
+  options: readonly TableSortDrawerOption<TSortId>[]
+  sortField: TSortId
+}
+
+/** Mobile sort drawer for DataTable screens. Extracted from the LlamaLend markets list. */
+export const TableSortDrawer = <TSortId extends string>({
+  buttonTestId,
+  drawerTestId,
+  onSortingChange,
+  options,
+  sortField,
+}: TableSortDrawerProps<TSortId>) => {
+  const [open, , closeDrawer, toggleDrawer] = useSwitch(false)
+  const menuRef = useRef<HTMLLIElement | null>(null)
+
+  const selectedOption = useMemo(() => options.find(option => option.id === sortField), [options, sortField])
+
+  const handleSort = useCallback(
+    (id: TSortId) => {
+      onSortingChange([{ id, desc: true }])
+      closeDrawer()
+    },
+    [onSortingChange, closeDrawer],
+  )
+
+  return (
+    <SwipeableDrawer
+      paperSx={{ maxHeight: SizesAndSpaces.MaxHeight.drawer }}
+      button={
+        <SelectableChip
+          size="medium"
+          selected={open}
+          icon={<CaretSortIcon />}
+          toggle={toggleDrawer}
+          data-testid={buttonTestId}
+        />
+      }
+      open={open}
+      setOpen={closeDrawer}
+    >
+      <DrawerHeader title={t`Sort by`} />
+      <DrawerItems data-testid={drawerTestId}>
+        <MenuList disablePadding sx={{ display: 'flex', flexDirection: 'column', gap: Spacing.sm }}>
+          {options.map(({ id, label }) => (
+            <InvertOnHover hoverRef={menuRef} key={id}>
+              <MenuItem
+                ref={menuRef}
+                value={id}
+                selected={selectedOption?.id === id}
+                onClick={() => handleSort(id)}
+                sx={{ justifyContent: 'space-between', minHeight: ButtonSize.sm }}
+              >
+                <Typography component="span" variant="bodyMBold">
+                  {label}
+                </Typography>
+                {selectedOption?.id === id && <CheckIcon sx={{ marginLeft: Spacing.sm }} />}
+              </MenuItem>
+            </InvertOnHover>
+          ))}
+        </MenuList>
+      </DrawerItems>
+    </SwipeableDrawer>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/filters.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/filters.tsx
@@ -1,8 +1,17 @@
 import type { FilterFn } from '@tanstack/react-table'
 import { Range } from '@ui-kit/types/util'
+import { formatNumber } from '@ui-kit/utils'
+import type { Unit } from '@ui-kit/utils/units'
 
 const RANGE_SEPARATOR = '~'
 const LIST_SEPARATOR = ','
+
+export type RangeFilterDefaults<T extends string | number> = Range<T | null | undefined>
+
+export const normalizeRangeFilterDefaults = <T extends string | number>(
+  range: Range<T | null>,
+  defaults: RangeFilterDefaults<T>,
+): Range<T | null> => range.map((value, index) => (value === defaults[index] ? null : value)) as Range<T | null>
 
 export const serializeRangeFilter = <T extends string | number>(range: Range<T | null> | null) =>
   range?.some(v => v != null) ? range.join(RANGE_SEPARATOR) : null
@@ -11,6 +20,21 @@ export const parseRangeFilter = (serialized: string | undefined) =>
   serialized?.split(RANGE_SEPARATOR).map(v => (v && !isNaN(+v) ? +v : null)) as
     | [number | null, number | null]
     | undefined
+
+export const getRangeFilterLabel = (
+  [min, max]: Range<number | null>,
+  unit?: Unit,
+  { defaultMin = 0 }: { defaultMin?: number } = {},
+) => {
+  const hasMin = min != null && min !== defaultMin
+  const formatValue = (value: number) => formatNumber(value, { abbreviate: true, ...(unit && { unit }) })
+
+  if (!hasMin && max != null) return `<${formatValue(max)}`
+  if (hasMin && max == null) return `>${formatValue(min)}`
+  if (hasMin && max != null) return `${formatValue(min)} - ${formatValue(max)}`
+
+  return null
+}
 
 export const serializeListFilter = (list: string[] | null | undefined) => list?.join(LIST_SEPARATOR) || null
 

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/hooks/useRangeFilter.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/hooks/useRangeFilter.ts
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from 'react'
 import { useUniqueDebounce } from '@ui-kit/hooks/useDebounce'
 import type { FilterProps } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { parseRangeFilter, serializeRangeFilter } from '@ui-kit/shared/ui/DataTable/filters'
+import {
+  normalizeRangeFilterDefaults,
+  parseRangeFilter,
+  serializeRangeFilter,
+} from '@ui-kit/shared/ui/DataTable/filters'
 import { Range } from '@ui-kit/types/util'
 
 export const useRangeFilter = <TColumnId extends string>({
@@ -13,19 +17,14 @@ export const useRangeFilter = <TColumnId extends string>({
   max,
 }: FilterProps<TColumnId> & { id: TColumnId; min?: number; max: number | undefined; isLoading?: boolean }) =>
   useUniqueDebounce({
-    // Separate default and applied range, the input's onBlur event that didn’t change anything could trigger the callback and clear the filter
+    // Separate default and applied range, the input's onBlur event that didn't change anything could trigger the callback and clear the filter.
     defaultValue: useMemo((): Range<number | null> => {
       const [minFilter, maxFilter] = parseRangeFilter(columnFiltersById[id]) ?? []
       return [minFilter ?? (isLoading ? null : min), maxFilter ?? (isLoading || max == null ? null : max)]
     }, [columnFiltersById, id, isLoading, min, max]),
     callback: useCallback(
       (newRange: Range<number | null>) =>
-        setColumnFilter(
-          id,
-          serializeRangeFilter(
-            newRange.map((value, i) => (value === [min, max][i] ? null : value)) as Range<number | null>,
-          ),
-        ),
+        setColumnFilter(id, serializeRangeFilter(normalizeRangeFilterDefaults(newRange, [min, max]))),
       [id, min, max, setColumnFilter],
     ),
   })


### PR DESCRIPTION
Extract the generic parts of the LlamaLend market table filters into shared DataTable components so the same filter drawer, chips, range inputs, active filter groups, hidden selected items, and mobile sort UI can be reused by the pool-list table.

Changes:
- Moved the filter overlay drawer/popover into shared DataTable UI
- Moved active/selected filter chip rendering into shared DataTable UI
- Moved hidden inline selected-item rendering into shared DataTable UI
- Moved the button group filter control into shared DataTable UI
- Moved the range filter input and range filter hook into shared DataTable UI
- Moved the mobile sort drawer into shared DataTable UI
- Updated LlamaLend markets to use the shared components while keeping existing behavior