### PR TITLE
refactor: form submission void

### DIFF
--- a/apps/main/src/bridge/features/bridge/components/BridgeForm.tsx
+++ b/apps/main/src/bridge/features/bridge/components/BridgeForm.tsx
@@ -51,7 +51,6 @@ export const BridgeForm = ({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <>

--- a/apps/main/src/dao/components/PageGauges/CreateVote/CreateVoteModal.tsx
+++ b/apps/main/src/dao/components/PageGauges/CreateVote/CreateVoteModal.tsx
@@ -52,7 +52,6 @@ export const CreateVoteModal = ({ isOpen, onClose }: CreateVoteModalProps) => {
       compact
       open={isOpen}
       onClose={onClose}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       formProps={{ onSubmit }}
       footer={
         <Button
@@ -68,8 +67,7 @@ export const CreateVoteModal = ({ isOpen, onClose }: CreateVoteModalProps) => {
       }
     >
       <FormProvider {...form}>
-        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule. */}
-        <Stack component="form" spacing={Spacing.lg} onSubmit={onSubmit}>
+        <Stack spacing={Spacing.lg}>
           <Stack spacing={Spacing.xs}>
             <Typography variant="bodySBold">{t`Requirements:`}</Typography>
 

--- a/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
+++ b/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
@@ -74,8 +74,7 @@ export const AddRewardToken = ({ chainId, poolId }: AddRewardTokenProps) => {
 
   return (
     <FormProvider {...form}>
-      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule. */}
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form onSubmit={event => void handleSubmit(onSubmit)(event)}>
         <FormContainer>
           <FormFieldsContainer>
             <FlexContainer>

--- a/apps/main/src/dex/features/deposit-gauge-reward/ui/ActionsStepper.tsx
+++ b/apps/main/src/dex/features/deposit-gauge-reward/ui/ActionsStepper.tsx
@@ -133,8 +133,7 @@ export const DepositStepper = ({ chainId, poolId }: { chainId: ChainId; poolId: 
           (!isLoadingDepositRewardApproved && isDepositRewardApproved)
             ? t`Spending Approved`
             : t`Approve Spending`,
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
-        onClick: handleSubmit(onSubmitApproval),
+        onClick: () => void handleSubmit(onSubmitApproval)(),
       },
       {
         key: 'DEPOSIT',
@@ -145,8 +144,7 @@ export const DepositStepper = ({ chainId, poolId }: { chainId: ChainId; poolId: 
         ),
         type: 'action',
         content: step === DepositRewardStep.CONFIRMATION ? t`Deposited` : t`Deposit`,
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
-        onClick: handleSubmit(onSubmitDeposit),
+        onClick: () => void handleSubmit(onSubmitDeposit)(),
       },
     ],
     [

--- a/apps/main/src/dex/features/manage-pool/components/RefuelForm.tsx
+++ b/apps/main/src/dex/features/manage-pool/components/RefuelForm.tsx
@@ -31,7 +31,6 @@ export const RefuelForm = ({ chainId, blockchainId, poolAddress }: RefuelFormPar
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={<RefuelFormList values={values} tokenA={tokenA} tokenB={tokenB} poolTvl={poolTvl} />}
     >

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -79,7 +79,6 @@ export const CreateLoanForm = <ChainId extends IChainId>({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <CreateLoanInfoList

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
@@ -40,7 +40,6 @@ export const AddCollateralForm = <ChainId extends IChainId>({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <AddCollateralInfoList

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -73,7 +73,6 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <BorrowMoreLoanInfoList

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -41,7 +41,6 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <RemoveCollateralInfoList

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -139,7 +139,6 @@ export const RepayForm = <ChainId extends IChainId>({
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <RepayLoanInfoList

--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/tabs/ClosePositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/tabs/ClosePositionForm.tsx
@@ -42,7 +42,6 @@ export const ClosePositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <ClosePositionInfoList

--- a/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
@@ -39,7 +39,6 @@ export const DepositForm = <ChainId extends IChainId>({ networks }: DepositFormP
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <DepositSupplyInfoList

--- a/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
@@ -45,7 +45,6 @@ export const StakeForm = <ChainId extends IChainId>({ networks }: StakeFormProps
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <StakeSupplyInfoList

--- a/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
@@ -28,7 +28,6 @@ export const UnstakeForm = <ChainId extends IChainId>({ networks }: UnstakeFormP
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <UnstakeSupplyInfoList

--- a/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
@@ -37,7 +37,6 @@ export const WithdrawForm = <ChainId extends IChainId>({ networks }: WithdrawFor
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
       onSubmit={onSubmit}
       footer={
         <WithdrawSupplyInfoList

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositForm.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositForm.tsx
@@ -31,7 +31,6 @@ export const ScrvUsdDepositForm = ({ network }: NetworkUrlParams) => {
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Form submit handlers are async through react-hook-form.
       onSubmit={onSubmit}
       footer={
         <ScrvUsdDepositInfoList

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
@@ -23,7 +23,6 @@ export const ScrvUsdWithdrawForm = ({ network }: NetworkUrlParams) => {
   return (
     <Form
       {...form}
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Form submit handlers are async through react-hook-form.
       onSubmit={onSubmit}
       footer={<ScrvUsdWithdrawInfoList form={form} params={params} networks={networks} />}
     >

--- a/packages/curve-ui-kit/src/features/forms/form.types.ts
+++ b/packages/curve-ui-kit/src/features/forms/form.types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import { type BaseSyntheticEvent } from 'react'
 import { type FieldValues, type Path, type PathValue } from 'react-hook-form'
 import { type PartialRecord } from '@primitives/objects.utils'
 
@@ -20,9 +21,10 @@ export type FormState<T extends FieldValues> = {
   dirtyFields: PartialFields<T>
 }
 
+export type FormSubmitHandler = (event?: BaseSyntheticEvent) => Promise<void> | void
 export type UseFormHandleSubmit<T extends FieldValues = FieldValues> = (
   onSubmit: (data: T) => Promise<void> | void,
-) => () => Promise<void> | void
+) => FormSubmitHandler
 
 export type FormUpdates<TFieldValues extends FieldValues> = Partial<{
   [K in FieldPath<TFieldValues>]: FieldPathValue<TFieldValues, K>

--- a/packages/curve-ui-kit/src/features/report-error/ErrorReportModal.tsx
+++ b/packages/curve-ui-kit/src/features/report-error/ErrorReportModal.tsx
@@ -62,8 +62,7 @@ export const ErrorReportModal = ({ isOpen, onClose, context }: ErrorReportModalP
       footer={
         <Button
           fullWidth
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises -- Existing violation before enabling this rule.
-          onClick={onSubmit}
+          onClick={event => void onSubmit(event)}
           data-testid="submit-error-report-submit"
           variant="contained"
           disabled={!form.formState.isValid}

--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -7,6 +7,7 @@ import CardHeader from '@mui/material/CardHeader'
 import Dialog from '@mui/material/Dialog'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
+import type { FormSubmitHandler } from '@ui-kit/features/forms'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { Responsive } from '@ui-kit/themes/basic-theme'
 import type { SxProps } from '@ui-kit/utils'
@@ -17,6 +18,10 @@ const {
   Width: { modal: modalWidth },
   Height: { modal: modalHeight },
 } = SizesAndSpaces
+
+type ModalFormProps = Omit<FormHTMLAttributes<HTMLFormElement>, 'children' | 'onSubmit'> & {
+  onSubmit?: FormSubmitHandler
+}
 
 type ModalDialogProps = {
   /** Content of the modal dialog */
@@ -69,7 +74,7 @@ type ModalDialogProps = {
    * When a form is used inside the modal, we need to wrap the contents of the modal with a form element,
    * so that we can keep the form submission in the footer.
    */
-  formProps?: Omit<FormHTMLAttributes<HTMLFormElement>, 'children'>
+  formProps?: ModalFormProps
 
   /** Optional test id for the dialog root */
   testId?: string
@@ -79,7 +84,9 @@ type ModalDialogProps = {
  * When we have a form inside the modal, we can use this component to wrap it with a form element,
  * so that we can keep the form submission in the footer.
  */
-const Form = (props: FormHTMLAttributes<HTMLFormElement>) => <form {...props} />
+const Form = ({ onSubmit, ...props }: ModalFormProps) => (
+  <form {...props} onSubmit={onSubmit ? event => void onSubmit(event) : undefined} />
+)
 
 export const ModalDialog = ({
   children,

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/Form.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/Form.tsx
@@ -1,6 +1,6 @@
-import { type SubmitEventHandler, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { FormProvider } from '@ui-kit/features/forms'
-import type { FieldValues, UseFormReturn } from '@ui-kit/features/forms'
+import type { FieldValues, FormSubmitHandler, UseFormReturn } from '@ui-kit/features/forms'
 import { FormContent } from './FormContent'
 
 /**
@@ -13,12 +13,12 @@ export const Form = <TFieldValues extends FieldValues>({
   footer,
   ...form
 }: {
-  onSubmit: SubmitEventHandler<HTMLFormElement>
+  onSubmit: FormSubmitHandler
   children: ReactNode
   footer: ReactNode
 } & UseFormReturn<TFieldValues>) => (
   <FormProvider {...form}>
-    <form onSubmit={onSubmit} style={{ overflowWrap: 'break-word' }}>
+    <form onSubmit={event => void onSubmit(event)} style={{ overflowWrap: 'break-word' }}>
       <FormContent footer={footer}>{children}</FormContent>
     </form>
   </FormProvider>

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
@@ -46,7 +46,6 @@ export const SlippageSettingsModal = ({
             <FormAlerts formErrors={form.formState.visibleErrors} handledErrors={SLIPPAGE_TYPES} />
           </Stack>
         }
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         formProps={{ onSubmit }}
         compact
       >


### PR DESCRIPTION
The return type of form submissions is `() => Promise<void> | void`, but we want to treat all submissions as if they're just `void` and with an optional `events` param. This PR gets rid of all silenced lint errors and makes sure we standardize and `void` all submission calls inside `Form.tsx`.