### PR TITLE
chore: replace pool list v2 tooltip e2e tests with component tests

### DIFF
--- a/apps/main/src/dex/features/pool-list/cells/RewardIcons.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/RewardIcons.tsx
@@ -35,7 +35,7 @@ const ExtraRewardTooltipBody = ({ reward }: { reward: ExtraReward }) => (
   </Stack>
 )
 
-const CampaignTooltip = ({ campaign, showApy }: { campaign: CampaignRewards; showApy: boolean }) => (
+export const CampaignTooltipContent = ({ campaign, showApy }: { campaign: CampaignRewards; showApy: boolean }) => (
   <Stack sx={{ gap: Spacing.sm }}>
     {showApy && campaign.reward?.type === 'apr' && (
       <Typography variant="bodySRegular" sx={{ textAlign: 'start' }}>
@@ -105,7 +105,7 @@ const CampaignRewardIcon = ({
     clickable
     placement={placement}
     testId="pool-campaign-reward-badge"
-    title={<CampaignTooltip campaign={campaign} showApy />}
+    title={<CampaignTooltipContent campaign={campaign} showApy />}
   >
     <CampaignIcon campaign={campaign} />
   </RewardIconTooltip>
@@ -150,7 +150,7 @@ export const PointsRewardIcon = ({
     clickable
     placement={placement}
     testId="pool-points-badge"
-    title={<CampaignTooltip campaign={campaign} showApy={false} />}
+    title={<CampaignTooltipContent campaign={campaign} showApy={false} />}
   >
     <Stack component="span" direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
       {showLabel && (

--- a/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
+++ b/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
@@ -1,0 +1,171 @@
+import type { ReactElement } from 'react'
+import { BaseApyTooltipContent } from '@/dex/components/BaseApyTooltipContent'
+import { CrvApyTooltipContent } from '@/dex/components/CrvApyTooltipContent'
+import { NetApyTooltipContent } from '@/dex/features/pool-list/cells/NetApyTooltipContent'
+import { CampaignTooltipContent } from '@/dex/features/pool-list/cells/RewardIcons'
+import { RewardsApyTooltipContent } from '@/dex/features/pool-list/cells/RewardsApyTooltipContent'
+import { aprToPoolApy } from '@/dex/features/pool-list/cells/utils'
+import type { PoolRow } from '@/dex/features/pool-list/types'
+import { fromDate } from '@curvefi/prices-api/timestamp'
+import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
+import type { CampaignRewards } from '@ui-kit/entities/campaigns'
+
+const CONTENT = '[data-testid="pool-tooltip-content"]'
+const POOL_ADDRESS = '0xefc6516323fbd28e80b85a497b65a86243a54b3e'
+const GAUGE_ADDRESS = '0x07a01471fa544d9c6531b631e6a96a79a9ad05e9'
+const POINTS_CAMPAIGN_LINK = 'https://www.liquity.org/forks/'
+const APR_CAMPAIGN_LINK = 'https://www.liquity.org/'
+const CAMPAIGN_ICON = 'https://cdn.jsdelivr.net/gh/curvefi/curve-assets/platforms/liquity.png'
+
+const BOLD = {
+  symbol: 'BOLD',
+  address: '0x6440f144b7e50d6a8439336510312d2f54beb01d',
+  name: 'BOLD Stablecoin',
+  decimals: 18,
+} as const
+const USDC = {
+  symbol: 'USDC',
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  name: 'USD Coin',
+  decimals: 6,
+} as const
+const EXTRA_REWARD = {
+  ...BOLD,
+  price: 1,
+  apr: 2,
+} satisfies PoolRow['extraRewardsApr'][number]
+
+const BOLD_CAMPAIGN: CampaignRewards = {
+  campaignName: 'Friendly Fork Program',
+  platform: 'Liquity',
+  platformImageId: CAMPAIGN_ICON,
+  dashboardLink: POINTS_CAMPAIGN_LINK,
+  action: 'lp',
+  tags: ['points'],
+  address: POOL_ADDRESS,
+  network: 'ethereum',
+  description:
+    'Providing liquidity earns you additional rewards from 15+ friendly forks. For more information please visit issuer.',
+  lock: false,
+  symbol: '15+',
+}
+
+const BOLD_APR_CAMPAIGN: CampaignRewards = {
+  ...BOLD_CAMPAIGN,
+  campaignName: 'BOLD liquidity rewards',
+  dashboardLink: APR_CAMPAIGN_LINK,
+  tags: ['tokens'],
+  description: 'Earn BOLD by providing liquidity.',
+  reward: { type: 'apr', value: 3, address: BOLD.address },
+  symbol: BOLD.symbol,
+}
+
+const createPool = (overrides: Partial<PoolRow> = {}): PoolRow => ({
+  chainId: 1,
+  name: 'BOLD/USDC Pool',
+  address: POOL_ADDRESS,
+  creationDate: fromDate(new Date('2025-05-18T19:37:59.000Z')),
+  poolType: 'stableswapng',
+  isMetapool: false,
+  basePool: null,
+  tvlUsd: 1_000_000,
+  tradingVolume24h: 100_000,
+  tradingFee24h: 1_000,
+  liquidityVolume24h: 90_000,
+  liquidityFee24h: 900,
+  coins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
+  baseDailyApr: 10,
+  baseWeeklyApr: 20,
+  crvApr: 5,
+  crvAprBoosted: 12.5,
+  extraRewardsApr: [EXTRA_REWARD],
+  vyperVersion: null,
+  gauge: { address: GAUGE_ADDRESS, isKilled: false },
+  gauges: [{ address: GAUGE_ADDRESS, isKilled: false }],
+  campaigns: [BOLD_CAMPAIGN, BOLD_APR_CAMPAIGN],
+  hasPosition: false,
+  hasVyperVulnerability: false,
+  network: 'ethereum',
+  url: `/dex/ethereum/pools/${POOL_ADDRESS}/deposit`,
+  ...overrides,
+})
+
+const mountContent = (content: ReactElement) =>
+  cy.mount(
+    <ComponentTestWrapper>
+      <div data-testid="pool-tooltip-content">{content}</div>
+    </ComponentTestWrapper>,
+  )
+
+const expectContent = (expected: readonly string[]) => {
+  for (const text of expected) cy.get(CONTENT).should('contain.text', text)
+}
+
+const expectLink = (href: string, text: string) =>
+  cy.get(`${CONTENT} a[href="${href}"]`).should('have.text', text).and('have.attr', 'target', '_blank')
+
+describe('V2 pool-list tooltip content', () => {
+  it('renders Base and CRV APY breakdowns without a tooltip wrapper', () => {
+    mountContent(<BaseApyTooltipContent dailyApy={aprToPoolApy(10)} weeklyApy={aprToPoolApy(20)} />)
+    cy.get(CONTENT).should('contain.text', 'past 24 hours')
+    expectContent(['Daily10.51%', 'Weekly22.09%'])
+
+    mountContent(<BaseApyTooltipContent dailyApy={0} weeklyApy={null} weekly />)
+    cy.get(CONTENT).should('contain.text', 'past 7 days')
+    expectContent(['Daily0%', 'Weekly-'])
+
+    mountContent(<BaseApyTooltipContent dailyApy={aprToPoolApy(10)} weeklyApy={aprToPoolApy(-10)} />)
+    cy.get(CONTENT).should('contain.text', 'Base APY can temporarily be negative')
+
+    mountContent(<CrvApyTooltipContent unboostedApy={aprToPoolApy(5)} maximumApy={aprToPoolApy(12.5)} />)
+    expectContent(['Unboosted5.12%', 'Max boost13.30%'])
+  })
+
+  it('renders the complete Net APY breakdown and BOLD campaign links', () => {
+    mountContent(<NetApyTooltipContent pool={createPool()} volatile={false} />)
+
+    expectContent([
+      'Base APY10.51%',
+      'Liquidity incentives10.19%',
+      'CRV5.12%',
+      'BOLD2.02%',
+      'BOLD3.04%',
+      'Net total APY20.70%',
+      'Max veCRV Boost (2.5x)13.30%',
+      'Total max veCRV APY28.87%',
+      'Points15+',
+    ])
+    cy.get(CONTENT).should('contain.text', 'weekly compounding rate').and('not.contain.text', 'unlikely to persist')
+    expectLink(APR_CAMPAIGN_LINK, '3.04%')
+    expectLink(POINTS_CAMPAIGN_LINK, '15+')
+  })
+
+  it('renders the volatile Net APY warning', () => {
+    mountContent(<NetApyTooltipContent pool={createPool()} volatile />)
+    cy.get(CONTENT).should('contain.text', 'This net APY is volatile and is unlikely to persist.')
+  })
+
+  it('renders the Rewards APY breakdown', () => {
+    mountContent(<RewardsApyTooltipContent pool={createPool()} />)
+    expectContent(['Liquidity incentives2.02%', 'BOLD2.02%', 'Campaign rewards3.04%', 'BOLD3.04%', 'Rewards APY5.06%'])
+    expectLink(APR_CAMPAIGN_LINK, '3.04%')
+  })
+
+  it('renders points and APR campaign details directly', () => {
+    mountContent(<CampaignTooltipContent campaign={BOLD_CAMPAIGN} showApy={false} />)
+
+    cy.get(CONTENT)
+      .should('contain.text', 'Friendly Fork Program')
+      .and('contain.text', 'by Liquity')
+      .and(
+        'contain.text',
+        'Providing liquidity earns you additional rewards from 15+ friendly forks. For more information please visit issuer.',
+      )
+      .and('not.contain.text', 'APY:')
+    expectLink(POINTS_CAMPAIGN_LINK, 'Go to issuer')
+
+    mountContent(<CampaignTooltipContent campaign={BOLD_APR_CAMPAIGN} showApy />)
+    expectContent(['APY: 3.04%', 'BOLD liquidity rewards', 'Earn BOLD by providing liquidity.'])
+    expectLink(APR_CAMPAIGN_LINK, 'Go to issuer')
+  })
+})

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -6,7 +6,6 @@ import {
 } from '@cy/support/helpers/dex-pool-list-v2-mocks'
 import {
   DESKTOP_VIEWPORT,
-  expectV2Tooltip,
   getV2PoolCell,
   getV2PoolRow,
   showV2PoolColumns,
@@ -64,13 +63,9 @@ describe('V2 pool-list columns', () => {
     }
 
     for (const columnId of [PoolColumnId.Volume, PoolColumnId.Tvl]) {
-      expectV2Tooltip(
-        () =>
-          getV2PoolCell(V2_POOL_FIXTURES.highRewards.address, columnId)
-            .find('[data-testid="pool-usd-value"]')
-            .should('have.text', '-'),
-        { contains: ['$0'] },
-      )
+      getV2PoolCell(V2_POOL_FIXTURES.highRewards.address, columnId)
+        .find('[data-testid="pool-usd-value"]')
+        .should('have.text', '-')
     }
 
     showV2PoolColumns(OPTIONAL_FULL_COLUMNS)
@@ -88,22 +83,9 @@ describe('V2 pool-list columns', () => {
       PoolColumnId.Age,
     ])
     getV2PoolCell(V2_POOL_FIXTURES.showcase.address, PoolColumnId.WeeklyBaseApy).should('contain.text', '22.09%')
-    const expectedExactDate = new Intl.DateTimeFormat(undefined, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    }).format(new Date(V2_POOL_FIXTURES.showcase.creation_date! * 1000))
-
-    expectV2Tooltip(
-      () =>
-        getV2PoolCell(V2_POOL_FIXTURES.showcase.address, PoolColumnId.Age)
-          .find('[data-testid="pool-age"]')
-          .should('have.text', '5 days'),
-      { contains: [expectedExactDate] },
-    )
+    getV2PoolCell(V2_POOL_FIXTURES.showcase.address, PoolColumnId.Age)
+      .find('[data-testid="pool-age"]')
+      .should('have.text', '5 days')
     getV2PoolCell(V2_POOL_FIXTURES.killed.address, PoolColumnId.Age)
       .find('[data-testid="pool-age"]')
       .should('have.text', '-')
@@ -154,7 +136,7 @@ describe('V2 pool-list columns', () => {
       .should('have.text', 'Inactive gauge')
   })
 
-  it('adds pool and token alert badges with severity colors and distinguishing tooltips', () => {
+  it('adds pool and token alert badges with severity colors', () => {
     visitV2PoolList({ viewport: DESKTOP_VIEWPORT })
 
     expectPoolBadgeSet(V2_POOL_FIXTURES.alerts.address, [
@@ -165,22 +147,19 @@ describe('V2 pool-list columns', () => {
       'badge-token-alert',
     ])
 
-    for (const { testId, severityClass, tooltipFragment } of [
+    for (const { testId, severityClass } of [
       {
         testId: 'badge-pool-alert',
         severityClass: 'MuiChip-colorAccent',
-        tooltipFragment: 'distressed CRV long positions',
       },
       {
         testId: 'badge-token-alert',
         severityClass: 'MuiChip-colorWarning',
-        tooltipFragment: 'Ren network is currently operational',
       },
     ]) {
       const getAlertBadge = () => getV2PoolRow(V2_POOL_FIXTURES.alerts.address).find(`[data-testid="${testId}"]`)
 
       getAlertBadge().should('have.class', severityClass)
-      expectV2Tooltip(getAlertBadge, { contains: [tooltipFragment] })
     }
   })
 })

--- a/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
@@ -2,7 +2,6 @@ import { setupDexPoolListV2Mocks, V2_POOL_FIXTURES } from '@cy/support/helpers/d
 import {
   MOBILE_VIEWPORT,
   expandV2PoolRow,
-  expectV2Tooltip,
   getV2PoolExpandedPanel,
   visitV2PoolList,
 } from '@cy/support/helpers/dex-pools-list-v2.helpers'
@@ -77,13 +76,6 @@ describe('V2 pool-list mobile panels', () => {
       .should('match', /^\s*-?[\d,.]+(?:\+)?%\s*→\s*-?[\d,.]+(?:\+)?%\s*$/)
 
     expectCampaignRowsToBeLinks(address, FULL_NETWORK_CAMPAIGN_IDS)
-  })
-
-  it('opens a tooltip from a metric value', () => {
-    const { address } = V2_POOL_FIXTURES.showcase
-    visitAndExpand(address)
-
-    expectV2Tooltip(() => getV2PoolExpandedPanel(address).find('[data-testid="pool-base-apy-value"]'))
   })
 
   it('shows the supported Lite metrics in the required mobile order', () => {

--- a/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
@@ -2,7 +2,6 @@ import { PoolColumnId } from '@/dex/features/pool-list/columns'
 import { setupDexPoolListV2Mocks, V2_POOL_FIXTURES } from '@cy/support/helpers/dex-pool-list-v2-mocks'
 import {
   DESKTOP_VIEWPORT,
-  expectV2Tooltip,
   getV2PoolCell,
   showV2PoolColumns,
   visitV2PoolList,
@@ -19,27 +18,6 @@ const YIELD_COLUMNS = [
   PoolColumnId.RewardsApy,
   PoolColumnId.CrvApy,
   PoolColumnId.Points,
-] as const
-
-const FULL_CAMPAIGN_LINKS = [
-  {
-    href: 'https://app.merkl.xyz/opportunities/ethereum/POOL/v2-apr-1',
-    text: '3.04%',
-  },
-  { href: 'https://app.termmax.ts.finance', text: '30x' },
-  { href: 'https://app.re.xyz/points', text: '20x' },
-  {
-    href: 'https://app.merkl.xyz/opportunities/ethereum/POOL/v2-points-1',
-    text: '-',
-  },
-  {
-    href: 'https://app.merkl.xyz/opportunities/ethereum/POOL/v2-points-2',
-    text: 'XP',
-  },
-  {
-    href: 'https://app.merkl.xyz/opportunities/ethereum/POOL/v2-points-3',
-    text: 'STAR',
-  },
 ] as const
 
 describe('V2 pool-list yields', () => {
@@ -76,54 +54,6 @@ describe('V2 pool-list yields', () => {
       cy.get(CAMPAIGN_REWARD_BADGE).should('have.length', 1)
       cy.get(CRV_REWARD_BADGE).should('not.exist')
     })
-
-    expectV2Tooltip(
-      () => getV2PoolCell(address, PoolColumnId.NetApy).find('[data-testid="pool-net-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Base APY', '10.51%'],
-          ['Liquidity incentives', '10.19%'],
-          ['CRV', '5.12%'],
-          ['Net total APY', '20.70%'],
-          ['Max veCRV Boost (2.5x)', '13.30%'],
-          ['Total max veCRV APY', '28.87%'],
-        ],
-        links: FULL_CAMPAIGN_LINKS,
-      },
-    )
-
-    expectV2Tooltip(
-      () => getV2PoolCell(address, PoolColumnId.BaseApy).find('[data-testid="pool-base-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Daily', '10.51%'],
-          ['Weekly', '22.09%'],
-        ],
-      },
-    )
-
-    expectV2Tooltip(
-      () => getV2PoolCell(address, PoolColumnId.RewardsApy).find('[data-testid="pool-rewards-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Liquidity incentives', '2.02%'],
-          ['RWD', '2.02%'],
-          ['Campaign rewards', '3.04%'],
-          ['RWD', '3.04%'],
-          ['Rewards APY', '5.06%'],
-        ],
-      },
-    )
-
-    expectV2Tooltip(
-      () => getV2PoolCell(address, PoolColumnId.CrvApy).find('[data-testid="pool-crv-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Unboosted', '5.12%'],
-          ['Max boost', '13.30%'],
-        ],
-      },
-    )
   })
 
   it('handles inactive, incomplete, empty, volatile, and high yield data', () => {
@@ -134,39 +64,17 @@ describe('V2 pool-list yields', () => {
     getV2PoolCell(killed, PoolColumnId.NetApy).should('contain.text', '6.07%')
     getV2PoolCell(killed, PoolColumnId.RewardsApy).should('contain.text', '5.06%')
     getV2PoolCell(killed, PoolColumnId.CrvApy).should('have.text', '-')
-    getV2PoolCell(killed, PoolColumnId.CrvApy).find('[data-testid="pool-crv-apy-tooltip-trigger"]').should('not.exist')
     getV2PoolCell(killed, PoolColumnId.NetApy).within(() => {
       cy.get(POINTS_BADGE).should('exist')
       cy.get(EXTRA_REWARD_BADGE).should('exist')
       cy.get(CAMPAIGN_REWARD_BADGE).should('exist')
       cy.get(CRV_REWARD_BADGE).should('not.exist')
     })
-    expectV2Tooltip(
-      () => getV2PoolCell(killed, PoolColumnId.NetApy).find('[data-testid="pool-net-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Liquidity incentives', '5.06%'],
-          ['Net total APY', '6.07%'],
-        ],
-        excludes: ['Max veCRV Boost (2.5x)'],
-      },
-    )
 
     const partial = V2_POOL_FIXTURES.partial.address
     getV2PoolCell(partial, PoolColumnId.NetApy).should('contain.text', '6.13%')
     getV2PoolCell(partial, PoolColumnId.CrvApy).should('have.text', '-')
-    getV2PoolCell(partial, PoolColumnId.CrvApy).find('[data-testid="pool-crv-apy-tooltip-trigger"]').should('not.exist')
     getV2PoolCell(partial, PoolColumnId.NetApy).find(CRV_REWARD_BADGE).should('not.exist')
-    expectV2Tooltip(
-      () => getV2PoolCell(partial, PoolColumnId.NetApy).find('[data-testid="pool-net-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['CRV', '5.12%'],
-          ['Net total APY', '6.13%'],
-        ],
-        excludes: ['Max veCRV Boost (2.5x)'],
-      },
-    )
 
     const empty = V2_POOL_FIXTURES.empty.address
     for (const column of [
@@ -179,20 +87,6 @@ describe('V2 pool-list yields', () => {
     ]) {
       getV2PoolCell(empty, column).should('have.text', '-').and('not.contain.text', '0%')
     }
-    getV2PoolCell(empty, PoolColumnId.NetApy).find('[data-testid="pool-net-apy-tooltip-trigger"]').should('not.exist')
-    getV2PoolCell(empty, PoolColumnId.RewardsApy)
-      .find('[data-testid="pool-rewards-apy-tooltip-trigger"]')
-      .should('not.exist')
-    getV2PoolCell(empty, PoolColumnId.CrvApy).find('[data-testid="pool-crv-apy-tooltip-trigger"]').should('not.exist')
-    expectV2Tooltip(
-      () => getV2PoolCell(empty, PoolColumnId.BaseApy).find('[data-testid="pool-base-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Daily', '0%'],
-          ['Weekly', '-'],
-        ],
-      },
-    )
 
     const volatile = V2_POOL_FIXTURES.volatile.address
     getV2PoolCell(volatile, PoolColumnId.NetApy).should('contain.text', '5,000+%')
@@ -200,10 +94,6 @@ describe('V2 pool-list yields', () => {
     getV2PoolCell(volatile, PoolColumnId.WeeklyBaseApy)
       .invoke('text')
       .should('match', /^-\d+\.\d+%$/)
-    expectV2Tooltip(
-      () => getV2PoolCell(volatile, PoolColumnId.NetApy).find('[data-testid="pool-net-apy-tooltip-trigger"]'),
-      { contains: [/volatile/i] },
-    )
 
     const highRewards = V2_POOL_FIXTURES.highRewards.address
     getV2PoolCell(highRewards, PoolColumnId.NetApy).should('contain.text', '11.75k%').and('not.contain.text', '5,000+%')
@@ -220,32 +110,5 @@ describe('V2 pool-list yields', () => {
 
     getV2PoolCell(address, PoolColumnId.RewardsApy).should('contain.text', '8.20%')
     getV2PoolCell(address, PoolColumnId.Points).find(POINTS_BADGE).should('have.text', 'TP')
-
-    expectV2Tooltip(
-      () => getV2PoolCell(address, PoolColumnId.RewardsApy).find('[data-testid="pool-rewards-apy-tooltip-trigger"]'),
-      {
-        rows: [
-          ['Liquidity incentives', '2.02%'],
-          ['LITE', '2.02%'],
-          ['Campaign rewards', '6.18%'],
-          ['TAPR', '6.18%'],
-          ['Rewards APY', '8.20%'],
-        ],
-        links: [
-          {
-            href: 'https://app.merkl.xyz/opportunities/taiko/POOL/v2-lite-apr-1',
-            text: '6.18%',
-          },
-        ],
-      },
-    )
-    expectV2Tooltip(() => getV2PoolCell(address, PoolColumnId.Points).find(POINTS_BADGE), {
-      links: [
-        {
-          href: 'https://app.merkl.xyz/opportunities/taiko/POOL/v2-lite-points-1',
-          text: 'Go to issuer',
-        },
-      ],
-    })
   })
 })

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -5,15 +5,6 @@ import { V2_POOL_FIXTURES } from './dex-pool-list-v2-mocks'
 export const DESKTOP_VIEWPORT = [1200, 800] as const
 export const MOBILE_VIEWPORT = [375, 800] as const
 
-const TOOLTIP = '[role="tooltip"]'
-
-export type V2TooltipExpectation = {
-  rows?: readonly (readonly [label: string, value: string])[]
-  contains?: readonly (string | RegExp)[]
-  excludes?: readonly (string | RegExp)[]
-  links?: readonly { href: string; text?: string | RegExp }[]
-}
-
 type V2PoolListNetwork = 'ethereum' | 'taiko'
 
 export const visitV2PoolList = ({
@@ -51,77 +42,6 @@ export const getV2PoolRow = (address: string) =>
 
 export const getV2PoolCell = (address: string, columnId: PoolColumnId) =>
   getV2PoolRow(address).find(`[data-testid="data-table-cell-${columnId}"]`)
-
-const normalizeText = (text: string | null | undefined) => text?.replace(/\s+/g, ' ').trim() ?? ''
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-
-const matchesText = (actual: string, expected: string | RegExp, exact = false) => {
-  if (typeof expected === 'string') return exact ? actual === expected : actual.includes(expected)
-
-  expected.lastIndex = 0
-  return expected.test(actual)
-}
-
-export const expectV2Tooltip = (
-  getTrigger: () => Cypress.Chainable<JQuery<HTMLElement>>,
-  expectation: V2TooltipExpectation = {},
-) => {
-  getTrigger().trigger('mouseover', { eventConstructor: 'MouseEvent' })
-  cy.get(TOOLTIP)
-    .filter(':visible')
-    .should('have.length', 1)
-    .should($tooltip => {
-      expect($tooltip.attr('id'), 'tooltip id').to.be.a('string')
-      expect($tooltip.attr('id'), 'tooltip id').not.to.equal('')
-    })
-    .then($tooltip => {
-      const tooltipId = $tooltip.attr('id')!
-      const ownedTooltip = `${TOOLTIP}[id="${tooltipId}"]`
-
-      getTrigger().should($trigger => {
-        const ownedTooltipId = $trigger.attr('aria-labelledby') ?? $trigger.attr('aria-describedby')
-
-        expect(ownedTooltipId, 'owned tooltip id').to.equal(tooltipId)
-      })
-
-      cy.get(ownedTooltip).should($tooltip => {
-        expect($tooltip).to.have.length(1)
-        expect($tooltip.is(':visible')).to.equal(true)
-
-        const tooltip = $tooltip[0]
-        const tooltipText = normalizeText(tooltip.textContent)
-
-        for (const [label, value] of expectation.rows ?? []) {
-          const rowPattern = new RegExp(`${escapeRegExp(label)}\\s*${escapeRegExp(value)}`)
-
-          expect(tooltipText, `tooltip row "${label}" with value "${value}"`).to.match(rowPattern)
-        }
-
-        for (const expected of expectation.contains ?? []) {
-          expect(matchesText(tooltipText, expected), `tooltip text to include ${expected.toString()}`).to.equal(true)
-        }
-        for (const excluded of expectation.excludes ?? []) {
-          expect(matchesText(tooltipText, excluded), `tooltip text to exclude ${excluded.toString()}`).to.equal(false)
-        }
-
-        const tooltipLinks = [...tooltip.querySelectorAll('a')]
-        for (const { href, text } of expectation.links ?? []) {
-          const matchingLink = tooltipLinks.find(
-            link =>
-              link.getAttribute('href') === href &&
-              (text == null || matchesText(normalizeText(link.textContent), text, typeof text === 'string')),
-          )
-
-          expect(
-            matchingLink,
-            `tooltip link "${href}"${text == null ? '' : ` with text "${text.toString()}"`}`,
-          ).not.to.equal(undefined)
-        }
-      })
-      getTrigger().trigger('mouseout', { eventConstructor: 'MouseEvent' })
-      cy.get(ownedTooltip).should('not.exist')
-    })
-}
 
 export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
   cy.get('[data-testid="btn-visibility-settings"]').click()


### PR DESCRIPTION
I kinda 'abused' e2e tests to test the shape / content of the tooltips, when a component test would be sufficient, quicker and less flaky. So this PR moves tooltip tests out of e2e and into a dedicated component test so that should get rid of the flakiness.