### PR TITLE
refactor: available liquidity column with amount

### DIFF
--- a/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketExpandedPanel.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent, useMemo } from 'react'
 import { NET_SUPPLY_RATE_TITLE } from '@/llamalend/constants'
+import { tokenMetric } from '@/llamalend/llama.utils'
 import { ArrowRight } from '@carbon/icons-react'
 import Button from '@mui/material/Button'
 import CardHeader from '@mui/material/CardHeader'
@@ -84,6 +85,7 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
     favoriteKey,
     assets,
     leverage,
+    liquidity,
     liquidityUsd,
     url,
     userHasPositions,
@@ -148,8 +150,11 @@ export const LlamaMarketExpandedPanel: ExpandedPanel<LlamaMarket> = ({ row: { or
           <Metric
             category={EXPANDED_DETAILS_METRIC_CATEGORY}
             label={t`Available Liquidity`}
-            value={constQ(liquidityUsd)}
-            valueOptions={{ unit: 'dollar' }}
+            {...tokenMetric({
+              value: constQ(liquidity),
+              symbol: assets.borrowed.symbol,
+              notional: constQ({ value: liquidityUsd, unit: 'dollar' as const }),
+            })}
           />
         </Grid>
         <Grid size={12}>

--- a/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
@@ -2,17 +2,31 @@ import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { LiquidityUsdTooltipContent } from '@/llamalend/widgets/tooltips/LiquidityUsdTooltipContent'
 import { CellContext } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
+import { TokenInfo } from '@ui-kit/shared/ui/TokenInfo'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
-import { CompactUsdCell } from './CompactUsdCell'
+import { formatNumber } from '@ui-kit/utils'
 
-export const LiquidityUsdCell = ({ row, ...ctx }: CellContext<LlamaMarket, number>) => (
-  <Tooltip
-    title={t`Available liquidity breakdown`}
-    body={<LiquidityUsdTooltipContent market={row.original} />}
-    placement="top"
-  >
-    <span>
-      <CompactUsdCell row={row} {...ctx} />
-    </span>
-  </Tooltip>
-)
+export const LiquidityUsdCell = ({ getValue, row }: CellContext<LlamaMarket, number>) => {
+  const { liquidity, assets } = row.original
+
+  return (
+    <Tooltip
+      title={t`Available liquidity breakdown`}
+      body={<LiquidityUsdTooltipContent market={row.original} />}
+      placement="top"
+    >
+      <span>
+        <TokenInfo
+          address={assets.borrowed.address}
+          blockchainId={assets.borrowed.chain}
+          iconSize="mui-sm"
+          iconPosition="right"
+          primary={formatNumber(liquidity, 'token.compact')}
+          secondary={formatNumber(getValue(), 'usd.notional')}
+          boldPrimary
+          sx={{ justifyContent: 'end' }}
+        />
+      </span>
+    </Tooltip>
+  )
+}

--- a/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
@@ -1,5 +1,6 @@
 import { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { LiquidityUsdTooltipContent } from '@/llamalend/widgets/tooltips/LiquidityUsdTooltipContent'
+import Box from '@mui/material/Box'
 import { CellContext } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { TokenInfo } from '@ui-kit/shared/ui/TokenInfo'
@@ -15,7 +16,7 @@ export const LiquidityUsdCell = ({ getValue, row }: CellContext<LlamaMarket, num
       body={<LiquidityUsdTooltipContent market={row.original} />}
       placement="top"
     >
-      <span>
+      <Box>
         <TokenInfo
           address={assets.borrowed.address}
           blockchainId={assets.borrowed.chain}
@@ -26,7 +27,7 @@ export const LiquidityUsdCell = ({ getValue, row }: CellContext<LlamaMarket, num
           boldPrimary
           sx={{ justifyContent: 'end' }}
         />
-      </span>
+      </Box>
     </Tooltip>
   )
 }

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -516,10 +516,12 @@ export const tokenMetric = ({
   value,
   symbol,
   usdRate,
+  notional,
 }: {
   value: MetricProps['value']
   symbol: string | null | undefined
-  usdRate: QueryProp<Amount>
+  usdRate?: QueryProp<Amount>
+  notional?: MetricProps['notional']
 }) =>
   ({
     value,
@@ -527,7 +529,10 @@ export const tokenMetric = ({
       abbreviate: true,
       unit: maybe(symbol, symbol => ({ symbol, position: 'suffix' as const })),
     },
-    notional: combineQueries([value, usdRate], (value, usdRate) =>
-      maybe(decimal(value), value => ({ value: decimalMultiply(value, usdRate), unit: 'dollar' as const })),
-    ),
+    notional:
+      notional ??
+      (usdRate &&
+        combineQueries([value, usdRate], (value, usdRate) =>
+          maybe(decimal(value), value => ({ value: decimalMultiply(value, usdRate), unit: 'dollar' as const })),
+        )),
   }) satisfies Pick<MetricProps, 'value' | 'valueOptions' | 'notional'>

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -74,6 +74,7 @@ export type LlamaMarket = {
   oracleAddress?: Address
   parameters: { A: number | null; loanDiscount: Decimal; liquidationDiscount: Decimal }
   utilizationPercent: number
+  liquidity: number
   liquidityUsd: number
   tvl: number
   totalDebtUsd: number
@@ -216,6 +217,7 @@ const convertLendingVault = (
     solvencyPercent,
     badDebtUsd,
     debtCeiling: null, // debt ceiling is not applicable for lend markets
+    liquidity: totalAssets - totalDebt,
     liquidityUsd: totalAssetsUsd - totalDebtUsd,
     totalDebtUsd,
     totalCollateralUsd: collateralBalanceUsd + borrowedBalanceUsd,
@@ -352,7 +354,8 @@ const convertMintMarket = (
     solvencyPercent: null,
     badDebtUsd,
     debtCeiling,
-    liquidityUsd: borrowable,
+    liquidity: borrowable,
+    liquidityUsd: borrowable, // TODO: Use borrowableUsd instead of assuming crvUSD is worth $1.
     tvl,
     totalDebtUsd: borrowedUsd,
     totalCollateralUsd: tvl,

--- a/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/LiquidityUsdTooltipContent.tsx
@@ -8,9 +8,10 @@ import {
 import Stack from '@mui/material/Stack'
 import { maybe } from '@primitives/objects.utils'
 import { t } from '@ui-kit/lib/i18n'
+import { LlamaMarketType } from '@ui-kit/types/market'
 import { formatNumber } from '@ui-kit/utils'
 
-const format = (value: number) => formatNumber(value, 'usd.notional')
+const formatToken = (value: number | null, symbol: string) => `${formatNumber(value, 'token.compact')} ${symbol}`
 
 const TITLE = { Lend: t`Total supplied`, Mint: t`Debt ceiling` }
 const TOOLTIP = {
@@ -20,10 +21,8 @@ const TOOLTIP = {
 
 export const LiquidityUsdTooltipContent = ({
   market: {
-    assets: {
-      collateral: { balanceUsd },
-    },
-    totalDebtUsd,
+    assets: { borrowed },
+    liquidity,
     liquidityUsd,
     debtCeiling,
     type,
@@ -35,14 +34,15 @@ export const LiquidityUsdTooltipContent = ({
     <TooltipDescription text={TOOLTIP[type]} />
     <Stack>
       <TooltipItems secondary>
-        {maybe({ Lend: balanceUsd, Mint: debtCeiling }[type], usd => (
-          <TooltipItem title={TITLE[type]}>{format(usd)}</TooltipItem>
+        {maybe(type === LlamaMarketType.Lend ? liquidity + (borrowed.balance ?? 0) : debtCeiling, total => (
+          <TooltipItem title={TITLE[type]}>{formatToken(total, borrowed.symbol)}</TooltipItem>
         ))}
-        <TooltipItem title={t`Total borrowed`}>-{format(totalDebtUsd)}</TooltipItem>
+        <TooltipItem title={t`Total borrowed`}>-{formatToken(borrowed.balance, borrowed.symbol)}</TooltipItem>
       </TooltipItems>
       <TooltipItems>
         <TooltipItem variant="primary" title={t`Available liquidity`}>
-          {format(liquidityUsd)}
+          {formatToken(liquidity, borrowed.symbol)}
+          {formatNumber(liquidityUsd, 'usd.notional')}
         </TooltipItem>
       </TooltipItems>
     </Stack>

--- a/packages/curve-ui-kit/src/features/activity-table/panels/PoolLiquidityExpandedPanel.tsx
+++ b/packages/curve-ui-kit/src/features/activity-table/panels/PoolLiquidityExpandedPanel.tsx
@@ -27,11 +27,7 @@ export const PoolLiquidityExpandedPanel: ExpandedPanel<PoolLiquidityRow> = ({
     <Stack>
       <Stack sx={{ paddingTop: Spacing.md, gap: Spacing.xs }}>
         {nonZeroAmounts.map(({ amount, token }, index) => (
-          <Stack
-            key={token?.address ?? index}
-            direction="row"
-            sx={{ justifyContent: 'space-between', alignItems: 'center' }}
-          >
+          <Stack key={token?.address} direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
             <Typography variant="bodyMRegular" color="textSecondary">
               {token?.symbol ?? `Token ${index}`}
             </Typography>

--- a/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { TokenIcon, type Size } from './TokenIcon'
 import { applySxProps, SxProps } from '@ui-kit/utils'
+import { TokenIcon, type Size } from './TokenIcon'
 
 const { Spacing } = SizesAndSpaces
 

--- a/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
@@ -3,6 +3,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { TokenIcon, type Size } from './TokenIcon'
+import { applySxProps, SxProps } from '@ui-kit/utils'
 
 const { Spacing } = SizesAndSpaces
 
@@ -19,6 +20,7 @@ export type TokenInfoTokenIconProps = TokenInfoBaseProps & {
   showChainIcon?: boolean
   iconSize?: Size
   icon?: never
+  sx?: SxProps
 }
 
 type TokenInfoCustomIconProps = TokenInfoBaseProps & {
@@ -27,6 +29,7 @@ type TokenInfoCustomIconProps = TokenInfoBaseProps & {
   blockchainId?: never
   showChainIcon?: never
   iconSize?: never
+  sx?: SxProps
 }
 
 export type TokenInfoProps = TokenInfoTokenIconProps | TokenInfoCustomIconProps
@@ -46,7 +49,7 @@ export const TokenInfo = (props: TokenInfoProps) => {
     )
 
   return (
-    <Stack direction="row" sx={{ gap: Spacing.xs, alignItems: 'center' }}>
+    <Stack direction="row" sx={applySxProps({ gap: Spacing.xs, alignItems: 'center' }, props.sx)}>
       {iconPosition === 'left' && tokenIcon}
 
       <Stack sx={{ gap: Spacing.xxs, alignItems: iconPosition === 'right' ? 'end' : 'start' }}>

--- a/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
@@ -49,7 +49,7 @@ export const TokenInfo = (props: TokenInfoProps) => {
     )
 
   return (
-    <Stack direction="row" sx={applySxProps({ gap: Spacing.xs, alignItems: 'center' }, props.sx)}>
+    <Stack direction="row" sx={applySxProps({ gap: Spacing.xs, alignItems: 'start' }, props.sx)}>
       {iconPosition === 'left' && tokenIcon}
 
       <Stack sx={{ gap: Spacing.xxs, alignItems: iconPosition === 'right' ? 'end' : 'start' }}>

--- a/tests/cypress/support/helpers/lending-mocks.ts
+++ b/tests/cypress/support/helpers/lending-mocks.ts
@@ -29,7 +29,8 @@ const oneLendingPool = (
   const liquidityUsd = Math.max(0, oneFloat(0, tvl)) // portion of TVL represented by (assets - debt)
   const totalAssetsUsd = liquidityUsd / (1 - utilization)
   const totalDebtUsd = totalAssetsUsd * utilization
-  const totalAssets = totalAssetsUsd / collateralPrice
+  // Vault assets and debt are both denominated in the borrowed token.
+  const totalAssets = totalAssetsUsd / borrowedPrice
   const totalDebt = totalDebtUsd / borrowedPrice
   const minBand = oneInt()
   const minted = onePrice()


### PR DESCRIPTION
- llamalend available liquidity column with amount and notional

<img width="752" height="793" alt="Screenshot 2026-07-10 at 18 20 39" src="https://github.com/user-attachments/assets/8f28e20e-c9cf-4208-b3af-7609926c1b8c" />
<img width="385" height="352" alt="Screenshot 2026-07-10 at 18 24 52" src="https://github.com/user-attachments/assets/6b006a02-0a53-456f-8945-c2cb93c6b7fe" />
<img width="349" height="171" alt="Screenshot 2026-07-10 at 17 50 53" src="https://github.com/user-attachments/assets/d47132b8-1d69-4b65-aa37-ce8c19d9905a" />
