### PR TITLE
fix: restore dex pool navigation url assertion e2e test

### DIFF
--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -1,10 +1,6 @@
 import { orderBy } from 'lodash'
 import { oneOf } from '@cy/support/generators'
-import {
-  DEX_POOL_LIST_NAVIGATION_POOL,
-  DEX_POOL_LIST_SEARCH,
-  setupDexPoolListMocks,
-} from '@cy/support/helpers/dex-pool-list-mocks'
+import { DEX_POOL_LIST_SEARCH, setupDexPoolListMocks } from '@cy/support/helpers/dex-pool-list-mocks'
 import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
 import { API_LOAD_TIMEOUT, type Breakpoint, LOAD_TIMEOUT, oneViewport } from '@cy/support/ui'
 import { assert } from '@primitives/objects.utils'
@@ -136,20 +132,13 @@ describe('DEX Pools', () => {
     })
 
     it('navigates to pool deposit page by clicking a row', () => {
-      const poolLink = `[data-testid="market-link-${DEX_POOL_LIST_NAVIGATION_POOL.address}"]`
-
+      cy.get('[data-testid^="data-table-row-"]').first().click()
       if (breakpoint === 'mobile') {
-        cy.get(poolLink, API_LOAD_TIMEOUT).closest('[data-testid^="data-table-row-"]').click()
-        cy.get('[data-testid="collapse-icon"]').should('be.visible')
+        cy.get('[data-testid="collapse-icon"]').first().should('be.visible')
         cy.get('[data-testid="pool-link-deposit"]').click()
-      } else {
-        cy.get(poolLink, API_LOAD_TIMEOUT).click()
       }
-      cy.url(LOAD_TIMEOUT).should(
-        'include',
-        `/dex/${DEX_POOL_LIST_NAVIGATION_POOL.network}/pools/${DEX_POOL_LIST_NAVIGATION_POOL.address}/deposit`,
-      )
-      cy.get('[data-testid="pool-form-tab-deposit"]', API_LOAD_TIMEOUT).should('be.visible')
+      cy.url(LOAD_TIMEOUT).should('match', /\/dex\/arbitrum\/pools\/[^/]+\/(deposit|swap)\/?$/)
+      cy.title().should('match', /Curve - Pool - .* - Curve/)
     })
   })
 


### PR DESCRIPTION
Changes:
- Restore dex-markets navigation e2e test to only assert the updated URL