### PR TITLE
Revert "Merge pull request #2978 from curvefi/feat/downgrade-chains"

### DIFF
--- a/apps/main/src/dex/lib/networks.ts
+++ b/apps/main/src/dex/lib/networks.ts
@@ -303,7 +303,6 @@ export const defaultNetworks = Object.entries({
       ...getBaseNetworksConfig<NetworkEnum, ChainId>(chainId, NETWORK_BASE_CONFIG[chainId]),
       ...DEFAULT_NETWORK_CONFIG,
       ...config,
-      isLite: DOWNGRADED_CHAINS.has(chainId),
       isCrvRewardsEnabled: true,
     }
     return prev

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "resolutions": {
-    "@curvefi/api": "2.69.12",
+    "@curvefi/api": "2.69.7",
     "@types/node": "26.1.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/chains.ts
+++ b/packages/curve-ui-kit/src/features/connect-wallet/lib/wagmi/chains.ts
@@ -83,9 +83,7 @@ export const DEPRECATED_CHAINS: Record<number, Date> = {
   [aurora.id]: deprecateDate,
   [kava.id]: deprecateDate,
 }
-export const DOWNGRADED_CHAINS = new Set<number>(
-  [aurora, avalanche, celo, fantom, kava, mantle, moonbeam, sonic, xLayer, zksync].map(c => c.id),
-)
+export const DOWNGRADED_CHAINS = new Set<number>([avalanche, xLayer, sonic, fantom].map(c => c.id))
 
 /** Mapping of chain IDs to their corresponding Wagmi chain configurations for easy lookup */
 export const wagmiChainsMap = Object.fromEntries(wagmiChains.map(chain => [chain.id, chain]))

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,15 +471,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@curvefi/api@npm:2.69.12":
-  version: 2.69.12
-  resolution: "@curvefi/api@npm:2.69.12"
+"@curvefi/api@npm:2.69.7":
+  version: 2.69.7
+  resolution: "@curvefi/api@npm:2.69.7"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:^10.0.2"
     ethers: "npm:^6.16.0"
     memoizee: "npm:^0.4.17"
-  checksum: 10c0/e4bde39d13c9a8418246da955c4614fb81dfad3f200d5fdcbc9aad99c688bf0d609cea33b86e8c2231a20ee483d0aa0d0e444f758581345afc33207e8fa4e09c
+  checksum: 10c0/e77dfb360087d1fdd78eebdd67d72c15289897dea45888abff5a3a8c7825f4e05655f15b2aa4b9d5b77419cbab8433f38209233f9b38dee6741c730e311f1b8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lite networks seem to have borked even more than they used to be, reverting this change

This also reverts curve-js back to 2.69.7, as [this PR](https://github.com/curvefi/curve-js/pull/553) is most likely the biggest culprit of breaking things.