### PR TITLE
fix: incorrect dex chart background color when switching themes

### DIFF
--- a/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
+++ b/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
@@ -141,7 +141,6 @@ export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActiv
             >
               <ChartWrapper
                 {...chart.ohlcChartProps}
-                betaBackgroundColor={theme.design.Layer[1].Fill}
                 onVisiblePriceRangeChange={showBands ? handleVisiblePriceRangeChange : undefined}
               />
               {showBands && (

--- a/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
+++ b/apps/main/src/llamalend/widgets/ChartAndActivityLayout.tsx
@@ -9,7 +9,6 @@ import {
   LlammaActivityTrades,
 } from '@/llamalend/features/llamma-activity'
 import Stack from '@mui/material/Stack'
-import { useTheme } from '@mui/material/styles'
 import { type Token } from '@primitives/address.utils'
 import { notFalsy } from '@primitives/objects.utils'
 import { ChartWrapper, type OhlcChartProps } from '@ui-kit/features/candle-chart/ChartWrapper'
@@ -64,7 +63,6 @@ type ChartAndActivityLayoutProps = {
 
 export const ChartAndActivityLayout = ({ chart, bands, activity }: ChartAndActivityLayoutProps) => {
   const { isConnected } = useConnection()
-  const theme = useTheme()
   const [isBandsVisible, setIsBandsVisible] = useBandsChartVisible()
   const toggleBandsVisible = useCallback(() => setIsBandsVisible(prev => !prev), [setIsBandsVisible])
   const bandsPalette = useBandsChartPalette()

--- a/packages/curve-ui-kit/src/features/candle-chart/ChartWrapper.tsx
+++ b/packages/curve-ui-kit/src/features/candle-chart/ChartWrapper.tsx
@@ -16,7 +16,6 @@ export type OhlcChartProps = {
   isEmpty?: boolean
   emptyMessage?: string
   error: Error | null
-  betaBackgroundColor?: string // Used during the beta phase of the new theme migration to pass theme bg color
   ohlcData: LpPriceOhlcDataFormatted[] | undefined
   oraclePriceData?: OraclePriceData[]
   liquidationRange?: LiquidationRanges
@@ -39,7 +38,6 @@ export const ChartWrapper = ({
   isEmpty,
   emptyMessage,
   error,
-  betaBackgroundColor,
   ohlcData,
   oraclePriceData,
   liquidationRange,
@@ -54,7 +52,7 @@ export const ChartWrapper = ({
   latestOraclePrice,
   onVisiblePriceRangeChange,
 }: OhlcChartProps) => {
-  const colors = useChartPalette({ backgroundOverride: betaBackgroundColor })
+  const colors = useChartPalette()
 
   const selectedChartLabel = selectChartList.find(c => c.key === selectedChartKey)?.label
   const errorMessage = selectedChartLabel

--- a/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartPalette.ts
+++ b/packages/curve-ui-kit/src/features/candle-chart/hooks/useChartPalette.ts
@@ -21,7 +21,7 @@ export type ChartColors = {
   rangeLineFutureBottom: string
 }
 
-export function useChartPalette({ backgroundOverride }: { backgroundOverride?: string } = {}): ChartColors {
+export function useChartPalette(): ChartColors {
   const theme = useTheme()
   return useMemo(() => {
     const {
@@ -32,21 +32,16 @@ export function useChartPalette({ backgroundOverride }: { backgroundOverride?: s
           LiquidationZone: { Current, CurrentBottomLine, CurrentTopLine, Future, FutureLine },
           Lines,
         },
+        Layer: Layer,
       },
       palette: {
-        background: { paper },
         primary: { main: primary },
         text: { highlight, tertiary },
       },
     } = theme
 
     return {
-      backgroundColor:
-        backgroundOverride ??
-        getComputedStyle(document.body ?? document.documentElement)
-          .getPropertyValue('--box--secondary--background-color')
-          .trim() ??
-        paper,
+      backgroundColor: Layer[1].Fill,
       lineColor: primary,
       textColor: tertiary,
       gridLine: Neutral[300],
@@ -64,5 +59,5 @@ export function useChartPalette({ backgroundOverride }: { backgroundOverride?: s
       rangeLineFutureTop: FutureLine,
       rangeLineFutureBottom: FutureLine,
     }
-  }, [backgroundOverride, theme])
+  }, [theme])
 }


### PR DESCRIPTION
Fixes incorrect background colors when switching themes. This was a bug becuase of an old beta fallback which is something I believe we no longer need.

<img width="1062" height="610" alt="image" src="https://github.com/user-attachments/assets/db5aff00-2747-4ad7-9081-e494952a8bc4" />
