### PR TITLE
chore: fix failing row expansion dex test

### DIFF
--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -341,7 +341,12 @@ describe('DEX Pools', () => {
     if (breakpoint === 'mobile') {
       getMatchedPoolRow().find('[data-testid="expand-icon"]').click()
       getMatchedPoolRow().find('[data-testid="collapse-icon"]').should('be.visible')
-      getMatchedPoolRow().next().find('[data-testid="pool-link-deposit"]').should('be.visible').click()
+      getMatchedPoolRow()
+        .next()
+        .should('have.attr', 'data-testid', 'data-table-expansion-row')
+        .find('[data-testid="pool-link-deposit"]')
+        .should('be.visible')
+        .click({ waitForAnimations: false })
     } else {
       cy.contains('[data-testid^="market-link-"]', filter).click()
     }


### PR DESCRIPTION
Even with seed this fails randomly and thus isn't a deterministic issue, so hopefully this fixes the flaky test. Suggestion was made by Cypress itself.