### PR TITLE
fix: incorrect token address, price, symbol and link for merkl apr campaigns in pool yield breakdown

### DIFF
--- a/apps/main/src/dex/features/pool-information/components/pool-composition/columns/columns.definitions.tsx
+++ b/apps/main/src/dex/features/pool-information/components/pool-composition/columns/columns.definitions.tsx
@@ -48,7 +48,7 @@ export const POOL_COMPOSITION_COLUMNS = [
     header: headers[PoolCompositionColumnId.Price],
     cell: ({ getValue }) => (
       <InlineTableCell>
-        <Typography>{formatNumber(getValue(), 'usd.amount')}</Typography>
+        <Typography>{formatNumber(getValue(), 'usd.precise')}</Typography>
       </InlineTableCell>
     ),
     enableSorting: false,

--- a/apps/main/src/dex/features/pool-information/components/yield-breakdown/columns/columns.definitions.tsx
+++ b/apps/main/src/dex/features/pool-information/components/yield-breakdown/columns/columns.definitions.tsx
@@ -49,7 +49,7 @@ export const YIELD_BREAKDOWN_COLUMNS = [
     header: headers[YieldBreakdownColumnId.Price],
     cell: ({ getValue }) => (
       <InlineTableCell>
-        <Typography>{formatNumber(getValue(), 'usd.amount')}</Typography>
+        <Typography>{formatNumber(getValue(), 'usd.precise')}</Typography>
       </InlineTableCell>
     ),
     enableSorting: false,

--- a/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
@@ -93,28 +93,29 @@ export const useYieldBreakdown = ({
       })
     })
 
-    campaigns
-      .filter(({ reward }) => reward?.type === 'apr')
-      .forEach(({ address, reward, platform, platformImageId }) => {
-        // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
-        rows.push({
-          source: {
-            icon: (
-              <Box
-                component="img"
-                src={platformImageId}
-                alt={platform}
-                sx={{ borderRadius: '50%', width: IconSize.lg, height: IconSize.lg }}
-              />
-            ),
-            iconPosition: 'left',
-            primary: platform,
-          },
-          address,
-          explorerUrl: scanAddressPath(network, address),
-          apy: aprToApy(reward?.value, COMPOUND_WINDOW) ?? undefined,
-        })
+    campaigns.forEach(({ reward, symbol, platform, platformImageId }) => {
+      if (reward?.type !== 'apr') return
+
+      // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
+      rows.push({
+        source: {
+          icon: (
+            <Box
+              component="img"
+              src={platformImageId}
+              alt={platform}
+              sx={{ borderRadius: '50%', width: IconSize.lg, height: IconSize.lg }}
+            />
+          ),
+          iconPosition: 'left',
+          primary: symbol,
+        },
+        address: reward.address,
+        explorerUrl: scanAddressPath(network, reward.address),
+        price: reward.price,
+        apy: aprToApy(reward.value, COMPOUND_WINDOW) ?? undefined,
       })
+    })
 
     // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
     rows.push({

--- a/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/merkl.ts
@@ -18,6 +18,8 @@ type MerklReward = {
     symbol: string
     /** Full URL to the icon. We should use this one because curve-assets repo might be missing some; these are guaranteed to be available */
     icon: string
+    /** The token price of the reward as calculated by Merkl */
+    price: number
   }
   /** Probably the USD value. Either way, only used to filter 'empty' campaigns, which are a thing apparantly. */
   value: 0
@@ -81,7 +83,9 @@ const opportunityToCampaignRewards = (opp: MerklOpportunity) => {
         lock: false, // Merkl doesn't offer 'locked' rewards.
 
         // Merkl campaigns might be a points campaign or just a token, but those campaigns report an APR of 0 as their only distinction
-        reward: opp.apr ? { type: 'apr', value: Math.min(opp.apr, MAX_APR) } : undefined,
+        reward: opp.apr
+          ? { type: 'apr', value: Math.min(opp.apr, MAX_APR), address: token.address, price: token.price }
+          : undefined,
         symbol: token.symbol,
 
         tags: ['tokens'], // Merkl rewards are tokens only as far as I know; no points.

--- a/packages/curve-ui-kit/src/entities/campaigns/types.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/types.ts
@@ -1,6 +1,8 @@
+import type { Address } from 'viem'
 import type { Campaign, CampaignPool } from '@external-rewards'
 
-type CampaignReward = { type: 'apr'; value: number } | { type: 'points'; value: number }
+type CampaignReward =
+  { type: 'apr'; value: number; address: Address; price?: number } | { type: 'points'; value: number }
 
 export type CampaignRewards = Pick<Campaign, 'campaignName' | 'platform' | 'platformImageId' | 'dashboardLink'> &
   Pick<CampaignPool, 'action' | 'tags' | 'address' | 'network'> & {

--- a/packages/curve-ui-kit/src/utils/number.ts
+++ b/packages/curve-ui-kit/src/utils/number.ts
@@ -183,6 +183,26 @@ export type NumberFormatOptions = {
 
 const TOKEN_BALANCE_SIGNIFICANT_DIGITS = 5
 
+const preciseFormatter = (value: Amount) => {
+  const absValue = Math.abs(Number(value))
+  return defaultNumberFormatter(
+    value,
+    // For values between 0 and 1, we want to round up to 5 significant digits,
+    // For values >= 1, we want to show up to 5 significant digits after the decimal point, depending on the magnitude of the number.
+    // For super big values that have more than 5 digits we don't want a max of 5 significant digits, as that will incorrectly round.
+    absValue && absValue < 1
+      ? { maximumSignificantDigits: TOKEN_BALANCE_SIGNIFICANT_DIGITS, trailingZeroDisplay: 'auto' }
+      : Number.isFinite(absValue)
+        ? {
+            maximumFractionDigits: Math.max(
+              DEFAULT_DECIMALS,
+              TOKEN_BALANCE_SIGNIFICANT_DIGITS - Math.floor(Math.log10(absValue)) - 1,
+            ),
+          }
+        : undefined,
+  )
+}
+
 const NUMBER_FORMAT_CATEGORIES = {
   multiplier: {
     abbreviate: false,
@@ -195,28 +215,11 @@ const NUMBER_FORMAT_CATEGORIES = {
   'token.compact': { abbreviate: true, fallback: '-' },
   'token.balance': {
     abbreviate: false,
-    formatter: (value: Amount) => {
-      const absValue = Math.abs(Number(value))
-      return defaultNumberFormatter(
-        value,
-        // For values between 0 and 1, we want to round up to 5 significant digits,
-        // For values >= 1, we want to show up to 5 significant digits after the decimal point, depending on the magnitude of the number.
-        // For super big values that have more than 5 digits we don't want a max of 5 significant digits, as that will incorrectly round.
-        absValue && absValue < 1
-          ? { maximumSignificantDigits: TOKEN_BALANCE_SIGNIFICANT_DIGITS, trailingZeroDisplay: 'auto' }
-          : Number.isFinite(absValue)
-            ? {
-                maximumFractionDigits: Math.max(
-                  DEFAULT_DECIMALS,
-                  TOKEN_BALANCE_SIGNIFICANT_DIGITS - Math.floor(Math.log10(absValue)) - 1,
-                ),
-              }
-            : undefined,
-      )
-    },
     fallback: '-',
+    formatter: preciseFormatter,
   },
   'usd.amount': { unit: 'dollar', abbreviate: false, fallback: '-' },
+  'usd.precise': { unit: 'dollar', abbreviate: false, fallback: '-', formatter: preciseFormatter },
   'usd.notional': { unit: 'dollar', abbreviate: true, fallback: '-' },
   'percent.value': { unit: 'percentage', abbreviate: false, fallback: '-' },
   'percent.rate': {


### PR DESCRIPTION
Also increases token price precision in tables.

**Before**
<img width="1068" height="220" alt="image" src="https://github.com/user-attachments/assets/ad44ab48-9476-4b63-90e3-89edacf2fb1b" />

**After**
<img width="1057" height="228" alt="image" src="https://github.com/user-attachments/assets/29fe4fcb-de68-4408-9cbd-11583713e770" />
