### PR TITLE
fix: prevent token overlap in LlammaEventChangeCell

### DIFF
--- a/packages/curve-ui-kit/src/features/activity-table/cells/LlammaEventChangeCell.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/cells/LlammaEventChangeCell.tsx
@@ -1,6 +1,7 @@
 import type { Chain } from '@curvefi/prices-api'
 import Stack from '@mui/material/Stack'
 import { type Token } from '@primitives/address.utils'
+import type { Size } from '@ui-kit/shared/ui//TokenIcon'
 import { InlineTableCell } from '@ui-kit/shared/ui/DataTable/inline-cells/InlineTableCell'
 import { TokenInfo } from '@ui-kit/shared/ui/TokenInfo'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -9,12 +10,23 @@ import type { LlammaEventRow } from '../types'
 
 const { Spacing } = SizesAndSpaces
 
-const AmountRow = ({ amount, token, chain }: { chain: Chain; amount: number; token: Token | undefined }) =>
+const AmountRow = ({
+  amount,
+  token,
+  chain,
+  iconSize,
+}: {
+  chain: Chain
+  amount: number
+  token: Token | undefined
+  iconSize?: Size
+}) =>
   token && (
     <TokenInfo
       address={token.address}
       blockchainId={chain}
       iconPosition="right"
+      iconSize={iconSize}
       primary={formatNumber(amount, { abbreviate: false })}
     />
   )
@@ -29,16 +41,21 @@ export const LlammaEventChangeCell = ({
   chain: Chain
   collateralToken: Token | undefined
   borrowToken: Token | undefined
-}) => (
-  <InlineTableCell>
-    <Stack sx={{ gap: Spacing.xs, alignItems: 'end' }}>
-      {deposit && <AmountRow amount={deposit.amount} token={collateralToken} chain={chain} />}
-      {!!withdrawal?.amountCollateral && (
-        <AmountRow amount={-withdrawal.amountCollateral} token={collateralToken} chain={chain} />
-      )}
-      {!!withdrawal?.amountBorrowed && (
-        <AmountRow amount={-withdrawal.amountBorrowed} token={borrowToken} chain={chain} />
-      )}
-    </Stack>
-  </InlineTableCell>
-)
+}) => {
+  // use a smaller icon size for cells containing two rows to eliminate token icon overlap
+  const iconSize = withdrawal?.amountCollateral && withdrawal.amountBorrowed ? 'mui-md' : undefined
+
+  return (
+    <InlineTableCell>
+      <Stack sx={{ gap: Spacing.xs, alignItems: 'end' }}>
+        {deposit && <AmountRow amount={deposit.amount} token={collateralToken} chain={chain} />}
+        {!!withdrawal?.amountCollateral && (
+          <AmountRow amount={-withdrawal.amountCollateral} token={collateralToken} chain={chain} iconSize={iconSize} />
+        )}
+        {!!withdrawal?.amountBorrowed && (
+          <AmountRow amount={-withdrawal.amountBorrowed} token={borrowToken} chain={chain} iconSize={iconSize} />
+        )}
+      </Stack>
+    </InlineTableCell>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { TokenIcon } from './TokenIcon'
+import { TokenIcon, type Size } from './TokenIcon'
 
 const { Spacing } = SizesAndSpaces
 
@@ -17,6 +17,7 @@ export type TokenInfoTokenIconProps = TokenInfoBaseProps & {
   address: string
   blockchainId: string
   showChainIcon?: boolean
+  iconSize?: Size
   icon?: never
 }
 
@@ -25,6 +26,7 @@ type TokenInfoCustomIconProps = TokenInfoBaseProps & {
   address?: never
   blockchainId?: never
   showChainIcon?: never
+  iconSize?: never
 }
 
 export type TokenInfoProps = TokenInfoTokenIconProps | TokenInfoCustomIconProps
@@ -36,7 +38,7 @@ export const TokenInfo = (props: TokenInfoProps) => {
       <TokenIcon
         blockchainId={props.blockchainId}
         address={props.address}
-        size="lg"
+        size={props.iconSize ?? 'lg'}
         showChainIcon={props.showChainIcon}
       />
     ) : (


### PR DESCRIPTION
Changes:
- Reduce token icon size for `LlammaEventChangeCell` when displaying two rows.

| Before | After |
|--------|--------|
|<img width="1077" height="90" alt="SCR-20260706-qkuo" src="https://github.com/user-attachments/assets/89f4e620-281e-4170-b888-ca8105d270b4" />|<img width="1077" height="98" alt="SCR-20260706-qkmd" src="https://github.com/user-attachments/assets/ebabc4a1-c8a7-4ac4-8db0-b614f4fc8040" />| 