### PR TITLE
feat: add robinhood wagmi chain definition

### DIFF
--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/chains.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/chains.ts
@@ -35,7 +35,7 @@ import {
   xLayer,
   zksync,
 } from '@wagmi/core/chains'
-import { ethereum as mainnet, expchain, hyperliquid, megaeth, strata } from './custom-chains'
+import { ethereum as mainnet, expchain, hyperliquid, megaeth, robinhood, strata } from './custom-chains'
 
 const wagmiChains = [
   arbitrum,
@@ -65,6 +65,7 @@ const wagmiChains = [
   plasma,
   plumeMainnet,
   polygon,
+  robinhood,
   sonic,
   stable,
   strata,

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/custom-chains.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/custom-chains.ts
@@ -66,3 +66,15 @@ export const expchain = defineChain({
   nativeCurrency: { name: 'tZKJ', symbol: 'tZKJ', decimals: 18 },
   rpcUrls: { default: { http: RPC[ChainId.ExpChain] } },
 })
+
+export const robinhood = defineChain({
+  ...chainConfig,
+  id: ChainId.Robinhood as const,
+  name: 'Robinhood',
+  testnet: false,
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  blockTime: 250,
+  rpcUrls: { default: { http: RPC[ChainId.Robinhood] } },
+  blockExplorers: { default: { name: 'Robinhood Explorer', url: 'https://robinhoodchain.blockscout.com' } },
+  contracts: { multicall3: { address: '0xca11bde05977b3631167028862be2a173976ca11' } },
+})

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/rpc.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/rpc.ts
@@ -37,4 +37,5 @@ export const RPC: Record<ChainId, string[]> = {
   [ChainId.ZkSync]: ['https://zksync.drpc.org', 'https://mainnet.era.zksync.io'],
   [ChainId.Monad]: [],
   [ChainId.Etherlink]: [],
+  [ChainId.Robinhood]: ['https://rpc.mainnet.chain.robinhood.com'],
 } as const

--- a/packages/primitives/src/network.utils.ts
+++ b/packages/primitives/src/network.utils.ts
@@ -29,4 +29,5 @@ export enum Chain {
   ExpChain = 18880,
   Monad = 143,
   Etherlink = 42793,
+  Robinhood = 4663,
 }


### PR DESCRIPTION
Wagmi doesn't have a built-in Robinhood Chain config yet, so we have to define it ourselves.