### PR TITLE
feat: cap displayed borrow and supply rates

### DIFF
--- a/apps/main/src/llamalend/features/market-list/MarketExpandedPanel.tsx
+++ b/apps/main/src/llamalend/features/market-list/MarketExpandedPanel.tsx
@@ -13,7 +13,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { MarketRateType } from '@ui-kit/types/market'
 import { constQ } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, borderStyle } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, borderStyle, formatCappedRateValue } from '@ui-kit/utils'
 import type { LlamaMarket } from '../../queries/market-list/llama-markets'
 import { LineGraphCell, RateTooltipProps } from './cells'
 import { BorrowRateTooltip } from './cells/RateCell/BorrowRateTooltip'
@@ -63,7 +63,12 @@ const RateItem = ({ market, type }: { market: LlamaMarket; type: MarketRateType 
               category="llamalend.marketListRates"
               label={title}
               value={constQ(rateValue)}
-              valueOptions={{ unit: 'percentage', disableTooltip: true }}
+              valueOptions={{
+                unit: 'percentage',
+                abbreviate: false,
+                formatter: formatCappedRateValue,
+                disableTooltip: true,
+              }}
               icon={<RewardsIcons market={market} rateType={type} />}
             />
           </Stack>

--- a/apps/main/src/llamalend/features/market-list/cells/RateCell/RateCell.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/RateCell/RateCell.tsx
@@ -8,7 +8,7 @@ import { CellContext } from '@tanstack/react-table'
 import { TooltipProps } from '@ui-kit/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { MarketType, MarketRateType } from '@ui-kit/types/market'
-import { formatNumber } from '@ui-kit/utils'
+import { formatCappedRatePercent } from '@ui-kit/utils'
 import { MarketColumnId } from '../../columns'
 import { BorrowRateTooltip } from './BorrowRateTooltip'
 import { RewardsIcons } from './RewardsIcons'
@@ -50,7 +50,7 @@ export const RateCell = ({
       <Tooltip market={market}>
         <Stack sx={{ gap: Spacing.xs, alignItems: 'end' }}>
           <Typography variant="tableCellMBold" color="textPrimary">
-            {rate == null ? '—' : formatNumber(rate, 'percent.rate')}
+            {rate == null ? '—' : formatCappedRatePercent(rate)}
           </Typography>
 
           <RewardsIcons market={market} rateType={rateType} />

--- a/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/SupplyPositionDetails.tsx
@@ -31,7 +31,13 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { TabsSwitcher } from '@ui-kit/shared/ui/Tabs/TabsSwitcher'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { mapQuery, q } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, type AverageCategory, decimalMultiply, formatNumber } from '@ui-kit/utils'
+import {
+  AVERAGE_CATEGORIES,
+  type AverageCategory,
+  decimalMultiply,
+  formatCappedRateValue,
+  formatNumber,
+} from '@ui-kit/utils'
 import { AmountSuppliedTooltipContent, VaultSharesTooltipContent } from './'
 
 const { Spacing } = SizesAndSpaces
@@ -136,7 +142,12 @@ export const SupplyPositionDetails = () => {
             category={METRIC_CATEGORY}
             label={USER_NET_SUPPLY_RATE_TITLE}
             value={mapQuery(supplyMetrics, ({ totalUserBoost }) => totalUserBoost)}
-            valueOptions={{ unit: 'percentage', ...(noGauge && { fallback: `No Gauge` }) }}
+            valueOptions={{
+              unit: 'percentage',
+              abbreviate: false,
+              formatter: formatCappedRateValue,
+              ...(noGauge && { fallback: `No Gauge` }),
+            }}
             notional={mapQuery(userSupplyBoost, data => t`your boost ${formatNumber(data, 'multiplier')}`)}
             valueTooltip={{
               title: USER_NET_SUPPLY_RATE_TITLE,

--- a/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
+++ b/apps/main/src/llamalend/widgets/BorrowAprMetric.tsx
@@ -5,7 +5,7 @@ import { t } from '@ui-kit/lib/i18n'
 import { Metric, type MetricProps } from '@ui-kit/shared/ui/Metric'
 import type { MarketType } from '@ui-kit/types/market'
 import { mapQuery, type QueryProp } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES, type AverageCategory } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, type AverageCategory, formatCappedRateValue } from '@ui-kit/utils'
 import { getBorrowRateTooltipTitle } from '../llama.utils'
 import { TooltipOptions as defaultTooltipOptions } from './tooltips'
 
@@ -39,11 +39,13 @@ export const BorrowAprMetric = ({ marketType, borrowRate, collateralSymbol, alig
       alignment={alignment}
       testId="market-net-borrow-apr"
       label={t`Net Borrow APR`}
-      value={mapQuery(borrowRate, borrowRate => borrowRate.totalBorrowRate)}
-      valueOptions={{ unit: 'percentage' }}
+      value={mapQuery(borrowRate, ({ totalBorrowRate }) => totalBorrowRate)}
+      valueOptions={{ unit: 'percentage', abbreviate: false, formatter: formatCappedRateValue }}
       notional={mapQuery(borrowRate, ({ totalAverageBorrowRate: data }) =>
         maybe(data, value => ({
           value,
+          abbreviate: false,
+          formatter: formatCappedRateValue,
           unit: { symbol: `% ${averageRatePeriod} Avg`, position: 'suffix' as const },
         })),
       )}

--- a/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
@@ -6,14 +6,14 @@ import { SmallLiquidationRangeChart } from '@/llamalend/widgets/small-liquidatio
 import Stack from '@mui/material/Stack'
 import { useTheme } from '@mui/material/styles'
 import { Decimal } from '@primitives/decimal.utils'
-import { notFalsy } from '@primitives/objects.utils'
+import { maybe, notFalsy } from '@primitives/objects.utils'
 import { useShowNetRate } from '@ui-kit/hooks/useLocalStorage'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate, type TxGasInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 import { constQ, mapQuery, type QueryProp, type Range, DISABLED_Q } from '@ui-kit/types/util'
-import { decimal, formatNumber } from '@ui-kit/utils'
+import { decimal, formatCappedRatePercent, formatNumber } from '@ui-kit/utils'
 import {
   getPriceImpactDisplay,
   getPriceImpactPercent,
@@ -141,14 +141,8 @@ export const LoanActionInfoList = ({
           {(rates ?? prevRates) && (
             <ActionInfo
               label={t`Borrow APR`}
-              value={mapQuery(
-                prevRates ?? DISABLED_Q,
-                data => data?.borrowApr && formatNumber(data.borrowApr, 'percent.rate'),
-              )}
-              futureValue={mapQuery(
-                rates ?? DISABLED_Q,
-                data => data?.borrowApr && formatNumber(data.borrowApr, 'percent.rate'),
-              )}
+              value={mapQuery(prevRates ?? DISABLED_Q, data => maybe(data?.borrowApr, formatCappedRatePercent))}
+              futureValue={mapQuery(rates ?? DISABLED_Q, data => maybe(data?.borrowApr, formatCappedRatePercent))}
               size="small"
               testId="borrow-apr"
             />
@@ -156,8 +150,8 @@ export const LoanActionInfoList = ({
           {shouldShowNetBorrowApr && (
             <ActionInfo
               label={t`Net borrow APR`}
-              value={mapQuery(prevNetBorrowApr ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
-              futureValue={mapQuery(netBorrowApr ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
+              value={mapQuery(prevNetBorrowApr ?? DISABLED_Q, data => formatCappedRatePercent(data))}
+              futureValue={mapQuery(netBorrowApr ?? DISABLED_Q, data => formatCappedRatePercent(data))}
               size="small"
               testId="borrow-net-apr"
             />

--- a/apps/main/src/llamalend/widgets/action-card/SupplyActionInfoList.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/SupplyActionInfoList.tsx
@@ -5,7 +5,7 @@ import { useShowNetRate } from '@ui-kit/hooks/useLocalStorage'
 import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate, type TxGasInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { mapQuery, DISABLED_Q, type QueryProp } from '@ui-kit/types/util'
-import { formatNumber } from '@ui-kit/utils'
+import { formatCappedRatePercent, formatNumber } from '@ui-kit/utils'
 import { ActionInfoCollapse } from './ActionInfoCollapse'
 import { useShouldShowNetRate } from './hooks/useShouldShowNetRate'
 import { formatAmount, ACTION_INFO_GROUP_SX } from './info-actions.helpers'
@@ -71,8 +71,8 @@ export const SupplyActionInfoList = ({
           {(supplyApy ?? prevSupplyApy) && (
             <ActionInfo
               label={t`Supply APY`}
-              value={mapQuery(prevSupplyApy ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
-              futureValue={mapQuery(supplyApy ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
+              value={mapQuery(prevSupplyApy ?? DISABLED_Q, data => formatCappedRatePercent(data))}
+              futureValue={mapQuery(supplyApy ?? DISABLED_Q, data => formatCappedRatePercent(data))}
               size="small"
               testId="supply-apy"
             />
@@ -80,8 +80,8 @@ export const SupplyActionInfoList = ({
           {shouldShowNetSupplyApy && (
             <ActionInfo
               label={NET_SUPPLY_RATE_TITLE}
-              value={mapQuery(prevNetSupplyApy ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
-              futureValue={mapQuery(netSupplyApy ?? DISABLED_Q, data => formatNumber(data, 'percent.rate'))}
+              value={mapQuery(prevNetSupplyApy ?? DISABLED_Q, data => formatCappedRatePercent(data))}
+              futureValue={mapQuery(netSupplyApy ?? DISABLED_Q, data => formatCappedRatePercent(data))}
               size="small"
               testId="supply-net-apy"
             />

--- a/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
+++ b/apps/main/src/llamalend/widgets/page-header/MetricsRow.tsx
@@ -9,7 +9,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { MarketType } from '@ui-kit/types/market'
 import { mapQuery, type QueryProp } from '@ui-kit/types/util'
-import { AVERAGE_CATEGORIES } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, formatCappedRateValue } from '@ui-kit/utils'
 import type { AvailableLiquidity, BorrowRate, SupplyRate } from './hooks/usePageHeader'
 
 const { Spacing } = SizesAndSpaces
@@ -52,11 +52,13 @@ export const MetricsRow = ({
           category={METRIC_CATEGORY}
           testId="market-net-supply-apy"
           label={NET_SUPPLY_RATE_TITLE}
-          value={mapQuery(supplyRate, supplyRate => supplyRate.totalMinBoost)}
-          valueOptions={{ unit: 'percentage' }}
+          value={mapQuery(supplyRate, ({ totalMinBoost }) => totalMinBoost)}
+          valueOptions={{ unit: 'percentage', abbreviate: false, formatter: formatCappedRateValue }}
           notional={mapQuery(supplyRate, ({ totalAverageMinBoost: data }) =>
             maybe(data, value => ({
               value,
+              abbreviate: false,
+              formatter: formatCappedRateValue,
               unit: { symbol: `% ${supplyRatePeriod} Avg`, position: 'suffix' as const },
             })),
           )}

--- a/apps/main/src/llamalend/widgets/tooltips/MarketNetBorrowAprTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketNetBorrowAprTooltipContent.tsx
@@ -8,7 +8,7 @@ import Stack from '@mui/material/Stack'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import { MarketType } from '@ui-kit/types/market'
-import { formatNumber } from '@ui-kit/utils'
+import { formatCappedRatePercent } from '@ui-kit/utils'
 import { RewardsTooltipItems } from './RewardTooltipItems'
 
 export type MarketNetBorrowAprTooltipContentProps = {
@@ -52,9 +52,9 @@ export const MarketNetBorrowAprTooltipContent = ({
 
     <Stack>
       <TooltipItems secondary>
-        <TooltipItem title={t`Borrow APR`}>{formatNumber(borrowApr ?? 0, 'percent.rate')}</TooltipItem>
+        <TooltipItem title={t`Borrow APR`}>{formatCappedRatePercent(borrowApr ?? 0)}</TooltipItem>
         <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-          {averageApr == null ? 'N/A' : formatNumber(averageApr, 'percent.rate')}
+          {averageApr == null ? 'N/A' : formatCappedRatePercent(averageApr)}
         </TooltipItem>
       </TooltipItems>
 
@@ -71,10 +71,10 @@ export const MarketNetBorrowAprTooltipContent = ({
 
       {rebasingYieldApr != null && (
         <TooltipItems secondary>
-          <TooltipItem title={t`Yield bearing tokens`}>{formatNumber(-rebasingYieldApr, 'percent.rate')}</TooltipItem>
+          <TooltipItem title={t`Yield bearing tokens`}>{formatCappedRatePercent(-rebasingYieldApr)}</TooltipItem>
           {!!collateralSymbol && (
             <TooltipItem variant="subItem" title={collateralSymbol}>
-              {formatNumber(-rebasingYieldApr, 'percent.rate')}
+              {formatCappedRatePercent(-rebasingYieldApr)}
             </TooltipItem>
           )}
         </TooltipItems>
@@ -83,10 +83,10 @@ export const MarketNetBorrowAprTooltipContent = ({
       {totalBorrowApr != null && (extraRewards.length || rebasingYieldApr != null) && (
         <TooltipItems>
           <TooltipItem variant="primary" title={t`Net borrow APR`}>
-            {formatNumber(totalBorrowApr, 'percent.rate')}
+            {formatCappedRatePercent(totalBorrowApr)}
           </TooltipItem>
           <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-            {totalAverageBorrowApr == null ? 'N/A' : formatNumber(totalAverageBorrowApr, 'percent.rate')}
+            {totalAverageBorrowApr == null ? 'N/A' : formatCappedRatePercent(totalAverageBorrowApr)}
           </TooltipItem>
         </TooltipItems>
       )}

--- a/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/MarketSupplyRateTooltipContent.tsx
@@ -9,7 +9,7 @@ import Stack from '@mui/material/Stack'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 import { t } from '@ui-kit/lib/i18n'
 import type { ExtraIncentive } from '@ui-kit/types/market'
-import { AVERAGE_CATEGORIES, formatNumber } from '@ui-kit/utils'
+import { AVERAGE_CATEGORIES, formatCappedRatePercent } from '@ui-kit/utils'
 import { RewardsTooltipItems } from './RewardTooltipItems'
 
 type SupplyBoostType = 'market' | 'user'
@@ -60,10 +60,10 @@ export const MarketSupplyRateTooltipContent = ({
       <Stack>
         <TooltipItems secondary>
           <TooltipItem title={t`Supply APY`} loading={isLoading}>
-            {formatNumber(supplyApy, 'percent.rate')}
+            {formatCappedRatePercent(supplyApy)}
           </TooltipItem>
           <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-            {averageSupplyApy == null ? 'N/A' : formatNumber(averageSupplyApy, 'percent.rate')}
+            {averageSupplyApy == null ? 'N/A' : formatCappedRatePercent(averageSupplyApy)}
           </TooltipItem>
         </TooltipItems>
 
@@ -81,11 +81,11 @@ export const MarketSupplyRateTooltipContent = ({
         {hasRebasingYield && (
           <TooltipItems secondary>
             <TooltipItem title={t`Yield bearing APY*`} loading={isLoading}>
-              {formatNumber(rebasingYieldApy, 'percent.rate')}
+              {formatCappedRatePercent(rebasingYieldApy)}
             </TooltipItem>
             {!!rebasingSymbol && (
               <TooltipItem variant="subItem" title={rebasingSymbol}>
-                {formatNumber(rebasingYieldApy, 'percent.rate')}
+                {formatCappedRatePercent(rebasingYieldApy)}
               </TooltipItem>
             )}
           </TooltipItems>
@@ -94,12 +94,12 @@ export const MarketSupplyRateTooltipContent = ({
         {totalApy != null && (hasIncentives || hasRebasingYield) && (
           <TooltipItems borderTop>
             <TooltipItem variant="primary" title={t`Net total APY`} loading={isLoading}>
-              {formatNumber(totalApy, 'percent.rate')}
+              {formatCappedRatePercent(totalApy)}
             </TooltipItem>
             {/* Historical boost data is only available at the market level, so user totals do not show an average. */}
             {boost.type === 'market' && (
               <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-                {totalAverageApy == null ? 'N/A' : formatNumber(totalAverageApy, 'percent.rate')}
+                {totalAverageApy == null ? 'N/A' : formatCappedRatePercent(totalAverageApy)}
               </TooltipItem>
             )}
           </TooltipItems>
@@ -108,7 +108,7 @@ export const MarketSupplyRateTooltipContent = ({
         {showBoostRow && (
           <TooltipItems secondary extraMargin>
             <TooltipItem title={t`Max veCRV Boost (2.5x)`} loading={isLoading}>
-              {formatNumber(boost.apy, 'percent.rate')}
+              {formatCappedRatePercent(boost.apy)}
             </TooltipItem>
           </TooltipItems>
         )}
@@ -116,10 +116,10 @@ export const MarketSupplyRateTooltipContent = ({
         {showBoostRow && (
           <TooltipItems borderTop>
             <TooltipItem variant="primary" title={t`Total max veCRV APY`} loading={isLoading}>
-              {formatNumber(boost.totalApy, 'percent.rate')}
+              {formatCappedRatePercent(boost.totalApy)}
             </TooltipItem>
             <TooltipItem variant="subItem" loading={isLoading} title={`${periodLabel} ${t`Average`}`}>
-              {boost.totalAverageApy == null ? 'N/A' : formatNumber(boost.totalAverageApy, 'percent.rate')}
+              {boost.totalAverageApy == null ? 'N/A' : formatCappedRatePercent(boost.totalAverageApy)}
             </TooltipItem>
           </TooltipItems>
         )}

--- a/packages/curve-ui-kit/src/utils/rates.ts
+++ b/packages/curve-ui-kit/src/utils/rates.ts
@@ -1,6 +1,28 @@
+import type { Amount } from '@primitives/decimal.utils'
 import { AVERAGE_CATEGORIES } from './average-categories'
+import { formatNumber } from './number'
 
 const DAYS_PER_YEAR = 365
+export const MAX_DISPLAY_RATE_PERCENT = 5000
+
+/**
+ * Formats a percentage rate without its unit. This is useful for components that render the percentage symbol
+ * separately through their number-formatting options.
+ */
+export const formatCappedRateValue = (value: Amount) => {
+  const numericValue = Number(value)
+  if (numericValue >= MAX_DISPLAY_RATE_PERCENT) {
+    const cappedValue = formatNumber(MAX_DISPLAY_RATE_PERCENT, { abbreviate: false })
+    return `${cappedValue}${numericValue > MAX_DISPLAY_RATE_PERCENT ? '+' : ''}`
+  }
+
+  return formatNumber(value, { abbreviate: true })
+}
+
+export const formatCappedRatePercent = (value: Amount | null | undefined) =>
+  value != null && Number(value) >= MAX_DISPLAY_RATE_PERCENT
+    ? `${formatCappedRateValue(value)}%`
+    : formatNumber(value, 'percent.rate')
 
 /**
  * Converts an APR into APY using periodic compounding based on a given number of days per compounding period.


### PR DESCRIPTION
Caps display values for borrow and supply rates in llamalend above 5000 to `5000+` like in dex cases