### PR TITLE
fix: broken token alignment for everything but liquidity usd cell

### DIFF
--- a/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/LiquidityUsdCell.tsx
@@ -22,6 +22,7 @@ export const LiquidityUsdCell = ({ getValue, row }: CellContext<LlamaMarket, num
           blockchainId={assets.borrowed.chain}
           iconSize="mui-sm"
           iconPosition="right"
+          iconAlignment="start"
           primary={formatNumber(liquidity, 'token.compact')}
           secondary={formatNumber(getValue(), 'usd.notional')}
           boldPrimary

--- a/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/TokenInfo.tsx
@@ -9,6 +9,7 @@ const { Spacing } = SizesAndSpaces
 
 type TokenInfoBaseProps = {
   iconPosition: 'left' | 'right'
+  iconAlignment?: 'start' | 'center' | 'end'
   primary: ReactNode
   secondary?: ReactNode
   boldPrimary?: boolean
@@ -35,7 +36,7 @@ type TokenInfoCustomIconProps = TokenInfoBaseProps & {
 export type TokenInfoProps = TokenInfoTokenIconProps | TokenInfoCustomIconProps
 
 export const TokenInfo = (props: TokenInfoProps) => {
-  const { iconPosition, primary, secondary, boldPrimary } = props
+  const { iconPosition, iconAlignment = 'center', primary, secondary, boldPrimary } = props
   const tokenIcon =
     'address' in props ? (
       <TokenIcon
@@ -49,7 +50,7 @@ export const TokenInfo = (props: TokenInfoProps) => {
     )
 
   return (
-    <Stack direction="row" sx={applySxProps({ gap: Spacing.xs, alignItems: 'start' }, props.sx)}>
+    <Stack direction="row" sx={applySxProps({ gap: Spacing.xs, alignItems: iconAlignment }, props.sx)}>
       {iconPosition === 'left' && tokenIcon}
 
       <Stack sx={{ gap: Spacing.xxs, alignItems: iconPosition === 'right' ? 'end' : 'start' }}>


### PR DESCRIPTION
This was broken when we wanted the icon on top for the liquidity usd cell on the markets page

**Before**
<img width="191" height="126" alt="image" src="https://github.com/user-attachments/assets/bd90b7df-135b-4f8e-83d9-4a8786b10284" />

**After**
<img width="177" height="121" alt="image" src="https://github.com/user-attachments/assets/ec312d89-cda7-43dc-9ec2-cee65040d950" />
