### PR TITLE
fix: chart error

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/Chart/EChartsLineChart.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Chart/EChartsLineChart.tsx
@@ -35,7 +35,7 @@ const getYAxisBounds = <TData extends Record<string, unknown>, TSeriesKey extend
 
   const min = Math.min(...values)
   const max = Math.max(...values)
-  const padding = min === max ? 1 : (max - min) * paddingRatio
+  const padding = max - min < 1e-10 ? 0.1 : (max - min) * paddingRatio
   return { yMin: min - padding, yMax: max + padding }
 }
 


### PR DESCRIPTION
- fixes Historical Borrow Rate dev-only  crash for [CRV lend market](https://www.curve.finance/lend/ethereum/markets/0xeda215b7666936ded834f76f3fbc6f323295110a)
- the difference between min and max rate is currently around 1e-17, which leads to echarts crashing due to isFinite checks
- lowers the padding from 1 to 0.1% for improved accuracy
<img width="1063" height="319" alt="image" src="https://github.com/user-attachments/assets/c22b0fb8-a93f-46de-810a-306b4f857937" />
