### PR TITLE
fix: hide bands chart when disconnected

### DIFF
--- a/apps/main/src/llamalend/features/bands-chart/hooks/useBandsData.ts
+++ b/apps/main/src/llamalend/features/bands-chart/hooks/useBandsData.ts
@@ -4,7 +4,6 @@ import { useMarketBandsBalances, useUserBandsBalances } from '@/llamalend/querie
 import { useMarketLiquidationBand, useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useLoanExists } from '@/llamalend/queries/user'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { useCurve } from '@ui-kit/features/connect-wallet'
 
 export const useBandsData = ({
   chainId,
@@ -15,7 +14,6 @@ export const useBandsData = ({
   marketId: string | undefined
   enabled?: boolean
 }) => {
-  const { isHydrated } = useCurve()
   const { address: userAddress } = useConnection()
   const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists(
     { chainId, marketId, userAddress },
@@ -45,7 +43,6 @@ export const useBandsData = ({
   })
 
   const isLoading =
-    !isHydrated ||
     isLiquidationBandLoading ||
     isMarketBandsBalancesLoading ||
     isMarketOraclePriceLoading ||

--- a/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
+++ b/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
+import { useConnection } from 'wagmi'
 import { BandsChart } from '@/llamalend/features/bands-chart/BandsChart'
 import { useBandsChartPalette } from '@/llamalend/features/bands-chart/hooks/useBandsChartPalette'
 import type { ChartDataPoint, FetchedBandsBalances } from '@/llamalend/features/bands-chart/types'
@@ -62,6 +63,7 @@ type ChartAndActivityLayoutProps = {
 }
 
 export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActivityLayoutProps) => {
+  const { isConnected } = useConnection()
   const theme = useTheme()
   const [isBandsVisible, setIsBandsVisible] = useBandsChartVisible()
   const toggleBandsVisible = useCallback(() => setIsBandsVisible(prev => !prev), [setIsBandsVisible])
@@ -75,7 +77,7 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
     )
   }, [])
 
-  const showBands = bands && isBandsVisible
+  const showBands = bands && isBandsVisible && isConnected
   const hasUserBands = !!bands?.userBandsBalances?.length
   const collateralSymbol = bands?.collateralToken?.symbol
   const borrowSymbol = bands?.borrowToken?.symbol
@@ -120,6 +122,7 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
               }}
               isLoading={chart.isLoading}
               customButton={
+                isConnected &&
                 bands && (
                   <ToggleBandsChartButton
                     label={t`Bands`}

--- a/packages/curve-ui-kit/src/shared/ui/Chart/ToggleBandsChartButton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/ToggleBandsChartButton.tsx
@@ -1,38 +1,31 @@
-import type { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import Stack from '@mui/material/Stack'
+import ToggleButton from '@mui/material/ToggleButton'
 import { EyeClosed } from '@ui-kit/shared/icons/EyeClosed'
 import { EyeOpen } from '@ui-kit/shared/icons/EyeOpen'
+import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
+import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { SelectableChip } from '../SelectableChip'
-import { Tooltip } from '../Tooltip'
 
 const { Spacing } = SizesAndSpaces
 
-export const ToggleBandsChartButton = (
-  {
-    label,
-    isVisible,
-    toggle,
-    tooltip,
-  }: {
-    label: string
-    isVisible: boolean
-    toggle: () => void
-    tooltip?: ReactNode
-  }, // todo: refactor chip to button
-) => (
-  <Tooltip title={tooltip} placement="top">
-    <span>
-      <SelectableChip
-        toggle={toggle}
-        label={
-          <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
-            {isVisible ? <EyeOpen /> : <EyeClosed />}
-            {label}
-          </Stack>
-        }
-        selected={false}
-      />
-    </span>
-  </Tooltip>
+export const ToggleBandsChartButton = ({
+  label,
+  isVisible,
+  toggle,
+  tooltip,
+}: {
+  label: string
+  isVisible: boolean
+  toggle: () => void
+  tooltip?: ReactNode
+}) => (
+  <ToggleButton size="extraSmall" onClick={toggle} value={true}>
+    <WithWrapper Wrapper={Tooltip} title={tooltip} placement="top" shouldWrap={tooltip}>
+      <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
+        {isVisible ? <EyeOpen /> : <EyeClosed />}
+        {label}
+      </Stack>
+    </WithWrapper>
+  </ToggleButton>
 )


### PR DESCRIPTION
- hide the bands chart when the wallet is disconnected, as it currently keeps loading forever
- replace chip toggle with a proper ToggleButton, fixing existing TODO