### PR TITLE
feat: chain switcher sort by tvl + lite section

### DIFF
--- a/apps/main/src/bridge/features/bridge/components/BridgeTargets.tsx
+++ b/apps/main/src/bridge/features/bridge/components/BridgeTargets.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import type { NetworkDef } from '@ui/utils'
+import { useNetworksTVL } from '@ui-kit/entities/prices-networks.query'
 import { ChainList } from '@ui-kit/features/switch-chain/ui/ChainList'
 import { ChainSwitcherIcon } from '@ui-kit/features/switch-chain/ui/ChainSwitcherIcon'
 import { usePathname } from '@ui-kit/hooks/router'
@@ -135,6 +136,7 @@ export const BridgeTargets = ({ networks, fromChainId, disabled, loading, onNetw
           showTestnets={false}
           options={networks}
           selectedNetworkId={getCurrentNetwork(usePathname())}
+          tvls={useNetworksTVL('lending')}
           onNetwork={useCallback(
             (network: NetworkDef) => {
               closeFrom()

--- a/apps/main/src/dex/lib/networks.ts
+++ b/apps/main/src/dex/lib/networks.ts
@@ -3,6 +3,7 @@ import { DEFAULT_NETWORK_CONFIG } from '@/dex/constants'
 import { ChainId, NetworkConfig, type NetworkEnum, type Networks } from '@/dex/types/main.types'
 import curve from '@curvefi/api'
 import { getBaseNetworksConfig, NETWORK_BASE_CONFIG as NETWORKS } from '@ui/utils/utilsNetworks'
+import { DOWNGRADED_CHAINS } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
 import { CRVUSD_ROUTES, getInternalUrl } from '@ui-kit/shared/routes'
 import { CRVUSD_ADDRESS } from '@ui-kit/utils'
 import { Chain } from '@ui-kit/utils/network'
@@ -346,7 +347,7 @@ export async function getNetworks() {
       tricryptoFactory: true,
       fxswapFactory: isLiteFxswapEnabled,
       pricesApi: isUpgraded,
-      isLite: !isUpgraded,
+      isLite: !isUpgraded || DOWNGRADED_CHAINS.has(chainId),
       isCrvRewardsEnabled: isUpgraded,
       ...(isOnlyPoolRewardsUpgraded && {
         isCrvRewardsEnabled: true,

--- a/packages/curve-ui-kit/src/entities/prices-networks.query.ts
+++ b/packages/curve-ui-kit/src/entities/prices-networks.query.ts
@@ -1,6 +1,10 @@
+import { useCallback } from 'react'
+import type { Chain } from '@curvefi/prices-api'
 import { getSupportedChains } from '@curvefi/prices-api/chains'
+import { fromEntries } from '@primitives/objects.utils'
 import { EmptyValidationSuite } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model'
+import { type QueryProp, useMappedQuery } from '@ui-kit/types/util'
 
 export const { useQuery: usePricesNetworks } = queryFactory({
   queryKey: () => ['prices', 'networks'] as const,
@@ -8,3 +12,18 @@ export const { useQuery: usePricesNetworks } = queryFactory({
   validationSuite: EmptyValidationSuite, // no args
   category: 'global.networks',
 })
+
+export type TvlSource = 'pool' | 'lending'
+
+export const useNetworksTVL = (source: TvlSource): QueryProp<Record<Chain, number>> =>
+  useMappedQuery(
+    usePricesNetworks({}),
+    useCallback(
+      networks =>
+        fromEntries(
+          networks?.map(network => [network.name, { lending: network.lendingTvl, pool: network.poolTvl }[source]]) ??
+            [],
+        ),
+      [source],
+    ),
+  )

--- a/packages/curve-ui-kit/src/entities/prices-networks.query.ts
+++ b/packages/curve-ui-kit/src/entities/prices-networks.query.ts
@@ -1,0 +1,10 @@
+import { getSupportedChains } from '@curvefi/prices-api/chains'
+import { EmptyValidationSuite } from '@ui-kit/lib'
+import { queryFactory } from '@ui-kit/lib/model'
+
+export const { useQuery: usePricesNetworks } = queryFactory({
+  queryKey: () => ['prices', 'networks'] as const,
+  queryFn: getSupportedChains,
+  validationSuite: EmptyValidationSuite, // no args
+  category: 'global.networks',
+})

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainList.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainList.tsx
@@ -4,6 +4,7 @@ import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Box from '@mui/material/Box'
 import MenuList from '@mui/material/MenuList'
+import { recordEntries } from '@primitives/objects.utils'
 import type { NetworkDef } from '@ui/utils'
 import { wagmiChainsMap } from '@ui-kit/features/connect-wallet/lib/wagmi/chains'
 import { usePathname } from '@ui-kit/hooks/router'
@@ -13,11 +14,21 @@ import { MenuItem } from '@ui-kit/shared/ui/MenuItem'
 import { MenuSectionHeader } from '@ui-kit/shared/ui/MenuSectionHeader'
 import { RouterLink as Link } from '@ui-kit/shared/ui/RouterLink'
 import { SearchField } from '@ui-kit/shared/ui/SearchField'
+import type { QueryProp } from '@ui-kit/types/util'
 import { ChainSwitcherIcon } from './ChainSwitcherIcon'
 
 enum ChainType {
   test = 'test',
   main = 'main',
+  lite = 'lite',
+  deprecated = 'deprecated',
+}
+
+const CHAIN_TYPE_NAMES: Record<ChainType, string> = {
+  [ChainType.main]: t`Active networks`,
+  [ChainType.test]: t`Test networks`,
+  [ChainType.lite]: t`Lite networks`,
+  [ChainType.deprecated]: t`Inactive networks`,
 }
 
 export function ChainList({
@@ -25,11 +36,13 @@ export function ChainList({
   showTestnets,
   selectedNetworkId,
   onNetwork,
+  tvls: { data: tvls, isLoading: tvlsLoading },
 }: {
   options: NetworkDef[]
   showTestnets: boolean
   selectedNetworkId: string | undefined
   onNetwork?: (network: NetworkDef) => void
+  tvls: QueryProp<Record<string, number>>
 }) {
   const pathname = usePathname()
   const [searchValue, setSearchValue] = useState('')
@@ -37,17 +50,16 @@ export function ChainList({
     () =>
       lodash.groupBy(
         options.filter(o => o.name.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase())),
-        o => (o.isTestnet ? ChainType.test : ChainType.main),
-      ),
-    [options, searchValue],
+        o =>
+          o.isTestnet
+            ? ChainType.test
+            : o.isLite || (tvls && tvls[o.id] === undefined)
+              ? ChainType.lite
+              : ChainType.main,
+      ) as Record<ChainType, NetworkDef[]>,
+    [options, searchValue, tvls],
   )
 
-  const chainTypeNames = {
-    [ChainType.test]: t`Test networks`,
-    [ChainType.main]: t`Main networks`,
-  }
-
-  const entries = Object.entries(groupedOptions)
   const missingWagmiChains = options.filter(({ isTestnet, chainId }) => !isTestnet && !wagmiChainsMap[chainId])
 
   return (
@@ -66,15 +78,14 @@ export function ChainList({
         name="chainName"
       />
       <Box sx={{ overflowY: 'auto', flexGrow: '1' }}>
-        {entries.length ? (
-          entries
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Existing violation before enabling this rule.
-            .filter(([key]) => showTestnets || key !== ChainType.test)
-            .flatMap(([key, networks]) => (
+        {options.length ? (
+          recordEntries(CHAIN_TYPE_NAMES)
+            .filter(([key]) => (showTestnets || key !== ChainType.test) && groupedOptions[key]?.length)
+            .flatMap(([key, title]) => (
               <Fragment key={key}>
-                {showTestnets && <MenuSectionHeader>{chainTypeNames[key as ChainType]}</MenuSectionHeader>}
+                <MenuSectionHeader>{title}</MenuSectionHeader>
                 <MenuList>
-                  {networks.map(network => (
+                  {groupedOptions[key]?.map(network => (
                     <MenuItem<string, typeof Link>
                       data-testid={`menu-item-chain-${network.id}`}
                       key={network.id}
@@ -86,6 +97,7 @@ export function ChainList({
                       icon={<ChainSwitcherIcon networkId={network.id} size={36} />}
                       label={network.name}
                       onMouseDown={() => onNetwork?.(network)} // onClick somehow doesn't work ???
+                      isLoading={tvlsLoading && key != ChainType.lite /* lite doesn't have tvl */}
                     />
                   ))}
                 </MenuList>

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainList.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainList.tsx
@@ -21,14 +21,12 @@ enum ChainType {
   test = 'test',
   main = 'main',
   lite = 'lite',
-  deprecated = 'deprecated',
 }
 
 const CHAIN_TYPE_NAMES: Record<ChainType, string> = {
-  [ChainType.main]: t`Active networks`,
-  [ChainType.test]: t`Test networks`,
-  [ChainType.lite]: t`Lite networks`,
-  [ChainType.deprecated]: t`Inactive networks`,
+  [ChainType.main]: t`Curve`,
+  [ChainType.lite]: t`Curve Lite`,
+  [ChainType.test]: t`Testnets`,
 }
 
 export function ChainList({
@@ -53,7 +51,7 @@ export function ChainList({
         o =>
           o.isTestnet
             ? ChainType.test
-            : o.isLite || (tvls && tvls[o.id] === undefined)
+            : o.isLite || (tvls && tvls[o.id] === undefined) // flag chains not supported by prices API as lite
               ? ChainType.lite
               : ChainType.main,
       ) as Record<ChainType, NetworkDef[]>,

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
@@ -1,11 +1,12 @@
 import lodash from 'lodash'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { getBlockchainId } from '@curvefi/prices-api'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import IconButton from '@mui/material/IconButton'
-import { fromEntries } from '@primitives/objects.utils'
+import { maybes } from '@primitives/objects.utils'
 import { NetworkMapping } from '@ui/utils'
-import { usePricesNetworks } from '@ui-kit/entities/prices-networks.query'
+import { type TvlSource, useNetworksTVL } from '@ui-kit/entities/prices-networks.query'
 import { usePathname } from '@ui-kit/hooks/router'
 import { useShowTestNets } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
@@ -13,7 +14,6 @@ import { t } from '@ui-kit/lib/i18n'
 import { type AppMenuOption, getCurrentNetwork } from '@ui-kit/shared/routes'
 import { ModalDialog } from '@ui-kit/shared/ui/ModalDialog'
 import { ModalSettingsButton } from '@ui-kit/shared/ui/ModalSettingsButton'
-import { useMappedQuery } from '@ui-kit/types/util'
 import { showToast } from '@ui-kit/widgets/Toast/toast.util'
 import { ChainList } from './ChainList'
 import { ChainSettings } from './ChainSettings'
@@ -24,33 +24,28 @@ type ChainSwitcherProps = {
   currentMenu: AppMenuOption
 }
 
+const TVL_SOURCES: Record<AppMenuOption, TvlSource> = {
+  dex: 'pool',
+  llamalend: 'lending',
+  dao: 'pool',
+  bridge: 'lending',
+  analytics: 'pool',
+}
+
 export const ChainSwitcher = ({ supportedNetworks, currentMenu }: ChainSwitcherProps) => {
   const networkId = getCurrentNetwork(usePathname())
-  const pricesNetworks = usePricesNetworks({})
+
   const [isOpen, , close, toggle] = useSwitch()
   const [isSettingsOpen, openSettings, closeSettings] = useSwitch()
   const [showTestnets, setShowTestnets] = useShowTestNets()
   useEffect(() => () => close(), [networkId, close]) // close on chain change
-
-  const tvls = useMappedQuery(
-    pricesNetworks,
-    useCallback(
-      pricesNetworks =>
-        fromEntries(
-          pricesNetworks?.map(network => [
-            network.name as string,
-            currentMenu === 'llamalend' ? network.lendingTvl : network.poolTvl,
-          ]) ?? [],
-        ),
-      [currentMenu],
-    ),
-  )
+  const tvls = useNetworksTVL(TVL_SOURCES[currentMenu])
 
   const options = useMemo(
     () =>
       lodash.orderBy(
         Object.values(supportedNetworks).filter(networkConfig => networkConfig.showInSelectNetwork),
-        [n => tvls.data?.[n.id] ?? 0, 'name'],
+        [n => maybes([getBlockchainId(n.id), tvls.data], (id, tvls) => tvls[id]) ?? 0, 'name'],
         ['desc', 'asc'],
       ),
     [supportedNetworks, tvls.data],

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
@@ -27,9 +27,9 @@ type ChainSwitcherProps = {
 const TVL_SOURCES: Record<AppMenuOption, TvlSource> = {
   dex: 'pool',
   llamalend: 'lending',
-  dao: 'pool',
-  bridge: 'lending',
-  analytics: 'pool',
+  dao: 'pool', // kind of irrelevant for tvl, since it only supports mainnet
+  bridge: 'pool', // only shows lending chains in the form but shows all networks in selector
+  analytics: 'pool', // only has crvUSD charts, but shows all networks in selector
 }
 
 export const ChainSwitcher = ({ supportedNetworks, currentMenu }: ChainSwitcherProps) => {

--- a/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
+++ b/packages/curve-ui-kit/src/features/switch-chain/ui/ChainSwitcher.tsx
@@ -1,39 +1,59 @@
 import lodash from 'lodash'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import IconButton from '@mui/material/IconButton'
+import { fromEntries } from '@primitives/objects.utils'
 import { NetworkMapping } from '@ui/utils'
+import { usePricesNetworks } from '@ui-kit/entities/prices-networks.query'
 import { usePathname } from '@ui-kit/hooks/router'
 import { useShowTestNets } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
-import { getCurrentNetwork } from '@ui-kit/shared/routes'
+import { type AppMenuOption, getCurrentNetwork } from '@ui-kit/shared/routes'
 import { ModalDialog } from '@ui-kit/shared/ui/ModalDialog'
 import { ModalSettingsButton } from '@ui-kit/shared/ui/ModalSettingsButton'
+import { useMappedQuery } from '@ui-kit/types/util'
 import { showToast } from '@ui-kit/widgets/Toast/toast.util'
 import { ChainList } from './ChainList'
 import { ChainSettings } from './ChainSettings'
 import { ChainSwitcherIcon } from './ChainSwitcherIcon'
 
 type ChainSwitcherProps = {
-  networks: NetworkMapping
+  supportedNetworks: NetworkMapping
+  currentMenu: AppMenuOption
 }
 
-export const ChainSwitcher = ({ networks }: ChainSwitcherProps) => {
+export const ChainSwitcher = ({ supportedNetworks, currentMenu }: ChainSwitcherProps) => {
   const networkId = getCurrentNetwork(usePathname())
+  const pricesNetworks = usePricesNetworks({})
   const [isOpen, , close, toggle] = useSwitch()
   const [isSettingsOpen, openSettings, closeSettings] = useSwitch()
   const [showTestnets, setShowTestnets] = useShowTestNets()
   useEffect(() => () => close(), [networkId, close]) // close on chain change
 
+  const tvls = useMappedQuery(
+    pricesNetworks,
+    useCallback(
+      pricesNetworks =>
+        fromEntries(
+          pricesNetworks?.map(network => [
+            network.name as string,
+            currentMenu === 'llamalend' ? network.lendingTvl : network.poolTvl,
+          ]) ?? [],
+        ),
+      [currentMenu],
+    ),
+  )
+
   const options = useMemo(
     () =>
-      lodash.sortBy(
-        Object.values(networks).filter(networkConfig => networkConfig.showInSelectNetwork),
-        n => n.name,
+      lodash.orderBy(
+        Object.values(supportedNetworks).filter(networkConfig => networkConfig.showInSelectNetwork),
+        [n => tvls.data?.[n.id] ?? 0, 'name'],
+        ['desc', 'asc'],
       ),
-    [networks],
+    [supportedNetworks, tvls.data],
   )
 
   const onClick =
@@ -68,7 +88,7 @@ export const ChainSwitcher = ({ networks }: ChainSwitcherProps) => {
           {isSettingsOpen ? (
             <ChainSettings showTestnets={showTestnets} setShowTestnets={setShowTestnets} />
           ) : (
-            <ChainList showTestnets={showTestnets} options={options} selectedNetworkId={networkId} />
+            <ChainList showTestnets={showTestnets} options={options} tvls={tvls} selectedNetworkId={networkId} />
           )}
         </ModalDialog>
       )}

--- a/packages/curve-ui-kit/src/lib/model/query/query-categories.ts
+++ b/packages/curve-ui-kit/src/lib/model/query/query-categories.ts
@@ -16,6 +16,7 @@ export const QUERY_CATEGORIES = {
   'global.integrations': staticData,
   'global.routerApi': urgent,
   'global.snapshots': table,
+  'global.networks': table, // not static, includes tvl
 
   // Bridge
   'bridge.capacity': marketDetail,

--- a/packages/curve-ui-kit/src/widgets/Header/DesktopHeader.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/DesktopHeader.tsx
@@ -47,7 +47,7 @@ export const DesktopHeader = ({
 
         <Box sx={{ display: 'flex', marginLeft: 2, justifyContent: 'flex-end', gap: 3, alignItems: 'center' }}>
           <UserProfile />
-          <ChainSwitcher networks={supportedNetworks} />
+          <ChainSwitcher supportedNetworks={supportedNetworks} currentMenu={currentMenu} />
           <ConnectWalletIndicator />
         </Box>
       </Container>

--- a/packages/curve-ui-kit/src/widgets/Header/MobileHeader.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/MobileHeader.tsx
@@ -71,7 +71,12 @@ export const MobileHeader = ({
     >
       <GlobalBanner networkId={networkId} chainId={chainId} backendMaintenance={backendMaintenance} />
       <Toolbar sx={t => ({ paddingBlock: PADDING_BLOCK, zIndex: t.zIndex.drawer + 1 })}>
-        <MobileTopBar networks={supportedNetworks} isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
+        <MobileTopBar
+          supportedNetworks={supportedNetworks}
+          isSidebarOpen={isSidebarOpen}
+          toggleSidebar={toggleSidebar}
+          currentMenu={currentMenu}
+        />
 
         <Drawer
           anchor="left"

--- a/packages/curve-ui-kit/src/widgets/Header/MobileTopBar.tsx
+++ b/packages/curve-ui-kit/src/widgets/Header/MobileTopBar.tsx
@@ -1,20 +1,22 @@
 import Stack from '@mui/material/Stack'
 import { NetworkMapping } from '@ui/utils'
 import { ChainSwitcher } from '@ui-kit/features/switch-chain'
+import type { AppMenuOption } from '@ui-kit/shared/routes'
 import { HeaderLogo } from './HeaderLogo'
 import { MenuToggleButton } from './MenuToggleButton'
 
 type MobileTopBarProps = {
   toggleSidebar: () => void
   isSidebarOpen: boolean
-  networks: NetworkMapping
+  supportedNetworks: NetworkMapping
+  currentMenu: AppMenuOption
 }
 
-export const MobileTopBar = ({ networks, isSidebarOpen, toggleSidebar }: MobileTopBarProps) => (
+export const MobileTopBar = ({ supportedNetworks, isSidebarOpen, toggleSidebar, currentMenu }: MobileTopBarProps) => (
   <Stack direction="row" sx={{ width: '100%', paddingX: 2 }}>
     <MenuToggleButton isOpen={isSidebarOpen} toggle={toggleSidebar} />
     <HeaderLogo />
     <Stack sx={{ flexGrow: 1 }} />
-    <ChainSwitcher networks={networks} />
+    <ChainSwitcher supportedNetworks={supportedNetworks} currentMenu={currentMenu} />
   </Stack>
 )

--- a/packages/prices-api/src/chains/schema.ts
+++ b/packages/prices-api/src/chains/schema.ts
@@ -15,9 +15,21 @@ const activity = z.object({
 const transactions = activity.extend({ transactions: z.number() })
 const users = activity.extend({ users: z.number() })
 
+const supportedChain = z
+  .object({
+    name: z.string(),
+    pool_tvl: z.number(),
+    lending_tvl: z.number(),
+  })
+  .transform(camelizeKeys)
+
 export const getSupportedChainsResponse = z
-  .object({ data: z.array(z.object({ name: z.string() })) })
-  .transform(({ data }) => data.map(item => item.name as Chain).filter(item => chains.includes(item)))
+  .object({ data: z.array(supportedChain) })
+  .transform(({ data }) =>
+    data.filter((item): item is { name: Chain; poolTvl: number; lendingTvl: number } =>
+      chains.includes(item.name as Chain),
+    ),
+  )
 
 export const getChainInfoResponse = z
   .object({

--- a/packages/prices-api/tests/seeds.ts
+++ b/packages/prices-api/tests/seeds.ts
@@ -138,14 +138,13 @@ export const nowRange = (days = 7) => {
 
 export const getSupportedChainSeed = once(async () => {
   const supportedChains = await chains.getSupportedChains(requestOptions)
-  return requireSeed(
-    supportedChains.find(chain => chain === PREFERRED_CHAIN) ?? supportedChains[0],
-    'chains.getSupportedChains',
-  )
+  const chainNames = supportedChains.map(chain => chain.name)
+
+  return requireSeed(chainNames.find(chain => chain === PREFERRED_CHAIN) ?? chainNames[0], 'chains.getSupportedChains')
 })
 
 export const getPoolSeed = once(async (): Promise<PoolSeed> => {
-  const supportedChains = await chains.getSupportedChains(requestOptions)
+  const supportedChains = (await chains.getSupportedChains(requestOptions)).map(chain => chain.name)
 
   for (const chain of shuffled(supportedChains)) {
     const response = await pools.getPools(chain, requestOptions)


### PR DESCRIPTION
- sort the networks by tvl (pool or lending tvl, depending on the app)
- separate the lite networks in another header