### PR TITLE
Revert "chore: update llamalend"

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.3.3",
+    "@curvefi/llamalend-api": "2.3.2",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.170.17",
     "@tanstack/react-router-devtools": "1.167.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@curvefi/ethcall@npm:6.0.16":
+  version: 6.0.16
+  resolution: "@curvefi/ethcall@npm:6.0.16"
+  dependencies:
+    "@types/node": "npm:^22.12.0"
+    abi-coder: "npm:^5.0.0"
+  peerDependencies:
+    ethers: ^6.0.0
+  checksum: 10c0/3bd41b3d84f0ed0654279a88920ad7ce38507804008fc8caa86fb2763520f594ef62953a260cb07661f6d71afd5467e41249fdda9eb3b71d10623a496679880e
+  languageName: node
+  linkType: hard
+
 "@curvefi/ethcall@npm:6.0.20":
   version: 6.0.20
   resolution: "@curvefi/ethcall@npm:6.0.20"
@@ -495,15 +507,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.3.3":
-  version: 2.3.3
-  resolution: "@curvefi/llamalend-api@npm:2.3.3"
+"@curvefi/llamalend-api@npm:2.3.2":
+  version: 2.3.2
+  resolution: "@curvefi/llamalend-api@npm:2.3.2"
   dependencies:
-    "@curvefi/ethcall": "npm:6.0.20"
+    "@curvefi/ethcall": "npm:6.0.16"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.17.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/6e3205ced46fe625a9d66100e2104d45ef1e7eb5448cabfa77873e46a323f0e5522f1c661576bce7673b2f3738268aa4bb6616d44885340a212a428c455497b4
+  checksum: 10c0/7a413c09212fd36a5c173b8dae9a106a1df39831bafefb9d62bbc3ae08676a6ca967c2ad932f1e218fce7af56c726f99787ff25a095d771739dad0767fbd82fe
   languageName: node
   linkType: hard
 
@@ -10755,7 +10767,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.3.3"
+    "@curvefi/llamalend-api": "npm:2.3.2"
     "@sentry/vite-plugin": "npm:5.3.0"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.170.17"


### PR DESCRIPTION
This reverts commit 857bd35ef106c5f8a3988754b65df21a6ed2129c from https://github.com/curvefi/curve-frontend/pull/2863, which apparently breaks the create-loan close position tests.

The `closes the loan` test gets stuck on `await waitFor(isSatisfied, { timeout })` when waiting for the approval with `isApproved: async () => await fetchCloseIsApproved({ marketId, chainId, userAddress }, { staleTime: 0 })`