### PR TITLE
feat: default to position history on market page for users with no active position but has historic ones

### DIFF
--- a/apps/main/src/llamalend/features/market-position-details/hooks/usePositionDetailsTabs.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/hooks/usePositionDetailsTabs.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react'
+import { type ReactNode, useEffect, useMemo } from 'react'
 import { UserPositionHistory } from '@/llamalend/features/user-position-history'
 import type { ParsedUserCollateralEvent } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
 import Stack from '@mui/material/Stack'
@@ -46,5 +46,12 @@ export const usePositionDetailsTabs = ({
   )
 
   const { tab = DEFAULT_TAB, onTabChange } = useTabs(tabOptions, DEFAULT_TAB)
+
+  useEffect(() => {
+    if (hasPosition === false && events.data?.length) {
+      onTabChange('activity')
+    }
+  }, [events.data?.length, hasPosition, onTabChange])
+
   return { tab, onTabChange, tabOptions }
 }


### PR DESCRIPTION
Changes:
- Set tab to `Activity` in user position details if a user doesn't have an open borrow position but has activity history.