### PR TITLE
chore: no-query-component-props rule

### DIFF
--- a/.eslint/no-query-component-props.rule.mjs
+++ b/.eslint/no-query-component-props.rule.mjs
@@ -1,0 +1,71 @@
+const isComponentName = name => /^[A-Z]/.test(name)
+
+const typeName = node => (node?.type === 'Identifier' ? node.name : null)
+
+const isComponentFunction = node => ['ArrowFunctionExpression', 'FunctionExpression'].includes(node?.type)
+
+const isQueryType = node => node?.type === 'TSTypeReference' && typeName(node.typeName) === 'Query'
+
+const getPropsAnnotation = param => param?.typeAnnotation?.typeAnnotation
+
+const getPropsTypeName = param => {
+  const annotation = getPropsAnnotation(param)
+  return annotation?.type === 'TSTypeReference' ? typeName(annotation.typeName) : null
+}
+
+const visitTypeNodes = (node, callback) => {
+  if (!node || typeof node.type !== 'string') return
+  callback(node)
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'parent') continue
+    if (Array.isArray(value)) value.forEach(child => visitTypeNodes(child, callback))
+    else if (value && typeof value.type === 'string') visitTypeNodes(value, callback)
+  }
+}
+
+const reportQueryProps = (context, node) => {
+  if (!node) return
+  visitTypeNodes(
+    node,
+    child =>
+      isQueryType(child) &&
+      context.report({
+        node: child,
+        messageId: 'queryProp',
+      }),
+  )
+}
+
+/**
+ * Forbids `Query<>` in React component props. Helpers and hooks may still use `Query<>`.
+ * @type {eslint.Rule.Module}
+ **/
+export const noQueryComponentPropsRule = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Disallow Query<> in React component props; use QueryProp<> instead' },
+    messages: { queryProp: 'Use `QueryProp<>` for React component props instead of `Query<>`.' },
+  },
+  create: context => {
+    const propsTypes = new Map()
+    const componentProps = new Set()
+
+    const trackComponent = (name, params) => {
+      if (!isComponentName(name)) return
+
+      const propsName = getPropsTypeName(params[0])
+      if (propsName) componentProps.add(propsName)
+      else reportQueryProps(context, getPropsAnnotation(params[0]))
+    }
+
+    return {
+      TSTypeAliasDeclaration: node => propsTypes.set(node.id.name, node.typeAnnotation),
+      TSInterfaceDeclaration: node => propsTypes.set(node.id.name, node),
+      FunctionDeclaration: node => trackComponent(node.id?.name, node.params),
+      VariableDeclarator: node =>
+        node.id.type === 'Identifier' && isComponentFunction(node.init) && trackComponent(node.id.name, node.init.params),
+      'Program:exit': () => componentProps.forEach(name => reportQueryProps(context, propsTypes.get(name))),
+    }
+  },
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ import { useMaybePatternRule } from './.eslint/use-maybe-pattern.rule.mjs'
 import { stableHookCallbacksRule } from './.eslint/stable-hook-callbacks.rule.mjs'
 import { noDoubleNegativeRule } from './.eslint/no-double-negative.rule.mjs'
 import { noJsxStringLiteralBracesRule } from './.eslint/no-jsx-string-literal-braces.rule.mjs'
+import { noQueryComponentPropsRule } from './.eslint/no-query-component-props.rule.mjs'
 import { noRedundantTernaryRule } from './.eslint/no-redundant-ternary.rule.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -56,6 +57,7 @@ const config = [
           'stable-hook-callbacks': stableHookCallbacksRule,
           'no-double-negative': noDoubleNegativeRule,
           'no-jsx-string-literal-braces': noJsxStringLiteralBracesRule,
+          'no-query-component-props': noQueryComponentPropsRule,
           'no-redundant-ternary': noRedundantTernaryRule,
         },
       },
@@ -81,6 +83,7 @@ const config = [
       'local/stable-hook-callbacks': 'error',
       'local/no-double-negative': 'error',
       'local/no-jsx-string-literal-braces': 'error',
+      'local/no-query-component-props': 'error',
       'local/no-redundant-ternary': 'error',
 
       'object-shorthand': 'warn',


### PR DESCRIPTION
- add lint rule to forbid `Query` usage for react components, suggesting `QueryProp` instead