### PR TITLE
fix: use tradable coins instead of literally all coins for new pools list

### DIFF
--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
@@ -51,7 +51,7 @@ const AlertBadge = ({ alert, source }: { alert: PoolAlert; source: 'pool' | 'tok
 
 /** Displays classification, status, pool alert, and token alert badges for a pool. */
 export const PoolBadges = ({ pool }: { pool: PoolRow }) => {
-  const tokenAddresses = useMemo(() => pool.tradeableCoins.map(({ address }) => address), [pool.tradeableCoins])
+  const tokenAddresses = useMemo(() => pool.coins.map(({ address }) => address), [pool.coins])
   const poolAlert = usePoolAlert({
     network: pool.network,
     poolAddress: pool.address,

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
@@ -51,7 +51,7 @@ const AlertBadge = ({ alert, source }: { alert: PoolAlert; source: 'pool' | 'tok
 
 /** Displays classification, status, pool alert, and token alert badges for a pool. */
 export const PoolBadges = ({ pool }: { pool: PoolRow }) => {
-  const tokenAddresses = useMemo(() => pool.coins.map(({ address }) => address), [pool.coins])
+  const tokenAddresses = useMemo(() => pool.tradeableCoins.map(({ address }) => address), [pool.tradeableCoins])
   const poolAlert = usePoolAlert({
     network: pool.network,
     poolAddress: pool.address,

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -22,7 +22,7 @@ const PoolListTitle = memo(function PoolListTitle({ pool }: { pool: PoolRow }) {
     <Stack direction="row" sx={{ height: Height.row }}>
       {pool.hasPosition && <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />}
       <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
-        <TokenIcons blockchainId={pool.network} tokens={pool.coins} />
+        <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
           <MarketTitle url={pool.url} address={pool.address} title={pool.name} addressLabel={t`pool`} />
           <PoolBadges pool={pool} />

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -286,6 +286,7 @@ const v2Pool = z
     liquidity_volume_24h: z.number(),
     liquidity_fee_24h: z.number(),
     coins: z.array(v2Coin),
+    tradeable_coins: z.array(v2Coin),
     base_daily_apr: z.number().nullable().optional(),
     base_weekly_apr: z.number().nullable().optional(),
     crv_apr: z.number().nullable().optional(),

--- a/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
+++ b/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
@@ -74,6 +74,7 @@ const createPool = (overrides: Partial<PoolRow> = {}): PoolRow => ({
   liquidityVolume24h: 90_000,
   liquidityFee24h: 900,
   coins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
+  tradeableCoins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
   baseDailyApr: 10,
   baseWeeklyApr: 20,
   crvApr: 5,

--- a/tests/cypress/support/helpers/dex-pool-list-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-mocks.ts
@@ -87,6 +87,7 @@ const createPool = ({
   liquidity_volume_24h: 10_000 + index,
   liquidity_fee_24h: 100 + index,
   coins: createCoins(chainId),
+  tradeable_coins: createCoins(chainId),
   base_daily_apr: (index % 50) / 1_000,
   base_weekly_apr: (index % 50) / 900,
   crv_apr: null,

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -5,6 +5,14 @@ import { Chain } from '@ui-kit/utils/network'
 
 type V2PoolNetwork = 'ethereum' | 'taiko'
 
+type V2Coin = {
+  pool_index: number
+  symbol: string
+  address: Address
+  name: string
+  decimals: number
+}
+
 type RawV2Pool = {
   chain_id: number
   name: string
@@ -18,13 +26,8 @@ type RawV2Pool = {
   trading_fee_24h: number
   liquidity_volume_24h: number
   liquidity_fee_24h: number
-  coins: {
-    pool_index: number
-    symbol: string
-    address: Address
-    name: string
-    decimals: number
-  }[]
+  coins: V2Coin[]
+  tradeable_coins: V2Coin[]
   base_daily_apr: number | null
   base_weekly_apr: number | null
   crv_apr: number | null
@@ -99,6 +102,7 @@ const createPoolFixture = ({
   liquidity_volume_24h: 100_000,
   liquidity_fee_24h: 100,
   coins: createCoins(network),
+  tradeable_coins: createCoins(network),
   base_daily_apr: 1,
   base_weekly_apr: 1,
   crv_apr: null,
@@ -130,6 +134,9 @@ export const V2_POOL_FIXTURES = {
     name: 'V2 Alert Badges',
     is_metapool: true,
     coins: createCoins('ethereum').map((coin, index) =>
+      index === 0 ? { ...coin, symbol: 'renBTC', address: ALERT_TOKEN_ADDRESS, name: 'renBTC', decimals: 8 } : coin,
+    ),
+    tradeable_coins: createCoins('ethereum').map((coin, index) =>
       index === 0 ? { ...coin, symbol: 'renBTC', address: ALERT_TOKEN_ADDRESS, name: 'renBTC', decimals: 8 } : coin,
     ),
     gauges: [{ address: address('2008'), is_killed: true }],


### PR DESCRIPTION
Adds the `tradeable_coins` pools v2 API property and uses it for token icons to fix metapools showing up.

**Before**
<img width="273" height="72" alt="image" src="https://github.com/user-attachments/assets/134a0b19-e31e-4eca-b0ad-08066a625dfd" />

**After**
<img width="270" height="77" alt="image" src="https://github.com/user-attachments/assets/947d3cf8-0dbe-4be5-81be-e6787b559d90" />
