### PR TITLE
fix LlamaLend market footer Learn More link

### DIFF
--- a/apps/main/src/llamalend/features/market-list/MarketsTableFooter.tsx
+++ b/apps/main/src/llamalend/features/market-list/MarketsTableFooter.tsx
@@ -5,6 +5,7 @@ import CardContent from '@mui/material/CardContent'
 import Grid from '@mui/material/Grid'
 import SvgIcon from '@mui/material/SvgIcon'
 import Typography from '@mui/material/Typography'
+import { EXTERNAL_LINKS } from '@ui/utils'
 import { t } from '@ui-kit/lib/i18n'
 import { CardStackPlusIcon } from '@ui-kit/shared/icons/CardStackPlusIcon'
 import { SignIcon } from '@ui-kit/shared/icons/SignIcon'
@@ -47,7 +48,7 @@ export const MarketsTableFooter = () => (
         </GridItem>
         <Grid size={12}>
           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <ExternalLink href="https://docs.curve.finance/lending/overview/" label={t`Learn More`} />
+            <ExternalLink href={EXTERNAL_LINKS.docs.user.llamalend.overview} label={t`Learn More`} />
           </Box>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary

- update the LlamaLend market-list footer's **Learn More** destination
- reuse the existing canonical `EXTERNAL_LINKS.docs.user.llamalend.overview` URL

## Why

The footer linked to the removed `/lending/overview/` documentation route, which returns a 404. It now links to the live LlamaLend overview at https://docs.curve.finance/user/llamalend/overview.

## Impact

Users can open the correct LlamaLend documentation from the card at the bottom of the market list.

## Validation

- `yarn format:check` — passed
- targeted ESLint for `MarketsTableFooter.tsx` — passed
- `yarn build` — passed
- destination page — verified live
- `curve-context check-locality` — passed
- `yarn lint` — blocked by 119 pre-existing SDK typing errors outside the changed file
- `yarn typecheck` — blocked by 4 pre-existing `ProcessEnv` typing errors in API server workspaces
