### PR TITLE
fix: rpc tests

### DIFF
--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -109,8 +109,8 @@ export const LOAN_TEST_MARKETS = {
       improveHealth: '0.01',
       chainId: Chain.Optimism,
       path: '/lend/optimism/markets/0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9',
-      hasLeverage: false, // leverage is temporarily disabled for v2 markets
-      hasLeverageManagement: false, // leverage is temporarily disabled for v2 markets
+      hasLeverage: true,
+      hasLeverageManagement: true,
       collateralDecimals,
       borrowedAddress: '0x4200000000000000000000000000000000000006', // WETH
       borrowedDecimals,


### PR DESCRIPTION
- #2830 enabled zapv2, but now rpc tests are broken because they find an unexpected leverage checkbox
- this PR updates the tests so they correctly expect leverage 
- [rpc test run](https://github.com/curvefi/curve-frontend/actions/runs/28602748359/job/84814979661)