### PR TITLE
chore: update curve-js to 2.69.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.69.7",
+    "@curvefi/api": "2.69.12",
     "@types/node": "26.1.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,15 +471,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/api@npm:2.69.7":
-  version: 2.69.7
-  resolution: "@curvefi/api@npm:2.69.7"
+"@curvefi/api@npm:2.69.12":
+  version: 2.69.12
+  resolution: "@curvefi/api@npm:2.69.12"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:^10.0.2"
     ethers: "npm:^6.16.0"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/e77dfb360087d1fdd78eebdd67d72c15289897dea45888abff5a3a8c7825f4e05655f15b2aa4b9d5b77419cbab8433f38209233f9b38dee6741c730e311f1b8c
+  checksum: 10c0/e4bde39d13c9a8418246da955c4614fb81dfad3f200d5fdcbc9aad99c688bf0d609cea33b86e8c2231a20ee483d0aa0d0e444f758581345afc33207e8fa4e09c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates curvejs to 2.69.12

- https://github.com/curvefi/curve-js/pull/551
- https://github.com/curvefi/curve-js/pull/552
- https://github.com/curvefi/curve-js/pull/553
- https://github.com/curvefi/curve-js/pull/555
- https://github.com/curvefi/curve-js/pull/557