### PR TITLE
fix: fallback to pool alert banner subtitle when message is empty in pool information card

### DIFF
--- a/apps/main/src/dex/features/pool-information/components/Alerts.tsx
+++ b/apps/main/src/dex/features/pool-information/components/Alerts.tsx
@@ -17,13 +17,13 @@ export const Alerts = ({ poolAlert, tokenAlert }: { poolAlert: PoolAlert | null;
   <Stack sx={{ gap: Spacing.sm, paddingBlockStart: Spacing.md, ':empty': { display: 'none' } }}>
     {poolAlert && !poolAlert.isDisableDeposit && !poolAlert.isInformationOnlyAndShowInForm && (
       <Alert variant="filled" severity={alertTypeToSeverity[poolAlert.alertType]}>
-        {poolAlert.message}
+        {poolAlert.message ?? poolAlert.banner?.subtitle}
       </Alert>
     )}
 
     {tokenAlert && tokenAlert.isInformationOnly && (
       <Alert variant="filled" severity={alertTypeToSeverity[tokenAlert.alertType]}>
-        {tokenAlert.message}
+        {tokenAlert.message ?? poolAlert?.banner?.subtitle}
       </Alert>
     )}
   </Stack>


### PR DESCRIPTION
This alert component needs a proper replacement in the future but this'll fix the issue at hand.

**Before**
<img width="1183" height="687" alt="image" src="https://github.com/user-attachments/assets/262b1047-c004-4d6e-aadd-0b4cc0f9b5a4" />

**After**
<img width="1032" height="280" alt="image" src="https://github.com/user-attachments/assets/df40377d-a612-48bf-a6a2-c7fb3e93c985" />
