### PR TITLE
refactor: avoid react anti-patterns when reloading market tables

### DIFF
--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -6,12 +6,12 @@ import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { q } from '@ui-kit/types/util'
 import { ListPageWrapper } from '@ui-kit/widgets/ListPageWrapper'
 import {
-  invalidateUserLendingSupplies,
-  invalidateAllUserLendingVaults,
+  resetUserLendingSupplies,
+  resetAllUserLendingVaults,
   resetLendingVaults,
 } from '../../queries/market-list/lending-vaults'
 import { useLlamaMarkets } from '../../queries/market-list/llama-markets'
-import { invalidateAllUserMintMarkets, resetMintMarkets } from '../../queries/market-list/mint-markets'
+import { resetAllUserMintMarkets, resetMintMarkets } from '../../queries/market-list/mint-markets'
 import { LendTableFooter } from './LendTableFooter'
 import { LlamaMarketsTable } from './LlamaMarketsTable'
 import { UserPositionsTables } from './UserPositionsTables'
@@ -29,9 +29,9 @@ const useTableLlamaMarkets = (address: Address | undefined) => {
       resetLendingVaults({}),
       resetMintMarkets({}),
       resetBadDebtMarkets(),
-      invalidateAllUserLendingVaults(address),
-      invalidateUserLendingSupplies({ userAddress: address }),
-      invalidateAllUserMintMarkets(address),
+      resetAllUserLendingVaults(address),
+      resetUserLendingSupplies({ userAddress: address }),
+      resetAllUserMintMarkets(address),
     ])
   }, [address])
 

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -37,7 +37,7 @@ const useTableLlamaMarkets = (address: Address | undefined) => {
 
   return {
     onReload,
-    tableQuery: q({ ...query, isLoading: query.isPending }),
+    tableQuery: q({ ...query, isLoading: query.isPending }), // isPending so that the table shows a loading state on initial load and manual reload, but not on cache refetches
   }
 }
 

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 import { useConnection } from 'wagmi'
 import { invalidateBadDebtMarkets } from '@/llamalend/queries/market'
 import type { Address } from '@primitives/address.utils'
@@ -16,39 +16,6 @@ import { LendTableFooter } from './LendTableFooter'
 import { LlamaMarketsTable } from './LlamaMarketsTable'
 import { UserPositionsTables } from './UserPositionsTables'
 
-/**
- * Creates a callback to reload the markets and user data.
- * Returns a tuple with:
- * - `isReloading`: boolean indicating if the reload is in progress.
- *                  without this, react-query will show the stale data so the user doesn't notice the reload.
- * - `onReload`: function to trigger the reload.
- * Note: It does not reload the snapshots (for now).
- */
-const useOnReload = ({ address: userAddress, isFetching }: { address?: Address; isFetching: boolean }) => {
-  const [isReloading, setIsReloading] = useState(false)
-  const onReload = useCallback(() => {
-    if (isReloading) return
-    setIsReloading(true)
-
-    void Promise.all([
-      invalidateLendingVaults({}),
-      invalidateMintMarkets({}),
-      invalidateBadDebtMarkets(),
-      invalidateAllUserLendingVaults(userAddress),
-      invalidateUserLendingSupplies({ userAddress }),
-      invalidateAllUserMintMarkets(userAddress),
-    ])
-  }, [isReloading, userAddress])
-
-  useEffect(() => {
-    // reset the isReloading state when the data is fetched
-    // eslint-disable-next-line @eslint-react/set-state-in-effect -- Existing violation before enabling this rule.
-    if (isReloading && !isFetching) setIsReloading(false)
-  }, [isFetching, isReloading])
-
-  return [isReloading && isFetching, onReload] as const
-}
-
 /** Fetches Llama markets and normalizes loading so initial load and manual reload show a loading state. */
 const useTableLlamaMarkets = (address: Address | undefined) => {
   const enableDeprecatedMarkets = useUserProfileStore(state => state.showDeprecatedMarkets)
@@ -56,13 +23,21 @@ const useTableLlamaMarkets = (address: Address | undefined) => {
     userAddress: address,
     enableDeprecatedMarkets,
   })
-  const { data, isError, isLoading, isFetching } = query
-  const [isReloading, onReload] = useOnReload({ address, isFetching })
-  const loading = isReloading || (!data && (!isError || isLoading)) // on initial render isLoading is still false
+
+  const onReload = useCallback(() => {
+    void Promise.all([
+      invalidateLendingVaults({}),
+      invalidateMintMarkets({}),
+      invalidateBadDebtMarkets(),
+      invalidateAllUserLendingVaults(address),
+      invalidateUserLendingSupplies({ userAddress: address }),
+      invalidateAllUserMintMarkets(address),
+    ])
+  }, [address])
 
   return {
     onReload,
-    tableQuery: q({ ...query, isLoading: loading }),
+    tableQuery: q({ ...query, isLoading: query.isFetching }),
   }
 }
 

--- a/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
+++ b/apps/main/src/llamalend/features/market-list/LlamaMarketsList.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useConnection } from 'wagmi'
-import { invalidateBadDebtMarkets } from '@/llamalend/queries/market'
+import { resetBadDebtMarkets } from '@/llamalend/queries/market'
 import type { Address } from '@primitives/address.utils'
 import { useUserProfileStore } from '@ui-kit/features/user-profile'
 import { q } from '@ui-kit/types/util'
@@ -8,10 +8,10 @@ import { ListPageWrapper } from '@ui-kit/widgets/ListPageWrapper'
 import {
   invalidateUserLendingSupplies,
   invalidateAllUserLendingVaults,
-  invalidateLendingVaults,
+  resetLendingVaults,
 } from '../../queries/market-list/lending-vaults'
 import { useLlamaMarkets } from '../../queries/market-list/llama-markets'
-import { invalidateAllUserMintMarkets, invalidateMintMarkets } from '../../queries/market-list/mint-markets'
+import { invalidateAllUserMintMarkets, resetMintMarkets } from '../../queries/market-list/mint-markets'
 import { LendTableFooter } from './LendTableFooter'
 import { LlamaMarketsTable } from './LlamaMarketsTable'
 import { UserPositionsTables } from './UserPositionsTables'
@@ -26,9 +26,9 @@ const useTableLlamaMarkets = (address: Address | undefined) => {
 
   const onReload = useCallback(() => {
     void Promise.all([
-      invalidateLendingVaults({}),
-      invalidateMintMarkets({}),
-      invalidateBadDebtMarkets(),
+      resetLendingVaults({}),
+      resetMintMarkets({}),
+      resetBadDebtMarkets(),
       invalidateAllUserLendingVaults(address),
       invalidateUserLendingSupplies({ userAddress: address }),
       invalidateAllUserMintMarkets(address),
@@ -37,7 +37,7 @@ const useTableLlamaMarkets = (address: Address | undefined) => {
 
   return {
     onReload,
-    tableQuery: q({ ...query, isLoading: query.isFetching }),
+    tableQuery: q({ ...query, isLoading: query.isPending }),
   }
 }
 

--- a/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
+++ b/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
@@ -34,6 +34,7 @@ const {
   getQueryOptions: getUserLendingVaultsOptions,
   getQueryData: getCurrentUserLendingVaults,
   invalidate: invalidateUserLendingVaults,
+  reset: resetUserLendingVaults,
 } = queryFactory({
   queryKey: ({ userAddress }: UserParams) => ['user-lending-vaults', { userAddress }, 'v2'] as const,
   queryFn: async ({ userAddress }: UserQuery) =>
@@ -51,6 +52,7 @@ const {
   getQueryOptions: getUserLendingVaultStatsOptions,
   useQuery: useUserLendingVaultStats,
   invalidate: invalidateUserLendingVaultStats,
+  reset: resetUserLendingVaultStats,
 } = queryFactory({
   queryKey: ({ userAddress, contractAddress, blockchainId }: UserContractParams) =>
     ['user-lending-vault', 'stats', { blockchainId }, { contractAddress }, { userAddress }, 'v1'] as const,
@@ -76,6 +78,22 @@ export async function invalidateAllUserLendingVaults(userAddress: Address | null
   await Promise.all(invalidateContracts)
 }
 
+export async function resetAllUserLendingVaults(userAddress: Address | null | undefined) {
+  await resetUserLendingVaults({ userAddress })
+
+  const resetContracts = recordEntries(getCurrentUserLendingVaults({ userAddress }) ?? {}).flatMap(
+    ([blockchainId, contracts]) =>
+      contracts.map(contractAddress =>
+        resetUserLendingVaultStats({
+          userAddress,
+          blockchainId,
+          contractAddress,
+        }),
+      ),
+  )
+  await Promise.all(resetContracts)
+}
+
 export type LendingPosition = {
   supplied: number
   earnings: number
@@ -85,7 +103,11 @@ export type LendingPosition = {
 /**
  * Fetches the user's lending supplies across all chains.
  */
-const { getQueryOptions: getUserLendingSuppliesOptions, invalidate: invalidateUserLendingSupplies } = queryFactory({
+const {
+  getQueryOptions: getUserLendingSuppliesOptions,
+  invalidate: invalidateUserLendingSupplies,
+  reset: resetUserLendingSupplies,
+} = queryFactory({
   queryKey: ({ userAddress }: UserParams) => ['user-lending-supplies', { userAddress }, 'v5'] as const,
   category: 'llamalend.user',
   queryFn: async ({ userAddress }: UserQuery): Promise<Record<ChainName, Record<Address, LendingPosition>>> => {
@@ -113,4 +135,5 @@ export {
   getUserLendingVaultStatsOptions,
   useUserLendingVaultStats,
   invalidateUserLendingSupplies,
+  resetUserLendingSupplies,
 }

--- a/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
+++ b/apps/main/src/llamalend/queries/market-list/lending-vaults.ts
@@ -20,7 +20,7 @@ import { EmptyValidationSuite } from '@ui-kit/lib/validation'
 
 export type LendingVault = Market & { chain: ChainName }
 
-export const { getQueryOptions: getLendingVaultsOptions, invalidate: invalidateLendingVaults } = queryFactory({
+export const { getQueryOptions: getLendingVaultsOptions, reset: resetLendingVaults } = queryFactory({
   queryKey: () => ['lending-vaults', 'v4'] as const,
   queryFn: async (): Promise<LendingVault[]> =>
     Object.entries(await getAllMarkets()).flatMap(([chain, markets]) =>

--- a/apps/main/src/llamalend/queries/market-list/mint-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/mint-markets.ts
@@ -20,7 +20,7 @@ export type MintMarket = MintMarketFromApi & {
   chain: Chain
 }
 
-export const { getQueryOptions: getMintMarketOptions, invalidate: invalidateMintMarkets } = queryFactory({
+export const { getQueryOptions: getMintMarketOptions, reset: resetMintMarkets } = queryFactory({
   queryKey: () => ['mint-markets', 'v4'] as const,
   queryFn: async (): Promise<MintMarket[]> =>
     recordEntries(await getAllMarkets()).flatMap(([chain, markets]) => markets.map(market => ({ ...market, chain }))),

--- a/apps/main/src/llamalend/queries/market-list/mint-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/mint-markets.ts
@@ -32,6 +32,7 @@ const {
   getQueryOptions: getUserMintMarketsQueryOptions,
   getQueryData: getCurrentUserMintMarkets,
   invalidate: invalidateUserMintMarkets,
+  reset: resetUserMintMarkets,
 } = queryFactory({
   queryKey: ({ userAddress }: UserParams) => ['user-mint-markets', { userAddress }, 'v1'] as const,
   queryFn: async ({ userAddress }: UserQuery): Promise<Record<Chain, Address[]>> =>
@@ -46,6 +47,7 @@ const {
   getQueryOptions: getUserMintMarketStatsQueryOptions,
   useQuery: useUserMintMarketStatsQuery,
   invalidate: invalidateUserMintMarketStats,
+  reset: resetUserMintMarketStats,
 } = queryFactory({
   queryKey: ({ userAddress, blockchainId, contractAddress }: UserContractParams) =>
     ['user-mint-markets', 'stats', { blockchainId }, { contractAddress }, { userAddress }, 'v1'] as const,
@@ -69,6 +71,22 @@ export const invalidateAllUserMintMarkets = async (userAddress: Address | null |
       ),
   )
   await Promise.all(invalidateContracts)
+}
+
+export const resetAllUserMintMarkets = async (userAddress: Address | null | undefined) => {
+  await resetUserMintMarkets({ userAddress })
+
+  const resetContracts = recordEntries(getCurrentUserMintMarkets({ userAddress }) ?? {}).flatMap(
+    ([blockchainId, contracts]) =>
+      contracts.map(contractAddress =>
+        resetUserMintMarketStats({
+          userAddress,
+          blockchainId,
+          contractAddress,
+        }),
+      ),
+  )
+  await Promise.all(resetContracts)
 }
 
 export const useUserMintMarketStats = useUserMintMarketStatsQuery

--- a/apps/main/src/llamalend/queries/market/market-bad-debt.query.ts
+++ b/apps/main/src/llamalend/queries/market/market-bad-debt.query.ts
@@ -13,7 +13,7 @@ const endpointFromMarketType: Record<LlamaMarketType, Endpoint> = {
   [LlamaMarketType.Mint]: 'crvusd',
 }
 
-const { getQueryOptions: getBadDebtMarketsOptionsQuery, invalidate: invalidateBadDebtMarketsQuery } = queryFactory({
+const { getQueryOptions: getBadDebtMarketsOptionsQuery, reset: resetBadDebtMarketsQuery } = queryFactory({
   queryKey: ({ type }: BadDebtParams) => ['getBadDebt', { type }, 'v1'] as const,
   queryFn: ({ type }: BadDebtParams) => getBadDebt({ endpoint: endpointFromMarketType[type] }),
   category: 'llamalend.market',
@@ -26,5 +26,5 @@ export const getBadDebtLendMarketsOptions = (enabled = true) =>
 export const getBadDebtMintMarketsOptions = (enabled = true) =>
   getBadDebtMarketsOptionsQuery({ type: LlamaMarketType.Mint }, enabled)
 
-export const invalidateBadDebtMarkets = async () =>
-  Promise.all(recordValues(LlamaMarketType).map(type => invalidateBadDebtMarketsQuery({ type })))
+export const resetBadDebtMarkets = async () =>
+  Promise.all(recordValues(LlamaMarketType).map(type => resetBadDebtMarketsQuery({ type })))


### PR DESCRIPTION
Found this overcomplicated reload functionality with `useState` and `useEffect` anti-pattern while working on JJ's new pool list filter PR which also contains (new) reload logic.

The gist is that resetting the given queries already resets `useLlamaMarkets`, which causes it to refetch and set `isPending` to true, indicating data is being (re)loaded. Note that `isPending` does not get set to true during stale cache refetching.