### PR TITLE
refactor: extended panel buttons

### DIFF
--- a/apps/main/src/dex/components/OhlcAndActivityComp/index.tsx
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/index.tsx
@@ -3,13 +3,7 @@ import { ChainId } from '@/dex/types/main.types'
 import type { Pool } from '@curvefi/prices-api/pools'
 import Stack from '@mui/material/Stack'
 import type { Address } from '@primitives/address.utils'
-import {
-  ActivityTable,
-  PoolTradesExpandedPanel,
-  PoolTradesExpandedPanelFooter,
-  PoolLiquidityExpandedPanel,
-  PoolLiquidityExpandedPanelFooter,
-} from '@ui-kit/features/activity-table'
+import { ActivityTable, PoolTradesExpandedPanel, PoolLiquidityExpandedPanel } from '@ui-kit/features/activity-table'
 import { ChartWrapper } from '@ui-kit/features/candle-chart/ChartWrapper'
 import { TIME_OPTIONS } from '@ui-kit/features/candle-chart/constants'
 import { t } from '@ui-kit/lib/i18n'
@@ -61,7 +55,7 @@ export const OhlcAndActivityComp = ({
             table={liquidityTable.table}
             emptyState={liquidityTable.emptyState}
             errorState={liquidityTable.errorState}
-            expandedPanel={{ Body: PoolLiquidityExpandedPanel, Footer: PoolLiquidityExpandedPanelFooter }}
+            expandedPanel={{ Body: PoolLiquidityExpandedPanel }}
           />
         )}
         {tab === 'trades' && (
@@ -69,7 +63,7 @@ export const OhlcAndActivityComp = ({
             table={tradesTable.table}
             emptyState={tradesTable.emptyState}
             errorState={tradesTable.errorState}
-            expandedPanel={{ Body: PoolTradesExpandedPanel, Footer: PoolTradesExpandedPanelFooter }}
+            expandedPanel={{ Body: PoolTradesExpandedPanel }}
           />
         )}
         {tab === 'chart' && (

--- a/apps/main/src/dex/entities/pool-liquidity.query.ts
+++ b/apps/main/src/dex/entities/pool-liquidity.query.ts
@@ -1,5 +1,5 @@
 import { getPoolLiquidityEvents, GetPoolLiquidityEventsParams } from '@curvefi/prices-api/pools'
-import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/dex/entities/pool-trades.query.ts
+++ b/apps/main/src/dex/entities/pool-trades.query.ts
@@ -1,5 +1,5 @@
 import { getAllPoolTrades, type GetAllPoolTradesParams } from '@curvefi/prices-api/pools'
-import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/dex/features/manage-pool/queries/recent-refuels.query.ts
+++ b/apps/main/src/dex/features/manage-pool/queries/recent-refuels.query.ts
@@ -1,6 +1,6 @@
 import { getRefuelDonationEvents } from '@curvefi/prices-api/refuel'
 import type { Address } from '@primitives/address.utils'
-import { DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys, type ChainNameQuery } from '@ui-kit/lib/model'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/dex/features/manage-pool/queries/timeseries.query.ts
+++ b/apps/main/src/dex/features/manage-pool/queries/timeseries.query.ts
@@ -1,6 +1,6 @@
 import { getRefuelTimeseries } from '@curvefi/prices-api/refuel'
 import type { Address } from '@primitives/address.utils'
-import { DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys, type ChainNameQuery } from '@ui-kit/lib/model'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/dex/features/pool-list/LegacyPoolListTable.tsx
+++ b/apps/main/src/dex/features/pool-list/LegacyPoolListTable.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react'
+import { ROUTE } from '@/dex/constants'
 import { type NetworkConfig } from '@/dex/types/main.types'
+import { getPath } from '@/dex/utils/utilsRouter'
 import { ExpandedState, getPaginationRowModel } from '@tanstack/react-table'
 import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { usePageFromQueryString } from '@ui-kit/hooks/usePageFromQueryString'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
-import { getHiddenCount, getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import {
+  getHiddenCount,
+  getTableOptions,
+  useTable,
+  type ExpandedPanelActionResolver,
+} from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { EmptyStateRow } from '@ui-kit/shared/ui/DataTable/EmptyStateRow'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
 import { LegacyDataTable } from '@ui-kit/shared/ui/DataTable/LegacyDataTable'
@@ -15,17 +22,34 @@ import { q } from '@ui-kit/types/util'
 import { LegacyPoolListChips } from './chips/LegacyPoolListChips'
 import { LEGACY_POOL_LIST_COLUMNS, LegacyPoolColumnId, getLegacyDefaultSort } from './columns'
 import { LegacyPoolListEmptyState } from './components/LegacyPoolListEmptyState'
-import {
-  LegacyPoolMobileExpandedPanel,
-  LegacyPoolMobileExpandedPanelFooter,
-} from './components/LegacyPoolMobileExpandedPanel'
+import { LegacyPoolMobileExpandedPanel } from './components/LegacyPoolMobileExpandedPanel'
 import { useLegacyPoolListData } from './hooks/useLegacyPoolListData'
 import { useLegacyPoolListVisibilitySettings } from './hooks/useLegacyPoolListVisibilitySettings'
+import type { LegacyPoolListItem } from './legacyPoolList.types'
 import { useLegacyPoolsGlobalFilterFn } from './legacyPoolsGlobalFilter'
 
 const LOCAL_STORAGE_KEY = 'dex-pool-list'
 
 const PER_PAGE = 50
+
+const getLegacyPoolMobileExpandedPanelActions: ExpandedPanelActionResolver<LegacyPoolListItem> = ({ row }) => {
+  const {
+    pool: { id: poolId },
+    network,
+  } = row.original
+  const path = getPath({ network }, `${ROUTE.PAGE_POOLS}/${poolId}`)
+
+  return [
+    {
+      id: 'deposit',
+      label: t`Deposit`,
+      href: path + ROUTE.PAGE_POOL_DEPOSIT,
+      testId: 'pool-link-deposit',
+    },
+    { id: 'withdraw', label: t`Withdraw`, href: path + ROUTE.PAGE_POOL_WITHDRAW },
+    { id: 'swap', label: t`Swap`, href: path + ROUTE.PAGE_SWAP },
+  ]
+}
 
 export const LegacyPoolListTable = ({ network }: { network: NetworkConfig }) => {
   const { isLite, poolFilters } = network
@@ -69,7 +93,10 @@ export const LegacyPoolListTable = ({ network }: { network: NetworkConfig }) => 
           <LegacyPoolListEmptyState columnFiltersById={columnFiltersById} resetFilters={resetFilters} />
         </EmptyStateRow>
       }
-      expandedPanel={{ Body: LegacyPoolMobileExpandedPanel, Footer: LegacyPoolMobileExpandedPanelFooter }}
+      expandedPanel={{
+        Body: LegacyPoolMobileExpandedPanel,
+        getActions: getLegacyPoolMobileExpandedPanelActions,
+      }}
       shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       loading={isLoading}
     >

--- a/apps/main/src/dex/features/pool-list/PoolListTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolListTable.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react'
+import { ROUTE } from '@/dex/constants'
 import { usePoolList } from '@/dex/queries/pool-list.query'
 import type { NetworkConfig } from '@/dex/types/main.types'
+import { getPath } from '@/dex/utils/utilsRouter'
 import type { SortDirection as PoolSortDirection, V2PoolSortField as PoolSortField } from '@curvefi/prices-api/pools'
 import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
@@ -8,16 +10,13 @@ import { type ExpandedState, getCoreRowModel, getExpandedRowModel } from '@tanst
 import { CURVE_SOCIALS } from '@ui/utils'
 import { useIsMobile, useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { t } from '@ui-kit/lib/i18n'
-import { useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import { useTable, type ExpandedPanelActionResolver } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import { TableFilters } from '@ui-kit/shared/ui/DataTable/TableFilters'
 import { useMappedQuery } from '@ui-kit/types/util'
 import { POOL_LIST_COLUMNS, PoolListColumnId } from './columns'
 import { PoolListFilterChips } from './components/PoolListFilterChips'
-import {
-  PoolListMobileExpandedPanel,
-  PoolListMobileExpandedPanelFooter,
-} from './components/PoolListMobileExpandedPanel'
+import { PoolListMobileExpandedPanel } from './components/PoolListMobileExpandedPanel'
 import { PoolListFilterDrawer } from './drawers/PoolListFilterDrawer'
 import { PoolListSortDrawer } from './drawers/PoolListSortDrawer'
 import { usePoolListFilters } from './hooks/usePoolListFilters'
@@ -26,9 +25,26 @@ import { usePoolListSorting } from './hooks/usePoolListSorting'
 import { usePoolListUserHasPosition } from './hooks/usePoolListUserHasPosition'
 import { usePoolListVisibilitySettings } from './hooks/usePoolListVisibilitySettings'
 import type { PoolListPoolType } from './poolList.constants'
+import type { PoolListItem } from './poolList.types'
 import { getPoolListItem } from './poolList.utils'
 
 const LOCAL_STORAGE_KEY = 'dex-pool-list'
+
+const getPoolListMobileExpandedPanelActions: ExpandedPanelActionResolver<PoolListItem> = ({ row }) => {
+  const pool = row.original
+  const path = getPath({ network: pool.network }, `${ROUTE.PAGE_POOLS}/${pool.address}`)
+
+  return [
+    {
+      id: 'deposit',
+      label: t`Deposit`,
+      href: path + ROUTE.PAGE_POOL_DEPOSIT,
+      testId: 'pool-link-deposit',
+    },
+    { id: 'withdraw', label: t`Withdraw`, href: path + ROUTE.PAGE_POOL_WITHDRAW },
+    { id: 'swap', label: t`Swap`, href: path + ROUTE.PAGE_SWAP },
+  ]
+}
 
 type PoolListTableParams = {
   network: NetworkConfig
@@ -122,7 +138,7 @@ export const PoolListTable = ({ network }: { network: NetworkConfig }) => {
           secondaryButton: { label: t`Telegram`, href: CURVE_SOCIALS.telegram.en },
         }}
         errorState={{ title: t`Unable to retrieve pool list` }}
-        expandedPanel={{ Body: PoolListMobileExpandedPanel, Footer: PoolListMobileExpandedPanelFooter }}
+        expandedPanel={{ Body: PoolListMobileExpandedPanel, getActions: getPoolListMobileExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
         <TableFilters<PoolListColumnId>

--- a/apps/main/src/dex/features/pool-list/PoolListTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolListTable.tsx
@@ -9,6 +9,7 @@ import Stack from '@mui/material/Stack'
 import { type ExpandedState, getCoreRowModel, getExpandedRowModel } from '@tanstack/react-table'
 import { CURVE_SOCIALS } from '@ui/utils'
 import { useIsMobile, useIsTablet } from '@ui-kit/hooks/useBreakpoints'
+import { copyToClipboardWithToast } from '@ui-kit/hooks/useCopyToClipboard'
 import { t } from '@ui-kit/lib/i18n'
 import { useTable, type ExpandedPanelActionResolver } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
@@ -43,6 +44,18 @@ const getPoolListMobileExpandedPanelActions: ExpandedPanelActionResolver<PoolLis
     },
     { id: 'withdraw', label: t`Withdraw`, href: path + ROUTE.PAGE_POOL_WITHDRAW },
     { id: 'swap', label: t`Swap`, href: path + ROUTE.PAGE_SWAP },
+    {
+      id: 'copy-pool-address',
+      label: t`Copy pool address`,
+      onClick: () =>
+        void copyToClipboardWithToast({
+          copyText: pool.address,
+          confirmationText: t`Pool address copied`,
+          failureText: t`Failed to copy pool address`,
+        }),
+      testId: `copy-pool-address-${pool.address}`,
+      alwaysInKebabMenu: true,
+    },
   ]
 }
 

--- a/apps/main/src/dex/features/pool-list/cells/PoolListTitleCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolListTitleCell.tsx
@@ -36,7 +36,7 @@ export const PoolListTitleCell = ({
         <Stack direction="column">
           <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
             <PoolAlertIcons poolAlert={poolAlert} tokenAlert={tokenAlert} />
-            <MarketTitle url={pool.url} address={pool.address} title={pool.name} />
+            <MarketTitle url={pool.url} address={pool.address} title={pool.name} addressLabel={t`Pool`} />
           </Stack>
           <PoolTokens tokenList={tokenList} filterValue={getFilterValue() as string} />
         </Stack>

--- a/apps/main/src/dex/features/pool-list/components/LegacyPoolMobileExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/LegacyPoolMobileExpandedPanel.tsx
@@ -1,11 +1,8 @@
 import { ReactNode } from 'react'
 import { CampaignRewardsRow } from '@/dex/components/CampaignRewardsRow'
 import { TableCellRewardsOthers } from '@/dex/components/TableCellRewardsOthers'
-import { ROUTE } from '@/dex/constants'
 import { useNetworkFromUrl } from '@/dex/hooks/useChainId'
-import { getPath } from '@/dex/utils/utilsRouter'
 import type { Chain } from '@curvefi/prices-api'
-import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -15,7 +12,6 @@ import { t } from '@ui-kit/lib/i18n'
 import { isSortedBy } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { Metric, MetricProps } from '@ui-kit/shared/ui/Metric'
-import { RouterLink } from '@ui-kit/shared/ui/RouterLink'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { constQ } from '@ui-kit/types/util'
 import { decimal } from '@ui-kit/utils'
@@ -132,25 +128,5 @@ export const LegacyPoolMobileExpandedPanel: ExpandedPanel<LegacyPoolListItem> = 
         </>
       )}
     </Grid>
-  )
-}
-
-export const LegacyPoolMobileExpandedPanelFooter: ExpandedPanel<LegacyPoolListItem> = ({ row }) => {
-  const {
-    pool: { id: poolId },
-    network,
-  } = row.original
-  const path = getPath({ network }, `${ROUTE.PAGE_POOLS}/${poolId}`)
-
-  return (
-    <>
-      <Button
-        data-testid="pool-link-deposit"
-        component={RouterLink}
-        href={path + ROUTE.PAGE_POOL_DEPOSIT}
-      >{t`Deposit`}</Button>
-      <Button component={RouterLink} href={path + ROUTE.PAGE_POOL_WITHDRAW}>{t`Withdraw`}</Button>
-      <Button component={RouterLink} href={path + ROUTE.PAGE_SWAP}>{t`Swap`}</Button>
-    </>
   )
 }

--- a/apps/main/src/dex/features/pool-list/components/PoolListMobileExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolListMobileExpandedPanel.tsx
@@ -1,11 +1,7 @@
-import { ROUTE } from '@/dex/constants'
-import { getPath } from '@/dex/utils/utilsRouter'
-import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { Metric, type MetricProps } from '@ui-kit/shared/ui/Metric'
-import { RouterLink } from '@ui-kit/shared/ui/RouterLink'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { constQ } from '@ui-kit/types/util'
 import { decimal } from '@ui-kit/utils'
@@ -63,20 +59,5 @@ export const PoolListMobileExpandedPanel: ExpandedPanel<PoolListItem> = ({ row, 
         <PoolListRewards pool={pool} mobile />
       </Grid>
     </Grid>
-  )
-}
-
-export const PoolListMobileExpandedPanelFooter: ExpandedPanel<PoolListItem> = ({ row }) => {
-  const pool = row.original
-  const path = getPath({ network: pool.network }, `${ROUTE.PAGE_POOLS}/${pool.address}`)
-
-  return (
-    <>
-      <Button component={RouterLink} href={path + ROUTE.PAGE_POOL_DEPOSIT} data-testid="pool-link-deposit">
-        {t`Deposit`}
-      </Button>
-      <Button component={RouterLink} href={path + ROUTE.PAGE_POOL_WITHDRAW}>{t`Withdraw`}</Button>
-      <Button component={RouterLink} href={path + ROUTE.PAGE_SWAP}>{t`Swap`}</Button>
-    </>
   )
 }

--- a/apps/main/src/llamalend/features/llamma-activity/LlammaActivityEvents.tsx
+++ b/apps/main/src/llamalend/features/llamma-activity/LlammaActivityEvents.tsx
@@ -1,8 +1,4 @@
-import {
-  ActivityTable,
-  LlammaEventsExpandedPanel,
-  LlammaEventsExpandedPanelFooter,
-} from '@ui-kit/features/activity-table'
+import { ActivityTable, LlammaEventsExpandedPanel } from '@ui-kit/features/activity-table'
 import { useLlammaActivityEventsConfig } from './hooks/useLlammaActivityEventsConfig'
 import { LlammaActivityProps } from './'
 
@@ -28,7 +24,7 @@ export const LlammaActivityEvents = ({
       table={table}
       emptyState={emptyState}
       errorState={errorState}
-      expandedPanel={{ Body: LlammaEventsExpandedPanel, Footer: LlammaEventsExpandedPanelFooter }}
+      expandedPanel={{ Body: LlammaEventsExpandedPanel }}
     />
   )
 }

--- a/apps/main/src/llamalend/features/llamma-activity/LlammaActivityTrades.tsx
+++ b/apps/main/src/llamalend/features/llamma-activity/LlammaActivityTrades.tsx
@@ -1,8 +1,4 @@
-import {
-  ActivityTable,
-  LlammaTradesExpandedPanel,
-  LlammaTradesExpandedPanelFooter,
-} from '@ui-kit/features/activity-table'
+import { ActivityTable, LlammaTradesExpandedPanel } from '@ui-kit/features/activity-table'
 import { useLlammaActivityTradesConfig } from './hooks/useLlammaActivityTradesConfig'
 import { LlammaActivityProps } from './'
 
@@ -21,7 +17,7 @@ export const LlammaActivityTrades = ({ network, ammAddress, endpoint, networkCon
       table={table}
       emptyState={emptyState}
       errorState={errorState}
-      expandedPanel={{ Body: LlammaTradesExpandedPanel, Footer: LlammaTradesExpandedPanelFooter }}
+      expandedPanel={{ Body: LlammaTradesExpandedPanel }}
     />
   )
 }

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
@@ -1,21 +1,23 @@
 import { useRef, useState } from 'react'
 import type { LlamaMarket, LlamaMarketsResult } from '@/llamalend/queries/market-list/llama-markets'
-import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
+import { notFalsy } from '@primitives/objects.utils'
 import { ExpandedState } from '@tanstack/react-table'
 import { useIsMobile, useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { LEND_MARKET_ROUTES } from '@ui-kit/shared/routes'
-import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import {
+  getTableOptions,
+  useTable,
+  type ExpandedPanelActionResolver,
+} from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
-import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { useFilters } from '@ui-kit/shared/ui/DataTable/hooks/useFilters'
 import { TableFilters } from '@ui-kit/shared/ui/DataTable/TableFilters'
 import { TableFiltersChip } from '@ui-kit/shared/ui/DataTable/TableFiltersChip'
 import { TableHeader } from '@ui-kit/shared/ui/DataTable/TableHeader'
-import { RouterLink as Link } from '@ui-kit/shared/ui/RouterLink'
 import { LlamaMarketType } from '@ui-kit/types/market'
 import { mapQuery, type QueryProp } from '@ui-kit/types/util'
 import { LlamaListChips } from './chips/LlamaListChips'
@@ -32,18 +34,16 @@ const LOCAL_STORAGE_KEY = 'Llamalend Markets'
 
 const pagination = { pageIndex: 0, pageSize: 200 }
 
-const MarketExpandedPanelFooter: ExpandedPanel<LlamaMarket> = ({ row: { original: market } }) => (
-  <>
-    {market.type === LlamaMarketType.Lend && (
-      <Button component={Link} href={market.url + LEND_MARKET_ROUTES.PAGE_VAULT} data-testid="llama-market-go-to-vault">
-        {t`Earn`}
-      </Button>
-    )}
-    <Button component={Link} href={market.url} data-testid="llama-market-go-to-borrow">
-      {t`Borrow`}
-    </Button>
-  </>
-)
+const getMarketExpandedPanelActions: ExpandedPanelActionResolver<LlamaMarket> = ({ row: { original: market } }) =>
+  notFalsy(
+    market.type === LlamaMarketType.Lend && {
+      id: 'earn',
+      label: t`Earn`,
+      href: market.url + LEND_MARKET_ROUTES.PAGE_VAULT,
+      testId: 'llama-market-go-to-vault',
+    },
+    { id: 'borrow', label: t`Borrow`, href: market.url, testId: 'llama-market-go-to-borrow' },
+  )
 
 export const LlamaMarketsTable = ({
   onReload,
@@ -96,7 +96,7 @@ export const LlamaMarketsTable = ({
           button: { onClick: resetFilters, label: t`Show All Markets` },
         }}
         errorState={{ title: t`Could not load markets`, onReload }}
-        expandedPanel={{ Body: LlamaMarketExpandedPanel, Footer: MarketExpandedPanelFooter }}
+        expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getMarketExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
         <TableFilters<LlamaMarketColumnId>

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
@@ -71,9 +71,7 @@ export const LlamaMarketsTable = ({
   )
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const filterProps = { columnFiltersById, setColumnFilter }
-  const getExpandedPanelActions = useLlamaMarketExpandedPanelActions(getMarketExpandedPanelActions, {
-    withFavorite: true,
-  })
+  const getExpandedPanelActions = useLlamaMarketExpandedPanelActions(getMarketExpandedPanelActions)
 
   const table = useTable({
     columns: LLAMA_MARKET_COLUMNS,

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsTable.tsx
@@ -27,6 +27,7 @@ import { getLlamaFacetedRowModel } from './filters/llamaFaceting'
 import { useLlamaGlobalFilterFn } from './filters/llamaGlobalFilter'
 import { LlamaTableFiltersCollapsible } from './filters/LlamaTableFiltersCollapsible'
 import { LlamaTableFiltersOverlay } from './filters/LlamaTableFiltersOverlay'
+import { useLlamaMarketExpandedPanelActions } from './hooks/useLlamaMarketExpandedPanelActions'
 import { getLlamaMarketsColumnVariant, useLlamaTableVisibility } from './hooks/useLlamaTableVisibility'
 import { LlamaMarketExpandedPanel } from './LlamaMarketExpandedPanel'
 
@@ -70,6 +71,9 @@ export const LlamaMarketsTable = ({
   )
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const filterProps = { columnFiltersById, setColumnFilter }
+  const getExpandedPanelActions = useLlamaMarketExpandedPanelActions(getMarketExpandedPanelActions, {
+    withFavorite: true,
+  })
 
   const table = useTable({
     columns: LLAMA_MARKET_COLUMNS,
@@ -96,7 +100,7 @@ export const LlamaMarketsTable = ({
           button: { onClick: resetFilters, label: t`Show All Markets` },
         }}
         errorState={{ title: t`Could not load markets`, onReload }}
-        expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getMarketExpandedPanelActions }}
+        expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
         <TableFilters<LlamaMarketColumnId>

--- a/apps/main/src/llamalend/features/market-list/UserPositionsMarketRateTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/UserPositionsMarketRateTable.tsx
@@ -16,6 +16,7 @@ import { MarketRateType } from '@ui-kit/types/market'
 import { QueryProp } from '@ui-kit/types/util'
 import type { LlamaMarket } from '../../queries/market-list/llama-markets'
 import { DEFAULT_SORT_BORROW, DEFAULT_SORT_SUPPLY, LLAMA_MARKET_COLUMNS } from './columns'
+import { useLlamaMarketExpandedPanelActions } from './hooks/useLlamaMarketExpandedPanelActions'
 import { useLlamaTableVisibility } from './hooks/useLlamaTableVisibility'
 import { LlamaMarketExpandedPanel } from './LlamaMarketExpandedPanel'
 
@@ -62,6 +63,7 @@ export const UserPositionsMarketRateTable = ({ tableQuery, marketRateType, onRel
   const [sorting, onSortingChange] = useSortFromQueryString(defaultSort, sortQueryField)
   const { columnVisibility } = useLlamaTableVisibility(storageKey, sorting, marketRateType)
   const [expanded, setExpanded] = useState<ExpandedState>({})
+  const getExpandedPanelActions = useLlamaMarketExpandedPanelActions(getUserPositionExpandedPanelActions)
 
   const table = useTable({
     columns: LLAMA_MARKET_COLUMNS,
@@ -80,7 +82,7 @@ export const UserPositionsMarketRateTable = ({ tableQuery, marketRateType, onRel
       table={table}
       viewAllLabel={t`View all ${rowCount} ${label} positions`}
       errorState={{ title: t`Could not load ${label} positions`, onReload }}
-      expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getUserPositionExpandedPanelActions }}
+      expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getExpandedPanelActions }}
       shouldStickFirstColumn={Boolean(useIsTablet() && rowCount)}
     >
       <Stack

--- a/apps/main/src/llamalend/features/market-list/UserPositionsMarketRateTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/UserPositionsMarketRateTable.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react'
-import Button from '@mui/material/Button'
 import CardHeader from '@mui/material/CardHeader'
 import Stack from '@mui/material/Stack'
 import { ExpandedState } from '@tanstack/react-table'
 import { useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSortFromQueryString } from '@ui-kit/hooks/useSortFromQueryString'
 import { t } from '@ui-kit/lib/i18n'
-import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import {
+  getTableOptions,
+  useTable,
+  type ExpandedPanelActionResolver,
+} from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
-import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { RouterLink } from '@ui-kit/shared/ui/RouterLink'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { MarketRateType } from '@ui-kit/types/market'
 import { QueryProp } from '@ui-kit/types/util'
@@ -45,15 +46,16 @@ type UserPositionsTableProps = {
 
 const pagination = { pageIndex: 0, pageSize: 50 }
 
-const UserPositionExpandedPanelFooter: ExpandedPanel<LlamaMarket> = ({ row: { original: market } }) => (
-  <Button
-    component={RouterLink}
-    href={market.url} // the url is already built for borrow/supply in the UserPositionsMarketRateTable
-    data-testid="llama-market-go-to-position"
-  >
-    {t`Manage position`}
-  </Button>
-)
+const getUserPositionExpandedPanelActions: ExpandedPanelActionResolver<LlamaMarket> = ({
+  row: { original: market },
+}) => [
+  {
+    id: 'manage-position',
+    label: t`Manage position`,
+    href: market.url, // the url is already built for borrow/supply in the UserPositionsMarketRateTable
+    testId: 'llama-market-go-to-position',
+  },
+]
 
 export const UserPositionsMarketRateTable = ({ tableQuery, marketRateType, onReload }: UserPositionsTableProps) => {
   const { title, label, defaultSort, sortQueryField, storageKey } = TABLE_CONFIG[marketRateType]
@@ -78,7 +80,7 @@ export const UserPositionsMarketRateTable = ({ tableQuery, marketRateType, onRel
       table={table}
       viewAllLabel={t`View all ${rowCount} ${label} positions`}
       errorState={{ title: t`Could not load ${label} positions`, onReload }}
-      expandedPanel={{ Body: LlamaMarketExpandedPanel, Footer: UserPositionExpandedPanelFooter }}
+      expandedPanel={{ Body: LlamaMarketExpandedPanel, getActions: getUserPositionExpandedPanelActions }}
       shouldStickFirstColumn={Boolean(useIsTablet() && rowCount)}
     >
       <Stack

--- a/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
+++ b/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
@@ -17,6 +17,13 @@ export const useLlamaMarketExpandedPanelActions = (getPrimaryActions: ExpandedPa
       return notFalsy(
         ...getPrimaryActions(context),
         {
+          id: 'toggle-favorite-market',
+          label: isFavorite ? t`Remove from favorites` : t`Add to favorites`,
+          onClick: () => toggleFavoriteMarket(favoriteKey),
+          testId: isFavorite ? 'favorite-btn-active' : 'favorite-btn',
+          alwaysInKebabMenu: true,
+        },
+        {
           id: 'copy-market-address',
           label: t`Copy market address`,
           onClick: () =>
@@ -26,13 +33,6 @@ export const useLlamaMarketExpandedPanelActions = (getPrimaryActions: ExpandedPa
               failureText: t`Failed to copy market address`,
             }),
           testId: `copy-market-address-${controllerAddress}`,
-          alwaysInKebabMenu: true,
-        },
-        {
-          id: 'toggle-favorite-market',
-          label: isFavorite ? t`Remove from favorites` : t`Add to favorites`,
-          onClick: () => toggleFavoriteMarket(favoriteKey),
-          testId: isFavorite ? 'favorite-btn-active' : 'favorite-btn',
           alwaysInKebabMenu: true,
         },
       )

--- a/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
+++ b/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react'
+import { useFavoriteMarkets } from '@/llamalend/queries/market-list/favorite-markets'
+import type { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
+import { notFalsy } from '@primitives/objects.utils'
+import { copyToClipboardWithToast } from '@ui-kit/hooks/useCopyToClipboard'
+import { t } from '@ui-kit/lib/i18n'
+import type { ExpandedPanelActionResolver } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+
+export const useLlamaMarketExpandedPanelActions = (
+  getPrimaryActions: ExpandedPanelActionResolver<LlamaMarket>,
+  { withFavorite = false }: { withFavorite?: boolean } = {},
+) => {
+  const [favoriteMarkets, toggleFavoriteMarket] = useFavoriteMarkets()
+
+  return useCallback<ExpandedPanelActionResolver<LlamaMarket>>(
+    context => {
+      const { controllerAddress, favoriteKey } = context.row.original
+      const isFavorite = favoriteMarkets.includes(favoriteKey)
+
+      return notFalsy(
+        ...getPrimaryActions(context),
+        {
+          id: 'copy-market-address',
+          label: t`Copy market address`,
+          onClick: () =>
+            void copyToClipboardWithToast({
+              copyText: controllerAddress,
+              confirmationText: t`Market address copied`,
+              failureText: t`Failed to copy market address`,
+            }),
+          testId: `copy-market-address-${controllerAddress}`,
+          alwaysInKebabMenu: true,
+        },
+        withFavorite && {
+          id: 'toggle-favorite-market',
+          label: isFavorite ? t`Remove from favorites` : t`Add to favorites`,
+          onClick: () => toggleFavoriteMarket(favoriteKey),
+          testId: isFavorite ? 'favorite-btn-active' : 'favorite-btn',
+          alwaysInKebabMenu: true,
+        },
+      )
+    },
+    [favoriteMarkets, getPrimaryActions, toggleFavoriteMarket, withFavorite],
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
+++ b/apps/main/src/llamalend/features/market-list/hooks/useLlamaMarketExpandedPanelActions.ts
@@ -6,10 +6,7 @@ import { copyToClipboardWithToast } from '@ui-kit/hooks/useCopyToClipboard'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanelActionResolver } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 
-export const useLlamaMarketExpandedPanelActions = (
-  getPrimaryActions: ExpandedPanelActionResolver<LlamaMarket>,
-  { withFavorite = false }: { withFavorite?: boolean } = {},
-) => {
+export const useLlamaMarketExpandedPanelActions = (getPrimaryActions: ExpandedPanelActionResolver<LlamaMarket>) => {
   const [favoriteMarkets, toggleFavoriteMarket] = useFavoriteMarkets()
 
   return useCallback<ExpandedPanelActionResolver<LlamaMarket>>(
@@ -31,7 +28,7 @@ export const useLlamaMarketExpandedPanelActions = (
           testId: `copy-market-address-${controllerAddress}`,
           alwaysInKebabMenu: true,
         },
-        withFavorite && {
+        {
           id: 'toggle-favorite-market',
           label: isFavorite ? t`Remove from favorites` : t`Add to favorites`,
           onClick: () => toggleFavoriteMarket(favoriteKey),
@@ -40,6 +37,6 @@ export const useLlamaMarketExpandedPanelActions = (
         },
       )
     },
-    [favoriteMarkets, getPrimaryActions, toggleFavoriteMarket, withFavorite],
+    [favoriteMarkets, getPrimaryActions, toggleFavoriteMarket],
   )
 }

--- a/apps/main/src/llamalend/features/user-position-history/RowExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/RowExpandedPanel.tsx
@@ -1,8 +1,7 @@
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { t } from '@ui-kit/lib/i18n'
-import { type ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
+import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
 import { formatNumber } from '@ui-kit/utils'
 import type { ParsedUserCollateralEvent } from './hooks/useUserCollateralEvents'
 
@@ -42,6 +41,3 @@ export const RowExpandedPanel: ExpandedPanel<ParsedUserCollateralEvent> = ({ row
     </Stack>
   )
 }
-
-export const RowExpandedPanelFooter: ExpandedPanel<ParsedUserCollateralEvent> = ({ row: { original: event } }) =>
-  event.url && <ExternalLink href={event.url} label={t`View Transaction`} size="extraSmall" />

--- a/apps/main/src/llamalend/features/user-position-history/UserEventsTable.tsx
+++ b/apps/main/src/llamalend/features/user-position-history/UserEventsTable.tsx
@@ -1,19 +1,28 @@
 import { useState } from 'react'
 import { SortingState } from '@tanstack/react-table'
+import { getTransactionActions } from '@ui-kit/features/activity-table'
 import { t } from '@ui-kit/lib/i18n'
-import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+import {
+  getTableOptions,
+  useTable,
+  type ExpandedPanelActionResolver,
+} from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable } from '@ui-kit/shared/ui/DataTable/DataTable'
 import type { QueryProp } from '@ui-kit/types/util'
 import { DEFAULT_SORT, USER_POSITION_HISTORY_COLUMNS } from './columns'
 import { ParsedUserCollateralEvent } from './hooks/useUserCollateralEvents'
 import { useUserPositionHistoryVisibility } from './hooks/useUserPositionHistoryVisibility'
-import { RowExpandedPanel, RowExpandedPanelFooter } from './RowExpandedPanel'
+import { RowExpandedPanel } from './RowExpandedPanel'
 
 type UserEventsTableProps = {
   eventsQuery: QueryProp<ParsedUserCollateralEvent[]>
 }
 
 const pagination = { pageIndex: 0, pageSize: 50 }
+
+const getRowExpandedPanelActions: ExpandedPanelActionResolver<ParsedUserCollateralEvent> = ({
+  row: { original: event },
+}) => getTransactionActions(event.url)
 
 export const UserEventsTable = ({ eventsQuery }: UserEventsTableProps) => {
   const { columnVisibility } = useUserPositionHistoryVisibility()
@@ -34,7 +43,7 @@ export const UserEventsTable = ({ eventsQuery }: UserEventsTableProps) => {
       table={table}
       emptyState={{ title: t`No events found` }}
       errorState={{ title: t`Could not load events` }}
-      expandedPanel={{ Body: RowExpandedPanel, Footer: RowExpandedPanelFooter }}
+      expandedPanel={{ Body: RowExpandedPanel, getActions: getRowExpandedPanelActions }}
     />
   )
 }

--- a/apps/main/src/llamalend/queries/llamma-events.query.ts
+++ b/apps/main/src/llamalend/queries/llamma-events.query.ts
@@ -1,6 +1,6 @@
 import { enforce, test } from 'vest'
 import { getEvents, type GetEventsParams } from '@curvefi/prices-api/llamma'
-import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/llamalend/queries/llamma-trades.query.ts
+++ b/apps/main/src/llamalend/queries/llamma-trades.query.ts
@@ -1,6 +1,6 @@
 import { enforce, test } from 'vest'
 import { getTrades, type GetTradesParams } from '@curvefi/prices-api/llamma'
-import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/constants'
+import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_START_INDEX } from '@ui-kit/features/activity-table/utils'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { contractValidationGroup } from '@ui-kit/lib/model/query/contract-validation'

--- a/apps/main/src/llamalend/queries/market-list/favorite-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/favorite-markets.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import type { Address } from '@primitives/address.utils'
-import { getFavoriteMarkets, useFavoriteMarkets } from '@ui-kit/hooks/useLocalStorage'
+import { getFavoriteMarkets, useFavoriteMarkets as useStoredFavoriteMarkets } from '@ui-kit/hooks/useLocalStorage'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model'
 
@@ -12,16 +12,30 @@ const { getQueryOptions: getFavoriteMarketOptions, invalidate: invalidateFavorit
   validationSuite: EmptyValidationSuite,
 })
 
+/** Provides the favorite markets and an operation to toggle one market. */
+export function useFavoriteMarkets() {
+  const [favorites, setFavorites] = useStoredFavoriteMarkets()
+  const toggleFavorite = useCallback(
+    (address: Address) => {
+      setFavorites(currentFavorites =>
+        currentFavorites.includes(address)
+          ? currentFavorites.filter(favorite => favorite !== address)
+          : [...currentFavorites, address],
+      )
+      void invalidateFavoriteMarkets({}) // todo: set the query value directly
+    },
+    [setFavorites],
+  )
+  return [favorites, toggleFavorite] as const
+}
+
 /**
  * Adapts `useFavoriteMarkets` to a single market address.
  */
 export function useFavoriteMarket(address: Address) {
-  const [favorites, setFavorites] = useFavoriteMarkets()
+  const [favorites, toggleFavoriteMarket] = useFavoriteMarkets()
   const isFavorite = useMemo(() => favorites.includes(address), [favorites, address])
-  const toggleFavorite = useCallback(() => {
-    setFavorites(isFavorite ? favorites.filter(id => id !== address) : [...favorites, address])
-    void invalidateFavoriteMarkets({}) // todo: set the query value directly
-  }, [favorites, isFavorite, address, setFavorites])
+  const toggleFavorite = useCallback(() => toggleFavoriteMarket(address), [address, toggleFavoriteMarket])
   return [isFavorite, toggleFavorite] as const
 }
 

--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.stories.tsx
@@ -13,13 +13,9 @@ import {
 } from './columns'
 import {
   LlammaEventsExpandedPanel,
-  LlammaEventsExpandedPanelFooter,
   LlammaTradesExpandedPanel,
-  LlammaTradesExpandedPanelFooter,
   PoolLiquidityExpandedPanel,
-  PoolLiquidityExpandedPanelFooter,
   PoolTradesExpandedPanel,
-  PoolTradesExpandedPanelFooter,
 } from './panels'
 import type { LlammaEventRow, LlammaTradeRow, PoolLiquidityRow, PoolTradeRow } from './types'
 
@@ -217,13 +213,13 @@ const DexPoolActivityComponent = () => {
         table={tradesTable}
         emptyState={{ title: 'No trades data found.' }}
         errorState={{ title: 'Could not load trades data.' }}
-        expandedPanel={{ Body: PoolTradesExpandedPanel, Footer: PoolTradesExpandedPanelFooter }}
+        expandedPanel={{ Body: PoolTradesExpandedPanel }}
       />
       <ActivityTable
         table={liquidityTable}
         emptyState={{ title: 'No liquidity data found.' }}
         errorState={{ title: 'Could not load liquidity data.' }}
-        expandedPanel={{ Body: PoolLiquidityExpandedPanel, Footer: PoolLiquidityExpandedPanelFooter }}
+        expandedPanel={{ Body: PoolLiquidityExpandedPanel }}
       />
     </>
   )
@@ -255,13 +251,13 @@ const LendMarketActivityComponent = () => {
         table={tradesTable}
         emptyState={{ title: 'No AMM trades found.' }}
         errorState={{ title: 'Could not load AMM trades.' }}
-        expandedPanel={{ Body: LlammaTradesExpandedPanel, Footer: LlammaTradesExpandedPanelFooter }}
+        expandedPanel={{ Body: LlammaTradesExpandedPanel }}
       />
       <ActivityTable
         table={eventsTable}
         emptyState={{ title: 'No controller events found.' }}
         errorState={{ title: 'Could not load controller events.' }}
-        expandedPanel={{ Body: LlammaEventsExpandedPanel, Footer: LlammaEventsExpandedPanelFooter }}
+        expandedPanel={{ Body: LlammaEventsExpandedPanel }}
       />
     </>
   )

--- a/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/ActivityTable.tsx
@@ -1,12 +1,15 @@
 import type { TableItem } from '@ui-kit/shared/ui/DataTable/data-table.utils'
 import { DataTable, DataTableProps } from '@ui-kit/shared/ui/DataTable/DataTable'
+import { getTransactionExpandedPanelActions } from './utils'
 
-type ActivityTableProps<TData extends TableItem> = Pick<
+type ActivityTableItem = TableItem & { txUrl?: string | null }
+
+type ActivityTableProps<TData extends ActivityTableItem> = Pick<
   DataTableProps<TData>,
   'table' | 'emptyState' | 'errorState' | 'expandedPanel'
 >
 
-export const ActivityTable = <TData extends TableItem>({
+export const ActivityTable = <TData extends ActivityTableItem>({
   table,
   emptyState,
   errorState,
@@ -17,6 +20,11 @@ export const ActivityTable = <TData extends TableItem>({
     table={table}
     emptyState={emptyState}
     errorState={errorState}
-    expandedPanel={expandedPanel}
+    expandedPanel={
+      expandedPanel && {
+        ...expandedPanel,
+        getActions: expandedPanel.getActions ?? getTransactionExpandedPanelActions,
+      }
+    }
   />
 )

--- a/packages/curve-ui-kit/src/features/activity-table/constants.ts
+++ b/packages/curve-ui-kit/src/features/activity-table/constants.ts
@@ -1,2 +1,0 @@
-export const DEFAULT_PAGE_SIZE = 50
-export const DEFAULT_PAGE_START_INDEX = 1

--- a/packages/curve-ui-kit/src/features/activity-table/hooks/useManualPagination.ts
+++ b/packages/curve-ui-kit/src/features/activity-table/hooks/useManualPagination.ts
@@ -1,6 +1,6 @@
 import { SetStateAction, useCallback, useMemo, useState } from 'react'
 import type { PaginationState } from '@tanstack/react-table'
-import { DEFAULT_PAGE_SIZE } from '../constants'
+import { DEFAULT_PAGE_SIZE } from '../utils'
 
 /**
  * Hook to manage manual pagination state for TanStack Table.

--- a/packages/curve-ui-kit/src/features/activity-table/index.ts
+++ b/packages/curve-ui-kit/src/features/activity-table/index.ts
@@ -1,5 +1,5 @@
 export * from './ActivityTable'
-export * from './constants'
+export * from './utils'
 export * from './cells'
 export * from './types'
 export * from './columns'

--- a/packages/curve-ui-kit/src/features/activity-table/panels/LlammaEventsExpandedPanel.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/LlammaEventsExpandedPanel.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography'
 import { shortenString } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber } from '@ui-kit/utils'
@@ -60,9 +59,3 @@ export const LlammaEventsExpandedPanel: ExpandedPanel<LlammaEventRow> = ({
     </Stack>
   </Stack>
 )
-
-export const LlammaEventsExpandedPanelFooter: ExpandedPanel<LlammaEventRow> = ({
-  row: {
-    original: { txUrl },
-  },
-}) => txUrl && <ExternalLink href={txUrl} label={t`View Transaction`} size="extraSmall" />

--- a/packages/curve-ui-kit/src/features/activity-table/panels/LlammaTradesExpandedPanel.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/LlammaTradesExpandedPanel.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography'
 import { shortenString } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber } from '@ui-kit/utils'
@@ -32,9 +31,3 @@ export const LlammaTradesExpandedPanel: ExpandedPanel<LlammaTradeRow> = ({
     </Stack>
   </Stack>
 )
-
-export const LlammaTradesExpandedPanelFooter: ExpandedPanel<LlammaTradeRow> = ({
-  row: {
-    original: { txUrl },
-  },
-}) => txUrl && <ExternalLink href={txUrl} label={t`View Transaction`} size="extraSmall" />

--- a/packages/curve-ui-kit/src/features/activity-table/panels/PoolLiquidityExpandedPanel.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/PoolLiquidityExpandedPanel.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography'
 import { shortenString } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber } from '@ui-kit/utils'
@@ -45,9 +44,3 @@ export const PoolLiquidityExpandedPanel: ExpandedPanel<PoolLiquidityRow> = ({
     </Stack>
   )
 }
-
-export const PoolLiquidityExpandedPanelFooter: ExpandedPanel<PoolLiquidityRow> = ({
-  row: {
-    original: { txUrl },
-  },
-}) => txUrl && <ExternalLink href={txUrl} label={t`View Transaction`} size="extraSmall" />

--- a/packages/curve-ui-kit/src/features/activity-table/panels/PoolTradesExpandedPanel.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/PoolTradesExpandedPanel.tsx
@@ -3,7 +3,6 @@ import Typography from '@mui/material/Typography'
 import { shortenString } from '@primitives/string.utils'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExpandedPanel } from '@ui-kit/shared/ui/DataTable/ExpansionRow'
-import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
 import { TokenIcon } from '@ui-kit/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { formatNumber } from '@ui-kit/utils'
@@ -32,9 +31,3 @@ export const PoolTradesExpandedPanel: ExpandedPanel<PoolTradeRow> = ({
     </Stack>
   </Stack>
 )
-
-export const PoolTradesExpandedPanelFooter: ExpandedPanel<PoolTradeRow> = ({
-  row: {
-    original: { txUrl },
-  },
-}) => txUrl && <ExternalLink href={txUrl} label={t`View Transaction`} size="extraSmall" />

--- a/packages/curve-ui-kit/src/features/activity-table/panels/index.ts
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/index.ts
@@ -1,4 +1,4 @@
-export { LlammaTradesExpandedPanel, LlammaTradesExpandedPanelFooter } from './LlammaTradesExpandedPanel'
-export { LlammaEventsExpandedPanel, LlammaEventsExpandedPanelFooter } from './LlammaEventsExpandedPanel'
-export { PoolTradesExpandedPanel, PoolTradesExpandedPanelFooter } from './PoolTradesExpandedPanel'
-export { PoolLiquidityExpandedPanel, PoolLiquidityExpandedPanelFooter } from './PoolLiquidityExpandedPanel'
+export { LlammaTradesExpandedPanel } from './LlammaTradesExpandedPanel'
+export { LlammaEventsExpandedPanel } from './LlammaEventsExpandedPanel'
+export { PoolTradesExpandedPanel } from './PoolTradesExpandedPanel'
+export { PoolLiquidityExpandedPanel } from './PoolLiquidityExpandedPanel'

--- a/packages/curve-ui-kit/src/features/activity-table/utils.ts
+++ b/packages/curve-ui-kit/src/features/activity-table/utils.ts
@@ -1,0 +1,15 @@
+import { notFalsy } from '@primitives/objects.utils'
+import { t } from '@ui-kit/lib/i18n'
+import type { ExpandedPanelAction, ExpandedPanelContext, TableItem } from '@ui-kit/shared/ui/DataTable/data-table.utils'
+
+export const DEFAULT_PAGE_SIZE = 50
+export const DEFAULT_PAGE_START_INDEX = 1
+
+export const getTransactionActions = (url?: string | null): readonly ExpandedPanelAction[] =>
+  notFalsy(url && { id: 'view-transaction', label: t`View Transaction`, href: url, size: 'extraSmall', color: 'ghost' })
+
+export const getTransactionExpandedPanelActions = <T extends TableItem & { txUrl?: string | null }>({
+  row: {
+    original: { txUrl },
+  },
+}: ExpandedPanelContext<T>) => getTransactionActions(txUrl)

--- a/packages/curve-ui-kit/src/hooks/useCopyToClipboard.ts
+++ b/packages/curve-ui-kit/src/hooks/useCopyToClipboard.ts
@@ -1,8 +1,30 @@
 import { useCallback } from 'react'
 import { t } from '@ui-kit/lib/i18n'
+import { copyToClipboard } from '@ui-kit/utils'
 import { showToast } from '@ui-kit/widgets/Toast/toast.util'
 
 const DEFAULT_TEST_ID = 'copy-confirmation' as const
+
+type CopyToClipboardWithToastOptions = {
+  copyText: string
+  confirmationText: string
+  failureText?: string
+  testId?: string
+}
+
+export const copyToClipboardWithToast = async ({
+  copyText,
+  confirmationText,
+  failureText = t`Failed to copy to clipboard`,
+  testId = DEFAULT_TEST_ID,
+}: CopyToClipboardWithToastOptions) => {
+  const copied = await copyToClipboard(copyText)
+  showToast(
+    copied
+      ? { message: copyText, severity: 'info', title: confirmationText, testId }
+      : { severity: 'error', title: failureText, testId },
+  )
+}
 
 export const useCopyToClipboard = ({
   copyText,
@@ -14,11 +36,5 @@ export const useCopyToClipboard = ({
   testId?: string
 }) =>
   useCallback(() => {
-    console.info(`Copying to clipboard: ${copyText}`)
-    return void (
-      navigator.clipboard?.writeText(copyText).then(
-        () => showToast({ message: copyText, severity: 'info', title: confirmationText, testId }),
-        e => showToast({ title: (e as Error).message, severity: 'error', testId }),
-      ) ?? showToast({ title: t`Clipboard not available`, severity: 'warning', testId })
-    )
+    void copyToClipboardWithToast({ copyText, confirmationText, testId })
   }, [copyText, confirmationText, testId])

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
@@ -1,3 +1,4 @@
+import { partition } from 'lodash'
 import { useId, useState } from 'react'
 import Button, { type ButtonOwnProps } from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
@@ -19,12 +20,23 @@ const { MaxHeight, Spacing } = SizesAndSpaces
 const VISIBLE_ACTION_COUNT = 2
 
 const ExpandedPanelActionButton = ({ action, inDrawer }: { action: ExpandedPanelAction; inDrawer?: boolean }) => {
-  const { id: _, label, href, testId, sx, type, color, size, ...buttonProps } = action
+  const {
+    id: _id,
+    alwaysInKebabMenu: _alwaysInKebabMenu,
+    label,
+    href,
+    testId,
+    sx,
+    type,
+    color,
+    size,
+    ...buttonProps
+  } = action
 
   const sharedProps = {
     ...buttonProps,
     color: inDrawer ? ('ghost' as const) : color,
-    size: inDrawer ? 'medium' : size,
+    size: inDrawer ? 'small' : size,
     sx: applySxProps({ flex: 1, minWidth: 0 }, sx),
     ...(testId && { 'data-testid': testId }),
   }
@@ -45,15 +57,17 @@ const ExpandedPanelActionButton = ({ action, inDrawer }: { action: ExpandedPanel
 export const ExpandedPanelActions = ({ actions }: { actions: readonly ExpandedPanelAction[] }) => {
   const [open, setOpen] = useState(false)
   const drawerId = useId()
-  const [primaryActions, overflowActions] = splitAt([...actions], VISIBLE_ACTION_COUNT)
-  const visibleButtonsSize = primaryActions[0].size ?? 'medium'
+  const [kebabOnlyActions, primaryActionCandidates] = partition(actions, action => action.alwaysInKebabMenu)
+  const [primaryActions, overflowActions] = splitAt(primaryActionCandidates, VISIBLE_ACTION_COUNT)
+  const drawerActions = [...overflowActions, ...kebabOnlyActions]
+  const visibleButtonsSize = primaryActions[0]?.size ?? 'medium'
 
   return (
     <Stack direction="row" sx={{ gap: Spacing.xs }}>
       {primaryActions.map(action => (
         <ExpandedPanelActionButton key={action.id} action={action} />
       ))}
-      {overflowActions.length > 0 && (
+      {drawerActions.length > 0 && (
         <SwipeableDrawer
           paperSx={{ maxHeight: MaxHeight.drawer }}
           button={
@@ -75,7 +89,7 @@ export const ExpandedPanelActions = ({ actions }: { actions: readonly ExpandedPa
         >
           <DrawerHeader title={t`More actions`} />
           <DrawerItems id={drawerId} data-testid="expanded-panel-actions-menu">
-            {overflowActions.map(action => (
+            {drawerActions.map(action => (
               <ExpandedPanelActionButton key={action.id} action={action} inDrawer />
             ))}
           </DrawerItems>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
@@ -1,0 +1,86 @@
+import { useId, useState } from 'react'
+import Button, { type ButtonOwnProps, type ButtonProps } from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import { splitAt } from '@primitives/array.utils'
+import { t } from '@ui-kit/lib/i18n'
+import { DotsVerticalIcon } from '@ui-kit/shared/icons/DotsVertical'
+import { ExternalLink } from '@ui-kit/shared/ui/ExternalLink'
+import { RouterLink } from '@ui-kit/shared/ui/RouterLink'
+import { DrawerHeader } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerHeader'
+import { DrawerItems } from '@ui-kit/shared/ui/SwipeableDrawer/DrawerItems'
+import { SwipeableDrawer } from '@ui-kit/shared/ui/SwipeableDrawer/SwipeableDrawer'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { applySxProps } from '@ui-kit/utils'
+import type { ExpandedPanelAction } from './data-table.utils'
+
+const { MaxHeight, Spacing } = SizesAndSpaces
+// number of button rendered before hiding the rest in a kebab menu
+const VISIBLE_ACTION_COUNT = 2
+
+const ExpandedPanelActionButton = ({ action, inDrawer }: { action: ExpandedPanelAction; inDrawer?: boolean }) => {
+  const { id: _, label, href, testId, sx, type, color, size, ...buttonProps } = action
+
+  const sharedProps = {
+    ...buttonProps,
+    color: inDrawer ? ('ghost' as const) : color,
+    size: inDrawer ? 'medium' : size,
+    sx: applySxProps({ flex: 1, minWidth: 0 }, sx),
+    ...(testId && { 'data-testid': testId }),
+  }
+
+  return href?.startsWith('https') ? (
+    <ExternalLink {...sharedProps} href={href} label={label} />
+  ) : href ? (
+    <Button {...(sharedProps as ButtonOwnProps)} component={RouterLink} href={href}>
+      {label}
+    </Button>
+  ) : (
+    <Button {...sharedProps} type={type ?? 'button'}>
+      {label}
+    </Button>
+  )
+}
+
+export const ExpandedPanelActions = ({ actions }: { actions: readonly ExpandedPanelAction[] }) => {
+  const [open, setOpen] = useState(false)
+  const drawerId = useId()
+  const [primaryActions, overflowActions] = splitAt([...actions], VISIBLE_ACTION_COUNT)
+  const visibleButtonsSize = primaryActions[0].size ?? 'medium'
+
+  return (
+    <Stack direction="row" sx={{ gap: Spacing.xs }}>
+      {primaryActions.map(action => (
+        <ExpandedPanelActionButton key={action.id} action={action} />
+      ))}
+      {overflowActions.length > 0 && (
+        <SwipeableDrawer
+          paperSx={{ maxHeight: MaxHeight.drawer }}
+          button={
+            <IconButton
+              aria-controls={drawerId}
+              aria-expanded={open}
+              aria-haspopup="dialog"
+              aria-label={t`More actions`}
+              color="primary"
+              data-testid="expanded-panel-actions-menu-button"
+              onClick={() => setOpen(true)}
+              size={visibleButtonsSize}
+            >
+              <DotsVerticalIcon />
+            </IconButton>
+          }
+          open={open}
+          setOpen={setOpen}
+        >
+          <DrawerHeader title={t`More actions`} />
+          <DrawerItems id={drawerId} data-testid="expanded-panel-actions-menu">
+            {overflowActions.map(action => (
+              <ExpandedPanelActionButton key={action.id} action={action} inDrawer />
+            ))}
+          </DrawerItems>
+        </SwipeableDrawer>
+      )}
+    </Stack>
+  )
+}

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
@@ -1,5 +1,5 @@
 import { partition } from 'lodash'
-import { useId, useState } from 'react'
+import { type MouseEvent, useId, useState } from 'react'
 import Button, { type ButtonOwnProps } from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
@@ -19,7 +19,13 @@ const { MaxHeight, Spacing } = SizesAndSpaces
 // number of button rendered before hiding the rest in a kebab menu
 const VISIBLE_ACTION_COUNT = 2
 
-const ExpandedPanelActionButton = ({ action, inDrawer }: { action: ExpandedPanelAction; inDrawer?: boolean }) => {
+const ExpandedPanelActionButton = ({
+  action,
+  onDrawerActionClick,
+}: {
+  action: ExpandedPanelAction
+  onDrawerActionClick?: () => void
+}) => {
   const {
     id: _id,
     alwaysInKebabMenu: _alwaysInKebabMenu,
@@ -30,11 +36,19 @@ const ExpandedPanelActionButton = ({ action, inDrawer }: { action: ExpandedPanel
     type,
     color,
     size,
+    onClick,
     ...buttonProps
   } = action
+  const inDrawer = !!onDrawerActionClick
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event)
+    onDrawerActionClick?.()
+  }
 
   const sharedProps = {
     ...buttonProps,
+    onClick: onDrawerActionClick ? handleClick : onClick,
     color: inDrawer ? ('ghost' as const) : color,
     size: inDrawer ? 'small' : size,
     sx: applySxProps({ flex: 1, minWidth: 0 }, sx),
@@ -90,7 +104,7 @@ export const ExpandedPanelActions = ({ actions }: { actions: readonly ExpandedPa
           <DrawerHeader title={t`More actions`} />
           <DrawerItems id={drawerId} data-testid="expanded-panel-actions-menu">
             {drawerActions.map(action => (
-              <ExpandedPanelActionButton key={action.id} action={action} inDrawer />
+              <ExpandedPanelActionButton key={action.id} action={action} onDrawerActionClick={() => setOpen(false)} />
             ))}
           </DrawerItems>
         </SwipeableDrawer>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpandedPanelActions.tsx
@@ -1,5 +1,5 @@
 import { useId, useState } from 'react'
-import Button, { type ButtonOwnProps, type ButtonProps } from '@mui/material/Button'
+import Button, { type ButtonOwnProps } from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import { splitAt } from '@primitives/array.utils'

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
@@ -1,21 +1,21 @@
-import { FunctionComponent, useCallback, useEffect, useState } from 'react'
+import { type FunctionComponent, useCallback, useEffect, useState } from 'react'
 import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
-import { type Row, type Table } from '@tanstack/react-table'
+import type { Row } from '@tanstack/react-table'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import type { TableItem } from './data-table.utils'
+import type { ExpandedPanelActionResolver, ExpandedPanelContext, TableItem } from './data-table.utils'
 import type { DataRowProps } from './DataRow'
+import { ExpandedPanelActions } from './ExpandedPanelActions'
 
 const { Spacing } = SizesAndSpaces
 
-// Panel used when row is expanded on mobile
-export type ExpandedPanel<T extends TableItem> = FunctionComponent<{ row: Row<T>; table: Table<T> }>
+export type ExpandedPanel<T extends TableItem> = FunctionComponent<ExpandedPanelContext<T>>
 
 export type ExpandedPanelConfig<T extends TableItem> = {
   Body: ExpandedPanel<T>
-  Footer?: ExpandedPanel<T>
+  getActions?: ExpandedPanelActionResolver<T>
 }
 
 /**
@@ -31,7 +31,8 @@ export function ExpansionRow<T extends TableItem>({
   colSpan: number
 }) {
   const { render, onExited, expanded } = useRowExpansion(row)
-  const { Body: ExpandedPanelBody, Footer: ExpandedPanelFooter } = expandedPanel
+  const { Body: ExpandedPanelBody, getActions } = expandedPanel
+  const actions = getActions?.({ row, table }) ?? []
   return (
     render && (
       <TableRow data-testid="data-table-expansion-row">
@@ -41,11 +42,7 @@ export function ExpansionRow<T extends TableItem>({
               <Stack sx={{ gap: Spacing.md, paddingInline: Spacing.md }}>
                 <ExpandedPanelBody row={row} table={table} />
               </Stack>
-              {ExpandedPanelFooter && (
-                <Stack direction="row" sx={{ gap: Spacing.xs, '& > *': { flex: 1 } }}>
-                  <ExpandedPanelFooter row={row} table={table} />
-                </Stack>
-              )}
+              {actions.length > 0 && <ExpandedPanelActions actions={actions} />}
             </Stack>
           </Collapse>
         </TableCell>

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/LegacyDataRow.tsx
@@ -14,7 +14,7 @@ import {
   type TableItem,
 } from './data-table.utils'
 import { DataCell } from './DataCell'
-import { ExpandedPanelConfig, ExpansionRow } from './ExpansionRow'
+import { type ExpandedPanelConfig, ExpansionRow } from './ExpansionRow'
 
 const onCellClick = (target: EventTarget, url: string, routerNavigate: (href: string) => void) => {
   // ignore clicks on elements that should be clickable inside the row

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
@@ -60,6 +60,8 @@ export type ExpandedPanelAction = Omit<ButtonProps, 'children' | 'component' | '
   label: ReactNode
   href?: string
   testId?: string
+  /** Keep this action always in the more-actions drawer */
+  alwaysInKebabMenu?: boolean
 }
 
 export type ExpandedPanelActionResolver<T extends TableItem> = (

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/data-table.utils.ts
@@ -1,4 +1,6 @@
 import { useMemo } from 'react'
+import type { ReactNode } from 'react'
+import type { ButtonProps } from '@mui/material/Button'
 import type { Theme } from '@mui/material/styles'
 import type { SxProps } from '@mui/system'
 import { maybe, type PartialRecord } from '@primitives/objects.utils'
@@ -15,6 +17,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
+  Row,
 } from '@tanstack/react-table'
 import { RowData, type Table, TableOptions } from '@tanstack/table-core'
 import { IncreasingLengthCategory } from '@ui-kit/hooks/useIncreasingLength'
@@ -50,6 +53,18 @@ export type TableItem = { url?: string | null }
 export type TanstackTable<T extends TableItem> = ReturnType<typeof useTable<T>>
 
 export type ColumnMeta = TanstackColumnMeta<TableItem, unknown>
+
+export type ExpandedPanelContext<T extends TableItem> = { row: Row<T>; table: Table<T> }
+export type ExpandedPanelAction = Omit<ButtonProps, 'children' | 'component' | 'href' | 'ref'> & {
+  id: string
+  label: ReactNode
+  href?: string
+  testId?: string
+}
+
+export type ExpandedPanelActionResolver<T extends TableItem> = (
+  context: ExpandedPanelContext<T>,
+) => readonly ExpandedPanelAction[]
 
 /**
  * Wrapper around useReactTable to create a table instance.

--- a/packages/curve-ui-kit/src/widgets/MarketTitle.tsx
+++ b/packages/curve-ui-kit/src/widgets/MarketTitle.tsx
@@ -9,7 +9,17 @@ import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from '../shared/ui/D
 import { RouterLink } from '../shared/ui/RouterLink'
 import { responsiveTitleEllipsisSx } from '../shared/ui/titleTruncate'
 
-export function MarketTitle({ address, title, url }: { address: Address; title: ReactNode; url: string }) {
+export function MarketTitle({
+  address,
+  title,
+  url,
+  addressLabel = t`Market`,
+}: {
+  address: Address
+  title: ReactNode
+  url: string
+  addressLabel?: string
+}) {
   const isMobile = useIsMobile()
   return (
     <Typography
@@ -38,9 +48,9 @@ export function MarketTitle({ address, title, url }: { address: Address; title: 
       </RouterLink>
       <CopyIconButton
         className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
-        label={t`Copy market address`}
+        label={t`Copy ${addressLabel} address`}
         copyText={address}
-        confirmationText={t`Market address copied`}
+        confirmationText={t`${addressLabel} address copied`}
         data-testid={`copy-market-address-${address}`}
         sx={{ display: { mobile: 'none', tablet: 'flex' } }}
       />

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -6,6 +6,7 @@ import {
   expandFirstRowOnMobile,
   getTableCellAssets,
   openDrawer,
+  withExpandedPanelDrawer,
   withFilters,
 } from '@cy/support/helpers/data-table.helpers'
 import { Chain, HIGH_TVL_ADDRESS, HIGH_UTILIZATION_ADDRESS } from '@cy/support/helpers/lending-mocks'
@@ -14,6 +15,7 @@ import {
   checkCoinSelection,
   checkLineGraphColor,
   checkTableFilterButtonGroupSelection,
+  clickMarketAction,
   enableGraphColumn,
   filterByMarketType,
   getOneColumnMedianValue,
@@ -22,7 +24,7 @@ import {
 } from '@cy/support/helpers/llamalend/llamalend-markets'
 import { setupLlamalendListMocks } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { assertInViewport, assertNotInViewport, LOAD_TIMEOUT, oneDesktopViewport, oneViewport } from '@cy/support/ui'
-import { assert, notFalsy, objectKeys, recordValues, repeat } from '@primitives/objects.utils'
+import { assert, objectKeys, recordValues, repeat } from '@primitives/objects.utils'
 import { LlamaMarketType, LlamaMarketVersion, MarketRateType } from '@ui-kit/types/market'
 
 const WST_ETH_MARKET = '0x100dAa78fC509Db39Ef7D04DE0c1ABD299f4C6CE' as const
@@ -40,17 +42,8 @@ testCases.forEach(([width, height, breakpoint]) => {
       visitAndWait([width, height])
     })
 
-    itSkipOnMobile(`should copy the market address`, () => {
-      expandFirstRowOnMobile(breakpoint)
-      cy.get(
-        notFalsy(
-          breakpoint === 'mobile' && `[data-testid="data-table-expansion-row"]`,
-          `[data-testid^="copy-market-address"]`,
-        ).join(' '),
-      )
-        .first()
-        // on desktop, the copy button is not visible until hovered - but cypress doesn't support that so use force
-        .click({ force: breakpoint === 'desktop' })
+    it(`should copy the market address`, () => {
+      withExpandedPanelDrawer(breakpoint, () => clickMarketAction(breakpoint, `[data-testid^="copy-market-address"]`))
       cy.get(`[data-testid="copy-confirmation"]`).should('be.visible')
     })
 
@@ -209,16 +202,14 @@ testCases.forEach(([width, height, breakpoint]) => {
       getTableCellAssets().first().contains('wstETH')
     })
 
-    itSkipOnMobile('should allow filtering favorites', () => {
-      expandFirstRowOnMobile(breakpoint)
-      // on desktop, the favorite icon is not visible until hovered - but cypress doesn't support that so use force
-      cy.get(`[data-testid="favorite-btn"]`).first().click({ force: true })
+    it('should allow filtering favorites', () => {
+      withExpandedPanelDrawer(breakpoint, () => clickMarketAction(breakpoint, `[data-testid="favorite-btn"]`))
 
       cy.get(`[data-testid="chip-favorites"]`).click()
       cy.url().should('include', 'isFavorite=yes')
       cy.get(`[data-testid^="data-table-row"]`).should('have.length', 1)
       cy.get(`[data-testid="favorite-btn"]`).should('not.exist')
-      cy.get(`[data-testid="favorite-btn-active"]`).click()
+      withExpandedPanelDrawer(breakpoint, () => clickMarketAction(breakpoint, `[data-testid="favorite-btn-active"]`))
       cy.get(`[data-testid="table-empty-row"]`).should('exist')
     })
 

--- a/tests/cypress/support/helpers/data-table.helpers.ts
+++ b/tests/cypress/support/helpers/data-table.helpers.ts
@@ -23,6 +23,31 @@ export function expandFirstRowOnMobile(breakpoint: Breakpoint) {
   }
 }
 
+/**
+ * Makes expanded-panel drawer actions available during the given callback. On mobile, actions are inside a row
+ * expansion and the kebab drawer.
+ */
+export function withExpandedPanelDrawer<T>(breakpoint: Breakpoint, callback: () => Cypress.Chainable<T>) {
+  if (breakpoint === 'mobile') {
+    cy.get('body').then($body => {
+      if (!$body.find('[data-testid="data-table-expansion-row"]').length) {
+        expandFirstRowOnMobile(breakpoint)
+      }
+    })
+    cy.get('[data-testid="data-table-expansion-row"]').should('be.visible')
+    cy.get('[data-testid="expanded-panel-actions-menu-button"]').click()
+    cy.get('[data-testid="expanded-panel-actions-menu"]').should('be.visible')
+  }
+
+  return callback().then(result => {
+    if (breakpoint === 'mobile') {
+      // The drawer can be hidden or unmounted depending on the state of the expanded panel. This works for both cases
+      cy.get('[data-testid="expanded-panel-actions-menu"]:visible').should('not.exist')
+    }
+    return cy.wrap(result)
+  })
+}
+
 export function openDrawer(breakpoint: Breakpoint, type: 'filter' | 'sort') {
   if (breakpoint == 'mobile') {
     cy.get(`[data-testid^="btn-drawer-${type}-"]`).click({ waitForAnimations: true })

--- a/tests/cypress/support/helpers/llamalend/llamalend-markets.ts
+++ b/tests/cypress/support/helpers/llamalend/llamalend-markets.ts
@@ -21,16 +21,13 @@ export function visitAndWait(
 }
 
 export function clickMarketAction(breakpoint: Breakpoint, selector: string) {
-  return cy
-    .get(
-      notFalsy(
-        breakpoint === 'mobile' && `[data-testid="expanded-panel-actions-menu"]`,
-        selector,
-      ).join(' '),
-    )
-    .first()
-    // On desktop, the action is not visible until hovered; Cypress does not support hovering.
-    .click({ force: breakpoint === 'desktop' })
+  return (
+    cy
+      .get(notFalsy(breakpoint === 'mobile' && `[data-testid="expanded-panel-actions-menu"]`, selector).join(' '))
+      .first()
+      // On desktop, the action is not visible until hovered; Cypress does not support hovering.
+      .click({ force: breakpoint === 'desktop' })
+  )
 }
 
 export function enableGraphColumn() {

--- a/tests/cypress/support/helpers/llamalend/llamalend-markets.ts
+++ b/tests/cypress/support/helpers/llamalend/llamalend-markets.ts
@@ -20,6 +20,19 @@ export function visitAndWait(
   cy.get('[data-testid="data-table"]', LOAD_TIMEOUT).should('be.visible')
 }
 
+export function clickMarketAction(breakpoint: Breakpoint, selector: string) {
+  return cy
+    .get(
+      notFalsy(
+        breakpoint === 'mobile' && `[data-testid="expanded-panel-actions-menu"]`,
+        selector,
+      ).join(' '),
+    )
+    .first()
+    // On desktop, the action is not visible until hovered; Cypress does not support hovering.
+    .click({ force: breakpoint === 'desktop' })
+}
+
 export function enableGraphColumn() {
   cy.get(`[data-testid="line-graph-${MarketRateType.Borrow}"]`).should('not.exist')
   cy.get(`[data-testid="btn-visibility-settings"]`).click()


### PR DESCRIPTION
depends on https://github.com/curvefi/curve-frontend/pull/2810

- refactor expanded panels actions buttons
- add back the copy address and favorites button for llamalend in the drawer
- add back the favorite and copy address tests
- add the copy address for the pool list expanded panel 


Llamalend:
<img width="392" height="324" alt="Screenshot 2026-07-10 at 18 28 46" src="https://github.com/user-attachments/assets/ee4b3127-343e-44c9-9f7e-3d614dc13038" />
<img width="391" height="243" alt="Screenshot 2026-07-10 at 18 28 53" src="https://github.com/user-attachments/assets/ca1c5c74-4a91-491c-9ce0-49792344bf09" />


Dex:
<img width="390" height="224" alt="Screenshot 2026-07-10 at 18 29 06" src="https://github.com/user-attachments/assets/26ec6ca2-81b0-49f9-9ef8-fc47c8c904de" />
<img width="392" height="299" alt="Screenshot 2026-07-10 at 18 29 16" src="https://github.com/user-attachments/assets/a1a737dc-580e-4fc3-8ddf-7746052d5c37" />

