### PR TITLE
fix: lower refresh interval of static data from 1d to 1h

### DIFF
--- a/packages/curve-ui-kit/src/themes/design/0_primitives.ts
+++ b/packages/curve-ui-kit/src/themes/design/0_primitives.ts
@@ -170,7 +170,7 @@ export const Duration = {
     Actionable: REFRESH_INTERVAL['1m'],
     Informative: REFRESH_INTERVAL['5m'],
     DontShowAfter: REFRESH_INTERVAL['10m'],
-    SemiStatic: REFRESH_INTERVAL['1d'],
+    SemiStatic: REFRESH_INTERVAL['1h'],
   },
 }
 


### PR DESCRIPTION
Lowers the cache refresh interval for (semi)static data from 1 day to 1 hour. 1 day is a bit too long when waiting for things like new networks being added. The only other query that uses the same data interval is that of the list of integrations.