### PR TITLE
Add LlamaLend market section navigation

### DIFF
--- a/apps/main/src/index.css
+++ b/apps/main/src/index.css
@@ -14,6 +14,10 @@ html {
   scrollbar-gutter: stable;
 }
 
+html:has([data-testid='market-section-nav']) {
+  scroll-behavior: smooth;
+}
+
 /*
  * Locks page scroll when a MUI modal or drawer is open.
  * MUI sets aria-hidden="true" on #root (the app root) to hide background content from assistive technologies when an 
@@ -37,7 +41,6 @@ body {
 
   color: var(--page--text-color);
   background-color: var(--page--background-color);
-  scroll-behavior: smooth;
 }
 
 * {

--- a/apps/main/src/lend/components/ChartAndActivityComp/index.tsx
+++ b/apps/main/src/lend/components/ChartAndActivityComp/index.tsx
@@ -3,7 +3,7 @@ import { networks } from '@/lend/networks'
 import { ChainId } from '@/lend/types/lend.types'
 import { useBandsData } from '@/llamalend/features/bands-chart/hooks/useBandsData'
 import { useMarketContext } from '@/llamalend/features/market-context'
-import { ChartAndActivityLayout } from '@/llamalend/widgets/ChartAndActivityLayout'
+import { ChartAndActivityLayout, type ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
 import { getBlockchainId } from '@curvefi/prices-api'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useBandsChartVisible } from '@ui-kit/hooks/useLocalStorage'
@@ -11,9 +11,11 @@ import type { Range } from '@ui-kit/types/util'
 
 type ChartAndActivityCompProps = {
   previewPrices: Range<Decimal> | undefined
+  tab?: ChartAndActivityTab
+  onTabChange?: (tab: ChartAndActivityTab) => void
 }
 
-export const ChartAndActivityComp = ({ previewPrices }: ChartAndActivityCompProps) => {
+export const ChartAndActivityComp = ({ previewPrices, tab, onTabChange }: ChartAndActivityCompProps) => {
   const {
     chainId,
     marketId,
@@ -75,6 +77,8 @@ export const ChartAndActivityComp = ({ previewPrices }: ChartAndActivityCompProp
         endpoint: 'lending',
         networkConfig,
       }}
+      tab={tab}
+      onTabChange={onTabChange}
     />
   )
 }

--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -3,6 +3,8 @@ import { networks } from '@/lend/networks'
 import { AdvancedDetails, MarketInfoLayout } from '@/llamalend/features/market-advanced-information'
 import { useMarketContext } from '@/llamalend/features/market-context'
 import { MarketFaq } from '@/llamalend/features/market-faq'
+import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
+import { MarketSection, type MarketSectionRef } from '@/llamalend/widgets/market-section-nav'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { MarketRateCurveChart } from '@/llamalend/widgets/MarketRateCurveChart'
 import Card from '@mui/material/Card'
@@ -18,32 +20,58 @@ import { PAGE_SPACING } from '@ui-kit/widgets/DetailPageLayout/constants'
 type MarketInformationCompProps = {
   rateType: MarketRateType
   previewPrices?: Range<Decimal> | undefined
+  sectionRefs: {
+    chartAndActivity?: MarketSectionRef
+    historicalRates: MarketSectionRef
+    advancedDetails: MarketSectionRef
+    faqs: MarketSectionRef
+  }
+  chartAndActivityTab?: ChartAndActivityTab
+  onChartAndActivityTabChange?: (tab: ChartAndActivityTab) => void
 }
 
 /**
  * Reusable component for OHLC charts, Bands (if applicable), and market parameters, used in market and vault pages.
  */
-export const MarketInformationComposite = ({ rateType, previewPrices }: MarketInformationCompProps) => {
+export const MarketInformationComposite = ({
+  rateType,
+  previewPrices,
+  sectionRefs,
+  chartAndActivityTab,
+  onChartAndActivityTabChange,
+}: MarketInformationCompProps) => {
   const { chainId } = useMarketContext()
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
-      {rateType === MarketRateType.Borrow && (
-        <>
-          <ChartAndActivityComp previewPrices={previewPrices} />
-          <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />
-        </>
+      {rateType === MarketRateType.Borrow && sectionRefs.chartAndActivity && (
+        <MarketSection id="price-chart" sectionRef={sectionRefs.chartAndActivity}>
+          <ChartAndActivityComp
+            previewPrices={previewPrices}
+            tab={chartAndActivityTab}
+            onTabChange={onChartAndActivityTabChange}
+          />
+        </MarketSection>
       )}
-      <MarketHistoricalRatesChart rateMode={MarketRateType.Supply} />
+      <MarketSection id="historical-rates" sectionRef={sectionRefs.historicalRates}>
+        <Stack sx={{ gap: PAGE_SPACING }}>
+          {rateType === MarketRateType.Borrow && <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />}
+          <MarketHistoricalRatesChart rateMode={MarketRateType.Supply} />
+        </Stack>
+      </MarketSection>
       <MarketRateCurveChart />
-      <Card size="small">
-        <CardHeader title={t`Advanced Details`} />
-        <CardContent component={Stack}>
-          <AdvancedDetails />
-          <MarketInfoLayout network={networks[chainId]} />
-        </CardContent>
-      </Card>
+      <MarketSection id="advanced-details" sectionRef={sectionRefs.advancedDetails}>
+        <Card size="small">
+          <CardHeader title={t`Advanced Details`} />
+          <CardContent component={Stack}>
+            <AdvancedDetails />
+            <MarketInfoLayout network={networks[chainId]} />
+          </CardContent>
+        </Card>
+      </MarketSection>
 
-      <MarketFaq />
+      <MarketSection id="faqs" sectionRef={sectionRefs.faqs}>
+        <MarketFaq />
+      </MarketSection>
     </Stack>
   )
 }

--- a/apps/main/src/lend/components/MarketInformationComposite.tsx
+++ b/apps/main/src/lend/components/MarketInformationComposite.tsx
@@ -4,7 +4,7 @@ import { AdvancedDetails, MarketInfoLayout } from '@/llamalend/features/market-a
 import { useMarketContext } from '@/llamalend/features/market-context'
 import { MarketFaq } from '@/llamalend/features/market-faq'
 import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
-import { MarketSection, type MarketSectionRef } from '@/llamalend/widgets/market-section-nav'
+import { MarketSection } from '@/llamalend/widgets/market-section-nav'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { MarketRateCurveChart } from '@/llamalend/widgets/MarketRateCurveChart'
 import Card from '@mui/material/Card'
@@ -20,12 +20,6 @@ import { PAGE_SPACING } from '@ui-kit/widgets/DetailPageLayout/constants'
 type MarketInformationCompProps = {
   rateType: MarketRateType
   previewPrices?: Range<Decimal> | undefined
-  sectionRefs: {
-    chartAndActivity?: MarketSectionRef
-    historicalRates: MarketSectionRef
-    advancedDetails: MarketSectionRef
-    faqs: MarketSectionRef
-  }
   chartAndActivityTab?: ChartAndActivityTab
   onChartAndActivityTabChange?: (tab: ChartAndActivityTab) => void
 }
@@ -36,15 +30,14 @@ type MarketInformationCompProps = {
 export const MarketInformationComposite = ({
   rateType,
   previewPrices,
-  sectionRefs,
   chartAndActivityTab,
   onChartAndActivityTabChange,
 }: MarketInformationCompProps) => {
   const { chainId } = useMarketContext()
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
-      {rateType === MarketRateType.Borrow && sectionRefs.chartAndActivity && (
-        <MarketSection id="price-chart" sectionRef={sectionRefs.chartAndActivity}>
+      {rateType === MarketRateType.Borrow && (
+        <MarketSection id="price-chart" aliases={['market-activity']}>
           <ChartAndActivityComp
             previewPrices={previewPrices}
             tab={chartAndActivityTab}
@@ -52,14 +45,14 @@ export const MarketInformationComposite = ({
           />
         </MarketSection>
       )}
-      <MarketSection id="historical-rates" sectionRef={sectionRefs.historicalRates}>
+      <MarketSection id="historical-rates">
         <Stack sx={{ gap: PAGE_SPACING }}>
           {rateType === MarketRateType.Borrow && <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />}
           <MarketHistoricalRatesChart rateMode={MarketRateType.Supply} />
         </Stack>
       </MarketSection>
       <MarketRateCurveChart />
-      <MarketSection id="advanced-details" sectionRef={sectionRefs.advancedDetails}>
+      <MarketSection id="advanced-details">
         <Card size="small">
           <CardHeader title={t`Advanced Details`} />
           <CardContent component={Stack}>
@@ -69,7 +62,7 @@ export const MarketInformationComposite = ({
         </Card>
       </MarketSection>
 
-      <MarketSection id="faqs" sectionRef={sectionRefs.faqs}>
+      <MarketSection id="faqs">
         <MarketFaq />
       </MarketSection>
     </Stack>

--- a/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketInformationComposite } from '@/lend/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/lend/components/PageLendMarket/CreateLoanTabs'
@@ -15,8 +15,15 @@ import { useLlamaMarket } from '@/llamalend/hooks/useLlamaMarket'
 import { getControllerAddress, getTokens, hasResetPosition } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
+import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
+import {
+  MarketSection,
+  MarketSectionNav,
+  type MarketSectionOption,
+} from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { getBlockchainId } from '@curvefi/prices-api'
+import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
@@ -44,6 +51,12 @@ export const LendMarketPage = () => {
   const { data: loanExists, isLoading: isLoanExistsLoading } = useLoanExists(queryParams)
 
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
+  const [chartAndActivityTab, setChartAndActivityTab] = useState<ChartAndActivityTab>('chart')
+  const positionDetailsRef = useRef<HTMLElement | null>(null)
+  const chartAndActivityRef = useRef<HTMLElement | null>(null)
+  const historicalRatesRef = useRef<HTMLElement | null>(null)
+  const advancedDetailsRef = useRef<HTMLElement | null>(null)
+  const faqsRef = useRef<HTMLElement | null>(null)
   const isLoading = !isInitialized || isMarketLoading
   const apiMarket = useLlamaMarket(
     {
@@ -71,6 +84,31 @@ export const LendMarketPage = () => {
   )
 
   const error = marketError ?? apiMarket.error
+  const sectionRefs = {
+    chartAndActivity: chartAndActivityRef,
+    historicalRates: historicalRatesRef,
+    advancedDetails: advancedDetailsRef,
+    faqs: faqsRef,
+  }
+  const sections: MarketSectionOption[] = [
+    { value: 'position-details', label: t`Position Details`, ref: positionDetailsRef },
+    {
+      value: 'price-chart',
+      label: t`Price Chart`,
+      ref: chartAndActivityRef,
+      onClick: () => setChartAndActivityTab('chart'),
+    },
+    {
+      value: 'market-activity',
+      label: t`Market Activity`,
+      ref: chartAndActivityRef,
+      onClick: () => setChartAndActivityTab('events'),
+    },
+    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
+    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
+    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
+  ]
+
   return error ? (
     <ErrorPage title={t`Error`} subtitle={error.message} continueUrl={getCollateralListPathname(params)} />
   ) : (
@@ -96,15 +134,28 @@ export const LendMarketPage = () => {
             <CreateLoanTabs onPricesUpdated={setPreviewPrices} />
           ))
         }
-        header={<MarketPageHeader isLoading={isLoading} />}
+        header={
+          <Stack>
+            <MarketPageHeader isLoading={isLoading} />
+            <MarketSectionNav sections={sections} />
+          </Stack>
+        }
       >
         <MarketBanners
           chainId={chainId}
           market={market}
           rewardsBanner={<CampaignRewardsBanner chainId={chainId} market={market} />}
         />
-        <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
-        <MarketInformationComposite rateType={MarketRateType.Borrow} previewPrices={previewPrices} />
+        <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+          <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
+        </MarketSection>
+        <MarketInformationComposite
+          rateType={MarketRateType.Borrow}
+          previewPrices={previewPrices}
+          sectionRefs={sectionRefs}
+          chartAndActivityTab={chartAndActivityTab}
+          onChartAndActivityTabChange={setChartAndActivityTab}
+        />
       </DetailPageLayout>
     </MarketContextProvider>
   )

--- a/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
+++ b/apps/main/src/lend/components/PageLendMarket/LendMarketPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketInformationComposite } from '@/lend/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/lend/components/PageLendMarket/CreateLoanTabs'
@@ -16,11 +16,7 @@ import { getControllerAddress, getTokens, hasResetPosition } from '@/llamalend/l
 import { useLoanExists } from '@/llamalend/queries/user'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
-import {
-  MarketSection,
-  MarketSectionNav,
-  type MarketSectionOption,
-} from '@/llamalend/widgets/market-section-nav'
+import { getBorrowMarketSections, MarketSection, MarketSectionNav } from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { getBlockchainId } from '@curvefi/prices-api'
 import Stack from '@mui/material/Stack'
@@ -52,11 +48,6 @@ export const LendMarketPage = () => {
 
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
   const [chartAndActivityTab, setChartAndActivityTab] = useState<ChartAndActivityTab>('chart')
-  const positionDetailsRef = useRef<HTMLElement | null>(null)
-  const chartAndActivityRef = useRef<HTMLElement | null>(null)
-  const historicalRatesRef = useRef<HTMLElement | null>(null)
-  const advancedDetailsRef = useRef<HTMLElement | null>(null)
-  const faqsRef = useRef<HTMLElement | null>(null)
   const isLoading = !isInitialized || isMarketLoading
   const apiMarket = useLlamaMarket(
     {
@@ -84,30 +75,7 @@ export const LendMarketPage = () => {
   )
 
   const error = marketError ?? apiMarket.error
-  const sectionRefs = {
-    chartAndActivity: chartAndActivityRef,
-    historicalRates: historicalRatesRef,
-    advancedDetails: advancedDetailsRef,
-    faqs: faqsRef,
-  }
-  const sections: MarketSectionOption[] = [
-    { value: 'position-details', label: t`Position Details`, ref: positionDetailsRef },
-    {
-      value: 'price-chart',
-      label: t`Price Chart`,
-      ref: chartAndActivityRef,
-      onClick: () => setChartAndActivityTab('chart'),
-    },
-    {
-      value: 'market-activity',
-      label: t`Market Activity`,
-      ref: chartAndActivityRef,
-      onClick: () => setChartAndActivityTab('events'),
-    },
-    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
-    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
-    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
-  ]
+  const sections = getBorrowMarketSections(setChartAndActivityTab)
 
   return error ? (
     <ErrorPage title={t`Error`} subtitle={error.message} continueUrl={getCollateralListPathname(params)} />
@@ -146,13 +114,12 @@ export const LendMarketPage = () => {
           market={market}
           rewardsBanner={<CampaignRewardsBanner chainId={chainId} market={market} />}
         />
-        <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+        <MarketSection id="position-details">
           <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
         </MarketSection>
         <MarketInformationComposite
           rateType={MarketRateType.Borrow}
           previewPrices={previewPrices}
-          sectionRefs={sectionRefs}
           chartAndActivityTab={chartAndActivityTab}
           onChartAndActivityTabChange={setChartAndActivityTab}
         />

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketInformationComposite } from '@/lend/components/MarketInformationComposite'
 import { VaultTabs } from '@/lend/components/PageVault/VaultTabs'
@@ -10,7 +11,13 @@ import { SupplyPositionDetails } from '@/llamalend/features/market-position-deta
 import { useLlamaMarket } from '@/llamalend/hooks/useLlamaMarket'
 import { useUserShares } from '@/llamalend/queries/user/user-balances.query'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
+import {
+  MarketSection,
+  MarketSectionNav,
+  type MarketSectionOption,
+} from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
+import Stack from '@mui/material/Stack'
 import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { useParams } from '@ui-kit/hooks/router'
@@ -29,6 +36,10 @@ export const Page = () => {
   const { data: market, isLoading: isMarketLoading, error: marketError } = marketQuery
   const network = networks[chainId]
   const { address: userAddress } = useConnection()
+  const positionDetailsRef = useRef<HTMLElement | null>(null)
+  const historicalRatesRef = useRef<HTMLElement | null>(null)
+  const advancedDetailsRef = useRef<HTMLElement | null>(null)
+  const faqsRef = useRef<HTMLElement | null>(null)
 
   useLendPageTitle(market?.collateral_token?.symbol, t`Supply`)
 
@@ -45,6 +56,21 @@ export const Page = () => {
   const supplied = +(useUserShares({ marketId: market?.id, chainId, userAddress }).data?.value ?? 0)
 
   const error = marketError ?? apiMarket.error
+  const hasSupplyPosition = !!market && supplied > 0
+  const sectionRefs = {
+    historicalRates: historicalRatesRef,
+    advancedDetails: advancedDetailsRef,
+    faqs: faqsRef,
+  }
+  const sections: MarketSectionOption[] = [
+    ...(hasSupplyPosition
+      ? [{ value: 'position-details' as const, label: t`Position Details`, ref: positionDetailsRef }]
+      : []),
+    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
+    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
+    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
+  ]
+
   return error ? (
     <ErrorPage
       title={t`Error`}
@@ -61,15 +87,24 @@ export const Page = () => {
     >
       <DetailPageLayout
         formTabs={(market ?? apiMarket.data) && <VaultTabs />}
-        header={<MarketPageHeader isLoading={isLoading} />}
+        header={
+          <Stack>
+            <MarketPageHeader isLoading={isLoading} />
+            <MarketSectionNav sections={sections} />
+          </Stack>
+        }
       >
         <MarketBanners
           chainId={chainId}
           market={market}
           rewardsBanner={<CampaignRewardsBanner chainId={chainId} market={market} />}
         />
-        {market && supplied > 0 && <SupplyPositionDetails />}
-        <MarketInformationComposite rateType={MarketRateType.Supply} />
+        {hasSupplyPosition && (
+          <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+            <SupplyPositionDetails />
+          </MarketSection>
+        )}
+        <MarketInformationComposite rateType={MarketRateType.Supply} sectionRefs={sectionRefs} />
       </DetailPageLayout>
     </MarketContextProvider>
   )

--- a/apps/main/src/lend/components/PageVault/Page.tsx
+++ b/apps/main/src/lend/components/PageVault/Page.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketInformationComposite } from '@/lend/components/MarketInformationComposite'
 import { VaultTabs } from '@/lend/components/PageVault/VaultTabs'
@@ -11,11 +10,7 @@ import { SupplyPositionDetails } from '@/llamalend/features/market-position-deta
 import { useLlamaMarket } from '@/llamalend/hooks/useLlamaMarket'
 import { useUserShares } from '@/llamalend/queries/user/user-balances.query'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
-import {
-  MarketSection,
-  MarketSectionNav,
-  type MarketSectionOption,
-} from '@/llamalend/widgets/market-section-nav'
+import { MarketSection, MarketSectionNav, type MarketSectionOption } from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import Stack from '@mui/material/Stack'
 import { useCurve } from '@ui-kit/features/connect-wallet'
@@ -36,10 +31,6 @@ export const Page = () => {
   const { data: market, isLoading: isMarketLoading, error: marketError } = marketQuery
   const network = networks[chainId]
   const { address: userAddress } = useConnection()
-  const positionDetailsRef = useRef<HTMLElement | null>(null)
-  const historicalRatesRef = useRef<HTMLElement | null>(null)
-  const advancedDetailsRef = useRef<HTMLElement | null>(null)
-  const faqsRef = useRef<HTMLElement | null>(null)
 
   useLendPageTitle(market?.collateral_token?.symbol, t`Supply`)
 
@@ -57,18 +48,11 @@ export const Page = () => {
 
   const error = marketError ?? apiMarket.error
   const hasSupplyPosition = !!market && supplied > 0
-  const sectionRefs = {
-    historicalRates: historicalRatesRef,
-    advancedDetails: advancedDetailsRef,
-    faqs: faqsRef,
-  }
   const sections: MarketSectionOption[] = [
-    ...(hasSupplyPosition
-      ? [{ value: 'position-details' as const, label: t`Position Details`, ref: positionDetailsRef }]
-      : []),
-    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
-    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
-    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
+    ...(hasSupplyPosition ? [{ value: 'position-details' as const, label: t`Position Details` }] : []),
+    { value: 'historical-rates', label: t`Historical Rates` },
+    { value: 'advanced-details', label: t`Advanced Details` },
+    { value: 'faqs', label: t`FAQs` },
   ]
 
   return error ? (
@@ -100,11 +84,11 @@ export const Page = () => {
           rewardsBanner={<CampaignRewardsBanner chainId={chainId} market={market} />}
         />
         {hasSupplyPosition && (
-          <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+          <MarketSection id="position-details">
             <SupplyPositionDetails />
           </MarketSection>
         )}
-        <MarketInformationComposite rateType={MarketRateType.Supply} sectionRefs={sectionRefs} />
+        <MarketInformationComposite rateType={MarketRateType.Supply} />
       </DetailPageLayout>
     </MarketContextProvider>
   )

--- a/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
+++ b/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
@@ -26,10 +26,10 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 
 const { Spacing } = SizesAndSpaces
 
-type Tab = 'chart' | 'trades' | 'events'
-const DEFAULT_TAB: Tab = 'chart'
+export type ChartAndActivityTab = 'chart' | 'trades' | 'events'
+const DEFAULT_TAB: ChartAndActivityTab = 'chart'
 
-const TABS: TabOption<Tab>[] = [
+const TABS: TabOption<ChartAndActivityTab>[] = [
   { value: 'chart', label: t`Chart` },
   { value: 'trades', label: t`Swaps` },
   { value: 'events', label: t`Activity` },
@@ -60,16 +60,20 @@ type ChartAndActivityLayoutProps = {
     borrowToken: Token | undefined
   }
   activity: LlammaActivityProps
+  tab?: ChartAndActivityTab
+  onTabChange?: (tab: ChartAndActivityTab) => void
 }
 
-export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActivityLayoutProps) => {
+export const ChartAndActivityLayout = ({ chart, bands, activity, tab, onTabChange }: ChartAndActivityLayoutProps) => {
   const { isConnected } = useConnection()
   const theme = useTheme()
   const [isBandsVisible, setIsBandsVisible] = useBandsChartVisible()
   const toggleBandsVisible = useCallback(() => setIsBandsVisible(prev => !prev), [setIsBandsVisible])
   const bandsPalette = useBandsChartPalette()
-  const [tab, setTab] = useState<Tab>(DEFAULT_TAB)
+  const [internalTab, setInternalTab] = useState<ChartAndActivityTab>(DEFAULT_TAB)
   const [candlePriceRange, setCandlePriceRange] = useState<{ min: number; max: number } | undefined>()
+  const activeTab = tab ?? internalTab
+  const setActiveTab = onTabChange ?? setInternalTab
 
   const handleVisiblePriceRangeChange = useCallback((min: number, max: number) => {
     setCandlePriceRange(previous =>
@@ -103,11 +107,11 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
 
   return (
     <Stack data-testid="market-chart-and-activity">
-      <TabsSwitcher variant="contained" value={tab} onChange={setTab} options={TABS} />
+      <TabsSwitcher variant="contained" value={activeTab} onChange={setActiveTab} options={TABS} />
       <Stack sx={{ backgroundColor: t => t.design.Layer[1].Fill }}>
-        {tab === 'events' && <LlammaActivityEvents {...activity} />}
-        {tab === 'trades' && <LlammaActivityTrades {...activity} />}
-        {tab === 'chart' && (
+        {activeTab === 'events' && <LlammaActivityEvents {...activity} />}
+        {activeTab === 'trades' && <LlammaActivityTrades {...activity} />}
+        {activeTab === 'chart' && (
           <Stack sx={{ gap: Spacing.sm, padding: Spacing.sm }}>
             <ChartHeader
               chartOptionVariant="select"

--- a/apps/main/src/llamalend/widgets/market-section-nav/MarketSection.tsx
+++ b/apps/main/src/llamalend/widgets/market-section-nav/MarketSection.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import { useLayoutStore } from '@ui-kit/features/layout'
+import type { MarketSectionId, MarketSectionRef } from './types'
+
+export const MarketSection = ({
+  id,
+  sectionRef,
+  children,
+}: {
+  id: MarketSectionId
+  sectionRef: MarketSectionRef
+  children: ReactNode
+}) => {
+  const navHeight = useLayoutStore(state => state.navHeight)
+
+  return (
+    <Box
+      ref={sectionRef}
+      id={id}
+      component="section"
+      data-testid={`market-section-${id}`}
+      sx={{ scrollMarginTop: `calc(${navHeight}px + 9rem)` }}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/apps/main/src/llamalend/widgets/market-section-nav/MarketSection.tsx
+++ b/apps/main/src/llamalend/widgets/market-section-nav/MarketSection.tsx
@@ -1,28 +1,25 @@
 import type { ReactNode } from 'react'
 import Box from '@mui/material/Box'
-import { useLayoutStore } from '@ui-kit/features/layout'
-import type { MarketSectionId, MarketSectionRef } from './types'
+import type { MarketSectionId } from './types'
 
 export const MarketSection = ({
   id,
-  sectionRef,
+  aliases = [],
   children,
 }: {
   id: MarketSectionId
-  sectionRef: MarketSectionRef
+  aliases?: MarketSectionId[]
   children: ReactNode
-}) => {
-  const navHeight = useLayoutStore(state => state.navHeight)
-
-  return (
-    <Box
-      ref={sectionRef}
-      id={id}
-      component="section"
-      data-testid={`market-section-${id}`}
-      sx={{ scrollMarginTop: `calc(${navHeight}px + 9rem)` }}
-    >
-      {children}
-    </Box>
-  )
-}
+}) => (
+  <Box
+    id={id}
+    component="section"
+    data-testid={`market-section-${id}`}
+    sx={{ scrollMarginTop: 'var(--detail-page-scroll-margin-top)' }}
+  >
+    {aliases.map(alias => (
+      <Box key={alias} id={alias} sx={{ scrollMarginTop: 'var(--detail-page-scroll-margin-top)' }} />
+    ))}
+    {children}
+  </Box>
+)

--- a/apps/main/src/llamalend/widgets/market-section-nav/MarketSectionNav.tsx
+++ b/apps/main/src/llamalend/widgets/market-section-nav/MarketSectionNav.tsx
@@ -1,0 +1,70 @@
+import { useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import { TabsSwitcher } from '@ui-kit/shared/ui/Tabs/TabsSwitcher'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import type { MarketSectionId, MarketSectionOption } from './types'
+
+const { Spacing } = SizesAndSpaces
+const SCROLL_GAP_PX = 8
+
+export const MarketSectionNav = ({ sections }: { sections: MarketSectionOption[] }) => {
+  const navRef = useRef<HTMLDivElement>(null)
+  const [activeSection, setActiveSection] = useState<MarketSectionId | undefined>(sections[0]?.value)
+  const activeValue = sections.some(section => section.value === activeSection) ? activeSection : sections[0]?.value
+
+  const scrollToSection = (section: MarketSectionOption) => {
+    section.onClick?.()
+    setActiveSection(section.value)
+
+    const sectionElement = section.ref.current
+    if (!sectionElement) return
+
+    const stickyBottom = navRef.current?.getBoundingClientRect().bottom ?? 0
+    window.scrollBy({
+      top: sectionElement.getBoundingClientRect().top - stickyBottom - SCROLL_GAP_PX,
+      behavior: 'smooth',
+    })
+  }
+
+  if (!sections.length) return null
+
+  return (
+    <Box
+      ref={navRef}
+      data-testid="market-section-nav"
+      sx={{
+        borderBottom: '1px solid',
+        borderColor: t => t.design.Color.Neutral[200],
+        marginBlockEnd: Spacing.md,
+        overflow: 'hidden',
+      }}
+    >
+      <TabsSwitcher
+        variant="underlined"
+        size="small"
+        value={activeValue}
+        options={sections}
+        onChange={value => {
+          const section = sections.find(section => section.value === value)
+          if (section) scrollToSection(section)
+        }}
+        overflow="standard"
+        hideInactiveBorders
+        sx={{
+          '& .MuiTabs-scroller': {
+            overflowX: 'auto !important',
+            scrollbarWidth: 'none',
+            WebkitOverflowScrolling: 'touch',
+          },
+          '& .MuiTabs-scroller::-webkit-scrollbar': {
+            display: 'none',
+          },
+          '& .MuiTabs-list': {
+            width: 'max-content',
+          },
+        }}
+        testIdPrefix="market-section-nav"
+      />
+    </Box>
+  )
+}

--- a/apps/main/src/llamalend/widgets/market-section-nav/MarketSectionNav.tsx
+++ b/apps/main/src/llamalend/widgets/market-section-nav/MarketSectionNav.tsx
@@ -1,41 +1,33 @@
-import { useRef, useState } from 'react'
+import { useEffect, useEffectEvent } from 'react'
 import Box from '@mui/material/Box'
+import { useLocation } from '@ui-kit/hooks/router'
+import { useLlamaMarketSectionNav } from '@ui-kit/hooks/useFeatureFlags'
 import { TabsSwitcher } from '@ui-kit/shared/ui/Tabs/TabsSwitcher'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import type { MarketSectionId, MarketSectionOption } from './types'
+import type { MarketSectionOption } from './types'
 
 const { Spacing } = SizesAndSpaces
-const SCROLL_GAP_PX = 8
 
-export const MarketSectionNav = ({ sections }: { sections: MarketSectionOption[] }) => {
-  const navRef = useRef<HTMLDivElement>(null)
-  const [activeSection, setActiveSection] = useState<MarketSectionId | undefined>(sections[0]?.value)
-  const activeValue = sections.some(section => section.value === activeSection) ? activeSection : sections[0]?.value
+export const MarketSectionNav = ({ sections }: { sections: readonly MarketSectionOption[] }) => {
+  const isMarketSectionNavEnabled = useLlamaMarketSectionNav()
+  const { hash } = useLocation()
+  const activeValue = sections.find(section => section.value === hash)?.value ?? sections[0]?.value
+  const options = sections.map(({ value, label }) => ({ value, label, href: `#${value}` }))
+  const activateSection = useEffectEvent(() => sections.find(section => section.value === hash)?.onSelect?.())
 
-  const scrollToSection = (section: MarketSectionOption) => {
-    section.onClick?.()
-    setActiveSection(section.value)
+  useEffect(() => {
+    if (isMarketSectionNavEnabled) activateSection()
+  }, [hash, isMarketSectionNavEnabled])
 
-    const sectionElement = section.ref.current
-    if (!sectionElement) return
-
-    const stickyBottom = navRef.current?.getBoundingClientRect().bottom ?? 0
-    window.scrollBy({
-      top: sectionElement.getBoundingClientRect().top - stickyBottom - SCROLL_GAP_PX,
-      behavior: 'smooth',
-    })
-  }
-
-  if (!sections.length) return null
+  if (!isMarketSectionNavEnabled || !sections.length) return null
 
   return (
     <Box
-      ref={navRef}
       data-testid="market-section-nav"
       sx={{
         borderBottom: '1px solid',
-        borderColor: t => t.design.Color.Neutral[200],
-        marginBlockEnd: Spacing.md,
+        borderColor: t => t.design.Tabs.UnderLined.Container_Border,
+        marginBlockEnd: Spacing.lg,
         overflow: 'hidden',
       }}
     >
@@ -43,26 +35,9 @@ export const MarketSectionNav = ({ sections }: { sections: MarketSectionOption[]
         variant="underlined"
         size="small"
         value={activeValue}
-        options={sections}
-        onChange={value => {
-          const section = sections.find(section => section.value === value)
-          if (section) scrollToSection(section)
-        }}
-        overflow="standard"
+        options={options}
+        overflow="scrollable"
         hideInactiveBorders
-        sx={{
-          '& .MuiTabs-scroller': {
-            overflowX: 'auto !important',
-            scrollbarWidth: 'none',
-            WebkitOverflowScrolling: 'touch',
-          },
-          '& .MuiTabs-scroller::-webkit-scrollbar': {
-            display: 'none',
-          },
-          '& .MuiTabs-list': {
-            width: 'max-content',
-          },
-        }}
         testIdPrefix="market-section-nav"
       />
     </Box>

--- a/apps/main/src/llamalend/widgets/market-section-nav/getBorrowMarketSections.ts
+++ b/apps/main/src/llamalend/widgets/market-section-nav/getBorrowMarketSections.ts
@@ -1,0 +1,14 @@
+import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
+import { t } from '@ui-kit/lib/i18n'
+import type { MarketSectionOption } from './types'
+
+export const getBorrowMarketSections = (
+  setChartAndActivityTab: (tab: ChartAndActivityTab) => void,
+): MarketSectionOption[] => [
+  { value: 'position-details', label: t`Position Details` },
+  { value: 'price-chart', label: t`Price Chart`, onSelect: () => setChartAndActivityTab('chart') },
+  { value: 'market-activity', label: t`Market Activity`, onSelect: () => setChartAndActivityTab('events') },
+  { value: 'historical-rates', label: t`Historical Rates` },
+  { value: 'advanced-details', label: t`Advanced Details` },
+  { value: 'faqs', label: t`FAQs` },
+]

--- a/apps/main/src/llamalend/widgets/market-section-nav/index.ts
+++ b/apps/main/src/llamalend/widgets/market-section-nav/index.ts
@@ -1,3 +1,4 @@
+export * from './getBorrowMarketSections'
 export * from './MarketSection'
 export * from './MarketSectionNav'
 export type * from './types'

--- a/apps/main/src/llamalend/widgets/market-section-nav/index.ts
+++ b/apps/main/src/llamalend/widgets/market-section-nav/index.ts
@@ -1,0 +1,3 @@
+export * from './MarketSection'
+export * from './MarketSectionNav'
+export type * from './types'

--- a/apps/main/src/llamalend/widgets/market-section-nav/types.ts
+++ b/apps/main/src/llamalend/widgets/market-section-nav/types.ts
@@ -1,5 +1,3 @@
-import type { RefObject } from 'react'
-
 export type MarketSectionId =
   | 'position-details'
   | 'price-chart'
@@ -8,11 +6,8 @@ export type MarketSectionId =
   | 'advanced-details'
   | 'faqs'
 
-export type MarketSectionRef = RefObject<HTMLElement | null>
-
 export type MarketSectionOption = {
   value: MarketSectionId
   label: string
-  ref: MarketSectionRef
-  onClick?: () => void
+  onSelect?: () => void
 }

--- a/apps/main/src/llamalend/widgets/market-section-nav/types.ts
+++ b/apps/main/src/llamalend/widgets/market-section-nav/types.ts
@@ -1,0 +1,18 @@
+import type { RefObject } from 'react'
+
+export type MarketSectionId =
+  | 'position-details'
+  | 'price-chart'
+  | 'market-activity'
+  | 'historical-rates'
+  | 'advanced-details'
+  | 'faqs'
+
+export type MarketSectionRef = RefObject<HTMLElement | null>
+
+export type MarketSectionOption = {
+  value: MarketSectionId
+  label: string
+  ref: MarketSectionRef
+  onClick?: () => void
+}

--- a/apps/main/src/loan/components/ChartAndActivityComp.tsx
+++ b/apps/main/src/loan/components/ChartAndActivityComp.tsx
@@ -1,5 +1,5 @@
 import { useBandsData } from '@/llamalend/features/bands-chart/hooks/useBandsData'
-import { ChartAndActivityLayout } from '@/llamalend/widgets/ChartAndActivityLayout'
+import { ChartAndActivityLayout, type ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
 import { useOhlcChartState } from '@/loan/hooks/useOhlcChartState'
 import { networks } from '@/loan/networks'
 import type { ChainId } from '@/loan/types/loan.types'
@@ -11,9 +11,11 @@ import { useMarketContext } from '../../llamalend/features/market-context'
 
 type ChartAndActivityCompProps = {
   previewPrices: Range<Decimal> | undefined
+  tab?: ChartAndActivityTab
+  onTabChange?: (tab: ChartAndActivityTab) => void
 }
 
-export const ChartAndActivityComp = ({ previewPrices }: ChartAndActivityCompProps) => {
+export const ChartAndActivityComp = ({ previewPrices, tab, onTabChange }: ChartAndActivityCompProps) => {
   const {
     chainId,
     marketId,
@@ -75,6 +77,8 @@ export const ChartAndActivityComp = ({ previewPrices }: ChartAndActivityCompProp
         endpoint: 'crvusd',
         networkConfig,
       }}
+      tab={tab}
+      onTabChange={onTabChange}
     />
   )
 }

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -2,7 +2,7 @@ import { AdvancedDetails, MarketInfoLayout } from '@/llamalend/features/market-a
 import { MarketFaq } from '@/llamalend/features/market-faq'
 import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
 import { CrvUsdPriceChart } from '@/llamalend/widgets/CrvUsdPriceChart'
-import { MarketSection, type MarketSectionRef } from '@/llamalend/widgets/market-section-nav'
+import { MarketSection } from '@/llamalend/widgets/market-section-nav'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { ChartAndActivityComp } from '@/loan/components/ChartAndActivityComp'
 import type { ChainId } from '@/loan/types/loan.types'
@@ -20,38 +20,31 @@ import { networks } from '../networks'
 
 type MarketInformationCompProps = {
   previewPrices: Range<Decimal> | undefined
-  sectionRefs: {
-    chartAndActivity: MarketSectionRef
-    historicalRates: MarketSectionRef
-    advancedDetails: MarketSectionRef
-    faqs: MarketSectionRef
-  }
   chartAndActivityTab?: ChartAndActivityTab
   onChartAndActivityTabChange?: (tab: ChartAndActivityTab) => void
 }
 
 export const MarketInformationComposite = ({
   previewPrices,
-  sectionRefs,
   chartAndActivityTab,
   onChartAndActivityTabChange,
 }: MarketInformationCompProps) => {
   const { chainId } = useMarketContext<ChainId>()
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
-      <MarketSection id="price-chart" sectionRef={sectionRefs.chartAndActivity}>
+      <MarketSection id="price-chart" aliases={['market-activity']}>
         <ChartAndActivityComp
           previewPrices={previewPrices}
           tab={chartAndActivityTab}
           onTabChange={onChartAndActivityTabChange}
         />
       </MarketSection>
-      <MarketSection id="historical-rates" sectionRef={sectionRefs.historicalRates}>
+      <MarketSection id="historical-rates">
         <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />
       </MarketSection>
       <CrvUsdPriceChart />
 
-      <MarketSection id="advanced-details" sectionRef={sectionRefs.advancedDetails}>
+      <MarketSection id="advanced-details">
         <Card size="small">
           <CardHeader title={t`Advanced Details`} />
           <CardContent component={Stack}>
@@ -61,7 +54,7 @@ export const MarketInformationComposite = ({
         </Card>
       </MarketSection>
 
-      <MarketSection id="faqs" sectionRef={sectionRefs.faqs}>
+      <MarketSection id="faqs">
         <MarketFaq />
       </MarketSection>
     </Stack>

--- a/apps/main/src/loan/components/MarketInformationComposite.tsx
+++ b/apps/main/src/loan/components/MarketInformationComposite.tsx
@@ -1,6 +1,8 @@
 import { AdvancedDetails, MarketInfoLayout } from '@/llamalend/features/market-advanced-information'
 import { MarketFaq } from '@/llamalend/features/market-faq'
+import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
 import { CrvUsdPriceChart } from '@/llamalend/widgets/CrvUsdPriceChart'
+import { MarketSection, type MarketSectionRef } from '@/llamalend/widgets/market-section-nav'
 import { MarketHistoricalRatesChart } from '@/llamalend/widgets/MarketHistoricalRatesChart'
 import { ChartAndActivityComp } from '@/loan/components/ChartAndActivityComp'
 import type { ChainId } from '@/loan/types/loan.types'
@@ -18,25 +20,50 @@ import { networks } from '../networks'
 
 type MarketInformationCompProps = {
   previewPrices: Range<Decimal> | undefined
+  sectionRefs: {
+    chartAndActivity: MarketSectionRef
+    historicalRates: MarketSectionRef
+    advancedDetails: MarketSectionRef
+    faqs: MarketSectionRef
+  }
+  chartAndActivityTab?: ChartAndActivityTab
+  onChartAndActivityTabChange?: (tab: ChartAndActivityTab) => void
 }
 
-export const MarketInformationComposite = ({ previewPrices }: MarketInformationCompProps) => {
+export const MarketInformationComposite = ({
+  previewPrices,
+  sectionRefs,
+  chartAndActivityTab,
+  onChartAndActivityTabChange,
+}: MarketInformationCompProps) => {
   const { chainId } = useMarketContext<ChainId>()
   return (
     <Stack sx={{ gap: PAGE_SPACING }}>
-      <ChartAndActivityComp previewPrices={previewPrices} />
-      <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />
+      <MarketSection id="price-chart" sectionRef={sectionRefs.chartAndActivity}>
+        <ChartAndActivityComp
+          previewPrices={previewPrices}
+          tab={chartAndActivityTab}
+          onTabChange={onChartAndActivityTabChange}
+        />
+      </MarketSection>
+      <MarketSection id="historical-rates" sectionRef={sectionRefs.historicalRates}>
+        <MarketHistoricalRatesChart rateMode={MarketRateType.Borrow} />
+      </MarketSection>
       <CrvUsdPriceChart />
 
-      <Card size="small">
-        <CardHeader title={t`Advanced Details`} />
-        <CardContent component={Stack}>
-          <AdvancedDetails />
-          <MarketInfoLayout network={networks[chainId]} />
-        </CardContent>
-      </Card>
+      <MarketSection id="advanced-details" sectionRef={sectionRefs.advancedDetails}>
+        <Card size="small">
+          <CardHeader title={t`Advanced Details`} />
+          <CardContent component={Stack}>
+            <AdvancedDetails />
+            <MarketInfoLayout network={networks[chainId]} />
+          </CardContent>
+        </Card>
+      </MarketSection>
 
-      <MarketFaq />
+      <MarketSection id="faqs" sectionRef={sectionRefs.faqs}>
+        <MarketFaq />
+      </MarketSection>
     </Stack>
   )
 }

--- a/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketContextProvider } from '@/llamalend/features/market-context'
 import { PositionDetailsComposite } from '@/llamalend/features/market-position-details'
@@ -8,6 +8,12 @@ import { useLlamaMarket } from '@/llamalend/hooks/useLlamaMarket'
 import { getControllerAddress, getTokens } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
+import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
+import {
+  MarketSection,
+  MarketSectionNav,
+  type MarketSectionOption,
+} from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { MarketInformationComposite } from '@/loan/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/loan/components/PageMintMarket/CreateLoanTabs'
@@ -16,6 +22,7 @@ import { networks } from '@/loan/networks'
 import { type CollateralUrlParams } from '@/loan/types/loan.types'
 import { getChainId, getCollateralListPathname } from '@/loan/utils/utilsRouter'
 import { getBlockchainId } from '@curvefi/prices-api'
+import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useCurve } from '@ui-kit/features/connect-wallet'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
@@ -34,6 +41,12 @@ export const MintMarketPage = () => {
   const chainId = getChainId(params)
   const { address } = useConnection()
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
+  const [chartAndActivityTab, setChartAndActivityTab] = useState<ChartAndActivityTab>('chart')
+  const positionDetailsRef = useRef<HTMLElement | null>(null)
+  const chartAndActivityRef = useRef<HTMLElement | null>(null)
+  const historicalRatesRef = useRef<HTMLElement | null>(null)
+  const advancedDetailsRef = useRef<HTMLElement | null>(null)
+  const faqsRef = useRef<HTMLElement | null>(null)
 
   const marketQuery = useMintMarket({ chainId, rMarket: rCollateralId })
   const { data: market, isLoading: isMarketLoading, error: marketError } = marketQuery
@@ -69,6 +82,31 @@ export const MintMarketPage = () => {
   )
 
   const error = marketError ?? apiMarket.error
+  const sectionRefs = {
+    chartAndActivity: chartAndActivityRef,
+    historicalRates: historicalRatesRef,
+    advancedDetails: advancedDetailsRef,
+    faqs: faqsRef,
+  }
+  const sections: MarketSectionOption[] = [
+    { value: 'position-details', label: t`Position Details`, ref: positionDetailsRef },
+    {
+      value: 'price-chart',
+      label: t`Price Chart`,
+      ref: chartAndActivityRef,
+      onClick: () => setChartAndActivityTab('chart'),
+    },
+    {
+      value: 'market-activity',
+      label: t`Market Activity`,
+      ref: chartAndActivityRef,
+      onClick: () => setChartAndActivityTab('events'),
+    },
+    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
+    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
+    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
+  ]
+
   return error ? (
     <ErrorPage
       title={t`Error`}
@@ -98,11 +136,23 @@ export const MintMarketPage = () => {
             <CreateLoanTabs onPricesUpdated={setPreviewPrices} />
           ))
         }
-        header={<MarketPageHeader isLoading={isLoading} />}
+        header={
+          <Stack>
+            <MarketPageHeader isLoading={isLoading} />
+            <MarketSectionNav sections={sections} />
+          </Stack>
+        }
       >
         <MarketBanners chainId={chainId} market={market} />
-        <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
-        <MarketInformationComposite previewPrices={previewPrices} />
+        <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+          <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
+        </MarketSection>
+        <MarketInformationComposite
+          previewPrices={previewPrices}
+          sectionRefs={sectionRefs}
+          chartAndActivityTab={chartAndActivityTab}
+          onChartAndActivityTabChange={setChartAndActivityTab}
+        />
       </DetailPageLayout>
     </MarketContextProvider>
   )

--- a/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
+++ b/apps/main/src/loan/components/PageMintMarket/MintMarketPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useConnection } from 'wagmi'
 import { MarketContextProvider } from '@/llamalend/features/market-context'
 import { PositionDetailsComposite } from '@/llamalend/features/market-position-details'
@@ -9,11 +9,7 @@ import { getControllerAddress, getTokens } from '@/llamalend/llama.utils'
 import { useLoanExists } from '@/llamalend/queries/user'
 import { MarketBanners } from '@/llamalend/widgets/banners/MarketBanners'
 import type { ChartAndActivityTab } from '@/llamalend/widgets/ChartAndActivityLayout'
-import {
-  MarketSection,
-  MarketSectionNav,
-  type MarketSectionOption,
-} from '@/llamalend/widgets/market-section-nav'
+import { getBorrowMarketSections, MarketSection, MarketSectionNav } from '@/llamalend/widgets/market-section-nav'
 import { MarketPageHeader } from '@/llamalend/widgets/page-header'
 import { MarketInformationComposite } from '@/loan/components/MarketInformationComposite'
 import { CreateLoanTabs } from '@/loan/components/PageMintMarket/CreateLoanTabs'
@@ -42,11 +38,6 @@ export const MintMarketPage = () => {
   const { address } = useConnection()
   const [previewPrices, setPreviewPrices] = useState<Range<Decimal> | undefined>(undefined)
   const [chartAndActivityTab, setChartAndActivityTab] = useState<ChartAndActivityTab>('chart')
-  const positionDetailsRef = useRef<HTMLElement | null>(null)
-  const chartAndActivityRef = useRef<HTMLElement | null>(null)
-  const historicalRatesRef = useRef<HTMLElement | null>(null)
-  const advancedDetailsRef = useRef<HTMLElement | null>(null)
-  const faqsRef = useRef<HTMLElement | null>(null)
 
   const marketQuery = useMintMarket({ chainId, rMarket: rCollateralId })
   const { data: market, isLoading: isMarketLoading, error: marketError } = marketQuery
@@ -82,30 +73,7 @@ export const MintMarketPage = () => {
   )
 
   const error = marketError ?? apiMarket.error
-  const sectionRefs = {
-    chartAndActivity: chartAndActivityRef,
-    historicalRates: historicalRatesRef,
-    advancedDetails: advancedDetailsRef,
-    faqs: faqsRef,
-  }
-  const sections: MarketSectionOption[] = [
-    { value: 'position-details', label: t`Position Details`, ref: positionDetailsRef },
-    {
-      value: 'price-chart',
-      label: t`Price Chart`,
-      ref: chartAndActivityRef,
-      onClick: () => setChartAndActivityTab('chart'),
-    },
-    {
-      value: 'market-activity',
-      label: t`Market Activity`,
-      ref: chartAndActivityRef,
-      onClick: () => setChartAndActivityTab('events'),
-    },
-    { value: 'historical-rates', label: t`Historical Rates`, ref: historicalRatesRef },
-    { value: 'advanced-details', label: t`Advanced Details`, ref: advancedDetailsRef },
-    { value: 'faqs', label: t`FAQs`, ref: faqsRef },
-  ]
+  const sections = getBorrowMarketSections(setChartAndActivityTab)
 
   return error ? (
     <ErrorPage
@@ -144,12 +112,11 @@ export const MintMarketPage = () => {
         }
       >
         <MarketBanners chainId={chainId} market={market} />
-        <MarketSection id="position-details" sectionRef={positionDetailsRef}>
+        <MarketSection id="position-details">
           <PositionDetailsComposite hasPosition={loanExists} events={collateralEvents} />
         </MarketSection>
         <MarketInformationComposite
           previewPrices={previewPrices}
-          sectionRefs={sectionRefs}
           chartAndActivityTab={chartAndActivityTab}
           onChartAndActivityTabChange={setChartAndActivityTab}
         />

--- a/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
+++ b/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useMemo } from 'react'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import { t } from '@ui-kit/lib/i18n'
 import { Accordion } from '@ui-kit/shared/ui/Accordion'
-import { IS_DEVELOPMENT } from '@ui-kit/utils'
+import { ENABLE_FORM_DEBUG } from '@ui-kit/utils'
 import type { FieldValues, UseFormReturn } from './form.types'
 import { FormContext } from './useFormContext'
 
@@ -59,7 +59,7 @@ export const FormProvider = <T extends FieldValues>({
       )}
     >
       {children}
-      {IS_DEVELOPMENT && (
+      {ENABLE_FORM_DEBUG && (
         <Accordion title={t`Form state`} ghost size="extraSmall">
           <AccordionDetails>
             <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -7,7 +7,6 @@ import { defaultReleaseChannel, ReleaseChannel } from '@ui-kit/utils'
 import { useReleaseChannel } from './useLocalStorage'
 
 const useBetaChannel = () => useReleaseChannel()[0] === ReleaseChannel.Beta
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const useStableChannel = () => useReleaseChannel()[0] !== ReleaseChannel.Legacy
 
 /**
@@ -24,6 +23,9 @@ export const useLlamaResetPosition = useStableChannel
 
 /** Split the LlamaLend (soon to be legacy) health into: Liquidation Buffer and Health */
 export const useNewLlamalendHealth = useBetaChannel
+
+/** LlamaLend market detail page section navigation */
+export const useLlamaMarketSectionNav = useBetaChannel
 
 /** New DEX pool list backed by Prices API v2 */
 export const useDexPoolListV2 = useBetaChannel

--- a/packages/curve-ui-kit/src/shared/ui/RouterLink.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/RouterLink.tsx
@@ -5,6 +5,9 @@ import { Link as TanstackLink } from '@tanstack/react-router'
  * MUI Link rendered as a TanStack Router Link. Accepts `href` instead of `to`.
  * Scroll is preserved when navigating to a query-string-only URL (starting with `?`).
  */
-export const RouterLink = ({ href, ...props }: MuiLinkProps) => (
-  <MuiLink component={TanstackLink} to={href} resetScroll={!href?.startsWith('?')} {...props} />
-)
+export const RouterLink = ({ href, ...props }: MuiLinkProps) =>
+  typeof href === 'string' && href.startsWith('#') ? (
+    <MuiLink href={href} {...props} />
+  ) : (
+    <MuiLink component={TanstackLink} to={href} resetScroll={!href?.startsWith('?')} {...props} />
+  )

--- a/packages/curve-ui-kit/src/shared/ui/Tabs/TabsSwitcher.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/Tabs/TabsSwitcher.tsx
@@ -34,7 +34,7 @@ export type TabsSwitcherProps<T> = Pick<TabsProps, 'sx' | 'children'> & {
   size?: keyof typeof TABS_SIZES_CLASSES
   variant?: TabSwitcherVariants
   /** The overflow behavior of the tabs. This is directly mapped to the MUI's variant prop. */
-  overflow?: Exclude<TabsProps['variant'], 'scrollable'> | 'kebab'
+  overflow?: TabsProps['variant'] | 'kebab'
   orientation?: TabsProps['orientation']
   value: T | undefined
   options: readonly TabOption<T>[]
@@ -49,6 +49,7 @@ const overflowToMuiVariant: Record<
   NonNullable<TabsProps['variant']>
 > = {
   standard: 'standard',
+  scrollable: 'scrollable',
   kebab: 'scrollable',
   /** native MUI's fullWidth doesn't behave as expected because all tabs have the same width.
    * Instead below we use flexGrow: 1 to make the tabs take all available width while having different tab's widths. */

--- a/packages/curve-ui-kit/src/utils/env.ts
+++ b/packages/curve-ui-kit/src/utils/env.ts
@@ -12,6 +12,7 @@ export const NO_CYPRESS_TEST_CONNECTOR = Boolean(
 )
 
 export const IS_DEVELOPMENT = NODE_ENV === 'development' || !!window.localStorage?.getItem('developer')
+export const ENABLE_FORM_DEBUG = !!window.localStorage?.getItem('developer')
 export const IS_PREVIEW_HOST = window.location.hostname.includes('vercel.app')
 
 const IS_DEFAULT_BETA = IS_DEVELOPMENT || IS_PREVIEW_HOST || IS_CYPRESS

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/DetailPageLayout.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/DetailPageLayout.tsx
@@ -79,7 +79,14 @@ export const DetailPageLayout = ({
       container
       data-testid={testId ?? 'detail-page-layout'}
       spacing={PAGE_SPACING}
-      sx={{ ...PAGE_MARGIN, ...(!header && { marginBlockStart: Spacing.xl }) }}
+      sx={{
+        ...PAGE_MARGIN,
+        '--detail-page-scroll-margin-top': {
+          mobile: `${navHeight}px`,
+          tablet: `${navHeight + pageHeaderHeight}px`,
+        },
+        ...(!header && { marginBlockStart: Spacing.xl }),
+      }}
       direction="row-reverse" // direction is only used when size<12 (on mobile, form shows first, otherwise children first)
     >
       {isMobile && <Grid size={12}>{headerStack}</Grid>}

--- a/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
@@ -8,6 +8,52 @@ const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/
 const shouldShowCanvas = (testId: string) =>
   cy.get(`[data-testid="${testId}"] canvas`, LOAD_TIMEOUT).should('be.visible')
 
+const getMarketSectionNavTab = (section: string) => cy.get(`[data-testid="market-section-nav-${section}"]`)
+
+const shouldShowMarketSection = (section: string) =>
+  cy.get(`[data-testid="market-section-${section}"]`, LOAD_TIMEOUT).should('be.visible')
+
+const shouldLoadMarketSectionNav = () => {
+  cy.get('[data-testid="market-section-nav"]', LOAD_TIMEOUT).should('be.visible')
+  getMarketSectionNavTab('advanced-details').should('be.visible')
+  getMarketSectionNavTab('faqs').should('be.visible')
+}
+
+const shouldNavigateBorrowMarketSections = () => {
+  getMarketSectionNavTab('position-details').should('be.visible')
+  getMarketSectionNavTab('price-chart').should('be.visible').click()
+  shouldShowMarketSection('price-chart')
+  cy.get('[data-testid="tab-chart"]').should('have.attr', 'aria-selected', 'true')
+
+  getMarketSectionNavTab('market-activity').should('be.visible').click()
+  shouldShowMarketSection('price-chart')
+  cy.get('[data-testid="tab-events"]').should('have.attr', 'aria-selected', 'true')
+
+  getMarketSectionNavTab('historical-rates').should('be.visible').click()
+  shouldShowMarketSection('historical-rates')
+
+  getMarketSectionNavTab('advanced-details').click()
+  shouldShowMarketSection('advanced-details')
+
+  getMarketSectionNavTab('faqs').click()
+  shouldShowMarketSection('faqs')
+}
+
+const shouldNavigateVaultMarketSections = ({ hasPosition }: { hasPosition: boolean }) => {
+  getMarketSectionNavTab('price-chart').should('not.exist')
+  getMarketSectionNavTab('market-activity').should('not.exist')
+  getMarketSectionNavTab('position-details').should(hasPosition ? 'be.visible' : 'not.exist')
+
+  getMarketSectionNavTab('historical-rates').should('be.visible').click()
+  shouldShowMarketSection('historical-rates')
+
+  getMarketSectionNavTab('advanced-details').click()
+  shouldShowMarketSection('advanced-details')
+
+  getMarketSectionNavTab('faqs').click()
+  shouldShowMarketSection('faqs')
+}
+
 const shouldLoadHistoricalBorrowRateChart = () => {
   getMetricValue('historical-borrow-current-rate').should('match', DECIMAL_REGEX)
   shouldShowCanvas('historical-borrow-rate-chart')
@@ -66,6 +112,7 @@ const shouldLoadMarketParameters = ({
 
 export const shouldLoadMarketDetails = () => {
   cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
+  shouldLoadMarketSectionNav()
   getActionValue('market-available-liquidity').should('match', DECIMAL_REGEX)
   cy.get('[data-testid="market-advanced-details"]', LOAD_TIMEOUT).should('be.visible')
   getActionValue('market-total-borrowers').should('match', DECIMAL_REGEX)
@@ -90,6 +137,7 @@ export const shouldLoadLendBorrowDetails = ({ hasWallet }: WalletOptions) => {
   shouldShowCanvas('interest-rate-utilization-chart')
   shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: false })
+  shouldNavigateBorrowMarketSections()
 }
 
 export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
@@ -98,6 +146,7 @@ export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
   getActionValue('market-total-collateral').should('match', DECIMAL_REGEX)
   shouldLoadMarketContracts({ hasMonetaryPolicy: hasWallet, hasOracle: hasWallet, hasVault: false })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: hasWallet, hasPricePerShare: false })
+  shouldNavigateBorrowMarketSections()
 }
 
 export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
@@ -110,4 +159,5 @@ export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
   shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: hasWallet })
   shouldLoadMarketDetails()
+  shouldNavigateVaultMarketSections({ hasPosition: hasWallet })
 }

--- a/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/market-details.helpers.ts
@@ -8,52 +8,6 @@ const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/
 const shouldShowCanvas = (testId: string) =>
   cy.get(`[data-testid="${testId}"] canvas`, LOAD_TIMEOUT).should('be.visible')
 
-const getMarketSectionNavTab = (section: string) => cy.get(`[data-testid="market-section-nav-${section}"]`)
-
-const shouldShowMarketSection = (section: string) =>
-  cy.get(`[data-testid="market-section-${section}"]`, LOAD_TIMEOUT).should('be.visible')
-
-const shouldLoadMarketSectionNav = () => {
-  cy.get('[data-testid="market-section-nav"]', LOAD_TIMEOUT).should('be.visible')
-  getMarketSectionNavTab('advanced-details').should('be.visible')
-  getMarketSectionNavTab('faqs').should('be.visible')
-}
-
-const shouldNavigateBorrowMarketSections = () => {
-  getMarketSectionNavTab('position-details').should('be.visible')
-  getMarketSectionNavTab('price-chart').should('be.visible').click()
-  shouldShowMarketSection('price-chart')
-  cy.get('[data-testid="tab-chart"]').should('have.attr', 'aria-selected', 'true')
-
-  getMarketSectionNavTab('market-activity').should('be.visible').click()
-  shouldShowMarketSection('price-chart')
-  cy.get('[data-testid="tab-events"]').should('have.attr', 'aria-selected', 'true')
-
-  getMarketSectionNavTab('historical-rates').should('be.visible').click()
-  shouldShowMarketSection('historical-rates')
-
-  getMarketSectionNavTab('advanced-details').click()
-  shouldShowMarketSection('advanced-details')
-
-  getMarketSectionNavTab('faqs').click()
-  shouldShowMarketSection('faqs')
-}
-
-const shouldNavigateVaultMarketSections = ({ hasPosition }: { hasPosition: boolean }) => {
-  getMarketSectionNavTab('price-chart').should('not.exist')
-  getMarketSectionNavTab('market-activity').should('not.exist')
-  getMarketSectionNavTab('position-details').should(hasPosition ? 'be.visible' : 'not.exist')
-
-  getMarketSectionNavTab('historical-rates').should('be.visible').click()
-  shouldShowMarketSection('historical-rates')
-
-  getMarketSectionNavTab('advanced-details').click()
-  shouldShowMarketSection('advanced-details')
-
-  getMarketSectionNavTab('faqs').click()
-  shouldShowMarketSection('faqs')
-}
-
 const shouldLoadHistoricalBorrowRateChart = () => {
   getMetricValue('historical-borrow-current-rate').should('match', DECIMAL_REGEX)
   shouldShowCanvas('historical-borrow-rate-chart')
@@ -112,7 +66,6 @@ const shouldLoadMarketParameters = ({
 
 export const shouldLoadMarketDetails = () => {
   cy.get('[data-testid^="detail-page-layout"]', LOAD_TIMEOUT).should('be.visible')
-  shouldLoadMarketSectionNav()
   getActionValue('market-available-liquidity').should('match', DECIMAL_REGEX)
   cy.get('[data-testid="market-advanced-details"]', LOAD_TIMEOUT).should('be.visible')
   getActionValue('market-total-borrowers').should('match', DECIMAL_REGEX)
@@ -137,7 +90,6 @@ export const shouldLoadLendBorrowDetails = ({ hasWallet }: WalletOptions) => {
   shouldShowCanvas('interest-rate-utilization-chart')
   shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: false })
-  shouldNavigateBorrowMarketSections()
 }
 
 export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
@@ -146,7 +98,6 @@ export const shouldLoadMintBorrowDetails = ({ hasWallet }: WalletOptions) => {
   getActionValue('market-total-collateral').should('match', DECIMAL_REGEX)
   shouldLoadMarketContracts({ hasMonetaryPolicy: hasWallet, hasOracle: hasWallet, hasVault: false })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: hasWallet, hasPricePerShare: false })
-  shouldNavigateBorrowMarketSections()
 }
 
 export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
@@ -159,5 +110,4 @@ export const shouldLoadLendVaultDetails = ({ hasWallet }: WalletOptions) => {
   shouldLoadMarketContracts({ hasMonetaryPolicy: true, hasOracle: true, hasVault: true })
   shouldLoadMarketParameters({ hasOnChainParameters: hasWallet, hasOraclePrice: true, hasPricePerShare: hasWallet })
   shouldLoadMarketDetails()
-  shouldNavigateVaultMarketSections({ hasPosition: hasWallet })
 }


### PR DESCRIPTION
## Summary
- add a local LlamaLend market section nav using existing underlined TabsSwitcher
- wire borrow, mint, and supply detail pages with explicit section refs and anchors
- allow the top-level nav to switch the existing chart/activity tab without duplicating chart UI
- add focused Cypress helper assertions for the new nav behavior

## Replacement PRs
- [ ] #2910 — UI Kit: XS and contained tabs 
- [ ] #2913 — UI Kit: semantic card spacing tokens 
- [ ] #2915 — LlamaLend: market header and Overview cards 
- [ ] #2916 — LlamaLend: native market section navigation 
- [ ] #2917 — LlamaLend: aligned market chart cards 
- [ ] #2918 — LlamaLend: compact position cards 
- [ ] #2919 — LlamaLend: market FAQ card 

## Deferred
- [ ] Market detail query and derivation deduplication 

## Verification
- yarn workspace main eslint src/lend/components/ChartAndActivityComp/index.tsx src/lend/components/MarketInformationComposite.tsx src/lend/components/PageLendMarket/LendMarketPage.tsx src/lend/components/PageVault/Page.tsx src/llamalend/widgets/ChartAndActivityLayout.tsx src/llamalend/widgets/market-section-nav/MarketSection.tsx src/llamalend/widgets/market-section-nav/MarketSectionNav.tsx src/llamalend/widgets/market-section-nav/types.ts src/loan/components/ChartAndActivityComp.tsx src/loan/components/MarketInformationComposite.tsx src/loan/components/PageMintMarket/MintMarketPage.tsx
- yarn workspace tests eslint cypress/support/helpers/llamalend/market-details.helpers.ts
- git diff --check

Cypress was not run.
