### PR TITLE
fix: rename 'swap fees' row to 'base apy' with tooltip

### DIFF
--- a/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
@@ -117,9 +117,10 @@ export const useYieldBreakdown = ({
       source: {
         icon: null,
         iconPosition: 'left',
-        primary: t`Swap fees`,
+        primary: t`Base APY`,
       },
       apy: maybe(rewardsApy?.base?.day, x => (+x > 0 ? +x : undefined)), // already APY, no need to calculate
+      apyTooltip: t`Base variable APY (vAPY) is the annualized yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`,
     })
 
     return rows


### PR DESCRIPTION
Brings back some nuance we've lost.

Tooltip only shows when you hover the actual APY rather than the datatable row, but row-wide tooltips require a bigger refactor.

![image.png](https://github.com/user-attachments/assets/23d596ba-2edf-4439-8482-69e835313a36)
