### PR TITLE
feat: zapv2 beta

### DIFF
--- a/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
@@ -175,11 +175,7 @@ export function useCreateLoanForm<ChainId extends LlamaChainId>({
     isLeverageSupported: !!market && hasLeverage(market),
     formErrors: formState.visibleErrors,
     disabledAlert,
-    solvencyModal: {
-      isOpen,
-      onClose,
-      onConfirm,
-    },
+    solvencyModal: { isOpen, onClose, onConfirm },
     routes: useMarketRoutes({
       chainId,
       marketAddress: ammAddress,

--- a/apps/main/src/llamalend/features/manage-loan/hooks/useBorrowMoreForm.ts
+++ b/apps/main/src/llamalend/features/manage-loan/hooks/useBorrowMoreForm.ts
@@ -165,11 +165,7 @@ export const useBorrowMoreForm = <ChainId extends LlamaChainId>({
     priceImpact,
     formErrors: formState.visibleErrors,
     disabledAlert,
-    solvencyModal: {
-      isOpen,
-      onClose,
-      onConfirm,
-    },
+    solvencyModal: { isOpen, onClose, onConfirm },
     routes: useMarketRoutes({
       chainId,
       marketAddress: ammAddress,

--- a/apps/main/src/llamalend/features/supply/hooks/useDepositForm.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useDepositForm.ts
@@ -83,10 +83,6 @@ export const useDepositForm = <ChainId extends LlamaChainId>({ network }: { netw
     isApproved: useDepositIsApproved(params),
     formErrors: formState.visibleErrors,
     disabledAlert,
-    solvencyModal: {
-      isOpen,
-      onClose,
-      onConfirm,
-    },
+    solvencyModal: { isOpen, onClose, onConfirm },
   }
 }

--- a/apps/main/src/llamalend/features/supply/hooks/useStakeForm.ts
+++ b/apps/main/src/llamalend/features/supply/hooks/useStakeForm.ts
@@ -88,10 +88,6 @@ export const useStakeForm = <ChainId extends LlamaChainId>({ network }: { networ
     hasGauge: marketHasGauge,
     formErrors: formState.visibleErrors,
     disabledAlert,
-    solvencyModal: {
-      isOpen,
-      onClose,
-      onConfirm,
-    },
+    solvencyModal: { isOpen, onClose, onConfirm },
   }
 }

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -60,6 +60,7 @@ export const hasLeverage = <T extends LlamaMarketTemplate | undefined>(market: T
  * but cannot calculate the leverage multiplier value.
  */
 export const hasLeverageValue = (market: LlamaMarketTemplate) =>
+  hasZapV2(market) ||
   (market instanceof LendMarketTemplate && hasV1Leverage(market)) ||
   (market instanceof MintMarketTemplate && hasV2Leverage(market))
 

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -43,7 +43,11 @@ export const tryGetLlamaMarket = (marketId: LlamaMarketTemplate | string | null 
  * - Mint Market and either its `leverageZap` is not the zero address or its `leverageV2` property has leverage
  */
 export const hasLeverage = <T extends LlamaMarketTemplate | undefined>(market: T) =>
-  maybe(market, market => hasV1Leverage(market) || (market instanceof MintMarketTemplate && hasV2Leverage(market)))
+  maybe(
+    market,
+    market =>
+      hasZapV2(market) || hasV1Leverage(market) || (market instanceof MintMarketTemplate && hasV2Leverage(market)),
+  )
 
 /**
  * Checks if leverage value (multiplier) can be calculated and displayed for this market.

--- a/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-query.helpers.ts
@@ -1,4 +1,4 @@
-import { getLlamaMarket, hasDeleverage, hasLeverage, hasV2Leverage, hasZapV2 } from '@/llamalend/llama.utils'
+import { getLlamaMarket, hasDeleverage, hasV1Leverage, hasV2Leverage, hasZapV2 } from '@/llamalend/llama.utils'
 import { LlamaMarketTemplate } from '@/llamalend/llamalend.types'
 import type { RepayQuery } from '@/llamalend/queries/validation/repay.types'
 import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
@@ -47,7 +47,7 @@ export function getRepayImplementation(
       const route = (routeMeta as RouteMutationMeta) ?? parseMutationRoute(market, { routeId, slippage, isRepay: true })
       return ['zapV2', market.leverageZapV2, [{ stateCollateral, userCollateral, ...route }]] as const
     }
-    if (hasLeverage(market)) return ['V1', market.leverage, [stateCollateral, userCollateral, userBorrowed]] as const
+    if (hasV1Leverage(market)) return ['V1', market.leverage, [stateCollateral, userCollateral, userBorrowed]] as const
   }
   throw new Error(
     // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions -- Existing violation before enabling this rule.

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -5,7 +5,7 @@ import type { Address } from '@primitives/address.utils'
 import { toArray } from '@primitives/array.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
-import { formatUnits } from '@ui-kit/utils'
+import { Chain, formatUnits } from '@ui-kit/utils'
 import { fetchApiRoutes, getRouteById } from './router-api.query'
 import type { RouteMeta, RouteMutationMeta, RoutesQuery } from './router-api.types'
 
@@ -41,12 +41,18 @@ export const parseMutationRoute = (
 }
 
 /**
+ * The curve-solver router supports more coins and routes than the curve router, e.g., sUSDe.
+ * However, it doesn't support all chains such as Optimism. So in those cases, we prefer the curve router.
+ */
+const PreferCurveSolver = [Chain.Ethereum, Chain.Arbitrum]
+
+/**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
  */
 export const getExpectedFn =
   ({
     chainId,
-    router = 'curve-solver', // router is unset when checking the max borrow
+    router = PreferCurveSolver.includes(chainId) ? 'curve-solver' : 'curve', // router is unset when checking the max borrow
     userAddress,
     slippage,
   }: Pick<RoutesQuery, 'chainId' | 'router' | 'slippage' | 'userAddress'>): GetExpectedFn =>

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -44,7 +44,7 @@ export const parseMutationRoute = (
  * The curve-solver router supports more coins and routes than the curve router, e.g., sUSDe.
  * However, it doesn't support all chains such as Optimism. So in those cases, we prefer the curve router.
  */
-const PreferCurveSolver = [Chain.Ethereum, Chain.Arbitrum]
+const SOLVER_CHAINS = [Chain.Ethereum, Chain.Arbitrum] as const
 
 /**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
@@ -52,7 +52,7 @@ const PreferCurveSolver = [Chain.Ethereum, Chain.Arbitrum]
 export const getExpectedFn =
   ({
     chainId,
-    router = PreferCurveSolver.includes(chainId) ? 'curve-solver' : 'curve', // router is unset when checking the max borrow
+    router = SOLVER_CHAINS.includes(chainId) ? 'curve-solver' : 'curve', // router is unset when checking the max borrow
     userAddress,
     slippage,
   }: Pick<RoutesQuery, 'chainId' | 'router' | 'slippage' | 'userAddress'>): GetExpectedFn =>

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -19,7 +19,7 @@ const LLV2_STABLE_RELEASE_DATE = new Date('2026-06-10T13:00:00Z') // 15:00 CEST
 const useAlphaChannel = () => useBetaChannel() && defaultReleaseChannel === ReleaseChannel.Beta
 
 /** New ZapV2 leverage implementation for LlamaLend markets */
-export const isZapV2Enabled = () => getReleaseChannel() !== ReleaseChannel.Legacy && !isZapV2Disabled()
+export const isZapV2Enabled = () => getReleaseChannel() === ReleaseChannel.Beta && !isZapV2Disabled()
 
 const useZapV2 = () => [useStableChannel(), !useDisableZapV2()].every(Boolean)
 

--- a/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
+++ b/packages/curve-ui-kit/src/hooks/useLocalStorage.ts
@@ -42,8 +42,8 @@ export const useReleaseChannel = () =>
     oldKey: 'beta',
   })
 
-export const useDisableZapV2 = () => useLocalStorage('disableZapV2', true)
-export const isZapV2Disabled = () => getFromLocalStorage<boolean>('disableZapV2') !== false
+export const useDisableZapV2 = () => useLocalStorage('disableZapV2', false)
+export const isZapV2Disabled = () => getFromLocalStorage<boolean>('disableZapV2') === true
 
 export const useFilterExpanded = (tableTitle: string) =>
   useLocalStorage<boolean>(`filter-expanded-${kebabCase(tableTitle)}`, false)


### PR DESCRIPTION
- add zapv2 check to hasLeverage and hasLeverageValue, since v2 markets don't support leverageV2 anymore
- use curve-solver only for arbitrum and ethereum