### PR TITLE
feat: enable leverage with Enso only

### DIFF
--- a/apps/main/src/llamalend/hooks/useMarketRoutes.ts
+++ b/apps/main/src/llamalend/hooks/useMarketRoutes.ts
@@ -86,15 +86,20 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
     enabled && !!slippage, // enforce slippage, important for ZapV2 but not required for API
   )
 
+  // Disabled providers can retain cached query data after switching release channels, so exclude them from selection.
   const selectedRoute = useMemo(
-    () =>
-      chosenRouter
-        ? (queries[chosenRouter].data ?? undefined)
-        : recordValues(queries)
-            .map(q => q.data)
-            .filter((q): q is RouteResponse => !!q)
-            // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
-            .sort(sortRoutes)[0],
+    () => {
+      const chosenRoute = chosenRouter && queries[chosenRouter].enabled ? queries[chosenRouter].data : undefined
+      return (
+        chosenRoute ??
+        recordValues(queries)
+          .filter(q => q.enabled)
+          .map(q => q.data)
+          .filter((q): q is RouteResponse => !!q)
+          // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
+          .sort(sortRoutes)[0]
+      )
+    },
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [chosenRouter, ...recordValues(queries)],
   )
@@ -104,7 +109,7 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
   const onChangeEffect = useEffectEvent(onChangeProp)
   useEffect(() => startTransition(() => onChangeEffect(selectedRoute)), [selectedRoute])
 
-  const selectedRouter = chosenRouter ?? selectedRoute?.router
+  const selectedRouter = chosenRouter && queries[chosenRouter].enabled ? chosenRouter : selectedRoute?.router
   const priceImpact = usePriceImpact({ params, selectedRoute, tokenIn, tokenOut, chainId }, enabled)
 
   return {

--- a/apps/main/src/llamalend/hooks/useMarketRoutes.ts
+++ b/apps/main/src/llamalend/hooks/useMarketRoutes.ts
@@ -88,18 +88,15 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
 
   // Disabled providers can retain cached query data after switching release channels, so exclude them from selection.
   const selectedRoute = useMemo(
-    () => {
-      const chosenRoute = chosenRouter && queries[chosenRouter].enabled ? queries[chosenRouter].data : undefined
-      return (
-        chosenRoute ??
-        recordValues(queries)
-          .filter(q => q.enabled)
-          .map(q => q.data)
-          .filter((q): q is RouteResponse => !!q)
-          // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
-          .sort(sortRoutes)[0]
-      )
-    },
+    () =>
+      chosenRouter && queries[chosenRouter].enabled
+        ? (queries[chosenRouter].data ?? undefined)
+        : recordValues(queries)
+            .filter(q => q.enabled)
+            .map(q => q.data)
+            .filter((q): q is RouteResponse => !!q)
+            // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
+            .sort(sortRoutes)[0],
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [chosenRouter, ...recordValues(queries)],
   )

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
@@ -7,7 +7,7 @@ import { assert, maybe, notFalsy, pick } from '@primitives/objects.utils'
 import { type RouteProvider, RouteProviders, type RouterRouteResponse } from '@primitives/router.utils'
 import { type QueryKey, useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { createHash } from '@ui-kit/entities/router-api/router-api.utils'
-import { use0xRouter } from '@ui-kit/hooks/useFeatureFlags'
+import { use0xRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { NoRetryError } from '@ui-kit/lib/model/query/factory'
@@ -192,17 +192,25 @@ export const useRouterQueries = <TData extends TGas | null, TKey extends QueryKe
 ): {
   queries: RouteQueries
   onRefresh: () => Promise<RouteResponse[][]>
-} => ({
-  queries: {
-    curve: useCurveRouterQuery(params, getRouteGasOptions, enabled),
-    'curve-solver': useRouterQuery(params, 'curve-solver', enabled),
-    enso: useRouterQuery(params, 'enso', !!params.zapAddress && enabled),
-    '0x': useRouterQuery(params, '0x', use0xRouter() && enabled),
-  },
-  onRefresh: useCallback(
-    () => Promise.all(RouteProviders.map(router => fetchApiRoutes({ ...params, router }))),
-    [params],
-  ),
-})
+} => {
+  const is0xEnabled = use0xRouter()
+  const isCurveSolverEnabled = useCurveSolverRouter()
+  const enabledProviders = RouteProviders.filter(
+    provider => (provider !== '0x' || is0xEnabled) && (provider !== 'curve-solver' || isCurveSolverEnabled),
+  )
+
+  return {
+    queries: {
+      curve: useCurveRouterQuery(params, getRouteGasOptions, enabled),
+      'curve-solver': useRouterQuery(params, 'curve-solver', isCurveSolverEnabled && enabled),
+      enso: useRouterQuery(params, 'enso', !!params.zapAddress && enabled),
+      '0x': useRouterQuery(params, '0x', is0xEnabled && enabled),
+    },
+    onRefresh: useCallback(
+      () => Promise.all(enabledProviders.map(router => fetchApiRoutes({ ...params, router }))),
+      [enabledProviders, params],
+    ),
+  }
+}
 
 export { useRouterApi, fetchApiRoutes }

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.query.ts
@@ -7,7 +7,7 @@ import { assert, maybe, notFalsy, pick } from '@primitives/objects.utils'
 import { type RouteProvider, RouteProviders, type RouterRouteResponse } from '@primitives/router.utils'
 import { type QueryKey, useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { createHash } from '@ui-kit/entities/router-api/router-api.utils'
-import { use0xRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
+import { use0xRouter, useCurveRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
 import { createValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory } from '@ui-kit/lib/model/query'
 import { NoRetryError } from '@ui-kit/lib/model/query/factory'
@@ -194,14 +194,18 @@ export const useRouterQueries = <TData extends TGas | null, TKey extends QueryKe
   onRefresh: () => Promise<RouteResponse[][]>
 } => {
   const is0xEnabled = use0xRouter()
+  const isCurveEnabled = useCurveRouter()
   const isCurveSolverEnabled = useCurveSolverRouter()
   const enabledProviders = RouteProviders.filter(
-    provider => (provider !== '0x' || is0xEnabled) && (provider !== 'curve-solver' || isCurveSolverEnabled),
+    provider =>
+      (provider !== '0x' || is0xEnabled) &&
+      (provider !== 'curve' || isCurveEnabled) &&
+      (provider !== 'curve-solver' || isCurveSolverEnabled),
   )
 
   return {
     queries: {
-      curve: useCurveRouterQuery(params, getRouteGasOptions, enabled),
+      curve: useCurveRouterQuery(params, getRouteGasOptions, isCurveEnabled && enabled),
       'curve-solver': useRouterQuery(params, 'curve-solver', isCurveSolverEnabled && enabled),
       enso: useRouterQuery(params, 'enso', !!params.zapAddress && enabled),
       '0x': useRouterQuery(params, '0x', is0xEnabled && enabled),

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -6,7 +6,7 @@ import type { Address } from '@primitives/address.utils'
 import { toArray } from '@primitives/array.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
-import { isCurveSolverRouterEnabled } from '@ui-kit/hooks/useFeatureFlags'
+import { isCurveRouterEnabled, isCurveSolverRouterEnabled } from '@ui-kit/hooks/useFeatureFlags'
 import { getReleaseChannel } from '@ui-kit/hooks/useLocalStorage'
 import { Chain, ReleaseChannel } from '@ui-kit/utils'
 import { fetchApiRoutes, getRouteById } from './router-api.query'
@@ -17,9 +17,11 @@ import type { RouteMeta, RouteMutationMeta, RoutesQuery } from './router-api.typ
  */
 export const parseRoute = (routeId: string | undefined): RouteMeta => {
   const route = getRouteById(routeId)
+  const releaseChannel = getReleaseChannel()
   assert(
-    route.router !== 'curve-solver' || isCurveSolverRouterEnabled(getReleaseChannel()),
-    'Curve Solver routes are only available in Beta',
+    (route.router !== 'curve' || isCurveRouterEnabled(releaseChannel)) &&
+      (route.router !== 'curve-solver' || isCurveSolverRouterEnabled(releaseChannel)),
+    'Curve routes are only available in Beta',
   )
   const {
     tx,
@@ -54,7 +56,11 @@ export const parseMutationRoute = (
 const SOLVER_CHAINS = [Chain.Ethereum, Chain.Arbitrum] as const
 
 export const getDefaultRouteProvider = (chainId: number, releaseChannel: ReleaseChannel) =>
-  isCurveSolverRouterEnabled(releaseChannel) && SOLVER_CHAINS.includes(chainId) ? 'curve-solver' : 'curve'
+  isCurveRouterEnabled(releaseChannel)
+    ? isCurveSolverRouterEnabled(releaseChannel) && SOLVER_CHAINS.includes(chainId)
+      ? 'curve-solver'
+      : 'curve'
+    : 'enso'
 
 /**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
@@ -66,9 +72,14 @@ export const getExpectedFn = ({
   zapAddress,
   slippage,
 }: Pick<RoutesQuery, 'chainId' | 'router' | 'slippage' | 'userAddress' | 'zapAddress'>): GetExpectedFn => {
+  const releaseChannel = getReleaseChannel()
   assert(
-    !toArray(router).includes('curve-solver') || isCurveSolverRouterEnabled(getReleaseChannel()),
-    'Curve Solver routes are only available in Beta',
+    toArray(router).every(
+      provider =>
+        (provider !== 'curve' || isCurveRouterEnabled(releaseChannel)) &&
+        (provider !== 'curve-solver' || isCurveSolverRouterEnabled(releaseChannel)),
+    ),
+    'Curve routes are only available in Beta',
   )
   return async (tokenIn, tokenOut, amountIn, blacklist) => {
     const routes = await fetchApiRoutes({

--- a/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
+++ b/packages/curve-ui-kit/src/entities/router-api/router-api.utils.ts
@@ -6,7 +6,9 @@ import type { Address } from '@primitives/address.utils'
 import { toArray } from '@primitives/array.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
-import { Chain } from '@ui-kit/utils'
+import { isCurveSolverRouterEnabled } from '@ui-kit/hooks/useFeatureFlags'
+import { getReleaseChannel } from '@ui-kit/hooks/useLocalStorage'
+import { Chain, ReleaseChannel } from '@ui-kit/utils'
 import { fetchApiRoutes, getRouteById } from './router-api.query'
 import type { RouteMeta, RouteMutationMeta, RoutesQuery } from './router-api.types'
 
@@ -14,11 +16,16 @@ import type { RouteMeta, RouteMutationMeta, RoutesQuery } from './router-api.typ
  * Converts a cached router route into the minimal zapV2 payload expected by llamalend.js.
  */
 export const parseRoute = (routeId: string | undefined): RouteMeta => {
+  const route = getRouteById(routeId)
+  assert(
+    route.router !== 'curve-solver' || isCurveSolverRouterEnabled(getReleaseChannel()),
+    'Curve Solver routes are only available in Beta',
+  )
   const {
     tx,
     amountOut: [outAmount],
     priceImpact,
-  } = getRouteById(routeId)
+  } = route
   const { to, data } = assert(tx, `No transaction information for route ${routeId}`)
   /* Enso returns no price impact when it has no usd price, the library will be updated to accept null */
   const quote = { outAmount, priceImpact: priceImpact! }
@@ -46,18 +53,24 @@ export const parseMutationRoute = (
  */
 const SOLVER_CHAINS = [Chain.Ethereum, Chain.Arbitrum] as const
 
+export const getDefaultRouteProvider = (chainId: number, releaseChannel: ReleaseChannel) =>
+  isCurveSolverRouterEnabled(releaseChannel) && SOLVER_CHAINS.includes(chainId) ? 'curve-solver' : 'curve'
+
 /**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
  */
-export const getExpectedFn =
-  ({
-    chainId,
-    router = SOLVER_CHAINS.includes(chainId) ? 'curve-solver' : 'curve', // router is unset when checking the max borrow
-    userAddress,
-    zapAddress,
-    slippage,
-  }: Pick<RoutesQuery, 'chainId' | 'router' | 'slippage' | 'userAddress' | 'zapAddress'>): GetExpectedFn =>
-  async (tokenIn, tokenOut, amountIn, blacklist) => {
+export const getExpectedFn = ({
+  chainId,
+  router = getDefaultRouteProvider(chainId, getReleaseChannel()), // router is unset when checking the max borrow
+  userAddress,
+  zapAddress,
+  slippage,
+}: Pick<RoutesQuery, 'chainId' | 'router' | 'slippage' | 'userAddress' | 'zapAddress'>): GetExpectedFn => {
+  assert(
+    !toArray(router).includes('curve-solver') || isCurveSolverRouterEnabled(getReleaseChannel()),
+    'Curve Solver routes are only available in Beta',
+  )
+  return async (tokenIn, tokenOut, amountIn, blacklist) => {
     const routes = await fetchApiRoutes({
       chainId,
       tokenIn: tokenIn as Address,
@@ -72,6 +85,7 @@ export const getExpectedFn =
     const route = assert(routes?.[0], 'No route available')
     return parseRoute(route.id).quote
   }
+}
 
 export const createHash = async (
   input: (number | string | null | undefined | readonly number[] | readonly string[])[],

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -19,6 +19,10 @@ const useAlphaChannel = () => useBetaChannel() && defaultReleaseChannel === Rele
 
 export const use0xRouter = useBetaChannel
 
+/** Curve Solver route provider for LlamaLend leverage */
+export const useCurveSolverRouter = useBetaChannel
+export const isCurveSolverRouterEnabled = (releaseChannel: ReleaseChannel) => releaseChannel === ReleaseChannel.Beta
+
 /** Reset position form for LlamaLend soft liquidation */
 export const useMarketResetPosition = useStableChannel
 

--- a/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
+++ b/packages/curve-ui-kit/src/hooks/useFeatureFlags.ts
@@ -6,7 +6,8 @@
 import { defaultReleaseChannel, ReleaseChannel } from '@ui-kit/utils'
 import { useReleaseChannel } from './useLocalStorage'
 
-const useBetaChannel = () => useReleaseChannel()[0] === ReleaseChannel.Beta
+const isBetaChannel = (releaseChannel: ReleaseChannel) => releaseChannel === ReleaseChannel.Beta
+const useBetaChannel = () => isBetaChannel(useReleaseChannel()[0])
 
 const useStableChannel = () => useReleaseChannel()[0] !== ReleaseChannel.Legacy
 
@@ -19,9 +20,11 @@ const useAlphaChannel = () => useBetaChannel() && defaultReleaseChannel === Rele
 
 export const use0xRouter = useBetaChannel
 
-/** Curve Solver route provider for LlamaLend leverage */
+/** Curve route providers for LlamaLend leverage */
+export const useCurveRouter = useBetaChannel
 export const useCurveSolverRouter = useBetaChannel
-export const isCurveSolverRouterEnabled = (releaseChannel: ReleaseChannel) => releaseChannel === ReleaseChannel.Beta
+export const isCurveRouterEnabled = isBetaChannel
+export const isCurveSolverRouterEnabled = isBetaChannel
 
 /** Reset position form for LlamaLend soft liquidation */
 export const useMarketResetPosition = useStableChannel

--- a/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
+++ b/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
@@ -8,7 +8,7 @@ import { maybes } from '@primitives/objects.utils'
 import type { RouteProvider } from '@primitives/router.utils'
 import type { BaseConfig } from '@ui/utils'
 import type { RouteQuery } from '@ui-kit/entities/router-api'
-import { use0xRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
+import { use0xRouter, useCurveRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { useEstimateGas } from '@ui-kit/lib/model/entities/gas-info'
 import { ReloadIcon } from '@ui-kit/shared/icons/ReloadIcon'
@@ -53,9 +53,11 @@ export const RouteProviderCard = ({
   const disabledTooltip = t`${RouteProviderLabels[router]} is unavailable on ${networks[chainId].name}.`
   const onClick = useCallback(() => (enabled ? onSelect(router) : undefined), [onSelect, router, enabled])
   const is0xEnabled = use0xRouter()
+  const isCurveEnabled = useCurveRouter()
   const isCurveSolverEnabled = useCurveSolverRouter()
   return (
     (is0xEnabled || router !== '0x') &&
+    (isCurveEnabled || router !== 'curve') &&
     (isCurveSolverEnabled || router !== 'curve-solver') && (
       <WithWrapper shouldWrap={!enabled} Wrapper={Tooltip} title={disabledTooltip}>
         <SelectableCard

--- a/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
+++ b/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProviderCard.tsx
@@ -8,7 +8,7 @@ import { maybes } from '@primitives/objects.utils'
 import type { RouteProvider } from '@primitives/router.utils'
 import type { BaseConfig } from '@ui/utils'
 import type { RouteQuery } from '@ui-kit/entities/router-api'
-import { use0xRouter } from '@ui-kit/hooks/useFeatureFlags'
+import { use0xRouter, useCurveSolverRouter } from '@ui-kit/hooks/useFeatureFlags'
 import { t } from '@ui-kit/lib/i18n'
 import { useEstimateGas } from '@ui-kit/lib/model/entities/gas-info'
 import { ReloadIcon } from '@ui-kit/shared/icons/ReloadIcon'
@@ -52,8 +52,11 @@ export const RouteProviderCard = ({
   const Icon = RouteProviderIcons[router]
   const disabledTooltip = t`${RouteProviderLabels[router]} is unavailable on ${networks[chainId].name}.`
   const onClick = useCallback(() => (enabled ? onSelect(router) : undefined), [onSelect, router, enabled])
+  const is0xEnabled = use0xRouter()
+  const isCurveSolverEnabled = useCurveSolverRouter()
   return (
-    (use0xRouter() || router !== '0x') && (
+    (is0xEnabled || router !== '0x') &&
+    (isCurveSolverEnabled || router !== 'curve-solver') && (
       <WithWrapper shouldWrap={!enabled} Wrapper={Tooltip} title={disabledTooltip}>
         <SelectableCard
           onClick={onClick}

--- a/tests/cypress/component/route-provider-card.cy.tsx
+++ b/tests/cypress/component/route-provider-card.cy.tsx
@@ -1,10 +1,12 @@
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import { mockedWagmiConfig } from '@cy/support/helpers/llamalend/test-wagmi.helpers'
 import { allViewports } from '@cy/support/ui'
+import type { RouteProvider } from '@primitives/router.utils'
 import type { BaseConfig } from '@ui/utils'
-import type { RouteResponse } from '@ui-kit/entities/router-api'
+import { type RouteResponse } from '@ui-kit/entities/router-api'
 import { lightTheme } from '@ui-kit/themes'
 import { constQ, q, type QueryProp } from '@ui-kit/types/util'
+import { ReleaseChannel } from '@ui-kit/utils'
 import { RouteProviderCard } from '@ui-kit/widgets/RouteProvider/RouteProviderCard'
 
 const { design } = lightTheme()
@@ -45,12 +47,14 @@ const mountRouteProviderCard = ({
   },
   isLoading = false,
   usdRate = constQ(1),
+  router = 'curve',
 }: {
   isSelected?: boolean
   enabled?: boolean
   route?: RouteResponse | null
   isLoading?: boolean
   usdRate?: QueryProp<number>
+  router?: RouteProvider
 } = {}) => {
   cy.mount(
     <ComponentTestWrapper config={mockedWagmiConfig}>
@@ -65,12 +69,26 @@ const mountRouteProviderCard = ({
         tokenOut={{ symbol: 'crvUSD', decimals: 18, usdRate }}
         isSelected={isSelected}
         bestOutputAmount="69.4241"
-        router="curve"
+        router={router}
         onSelect={() => undefined}
       />
     </ComponentTestWrapper>,
   )
 }
+
+describe('route provider release channels', () => {
+  it('shows Curve Solver on Beta', () => {
+    window.localStorage.setItem('release-channel-v1', JSON.stringify(ReleaseChannel.Beta))
+    mountRouteProviderCard({ router: 'curve-solver' })
+    cy.get('[data-testid="route-provider-card"]').should('be.visible')
+  })
+
+  it('hides Curve Solver on Stable', () => {
+    window.localStorage.setItem('release-channel-v1', JSON.stringify(ReleaseChannel.Stable))
+    mountRouteProviderCard({ router: 'curve-solver' })
+    cy.get('[data-testid="route-provider-card"]').should('not.exist')
+  })
+})
 
 allViewports().forEach(([width, height, breakpoint]) => {
   describe(`RouteProviderCard (${breakpoint})`, () => {

--- a/tests/cypress/component/route-provider-card.cy.tsx
+++ b/tests/cypress/component/route-provider-card.cy.tsx
@@ -3,10 +3,10 @@ import { mockedWagmiConfig } from '@cy/support/helpers/llamalend/test-wagmi.help
 import { allViewports } from '@cy/support/ui'
 import type { RouteProvider } from '@primitives/router.utils'
 import type { BaseConfig } from '@ui/utils'
-import { type RouteResponse } from '@ui-kit/entities/router-api'
+import { getDefaultRouteProvider, type RouteResponse } from '@ui-kit/entities/router-api'
 import { lightTheme } from '@ui-kit/themes'
 import { constQ, q, type QueryProp } from '@ui-kit/types/util'
-import { ReleaseChannel } from '@ui-kit/utils'
+import { Chain, ReleaseChannel } from '@ui-kit/utils'
 import { RouteProviderCard } from '@ui-kit/widgets/RouteProvider/RouteProviderCard'
 
 const { design } = lightTheme()
@@ -87,6 +87,18 @@ describe('route provider release channels', () => {
     window.localStorage.setItem('release-channel-v1', JSON.stringify(ReleaseChannel.Stable))
     mountRouteProviderCard({ router: 'curve-solver' })
     cy.get('[data-testid="route-provider-card"]').should('not.exist')
+  })
+
+  it('hides Curve on Stable', () => {
+    window.localStorage.setItem('release-channel-v1', JSON.stringify(ReleaseChannel.Stable))
+    mountRouteProviderCard({ router: 'curve' })
+    cy.get('[data-testid="route-provider-card"]').should('not.exist')
+  })
+
+  it('uses Enso for Stable default fetching', () => {
+    expect(getDefaultRouteProvider(Chain.Ethereum, ReleaseChannel.Beta)).to.equal('curve-solver')
+    expect(getDefaultRouteProvider(Chain.Optimism, ReleaseChannel.Beta)).to.equal('curve')
+    expect(getDefaultRouteProvider(Chain.Ethereum, ReleaseChannel.Stable)).to.equal('enso')
   })
 })
 


### PR DESCRIPTION
- move the `curve-router` and `curve-solver` leverage providers behind Beta channel