### PR TITLE
chore: update llamalend to 2.3.6

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.3.2",
+    "@curvefi/llamalend-api": "2.3.6",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.170.17",
     "@tanstack/react-router-devtools": "1.167.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,18 +483,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/ethcall@npm:6.0.16":
-  version: 6.0.16
-  resolution: "@curvefi/ethcall@npm:6.0.16"
-  dependencies:
-    "@types/node": "npm:^22.12.0"
-    abi-coder: "npm:^5.0.0"
-  peerDependencies:
-    ethers: ^6.0.0
-  checksum: 10c0/3bd41b3d84f0ed0654279a88920ad7ce38507804008fc8caa86fb2763520f594ef62953a260cb07661f6d71afd5467e41249fdda9eb3b71d10623a496679880e
-  languageName: node
-  linkType: hard
-
 "@curvefi/ethcall@npm:6.0.20":
   version: 6.0.20
   resolution: "@curvefi/ethcall@npm:6.0.20"
@@ -507,15 +495,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.3.2":
-  version: 2.3.2
-  resolution: "@curvefi/llamalend-api@npm:2.3.2"
+"@curvefi/llamalend-api@npm:2.3.6":
+  version: 2.3.6
+  resolution: "@curvefi/llamalend-api@npm:2.3.6"
   dependencies:
-    "@curvefi/ethcall": "npm:6.0.16"
+    "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.17.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/7a413c09212fd36a5c173b8dae9a106a1df39831bafefb9d62bbc3ae08676a6ca967c2ad932f1e218fce7af56c726f99787ff25a095d771739dad0767fbd82fe
+  checksum: 10c0/14b2c836e6d1173d1e0f1e047d071a00a614650b69536b6ce15178ac1ea123a86341731edb6f6e11eaf1fcbd1aaab238f1780fa3d15cd58949a596852e9eec18
   languageName: node
   linkType: hard
 
@@ -10767,7 +10755,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.3.2"
+    "@curvefi/llamalend-api": "npm:2.3.6"
     "@sentry/vite-plugin": "npm:5.3.0"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.170.17"


### PR DESCRIPTION
Updates llamalend from 2.3.2 to 2.3.6

1. This enables llv2 on mainnet.
2. There's been a couple of commits aiming at fixing approval issues regarding self liquidation.

[RPC Tests](https://github.com/curvefi/curve-frontend/actions/runs/29330504407)