### PR TITLE
fix: dex flaky test on mobile

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
@@ -29,15 +29,21 @@ export function ExpansionRow<T extends TableItem>({
   colSpan: number
 }) {
   const { render, onExited, expanded } = useRowExpansion(row)
+  const [testId, setTestId] = useState<string | null>(null)
   const { design } = useTheme()
   const boxShadow = useMemo(() => getShadow(design, 3), [design])
   const insetShadow = useMemo(() => getInsetShadow(design, 3), [design])
   return (
     // add a scale(1) so the box-shadow is applied correctly on top of the next table row
     render && (
-      <TableRow sx={{ boxShadow, transform: 'scale(1)' }} data-testid="data-table-expansion-row">
+      <TableRow sx={{ boxShadow, transform: 'scale(1)' }} data-testid={testId}>
         <TableCell colSpan={colSpan} sx={{ padding: 0, boxShadow: insetShadow }}>
-          <Collapse in={expanded} onExited={onExited}>
+          <Collapse
+            in={expanded}
+            onEntered={() => setTestId('data-table-expansion-row')}
+            onExit={() => setTestId(null)}
+            onExited={onExited}
+          >
             <Stack
               direction="column"
               sx={{

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -317,6 +317,7 @@ describe('DEX Pools', () => {
       cy.get('[data-testid^="data-table-row-"]').first().click()
       if (breakpoint === 'mobile') {
         cy.get('[data-testid="collapse-icon"]').first().should('be.visible')
+        cy.get('[data-testid="data-table-expansion-row"]').should('be.visible')
         cy.get('[data-testid="pool-link-deposit"]').click()
       }
       cy.url(LOAD_TIMEOUT).should('match', /\/dex\/\w+\/pools\/0x[0-9a-fA-F]{40}\/(deposit|swap)\/?$/)
@@ -333,6 +334,7 @@ describe('DEX Pools', () => {
     cy.contains('[data-testid^="market-link-"]', filter, API_LOAD_TIMEOUT).should('be.visible')
     if (breakpoint === 'mobile') {
       cy.get('[data-testid^="data-table-row-"]').first().click()
+      cy.get('[data-testid="data-table-expansion-row"]').should('be.visible')
       cy.get(`[data-testid="pool-link-deposit"]`).click()
     } else {
       cy.contains('[data-testid^="market-link-"]', filter).click()


### PR DESCRIPTION
- fixes [flaky test](https://github.com/curvefi/curve-frontend/actions/runs/29319268040/job/87040398852?pr=2875)
- on mobile, clicking the row mounts ExpansionRow, which uses MUI Collapse. The deposit link exists while the collapse animation is still moving, so Cypress refuses to click it.