### PR TITLE
fix: keep OHLC pages immutable when flattening

### DIFF
--- a/packages/curve-ui-kit/src/features/candle-chart/utils.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/utils.ts
@@ -52,7 +52,7 @@ export const applyLatestOraclePrice = (data: OraclePriceData[], oraclePrice: num
 export const flattenOhlcPagesChronologically = <TPage, TItem>(
   pages: TPage[] | undefined,
   selectItems: (page: TPage) => TItem[],
-) => maybe(pages, pages => pages.reverse().flatMap(selectItems))
+) => maybe(pages, pages => pages.toReversed().flatMap(selectItems))
 
 const clampPercentile = (value: number, fallback: number) =>
   Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : fallback


### PR DESCRIPTION
- fix a production-only candle chart crash when scaling/panning into historical OHLC data.
- replace in-place page reversal with an immutable reverse so React Query’s cached pages array is not mutated during chart data flattening.
- prevent lightweight-charts from receiving non-ascending duplicate timestamp data after historical pagination and re-renders.