### PR TITLE
fix: flaky tests

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
@@ -69,6 +69,7 @@ export const TableFiltersOverlay = ({
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       slotProps={{
         paper: {
+          ...{ 'data-testid': 'table-filters-popover-root' },
           sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
         },
         // Keep test IDs until exit completes so tests cannot reopen the popover during its closing transition.

--- a/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/TableFiltersOverlay.tsx
@@ -71,8 +71,8 @@ export const TableFiltersOverlay = ({
         paper: {
           sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
         },
-        // Set the test ID once transition is ready to avoid flaky tests clicking during transition.
-        transition: { onEntered: setReady, onExit: resetReady },
+        // Keep test IDs until exit completes so tests cannot reopen the popover during its closing transition.
+        transition: { onEntered: setReady, onExited: resetReady },
       }}
     >
       <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} {...testId('table-filters-popover', isReady)}>

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -1,6 +1,5 @@
 import { orderBy } from 'lodash'
 import { getPoolsTvlLabelRange, POOL_DEFAULT_TVL_MIN } from '@/dex/features/pool-list/filters/utils'
-import { expandFirstRowOnMobile } from '@cy/support/helpers/data-table.helpers'
 import { DEX_POOL_LIST_SEARCH, setupDexPoolListMocks } from '@cy/support/helpers/dex-pool-list-mocks'
 import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
 import { API_LOAD_TIMEOUT, type Breakpoint, LOAD_TIMEOUT, oneViewport } from '@cy/support/ui'
@@ -335,10 +334,14 @@ describe('DEX Pools', () => {
     cy.get('[data-testid="table-text-search-dex-pool-list"] input').type(filter)
     cy.url().should('include', `?search=${filter}`)
     cy.wait('@dex-pools', API_LOAD_TIMEOUT)
-    cy.contains('[data-testid^="market-link-"]', filter, API_LOAD_TIMEOUT).should('be.visible')
+    const getMatchedPoolRow = () =>
+      cy.contains('[data-testid^="data-table-row-"]', filter, API_LOAD_TIMEOUT).should('be.visible')
+
+    getMatchedPoolRow()
     if (breakpoint === 'mobile') {
-      expandFirstRowOnMobile(breakpoint)
-      cy.get(`[data-testid="pool-link-deposit"]`).click({ waitForAnimations: false })
+      getMatchedPoolRow().find('[data-testid="expand-icon"]').click()
+      getMatchedPoolRow().find('[data-testid="collapse-icon"]').should('be.visible')
+      getMatchedPoolRow().next().find('[data-testid="pool-link-deposit"]').should('be.visible').click()
     } else {
       cy.contains('[data-testid^="market-link-"]', filter).click()
     }

--- a/tests/cypress/e2e/dex/refuel.cy.ts
+++ b/tests/cypress/e2e/dex/refuel.cy.ts
@@ -29,7 +29,7 @@ describe('Refuel page', () => {
     getTestById('bi-weekly-action-info').should('contain.text', 'Bi-weekly')
     getTestById('monthly-action-info').should('contain.text', 'Monthly')
 
-    getTestById('size-action-info-value').should('have.attr', 'data-value', '-')
+    getTestById('size-action-info-value', API_LOAD_TIMEOUT).should('have.attr', 'data-value', '-')
     getTestById('weekly-action-info-value').should('have.attr', 'data-value', '-')
     getTestById('bi-weekly-action-info-value').should('have.attr', 'data-value', '-')
     getTestById('monthly-action-info-value').should('have.attr', 'data-value', '-')

--- a/tests/cypress/e2e/dex/refuel.cy.ts
+++ b/tests/cypress/e2e/dex/refuel.cy.ts
@@ -48,7 +48,7 @@ describe('Refuel page', () => {
     getTestById('prices-chart').contains('Price scale').should('be.visible')
 
     getTestById('budget-chart').should('be.visible')
-    getTestById('shares-value').invoke('attr', 'data-value').should('match', /\d/)
+    getTestById('shares-value').invoke(LOAD_TIMEOUT, 'attr', 'data-value').should('match', /\d/)
     getTestById('duration-value').invoke('attr', 'data-value').should('match', /\d/)
     getTestById('max-ratio-value').invoke('attr', 'data-value').should('match', /\d/)
     getTestById('budget-chart').contains('Refuel shares').should('be.visible')

--- a/tests/cypress/support/helpers/ComponentTestWrapper.tsx
+++ b/tests/cypress/support/helpers/ComponentTestWrapper.tsx
@@ -33,6 +33,7 @@ export function ComponentTestWrapper({ config, children, autoConnect }: Props) {
   return (
     <ThemeProvider theme="light">
       <WithWrapper Wrapper={WagmiProvider} shouldWrap={config} config={config!} reconnectOnMount={autoConnect}>
+        {/* Persistence can restore stale mocked queries after Cypress clears state, leaking data between tests. */}
         <QueryProvider persister={null} queryClient={queryClient}>
           <RouterProvider router={router} />
           <Toast />

--- a/tests/cypress/support/helpers/ComponentTestWrapper.tsx
+++ b/tests/cypress/support/helpers/ComponentTestWrapper.tsx
@@ -2,7 +2,7 @@ import { type ReactElement } from 'react'
 import { WagmiProvider, type ResolvedRegister } from 'wagmi'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { createMemoryHistory, createRootRoute, createRouter, RouterProvider } from '@tanstack/react-router'
-import { persister, queryClient, QueryProvider } from '@ui-kit/lib/api'
+import { queryClient, QueryProvider } from '@ui-kit/lib/api'
 import { ThemeProvider } from '@ui-kit/shared/ui/ThemeProvider'
 import { WithWrapper } from '@ui-kit/shared/ui/WithWrapper'
 import { Toast } from '@ui-kit/widgets/Toast'
@@ -33,7 +33,7 @@ export function ComponentTestWrapper({ config, children, autoConnect }: Props) {
   return (
     <ThemeProvider theme="light">
       <WithWrapper Wrapper={WagmiProvider} shouldWrap={config} config={config!} reconnectOnMount={autoConnect}>
-        <QueryProvider persister={persister} queryClient={queryClient}>
+        <QueryProvider persister={null} queryClient={queryClient}>
           <RouterProvider router={router} />
           <Toast />
           <ReactQueryDevtools />

--- a/tests/cypress/support/helpers/data-table.helpers.ts
+++ b/tests/cypress/support/helpers/data-table.helpers.ts
@@ -67,7 +67,7 @@ export function withFilters<T>(breakpoint: Breakpoint, callback: () => Cypress.C
       closeDrawer(breakpoint)
     } else {
       cy.get('[data-testid="btn-close-filters"]').click({ waitForAnimations: true })
-      cy.get('[data-testid="btn-close-filters"]').should('not.exist')
+      cy.get('[data-testid="table-filters-popover-root"]').should('not.exist')
     }
     return cy.wrap(result)
   })


### PR DESCRIPTION
I used the Cypress Flake Detection workflow to identify and fix flaky tests, and it worked really well. The workflow dispatched 120 Cypress jobs, grouped the failures, and then for each group I applied a targeted fix and reran the same jobs and seeds for verification.

I’m happy that the diff stayed small, the final verification passed all 120 Cypress jobs. This should drastically reduce the amount of failing tests. Also didn't test RPC tests

- isolate React Query state between Cypress component tests
- wait for the filter popover to fully unmount before reopening it
- target the matched DEX pool row during mobile expansion and navigation
- use appropriate loading timeouts for refuel data assertions

### Verification

All **120  jobs passed**: 

- [Component tests](https://github.com/curvefi/curve-frontend/actions/runs/30711892654)
- [LlamaLend E2E tests](https://github.com/curvefi/curve-frontend/actions/runs/30711893745)
- [DEX E2E tests](https://github.com/curvefi/curve-frontend/actions/runs/30711894692)
- [Other E2E tests](https://github.com/curvefi/curve-frontend/actions/runs/30711895592)