### PR TITLE
feat: manage soft liq when fully converted

### DIFF
--- a/apps/main/src/llamalend/features/manage-soft-liquidation/ui/cells/ValueCell.tsx
+++ b/apps/main/src/llamalend/features/manage-soft-liquidation/ui/cells/ValueCell.tsx
@@ -45,7 +45,7 @@ export const ValueCellDisplay = ({
           {tokens.map((token, i) => (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- Existing violation before enabling this rule.
             <span key={i} style={{ whiteSpace: 'nowrap', ...(i > 0 && { marginInlineStart: '0.25rem' }) }}>
-              {i && ' + '}
+              {i > 0 && ' + '}
               {formatToken(token.amount, token.symbol)}
             </span>
           ))}

--- a/apps/main/src/llamalend/features/market-position-details/hooks/useUserLiquidationStatus.ts
+++ b/apps/main/src/llamalend/features/market-position-details/hooks/useUserLiquidationStatus.ts
@@ -25,4 +25,6 @@ export const useLiquidationStatus = (params: UserMarketParams, enabled?: boolean
   )
 
 export const useIsInSoftLiquidation = (params: UserMarketParams, enabled?: boolean) =>
-  mapQuery(useLiquidationStatus(params, enabled), status => ['softLiquidation', 'hardLiquidation'].includes(status))
+  mapQuery(useLiquidationStatus(params, enabled), status =>
+    ['softLiquidation', 'hardLiquidation', 'fullyConverted'].includes(status),
+  )


### PR DESCRIPTION
1. Shows the manage soft liquidation form for users that have been fully converted. This way they are able to close the position properly and get the remaining collateral.
2. Fixes a "0" in front of all close position table values. Silly jabascript.