### PR TITLE
refactor: ActionInfo query support

### DIFF
--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/BorrowRate.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/BorrowRate.tsx
@@ -1,9 +1,9 @@
 import { t } from '@ui-kit/lib/i18n'
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { Delta } from './types'
 import { formatValue } from './util'
 
-export type Props = Delta & Partial<ActionInfoProps>
+export type Props = Delta & ActionInfoOverrideProps
 
 /** Borrow rate values the user is paying to keep the loan open */
 export const BorrowRate = ({ current, next, ...actionInfoProps }: Props) => (

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Borrowed.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Borrowed.tsx
@@ -1,9 +1,9 @@
 import type { Decimal } from '@primitives/decimal.utils'
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { TokenAmount } from './types'
 import { formatTokens } from './util'
 
-export type Props = TokenAmount & { next?: Decimal } & Partial<ActionInfoProps>
+export type Props = TokenAmount & { next?: Decimal } & ActionInfoOverrideProps
 
 /** Borrowed collateral token information */
 export const Borrowed = ({ symbol, amount, next, ...actionInfoProps }: Props) => (

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Collateral.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Collateral.tsx
@@ -1,8 +1,8 @@
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { TokenAmount } from './types'
 import { formatTokens } from './util'
 
-export type Props = { collateral: TokenAmount[] } & Partial<ActionInfoProps>
+export type Props = { collateral: TokenAmount[] } & ActionInfoOverrideProps
 
 /** Array of collateral assets - only renders when provided */
 export const Collateral = ({ collateral, ...actionInfoProps }: Props) =>

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Debt.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Debt.tsx
@@ -1,9 +1,9 @@
 import type { Decimal } from '@primitives/decimal.utils'
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { TokenAmount } from './types'
 import { formatTokens } from './util'
 
-export type Props = TokenAmount & { next?: Decimal } & Partial<ActionInfoProps>
+export type Props = TokenAmount & { next?: Decimal } & ActionInfoOverrideProps
 
 /** Debt token with amount and optional new amount for comparison */
 export const Debt = ({ symbol, amount, next, ...actionInfoProps }: Props) => (

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Health.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Health.tsx
@@ -1,5 +1,5 @@
 import { HEALTH_THRESHOLDS } from '@/llamalend/features/market-position-details'
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { Delta, TextColor } from './types'
 import { formatValue } from './util'
 
@@ -19,7 +19,7 @@ const newHealthColor = ({ current, next }: Props): TextColor =>
 const healthColor = (current: number): TextColor =>
   current <= HEALTH_THRESHOLDS.CRITICAL ? 'error' : current <= HEALTH_THRESHOLDS.RISKY ? 'warning' : 'success'
 
-export type Props = Delta & Partial<ActionInfoProps>
+export type Props = Delta & ActionInfoOverrideProps
 
 /**
  * Health display logic for the accordion title.

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Leverage.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Leverage.tsx
@@ -1,8 +1,8 @@
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { formatNumber } from '@ui-kit/utils'
 import type { Delta } from './types'
 
-export type Props = Delta & Partial<ActionInfoProps>
+export type Props = Delta & ActionInfoOverrideProps
 
 /** The leverage multiplier if present, like 9x or 10x */
 export const Leverage = ({ current, next, ...actionInfoProps }: Props) => (

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Ltv.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/action-infos/Ltv.tsx
@@ -1,8 +1,8 @@
-import { type ActionInfoProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
+import { type ActionInfoOverrideProps, ActionInfo } from '@ui-kit/shared/ui/ActionInfo'
 import type { Delta } from './types'
 import { formatValue } from './util'
 
-export type Props = Delta & Partial<ActionInfoProps>
+export type Props = Delta & ActionInfoOverrideProps
 
 /** LTV value indicates how big the loan is compared to the collateral */
 export const Ltv = ({ current, next, ...actionInfoProps }: Props) => (

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -9,6 +9,7 @@ import { ErrorIconButton } from '@ui-kit/shared/ui/ErrorIconButton'
 import { IconButtonIconSize } from '@ui-kit/themes/components/button'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { TypographyVariantKey } from '@ui-kit/themes/typography'
+import type { QueryProp } from '@ui-kit/types/util'
 import { applySxProps } from '@ui-kit/utils'
 import { LabelTooltipIcon } from '../LabelTooltipIcon'
 import { Tooltip, type TooltipProps } from '../Tooltip'
@@ -19,15 +20,16 @@ const { Spacing, ButtonSize, IconSize } = SizesAndSpaces
 
 export type ActionInfoSize = 'small' | 'medium'
 
-export type ActionInfoProps = {
+type ActionInfoLoading = boolean | [number, number] | string
+type ActionInfoError = boolean | Error | string | null
+
+type ActionInfoBaseProps = {
   /** Label displayed on the left side */
   label: ReactNode
   /** Optional tooltip content shown next to the label with an info icon */
   labelTooltip?: Omit<TooltipProps, 'children'>
   /** Custom color for the label text */
   labelColor?: TypographyProps['color']
-  /** Primary value to display and copy */
-  value: ReactNode
   /** Custom color for the value text */
   valueColor?: TypographyProps['color']
   /** Optional content to display to the left of the value */
@@ -46,19 +48,35 @@ export type ActionInfoProps = {
   copiedTitle?: string
   /** Size of the component */
   size?: ActionInfoSize
-  /** Whether the component is in a loading state. Can be one of:
-   * - boolean
-   * - string (value is used for skeleton width inference)
-   * - [number, number] (explicit skeleton width and height in px)
-   **/
-  loading?: boolean | [number, number] | string
-  /** Error state; Unused for now, but kept for future use */
-  error?: boolean | Error | string | null
   /** Test ID for the component */
   testId?: string
   /** Additional styles */
   sx?: StackProps['sx']
 }
+
+export type ActionInfoOverrideProps = Partial<ActionInfoBaseProps>
+
+type ActionInfoValueProps =
+  | {
+      /** Primary value to display and copy */
+      value: ReactNode
+      /** Whether the component is in a loading state. Can be one of:
+       * - boolean
+       * - string (value is used for skeleton width inference)
+       * - [number, number] (explicit skeleton width and height in px)
+       **/
+      loading?: ActionInfoLoading
+      /** Error state; Unused for now, but kept for future use */
+      error?: ActionInfoError
+    }
+  | {
+      /** Query whose data is the primary value to display and copy. */
+      value: QueryProp<ReactNode>
+      loading?: never
+      error?: never
+    }
+
+export type ActionInfoProps = ActionInfoBaseProps & ActionInfoValueProps
 
 const DEFAULT_SIZE: ActionInfoSize = 'medium'
 
@@ -84,7 +102,7 @@ const rowHeight: Record<ActionInfoSize, string> = {
   medium: ButtonSize.xs,
 }
 
-type ValueDecoratorProps = Pick<ActionInfoProps, 'size' | 'error' | 'valueColor' | 'testId' | 'value'>
+type ValueDecoratorProps = Pick<ActionInfoProps, 'size' | 'error' | 'valueColor' | 'testId'> & { value: ReactNode }
 
 const ValueTypography = ({
   size = DEFAULT_SIZE,
@@ -122,25 +140,32 @@ const ValueDecorator = (props: ValueDecoratorProps) => (
     {props.value}
   </WithWrapper>
 )
-export const ActionInfo = ({
-  label,
-  labelTooltip,
-  labelColor,
-  prevValue: givenPrevValue,
-  prevValueColor,
-  value: givenValue,
-  valueColor,
-  valueLeft,
-  valueRight,
-  valueTooltip,
-  size = DEFAULT_SIZE,
-  copyValue,
-  copiedTitle,
-  loading = false,
-  error = false,
-  testId = 'action-info',
-  sx,
-}: ActionInfoProps) => {
+const isQuery = (value: ActionInfoProps['value']): value is QueryProp<ReactNode> =>
+  value != null && typeof value === 'object'
+
+export const ActionInfo = (props: ActionInfoProps) => {
+  const {
+    label,
+    labelTooltip,
+    labelColor,
+    prevValue: givenPrevValue,
+    prevValueColor,
+    value: propValue,
+    valueColor,
+    valueLeft,
+    valueRight,
+    valueTooltip,
+    size = DEFAULT_SIZE,
+    copyValue,
+    copiedTitle,
+    testId = 'action-info',
+    sx,
+  } = props
+  const {
+    data: givenValue,
+    isLoading: loading,
+    error,
+  } = isQuery(propValue) ? propValue : { data: propValue, isLoading: props.loading ?? false, error: props.error }
   const buttonSize = iconButtonSize[size]
   const iconSize = IconButtonIconSize[buttonSize]
   const value = givenValue ?? givenPrevValue

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -9,7 +9,7 @@ import { ErrorIconButton } from '@ui-kit/shared/ui/ErrorIconButton'
 import { IconButtonIconSize } from '@ui-kit/themes/components/button'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { TypographyVariantKey } from '@ui-kit/themes/typography'
-import type { QueryProp } from '@ui-kit/types/util'
+import { isQuery, type QueryProp } from '@ui-kit/types/util'
 import { applySxProps } from '@ui-kit/utils'
 import { LabelTooltipIcon } from '../LabelTooltipIcon'
 import { Tooltip, type TooltipProps } from '../Tooltip'
@@ -140,8 +140,6 @@ const ValueDecorator = (props: ValueDecoratorProps) => (
     {props.value}
   </WithWrapper>
 )
-const isQuery = (value: ActionInfoProps['value']): value is QueryProp<ReactNode> =>
-  value != null && typeof value === 'object'
 
 export const ActionInfo = (props: ActionInfoProps) => {
   const {

--- a/packages/curve-ui-kit/src/shared/ui/ActionInfo/index.ts
+++ b/packages/curve-ui-kit/src/shared/ui/ActionInfo/index.ts
@@ -1,5 +1,5 @@
 export { ActionInfo } from './ActionInfo'
-export type { ActionInfoProps } from './ActionInfo'
+export type { ActionInfoOverrideProps, ActionInfoProps } from './ActionInfo'
 
 export { ActionInfoGasEstimate } from './ActionInfoGasEstimate'
 export type { TxGasInfo, EstimatedTxCostProps } from './ActionInfoGasEstimate'

--- a/packages/curve-ui-kit/src/types/util.ts
+++ b/packages/curve-ui-kit/src/types/util.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { maybe } from '@primitives/objects.utils'
+import { maybe, objectKeys } from '@primitives/objects.utils'
 import type { UseQueryResult } from '@tanstack/react-query'
 
 export type Range<T> = [T, T]
@@ -118,3 +118,10 @@ export const useMappedQuery = <TSource, TResult>(
     data: useMemo(() => maybe(data, data => transform(data) ?? undefined), [data, transform]),
     error,
   })
+
+/** a list of keys for query objects, i.e., data, isLoading, error */
+const queryObjectKeys = objectKeys(constQ(1))
+
+/** Checks if a value is a query. */
+export const isQuery = <T>(value: unknown): value is QueryProp<T> =>
+  value != null && typeof value === 'object' && queryObjectKeys.every(key => key in value)


### PR DESCRIPTION
- add support to query props in action info
- do not update usages yet, that can be done in separate PRs