### PR TITLE
fix: rotate Cypress seed on workflow reruns

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
-          TEST_SEED: ${{ github.run_id }}-${{ matrix.count }}
+          TEST_SEED: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.count }}
 
       - uses: actions/upload-artifact@v7
         if: failure()
@@ -141,7 +141,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
-          TEST_SEED: ${{ github.run_id }}-rpc
+          TEST_SEED: ${{ github.run_id }}-${{ github.run_attempt }}-rpc
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
@@ -221,7 +221,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # send console logs to stdout in electron browser
           NODE_ENV: test
-          TEST_SEED: ${{ github.run_id }}-${{ matrix.count }}
+          TEST_SEED: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.count }}
           CYPRESS_VIDEO: ${{ matrix.browser == 'firefox' && 'false' || 'true' }} # Firefox doesn't support recording
 
       - name: Check runtime errors

--- a/.github/workflows/rpc-tests.yaml
+++ b/.github/workflows/rpc-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           ELECTRON_ENABLE_LOGGING: true # Electron writes console to stdout
           NODE_ENV: test
-          TEST_SEED: ${{ github.run_id }}-rpc
+          TEST_SEED: ${{ github.run_id }}-${{ github.run_attempt }}-rpc
           CYPRESS_TENDERLY_ACCOUNT_SLUG: ${{ vars.TENDERLY_ACCOUNT_SLUG }}
           CYPRESS_TENDERLY_PROJECT_SLUG: ${{ vars.TENDERLY_PROJECT_SLUG }}
           CYPRESS_TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,7 +46,7 @@ TEST_SEED=18273645-1 yarn cy:run:e2e --browser firefox --spec cypress/e2e/llamal
 TEST_SEED=18273645-1 yarn cy:run:component --browser firefox --spec cypress/component/<path>/<test>.cy.tsx
 ```
 
-GitHub Actions uses the run ID and test iteration as its seed. The same iteration uses the same seed across browsers, and rerunning a GitHub workflow run reuses its seeds.
+CI uses the run ID, run attempt, and test iteration as its seed. The same iteration uses the same seed across browsers within an attempt, while rerunning failed CI jobs gets a new replayable seed. The flake-detection workflow intentionally reuses its seeds when rerun.
 
 ### Flake Detection
 


### PR DESCRIPTION
The test seed introduced in https://github.com/curvefi/curve-frontend/pull/2951 makes retrying a failed test useless because retries use the same seed and therefore produce the same deterministic output.

- rotate Cypress seed on workflow reruns