### PR TITLE
fix: make sure user debt is loaded before calculating repayment values

### DIFF
--- a/apps/main/src/llamalend/queries/repay/repay-expected-borrowed.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-expected-borrowed.query.ts
@@ -1,3 +1,4 @@
+import { getUserStateKey } from '@/llamalend/queries/user/user-state.query'
 import type { RepayQuery, RepayParams } from '@/llamalend/queries/validation/repay.types'
 import { repayValidationSuite } from '@/llamalend/queries/validation/repay.validation'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -71,4 +72,5 @@ export const {
   },
   category: 'llamalend.repay',
   validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false }),
+  dependencies: params => [getUserStateKey(params)],
 })

--- a/apps/main/src/llamalend/queries/repay/repay-is-available.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-is-available.query.ts
@@ -1,3 +1,4 @@
+import { getUserStateKey } from '@/llamalend/queries/user/user-state.query'
 import type { RepayQuery, RepayParams } from '@/llamalend/queries/validation/repay.types'
 import { repayValidationSuite } from '@/llamalend/queries/validation/repay.validation'
 import { queryFactory, rootKeys } from '@ui-kit/lib/model'
@@ -53,4 +54,5 @@ export const { useQuery: useRepayIsAvailable, invalidate: invalidateRepayIsAvail
   },
   category: 'llamalend.repay',
   validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false }),
+  dependencies: params => [getUserStateKey(params)],
 })

--- a/apps/main/src/llamalend/queries/repay/repay-is-full.query.ts
+++ b/apps/main/src/llamalend/queries/repay/repay-is-full.query.ts
@@ -1,4 +1,5 @@
 import { repayExpectedBorrowedQueryKey } from '@/llamalend/queries/repay/repay-expected-borrowed.query'
+import { getUserStateKey } from '@/llamalend/queries/user/user-state.query'
 import type { RepayQuery, RepayParams } from '@/llamalend/queries/validation/repay.types'
 import { repayValidationSuite } from '@/llamalend/queries/validation/repay.validation'
 import { queryFactory, rootKeys } from '@ui-kit/lib/model'
@@ -55,5 +56,5 @@ export const { useQuery: useRepayIsFull, invalidate: invalidateRepayIsFull } = q
   },
   category: 'llamalend.repay',
   validationSuite: repayValidationSuite({ leverageRequired: false, validateMax: false }),
-  dependencies: params => [repayExpectedBorrowedQueryKey(params)],
+  dependencies: params => [getUserStateKey(params), repayExpectedBorrowedQueryKey(params)],
 })


### PR DESCRIPTION
Realistically this race condition only happens in the tests