### PR TITLE
test: seed Cypress randomness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
+          TEST_SEED: ${{ github.run_id }}-${{ matrix.count }}
 
       - uses: actions/upload-artifact@v7
         if: failure()
@@ -140,6 +141,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
+          TEST_SEED: ${{ github.run_id }}-rpc
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
@@ -219,6 +221,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
+          TEST_SEED: ${{ github.run_id }}-${{ matrix.count }}
           CYPRESS_VIDEO: ${{ matrix.browser == 'firefox' && 'false' || 'true' }} # Firefox doesn't support recording
 
       - name: Check runtime errors

--- a/.github/workflows/cypress-flake-detection.yaml
+++ b/.github/workflows/cypress-flake-detection.yaml
@@ -142,17 +142,19 @@ jobs:
         timeout-minutes: 20
         env:
           BROWSER: ${{ matrix.browser }}
-          CYPRESS_VIDEO: false
+          CYPRESS_VIDEO: ${{ matrix.browser == 'firefox' && 'false' || 'true' }} # Firefox doesn't support recording
           ELECTRON_ENABLE_LOGGING: true
           NODE_ENV: test
           SPEC_OVERRIDE: ${{ inputs.specs }}
           SUITE: ${{ inputs.suite }}
           TEST_SEED: ${{ inputs.seed_prefix || github.run_id }}-${{ matrix.iteration }}
         run: |
+          cypress_config=()
           case "$SUITE" in
             component)
               testing_type=component
               specs='cypress/component/**/!(*.rpc).cy.{ts,tsx}'
+              cypress_config=(--config 'excludeSpecPattern=**/*.rpc.cy.*')
               ;;
             e2e-llamalend)
               testing_type=e2e
@@ -181,7 +183,7 @@ jobs:
           fi
 
           set -o pipefail
-          yarn cypress run --"$testing_type" --browser "$BROWSER" --spec "$specs" 2>&1 | \
+          yarn cypress run --"$testing_type" --browser "$BROWSER" --spec "$specs" "${cypress_config[@]}" 2>&1 | \
             tee "../cypress-flake-$SUITE-$BROWSER-${{ matrix.iteration }}.log" \
               >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
 

--- a/.github/workflows/cypress-flake-detection.yaml
+++ b/.github/workflows/cypress-flake-detection.yaml
@@ -1,0 +1,214 @@
+name: Cypress Flake Detection
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Test suite to run
+        required: true
+        default: component
+        type: choice
+        options:
+          - component
+          - e2e-llamalend
+          - e2e-dex
+          - e2e-other
+      specs:
+        description: Optional Cypress spec or glob overriding the selected suite
+        required: false
+        type: string
+      browser:
+        description: Browser to test
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - chrome
+          - firefox
+          - electron
+      repetitions:
+        description: Number of independent jobs per browser (1-30)
+        required: true
+        default: 10
+        type: number
+      start_iteration:
+        description: First iteration number, used to replay a specific seed
+        required: true
+        default: 1
+        type: number
+      seed_prefix:
+        description: Optional seed prefix; defaults to this workflow run ID
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  DO_NOT_TRACK: 1
+  VERCEL_ALLOW_NODEJS_24: 1
+  IBM_TELEMETRY_DISABLED: true
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+
+jobs:
+  prepare:
+    name: Prepare test matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        name: Build browser and iteration matrix
+        env:
+          BROWSER: ${{ inputs.browser }}
+          REPETITIONS: ${{ inputs.repetitions }}
+          START_ITERATION: ${{ inputs.start_iteration }}
+        run: |
+          if ! [[ "$REPETITIONS" =~ ^[0-9]+$ ]] || (( REPETITIONS < 1 || REPETITIONS > 30 )); then
+            echo "repetitions must be between 1 and 30" >&2
+            exit 1
+          fi
+          if ! [[ "$START_ITERATION" =~ ^[0-9]+$ ]] || (( START_ITERATION < 1 )); then
+            echo "start_iteration must be at least 1" >&2
+            exit 1
+          fi
+
+          if [[ "$BROWSER" == "all" ]]; then
+            browsers='["chrome","firefox","electron"]'
+          else
+            browsers="[\"$BROWSER\"]"
+          fi
+
+          matrix=$(jq -cn \
+            --argjson browsers "$browsers" \
+            --argjson start "$START_ITERATION" \
+            --argjson repetitions "$REPETITIONS" \
+            '{include: [range($start; $start + $repetitions) as $iteration | $browsers[] as $browser | {browser: $browser, iteration: $iteration}]}')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  cypress:
+    name: ${{ inputs.suite }} in ${{ matrix.browser }} ${{ matrix.iteration }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Restore cache
+        uses: ./.github/actions/restore-cache
+      - run: yarn set version stable
+      - run: yarn install --immutable
+
+      - name: Optimize component dependencies
+        if: inputs.suite == 'component'
+        run: yarn vite optimize --config vite.config.ts
+        working-directory: tests
+
+      - name: Build app
+        if: inputs.suite != 'component'
+        run: |
+          set -o pipefail
+          yarn build 2>&1 | tee e2e-build-${{ matrix.browser }}-${{ matrix.iteration }}.log
+
+      - name: Start app
+        if: inputs.suite != 'component'
+        run: yarn start 2>&1 | tee ../../e2e-dev-${{ matrix.browser }}-${{ matrix.iteration }}.log &
+        working-directory: apps/main
+
+      - name: Start router API
+        if: inputs.suite != 'component'
+        run: yarn dev 2>&1 | tee ../../e2e-router-api-${{ matrix.browser }}-${{ matrix.iteration }}.log &
+        working-directory: apps/router-api
+
+      - name: Start Merkl API
+        if: inputs.suite != 'component'
+        run: yarn dev 2>&1 | tee ../../e2e-merkl-api-${{ matrix.browser }}-${{ matrix.iteration }}.log &
+        working-directory: apps/merkl-api
+        env:
+          MERKL_API_KEY: ${{ secrets.MERKL_API_KEY }}
+
+      - name: Run Cypress
+        working-directory: tests
+        timeout-minutes: 20
+        env:
+          BROWSER: ${{ matrix.browser }}
+          CYPRESS_VIDEO: false
+          ELECTRON_ENABLE_LOGGING: true
+          NODE_ENV: test
+          SPEC_OVERRIDE: ${{ inputs.specs }}
+          SUITE: ${{ inputs.suite }}
+          TEST_SEED: ${{ inputs.seed_prefix || github.run_id }}-${{ matrix.iteration }}
+        run: |
+          case "$SUITE" in
+            component)
+              testing_type=component
+              specs='cypress/component/**/!(*.rpc).cy.{ts,tsx}'
+              ;;
+            e2e-llamalend)
+              testing_type=e2e
+              specs='cypress/e2e/loan/**/*,cypress/e2e/lend/**/*,cypress/e2e/llamalend/**/*'
+              ;;
+            e2e-dex)
+              testing_type=e2e
+              specs='cypress/e2e/dex/**/*'
+              ;;
+            e2e-other)
+              testing_type=e2e
+              specs='cypress/e2e/all/**/*,cypress/e2e/analytics/**/*,cypress/e2e/bridge/**/*,cypress/e2e/dao/**/*'
+              ;;
+          esac
+
+          if [[ -n "$SPEC_OVERRIDE" ]]; then
+            specs="$SPEC_OVERRIDE"
+          fi
+          if [[ "$specs" == *".rpc.cy."* ]]; then
+            echo "RPC specs are intentionally excluded from this workflow" >&2
+            exit 1
+          fi
+
+          if [[ "$testing_type" == "e2e" ]]; then
+            yarn wait-on http://localhost:3000 --timeout 1m
+          fi
+
+          set -o pipefail
+          yarn cypress run --"$testing_type" --browser "$BROWSER" --spec "$specs" 2>&1 | \
+            tee "../cypress-flake-$SUITE-$BROWSER-${{ matrix.iteration }}.log" \
+              >(grep --line-buffered --invert-match --fixed-strings 'INFO:CONSOLE' >&1) > /dev/null
+
+      - name: Check runtime errors
+        if: (success() || failure()) && inputs.suite != 'component'
+        env:
+          RUNTIME_ERRORS: |-
+            update depth exceeded
+            many re-renders
+            unmounted component
+            non-unique keys
+            uncontrolled to controlled
+            properties of undefined
+            cannot destructure
+            was reexported through module
+            dependencies of each other
+        run: |
+          ! grep --ignore-case --extended-regexp "$(echo -n "$RUNTIME_ERRORS" | tr '\n' '|')" e2e-*.log
+
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cypress-flake-${{ inputs.suite }}-${{ matrix.browser }}-${{ matrix.iteration }}
+          path: |
+            tests/cypress/screenshots
+            cypress-flake-*.log
+            e2e-*.log
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/cypress-flake-detection.yaml
+++ b/.github/workflows/cypress-flake-detection.yaml
@@ -201,7 +201,7 @@ jobs:
             was reexported through module
             dependencies of each other
         run: |
-          ! grep --ignore-case --extended-regexp "$(echo -n "$RUNTIME_ERRORS" | tr '\n' '|')" e2e-*.log
+          ! grep --ignore-case --extended-regexp "$(echo -n "$RUNTIME_ERRORS" | tr '\n' '|')" e2e-*.log cypress-flake-*.log
 
       - name: Upload failure evidence
         if: failure()

--- a/.github/workflows/rpc-tests.yaml
+++ b/.github/workflows/rpc-tests.yaml
@@ -1,6 +1,6 @@
 name: RPC Tests
 on:
-  workflow_dispatch:  # triggered manually
+  workflow_dispatch: # triggered manually
 env:
   DO_NOT_TRACK: 1
   IBM_TELEMETRY_DISABLED: true
@@ -33,6 +33,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
+          TEST_SEED: ${{ github.run_id }}-rpc
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,6 +39,15 @@ yarn cy run --e2e --spec cypress/e2e/<path>/<test>.cy.ts
 yarn cy run --component --spec cypress/component/<path>/<test>.cy.tsx
 ```
 
+Each Cypress run prints the seed used to generate random test data. Runs without `TEST_SEED` use a new seed, while reusing a seed replays the same random sequence for each spec:
+
+```sh
+TEST_SEED=18273645-1 yarn cy:run:e2e --browser firefox --spec cypress/e2e/llamalend/llamalend-markets.cy.ts
+TEST_SEED=18273645-1 yarn cy:run:component --browser firefox --spec cypress/component/<path>/<test>.cy.tsx
+```
+
+GitHub Actions uses the run ID and test iteration as its seed. The same iteration uses the same seed across browsers, and rerunning a GitHub workflow run reuses its seeds.
+
 ### Folder Structure
 
 Tests for each DApp are created in the corresponding directory:

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,6 +48,28 @@ TEST_SEED=18273645-1 yarn cy:run:component --browser firefox --spec cypress/comp
 
 GitHub Actions uses the run ID and test iteration as its seed. The same iteration uses the same seed across browsers, and rerunning a GitHub workflow run reuses its seeds.
 
+### Flake Detection
+
+Run repeated component or end-to-end tests with the manual `Cypress Flake Detection` workflow:
+
+```sh
+gh workflow run cypress-flake-detection.yaml --ref <branch> \
+  -f suite=e2e-llamalend \
+  -f browser=all \
+  -f repetitions=10
+```
+
+Use the optional `specs`, `seed_prefix`, and `start_iteration` inputs to target a spec or replay known seeds. RPC specs and video recording are intentionally excluded.
+
+Download uploaded artifacts and the failed step log from every failed job:
+
+```sh
+RUN_ID=<run-id> WORKFLOW=cypress-flake-detection \
+  yarn workspace tests download:artifacts --skip-cleanup
+```
+
+Failure evidence is stored under `artifacts/<branch>/<run-id>`, including a `failed-job-logs` directory. The workflow must exist on the default branch before GitHub allows manual dispatches.
+
 ### Folder Structure
 
 Tests for each DApp are created in the corresponding directory:

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,7 +59,7 @@ gh workflow run cypress-flake-detection.yaml --ref <branch> \
   -f repetitions=10
 ```
 
-Use the optional `specs`, `seed_prefix`, and `start_iteration` inputs to target a spec or replay known seeds. RPC specs and video recording are intentionally excluded.
+Use the optional `specs`, `seed_prefix`, and `start_iteration` inputs to target a spec or replay known seeds. RPC specs are intentionally excluded. Videos are recorded in Chrome and Electron; Firefox does not support recording.
 
 Download uploaded artifacts and the failed step log from every failed job:
 

--- a/tests/cypress.config.ts
+++ b/tests/cypress.config.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from 'node:crypto'
 import { defineConfig } from 'cypress'
 import { vitePreprocessor } from './vite-cypress-preprocessor'
+
+const testSeed = (process.env.TEST_SEED = process.env.TEST_SEED?.trim() || randomUUID())
+console.info(`Cypress test seed: ${testSeed}`)
 
 export default defineConfig({
   allowCypressEnv: false,

--- a/tests/cypress/support/generators.ts
+++ b/tests/cypress/support/generators.ts
@@ -4,11 +4,15 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { range, recordValues } from '@primitives/objects.utils'
 import { TIME_FRAMES } from '@ui-kit/lib/model/time'
 import { decimal } from '@ui-kit/utils/decimal'
+import { createSeededRandom, getTestSeed } from './seed'
 
 export const MAX_USD_VALUE = 400_000_000
 
+let seededRandom: (() => number) | undefined
+const random = () => (seededRandom ??= createSeededRandom(getTestSeed()))()
+
 export const oneFloat = (minOrMax = 1, maxExclusive?: number): number =>
-  maxExclusive == null ? Math.random() * minOrMax : minOrMax + Math.random() * (maxExclusive - minOrMax)
+  maxExclusive == null ? random() * minOrMax : minOrMax + random() * (maxExclusive - minOrMax)
 
 export const oneDecimal = (minOrMax = 1, maxExclusive?: number, maxDecimals = 6): Decimal =>
   decimal(new BigNumber(oneFloat(minOrMax, maxExclusive)).decimalPlaces(maxDecimals, BigNumber.ROUND_DOWN).toString())!

--- a/tests/cypress/support/helpers/tenderly/vnet.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet.ts
@@ -1,5 +1,4 @@
 import { generatePrivateKey } from 'viem/accounts'
-import { oneInt } from '@cy/support/generators'
 import type { Hex } from '@primitives/address.utils'
 import { resetWagmiConfigForTests } from '@ui-kit/features/connect-wallet/lib/wagmi/wagmi-config'
 import { DeepPartial } from '@ui-kit/types/util'
@@ -87,6 +86,9 @@ export function withVirtualTestnet(opts: () => GetVirtualTestnetOptions) {
   return () => vnet
 }
 
+// Resource identities must stay unique when a failed VNet is retained for debugging.
+const oneVnetId = () => Cypress._.random(0, Number.MAX_SAFE_INTEGER)
+
 /**
  * Creates a Cypress test helper that creates and manages a Tenderly virtual testnet lifecycle
  *
@@ -112,7 +114,7 @@ export function createVirtualTestnet(
   let shouldDeleteVnet = true
 
   before(() => {
-    const uuid = oneInt(0, 1e6 + 1)
+    const uuid = oneVnetId()
     const { chain_id = 1, ...givenOptions } = opts(uuid)
 
     const defaultOptions: CreateVirtualTestnetOptions = {
@@ -168,7 +170,7 @@ export function forkVirtualTestnet(
   let vnet: ForkVirtualTestnetResponse
 
   before(() => {
-    const uuid = oneInt(0, 1e6 + 1)
+    const uuid = oneVnetId()
     const defaultOpts = { wait: true }
     loadTenderlyAccount().then(tenderlyAccount => {
       const finalOpts = Cypress._.merge(tenderlyAccount, defaultOpts, opts(uuid))

--- a/tests/cypress/support/helpers/tenderly/vnet.ts
+++ b/tests/cypress/support/helpers/tenderly/vnet.ts
@@ -1,4 +1,5 @@
 import { generatePrivateKey } from 'viem/accounts'
+import { oneInt } from '@cy/support/generators'
 import type { Hex } from '@primitives/address.utils'
 import { resetWagmiConfigForTests } from '@ui-kit/features/connect-wallet/lib/wagmi/wagmi-config'
 import { DeepPartial } from '@ui-kit/types/util'
@@ -111,7 +112,7 @@ export function createVirtualTestnet(
   let shouldDeleteVnet = true
 
   before(() => {
-    const uuid = Cypress._.random(0, 1e6)
+    const uuid = oneInt(0, 1e6 + 1)
     const { chain_id = 1, ...givenOptions } = opts(uuid)
 
     const defaultOptions: CreateVirtualTestnetOptions = {
@@ -167,7 +168,7 @@ export function forkVirtualTestnet(
   let vnet: ForkVirtualTestnetResponse
 
   before(() => {
-    const uuid = Cypress._.random(0, 1e6)
+    const uuid = oneInt(0, 1e6 + 1)
     const defaultOpts = { wait: true }
     loadTenderlyAccount().then(tenderlyAccount => {
       const finalOpts = Cypress._.merge(tenderlyAccount, defaultOpts, opts(uuid))

--- a/tests/cypress/support/seed.ts
+++ b/tests/cypress/support/seed.ts
@@ -1,0 +1,27 @@
+/** Produces replayable Cypress randomness by combining the logged run seed with the current spec path. */
+
+const hashSeed = (seed: string) => {
+  let hash = 2166136261
+
+  for (let index = 0; index < seed.length; index++) {
+    hash ^= seed.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return hash >>> 0
+}
+
+export const createSeededRandom = (seed: string) => {
+  let state = hashSeed(seed)
+
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+export const getTestSeed = () => {
+  const seed = process.env.TEST_SEED
+  if (typeof seed !== 'string' || seed.length === 0) throw new Error('Missing Cypress TEST_SEED')
+  return `${seed}:${Cypress.spec.relative}`
+}

--- a/tests/scripts/download-artifacts.ts
+++ b/tests/scripts/download-artifacts.ts
@@ -1,9 +1,16 @@
 import { execFileSync, type ExecFileSyncOptionsWithStringEncoding, spawnSync } from 'child_process'
-import { mkdir, readdir, rmdir, unlink } from 'fs/promises'
+import { mkdir, readdir, rmdir, unlink, writeFile } from 'fs/promises'
 import { dirname, join } from 'path'
+import { stripVTControlCharacters } from 'util'
 
 const { BRANCH, WORKFLOW, RUN_ID, REPOSITORY = 'curvefi/curve-frontend' } = process.env
 const DEST_DIR = 'artifacts'
+const MAX_LOG_SIZE = 100 * 1024 * 1024
+
+type WorkflowJob = {
+  databaseId: number
+  name: string
+}
 
 /**
  * Execute a command and return trimmed stdout.
@@ -54,6 +61,45 @@ const findLatestRunId = (branch: string, workflow: string): string =>
 const downloadArtifacts = (runId: string, dest: string) => {
   runStreaming('gh', ['run', 'download', runId, '--repo', REPOSITORY, '--dir', dest])
 }
+
+const getFailedJobs = (runId: string): WorkflowJob[] =>
+  JSON.parse(
+    run('gh', [
+      'run',
+      'view',
+      runId,
+      '--repo',
+      REPOSITORY,
+      '--json',
+      'jobs',
+      '--jq',
+      '[.jobs[] | select(.conclusion == "failure") | {databaseId, name}]',
+    ]),
+  ) as WorkflowJob[]
+
+const safeFilename = (name: string) => name.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-|-$/g, '')
+
+/** Download the failed steps from each failed job because Actions logs are not workflow artifacts. */
+async function downloadFailedJobLogs(runId: string, dest: string) {
+  const failedJobs = getFailedJobs(runId)
+  if (failedJobs.length === 0) return console.info('No failed job logs to download.')
+
+  const logsDir = join(dest, 'failed-job-logs')
+  await mkdir(logsDir, { recursive: true })
+
+  for (const job of failedJobs) {
+    const log = run('gh', ['run', 'view', '--repo', REPOSITORY, '--job', String(job.databaseId), '--log-failed'], {
+      encoding: 'utf8',
+      maxBuffer: MAX_LOG_SIZE,
+    })
+    const path = join(logsDir, `${job.databaseId}-${safeFilename(job.name)}.log`)
+    await writeFile(path, `${stripVTControlCharacters(log)}\n`)
+    console.info(`Downloaded failed job log: ${path}`)
+  }
+}
+
+const getArtifactCount = (runId: string) =>
+  Number(run('gh', ['api', `repos/${REPOSITORY}/actions/runs/${runId}/artifacts`, '--jq', '.total_count']))
 
 /**
  * Check if a directory contains any .png files (indicating test failures).
@@ -125,8 +171,16 @@ async function downloadLatestArtifacts({ cleanup }: { cleanup: boolean }): Promi
   const destination = join(repoRoot, path)
   await mkdir(destination, { recursive: true })
 
-  console.info(`Downloading artifacts for branch '${branch}' (workflow: ${workflow}, run: ${runId}) into '${path}'...`)
-  downloadArtifacts(runId, destination)
+  console.info(
+    `Downloading failure evidence for branch '${branch}' (workflow: ${workflow}, run: ${runId}) into '${path}'...`,
+  )
+  await downloadFailedJobLogs(runId, destination)
+
+  if (getArtifactCount(runId) > 0) {
+    downloadArtifacts(runId, destination)
+  } else {
+    console.info('No workflow artifacts to download.')
+  }
 
   if (cleanup) {
     console.info('Cleaning up videos from successful tests...')
@@ -140,7 +194,7 @@ async function downloadLatestArtifacts({ cleanup }: { cleanup: boolean }): Promi
  *  node --experimental-strip-types scripts/download-artifacts.ts
  *
  * Custom usage:
- *  cd tests && BRANCH=main WORKFLOW=rpc-tests.yaml DEST_DIR=tests/artifacts \
+ *  cd tests && BRANCH=main WORKFLOW=rpc-tests \
  *    node --experimental-strip-types scripts/download-artifacts.ts --skip-cleanup
  */
 downloadLatestArtifacts({ cleanup: !process.argv.includes('--skip-cleanup') }).catch(error => {

--- a/tests/vite-cypress-preprocessor.ts
+++ b/tests/vite-cypress-preprocessor.ts
@@ -13,6 +13,7 @@ export const vitePreprocessor = () => async (file: Cypress.FileObject) => {
   const { filePath, outputPath, shouldWatch } = file
   if (cache.has(filePath)) return cache.get(filePath)!
 
+  const testSeed = process.env.TEST_SEED ?? ''
   const filename = path.basename(outputPath)
   const filenameBase = path.basename(outputPath, path.extname(outputPath))
   const isHtml = filename.endsWith('.html')
@@ -24,8 +25,8 @@ export const vitePreprocessor = () => async (file: Cypress.FileObject) => {
     },
     define: {
       // Shim process for browser-only bundles; some deps expect it to exist.
-      'process.env': {},
-      process: { env: {} },
+      'process.env': { TEST_SEED: testSeed },
+      process: { env: { TEST_SEED: testSeed } },
     },
     build: {
       emptyOutDir: false, // do not clear between specs

--- a/tests/vite.config.ts
+++ b/tests/vite.config.ts
@@ -20,5 +20,6 @@ export default defineConfig({
   },
   define: {
     'process.env.CYPRESS_COMPONENT_TEST': '"true"',
+    'process.env.TEST_SEED': JSON.stringify(process.env.TEST_SEED ?? ''),
   },
 })


### PR DESCRIPTION
This lays the groundwork for an AI-assisted workflow that runs tests, identifies failing cases, proposes and pushes fixes to a branch, then reads the resulting GitHub Actions output and iterates. In order to do that, reproducible test data and configurable actions are necessary for the agent to reliably replay failures and verify its changes.

New workflows can only work on the main branch, so to test we have to merge this branch first.

- seed Cypress test data so failures can be replayed locally and across browsers
- add a manual workflow for repeated, targeted flake detection runs
- collect failed job logs alongside uploaded screenshots and server logs