### PR TITLE
fix: negative base APY wasn't shown in yield breakdown

### DIFF
--- a/apps/main/src/dex/features/pool-information/components/yield-breakdown/index.tsx
+++ b/apps/main/src/dex/features/pool-information/components/yield-breakdown/index.tsx
@@ -37,8 +37,7 @@ export const YieldBreakdown = ({
   })
 
   return (
-    rows.length > 0 &&
-    total != 0 && (
+    rows.length > 0 && (
       <Stack>
         <CardHeader title={t`Yield Breakdown`} size="small" />
         <DataTable<YieldBreakdownRow>

--- a/apps/main/src/dex/features/pool-information/components/yield-breakdown/index.tsx
+++ b/apps/main/src/dex/features/pool-information/components/yield-breakdown/index.tsx
@@ -38,7 +38,7 @@ export const YieldBreakdown = ({
 
   return (
     rows.length > 0 &&
-    total > 0 && (
+    total != 0 && (
       <Stack>
         <CardHeader title={t`Yield Breakdown`} size="small" />
         <DataTable<YieldBreakdownRow>

--- a/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
@@ -119,7 +119,7 @@ export const useYieldBreakdown = ({
         iconPosition: 'left',
         primary: t`Base APY`,
       },
-      apy: maybe(rewardsApy?.base?.day, x => (+x > 0 ? +x : undefined)), // already APY, no need to calculate
+      apy: maybe(rewardsApy?.base?.day, x => +x), // already APY, no need to calculate
       apyTooltip: t`Base variable APY (vAPY) is the annualized yield from trading fees based on the activity over the past 24h. If a pool holds a yield bearing asset, the intrinsic yield is added.`,
     })
 


### PR DESCRIPTION
Base APY can be negative due to rebases and such

Pool: `0xeC19D5f427c56e5A2Df1c620539ECd20a4D0a419`
<img width="1067" height="563" alt="image" src="https://github.com/user-attachments/assets/05930734-b0b5-4ef2-a9e1-37132971c7dd" />
