### PR TITLE
feat: add support for lite networks in new pools list

### DIFF
--- a/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
+++ b/apps/main/src/dex/components/PagePool/components/CampaignRewardsBanner.tsx
@@ -1,6 +1,5 @@
 import { useNetworkByChain } from '@/dex/entities/networks'
 import type { ChainId } from '@/dex/types/main.types'
-import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { CampaignBannerComp } from '@ui/CampaignRewards/CampaignBannerComp'
 import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
@@ -14,7 +13,7 @@ type CampaignRewardsBannerProps = {
 export const CampaignRewardsBanner = ({ chainId, address }: CampaignRewardsBannerProps) => {
   const { data: network } = useNetworkByChain({ chainId })
   const { data: campaigns } = useCampaignsByAddress({
-    blockchainId: network.networkId as Chain,
+    blockchainId: network.networkId,
     address: address as Address,
   })
   const message = campaigns.some(campaign => campaign.tags.includes('points'))

--- a/apps/main/src/dex/features/pool-information/hooks/usePointsCampaigns.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/usePointsCampaigns.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { type Address } from 'viem'
 import { useNetworkByChain } from '@/dex/entities/networks'
 import type { ChainId, PoolDataCacheOrApi } from '@/dex/types/main.types'
-import type { Chain as BlockchainId } from '@curvefi/prices-api'
 import Box from '@mui/material/Box'
 import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -21,7 +20,7 @@ export const usePointsCampaigns = ({
   const poolAddress = poolDataCacheOrApi.pool.address as Address
   const { data: network } = useNetworkByChain({ chainId })
   const { data: campaigns } = useCampaignsByAddress({
-    blockchainId: network?.networkId as BlockchainId | undefined,
+    blockchainId: network?.networkId,
     address: poolAddress,
   })
 

--- a/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
@@ -7,7 +7,6 @@ import { useNetworkByChain } from '@/dex/entities/networks'
 import { defaultNetworks } from '@/dex/lib/networks'
 import { useStore } from '@/dex/store/useStore'
 import type { ChainId, PoolDataCacheOrApi } from '@/dex/types/main.types'
-import type { Chain as BlockchainId } from '@curvefi/prices-api'
 import { maybe, maybes } from '@primitives/objects.utils'
 import { scanAddressPath, scanTokenPath } from '@ui/utils'
 import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
@@ -36,7 +35,7 @@ export const useYieldBreakdown = ({
   const rewardsApy = useStore(state => state.pools.rewardsApyMapper[chainId]?.[poolId])
 
   const { data: campaigns } = useCampaignsByAddress({
-    blockchainId: network?.networkId as BlockchainId | undefined,
+    blockchainId: network?.networkId,
     address: poolAddress,
   })
 

--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import type { NetworkConfig } from '@/dex/types/main.types'
 import Stack from '@mui/material/Stack'
-import type { ExpandedState } from '@tanstack/react-table'
+import type { ExpandedState, FilterFn } from '@tanstack/react-table'
 import { CURVE_SOCIALS } from '@ui/utils'
 import { useIsMobile, useIsTablet } from '@ui-kit/hooks/useBreakpoints'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
@@ -32,25 +32,37 @@ const POOL_EXPANDED_PANEL_BODIES = {
   lite: props => <PoolExpandedPanel {...props} variant="lite" />,
 } satisfies Record<PoolColumnVariant, ExpandedPanelComponent<PoolRow>>
 
+/** Temporary local but global pool filter for lite networks until the new API supports server-side filtering. Could've used fuse.js but meh. */
+const poolsGlobalFilter: FilterFn<PoolRow> = ({ original }, _columnId, filterValue: string) =>
+  !filterValue.trim() ||
+  ((pool: PoolRow) => [
+    pool.name,
+    pool.address,
+    pool.gauge?.address,
+    ...pool.gauges.map(({ address }) => address),
+    ...pool.coins.flatMap(({ symbol, address }) => [symbol, address]),
+  ])(original).some(value => value?.toLocaleLowerCase().includes(filterValue.trim().toLocaleLowerCase()))
+
 export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
+  const isLite = network.isLite
   const isMobile = useIsMobile()
   const [filtersOpen, , , , setFiltersOpen] = useSwitch(false)
   const filterChipRef = useRef<HTMLDivElement>(null)
   const { onPaginationChange, pagination, updateQueryAndResetPage } = usePoolsPagination()
   const { globalFilter, columnFilters, apiParams, filterProps, onSearch, resetFilters, searchText } = usePoolsFilters()
   const { onSortingChange, sortBy, sortDirection, sortField, sorting, sortOptions } = usePoolsSorting(
-    network.isLite,
+    isLite,
     updateQueryAndResetPage,
   )
 
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const { columnSettings, columnVisibility, toggleVisibility, variant } = usePoolsVisibility(LOCAL_STORAGE_KEY, {
-    isLite: network.isLite,
+    isLite,
     sorting,
   })
 
   const { isFetching, onReload, pageCount, userHasPositions, tableQuery } = usePoolsTable({
-    filters: apiParams,
+    filters: isLite ? {} : apiParams,
     network,
     page: pagination.pageIndex + 1,
     searchText,
@@ -61,18 +73,25 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   const table = useTable({
     columns: POOL_COLUMNS,
     query: tableQuery,
-    state: { expanded, sorting, pagination, columnVisibility, columnFilters, globalFilter },
+    state: {
+      expanded,
+      sorting,
+      columnVisibility,
+      globalFilter,
+      ...(!isLite && { pagination, columnFilters }),
+    },
     onExpandedChange: setExpanded,
-    onPaginationChange,
+    ...(!isLite && { onPaginationChange }),
     onSortingChange,
     manualPagination: true,
-    manualSorting: true,
-    manualFiltering: true,
-    pageCount,
+    manualSorting: !isLite,
+    manualFiltering: !isLite,
+    pageCount: isLite ? 1 : pageCount,
+    ...(isLite && { globalFilterFn: poolsGlobalFilter }),
     ...getTableOptions(tableQuery ? tableQuery.data : undefined),
   })
 
-  const hasActiveFilters = !!table.getState().columnFilters.length
+  const hasActiveFilters = !isLite && !!table.getState().columnFilters.length
 
   return (
     <Stack>
@@ -95,23 +114,29 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
           toggleVisibility={toggleVisibility}
           searchText={searchText}
           onSearch={onSearch}
-          collapsibleFilters={{
-            collapsible: (
-              <PoolsFiltersCollapsible
-                hasActiveFilters={hasActiveFilters}
-                resetFilters={resetFilters}
-                {...filterProps}
-              />
-            ),
-            hasActiveFilters,
-          }}
+          collapsibleFilters={
+            isLite
+              ? undefined
+              : {
+                  collapsible: (
+                    <PoolsFiltersCollapsible
+                      hasActiveFilters={hasActiveFilters}
+                      resetFilters={resetFilters}
+                      {...filterProps}
+                    />
+                  ),
+                  hasActiveFilters,
+                }
+          }
           filterChip={
-            <TableFiltersChip
-              popoverFilterChipRef={filterChipRef}
-              open={filtersOpen}
-              setOpen={setFiltersOpen}
-              testId="btn-open-filters-dex-pools"
-            />
+            !isLite && (
+              <TableFiltersChip
+                popoverFilterChipRef={filterChipRef}
+                open={filtersOpen}
+                setOpen={setFiltersOpen}
+                testId="btn-open-filters-dex-pools"
+              />
+            )
           }
           sortChip={
             isMobile && (
@@ -127,17 +152,19 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
         />
       </DataTable>
       {/* Keep the overlay outside DataTable children because DataTable remounts them when switching sticky header layout. */}
-      <TableFiltersOverlay
-        anchorRef={filterChipRef}
-        drawerTestId="drawer-filter-menu-dex-pools"
-        hasActiveFilters={hasActiveFilters}
-        open={filtersOpen}
-        resetFilters={resetFilters}
-        setOpen={setFiltersOpen}
-        title={t`Filter pools`}
-      >
-        <PoolsFilters {...filterProps} />
-      </TableFiltersOverlay>
+      {!isLite && (
+        <TableFiltersOverlay
+          anchorRef={filterChipRef}
+          drawerTestId="drawer-filter-menu-dex-pools"
+          hasActiveFilters={hasActiveFilters}
+          open={filtersOpen}
+          resetFilters={resetFilters}
+          setOpen={setFiltersOpen}
+          title={t`Filter pools`}
+        >
+          <PoolsFilters {...filterProps} />
+        </TableFiltersOverlay>
+      )}
     </Stack>
   )
 }

--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -20,6 +20,7 @@ import { PoolExpandedPanelActions } from './components/PoolExpandedPanelActions'
 import { PoolsFilters } from './filters/PoolsFilters'
 import { PoolsFiltersCollapsible } from './filters/PoolsFiltersCollapsible'
 import { usePoolsFilters } from './hooks/usePoolsFilters'
+import { usePoolsGlobalFilterFn } from './hooks/usePoolsGlobalFilter'
 import { usePoolsPagination } from './hooks/usePoolsPagination'
 import { usePoolsSorting } from './hooks/usePoolsSorting'
 import { usePoolsTable } from './hooks/usePoolsTable'
@@ -27,52 +28,65 @@ import { type PoolColumnVariant, usePoolsVisibility } from './hooks/usePoolsVisi
 import type { PoolRow } from './types'
 
 const LOCAL_STORAGE_KEY = 'dex-pool-list'
+const EMPTY_POOL_ROWS: readonly PoolRow[] = []
 const POOL_EXPANDED_PANEL_BODIES = {
   full: props => <PoolExpandedPanel {...props} variant="full" />,
   lite: props => <PoolExpandedPanel {...props} variant="lite" />,
 } satisfies Record<PoolColumnVariant, ExpandedPanelComponent<PoolRow>>
 
 export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
+  const isLite = network.isLite
   const isMobile = useIsMobile()
   const [filtersOpen, , , , setFiltersOpen] = useSwitch(false)
   const filterChipRef = useRef<HTMLDivElement>(null)
   const { onPaginationChange, pagination, updateQueryAndResetPage } = usePoolsPagination()
   const { globalFilter, columnFilters, apiParams, filterProps, onSearch, resetFilters, searchText } = usePoolsFilters()
   const { onSortingChange, sortBy, sortDirection, sortField, sorting, sortOptions } = usePoolsSorting(
-    network.isLite,
+    isLite,
     updateQueryAndResetPage,
   )
 
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const { columnSettings, columnVisibility, toggleVisibility, variant } = usePoolsVisibility(LOCAL_STORAGE_KEY, {
-    isLite: network.isLite,
+    isLite,
     sorting,
   })
 
   const { isFetching, onReload, pageCount, userHasPositions, tableQuery } = usePoolsTable({
-    filters: apiParams,
+    filters: isLite ? {} : apiParams,
     network,
     page: pagination.pageIndex + 1,
     searchText,
     sortBy,
     sortDirection,
   })
+  const globalFilterFn = usePoolsGlobalFilterFn(
+    isLite ? (tableQuery?.data ?? EMPTY_POOL_ROWS) : EMPTY_POOL_ROWS,
+    globalFilter,
+  )
 
   const table = useTable({
     columns: POOL_COLUMNS,
     query: tableQuery,
-    state: { expanded, sorting, pagination, columnVisibility, columnFilters, globalFilter },
+    state: {
+      expanded,
+      sorting,
+      columnVisibility,
+      globalFilter,
+      ...(!isLite && { pagination, columnFilters }),
+    },
     onExpandedChange: setExpanded,
-    onPaginationChange,
+    ...(!isLite && { onPaginationChange }),
     onSortingChange,
     manualPagination: true,
-    manualSorting: true,
-    manualFiltering: true,
-    pageCount,
+    manualSorting: !isLite,
+    manualFiltering: !isLite,
+    pageCount: isLite ? 1 : pageCount,
+    ...(isLite && { globalFilterFn }),
     ...getTableOptions(tableQuery ? tableQuery.data : undefined),
   })
 
-  const hasActiveFilters = !!table.getState().columnFilters.length
+  const hasActiveFilters = !isLite && !!table.getState().columnFilters.length
 
   return (
     <Stack>
@@ -95,23 +109,29 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
           toggleVisibility={toggleVisibility}
           searchText={searchText}
           onSearch={onSearch}
-          collapsibleFilters={{
-            collapsible: (
-              <PoolsFiltersCollapsible
-                hasActiveFilters={hasActiveFilters}
-                resetFilters={resetFilters}
-                {...filterProps}
-              />
-            ),
-            hasActiveFilters,
-          }}
+          collapsibleFilters={
+            isLite
+              ? undefined
+              : {
+                  collapsible: (
+                    <PoolsFiltersCollapsible
+                      hasActiveFilters={hasActiveFilters}
+                      resetFilters={resetFilters}
+                      {...filterProps}
+                    />
+                  ),
+                  hasActiveFilters,
+                }
+          }
           filterChip={
-            <TableFiltersChip
-              popoverFilterChipRef={filterChipRef}
-              open={filtersOpen}
-              setOpen={setFiltersOpen}
-              testId="btn-open-filters-dex-pools"
-            />
+            !isLite && (
+              <TableFiltersChip
+                popoverFilterChipRef={filterChipRef}
+                open={filtersOpen}
+                setOpen={setFiltersOpen}
+                testId="btn-open-filters-dex-pools"
+              />
+            )
           }
           sortChip={
             isMobile && (
@@ -127,17 +147,19 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
         />
       </DataTable>
       {/* Keep the overlay outside DataTable children because DataTable remounts them when switching sticky header layout. */}
-      <TableFiltersOverlay
-        anchorRef={filterChipRef}
-        drawerTestId="drawer-filter-menu-dex-pools"
-        hasActiveFilters={hasActiveFilters}
-        open={filtersOpen}
-        resetFilters={resetFilters}
-        setOpen={setFiltersOpen}
-        title={t`Filter pools`}
-      >
-        <PoolsFilters {...filterProps} />
-      </TableFiltersOverlay>
+      {!isLite && (
+        <TableFiltersOverlay
+          anchorRef={filterChipRef}
+          drawerTestId="drawer-filter-menu-dex-pools"
+          hasActiveFilters={hasActiveFilters}
+          open={filtersOpen}
+          resetFilters={resetFilters}
+          setOpen={setFiltersOpen}
+          title={t`Filter pools`}
+        >
+          <PoolsFilters {...filterProps} />
+        </TableFiltersOverlay>
+      )}
     </Stack>
   )
 }

--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -60,6 +60,7 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
     sortBy,
     sortDirection,
   })
+
   const globalFilterFn = usePoolsGlobalFilterFn(
     isLite ? (tableQuery?.data ?? EMPTY_POOL_ROWS) : EMPTY_POOL_ROWS,
     globalFilter,
@@ -99,7 +100,11 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
           button: { label: t`Show all pools`, onClick: resetFilters, testId: 'dex-pool-empty-state-reset' },
           secondaryButton: { label: t`Telegram`, href: CURVE_SOCIALS.telegram.en },
         }}
-        errorState={{ title: t`Unable to retrieve pool list`, onReload }}
+        errorState={{
+          title: t`Unable to retrieve pool list`,
+          description: tableQuery.error?.message,
+          onReload,
+        }}
         expandedPanel={{ Body: POOL_EXPANDED_PANEL_BODIES[variant], Actions: PoolExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >

--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -14,7 +14,7 @@ import { TableFiltersChip } from '@ui-kit/shared/ui/DataTable/TableFiltersChip'
 import { TableFiltersOverlay } from '@ui-kit/shared/ui/DataTable/TableFiltersOverlay'
 import { TableHeader } from '@ui-kit/shared/ui/DataTable/TableHeader'
 import { TableSortDrawer } from '@ui-kit/shared/ui/DataTable/TableSortDrawer'
-import { POOL_COLUMNS, PoolColumnId } from './columns'
+import { LITE_POOL_COLUMNS, POOL_COLUMNS, PoolColumnId } from './columns'
 import { PoolExpandedPanel } from './components/PoolExpandedPanel'
 import { PoolExpandedPanelActions } from './components/PoolExpandedPanelActions'
 import { PoolsFilters } from './filters/PoolsFilters'
@@ -67,7 +67,7 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   )
 
   const table = useTable({
-    columns: POOL_COLUMNS,
+    columns: isLite ? LITE_POOL_COLUMNS : POOL_COLUMNS,
     query: tableQuery,
     state: {
       expanded,

--- a/apps/main/src/dex/features/pool-list/cells/PointsCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PointsCell.tsx
@@ -28,7 +28,6 @@ export const PointsCell = ({ pool }: { pool: PoolRow }) => {
         columnGap: Spacing.sm,
         rowGap: Spacing.xs,
         justifyContent: 'flex-end',
-        maxWidth: '12rem',
       }}
     >
       {campaigns.map((campaign, index) => (

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
@@ -3,7 +3,6 @@ import { usePoolAlert } from '@/dex/hooks/usePoolAlert'
 import { useTokenAlert } from '@/dex/hooks/useTokenAlert'
 import type { AlertType, PoolAlert } from '@/dex/types/main.types'
 import { AlertIcons } from '@/dex/utils/alerts'
-import type { PoolType } from '@curvefi/prices-api/pools'
 import Stack from '@mui/material/Stack'
 import { t } from '@ui-kit/lib/i18n'
 import { Badge, type BadgeProps } from '@ui-kit/shared/ui/Badge'
@@ -12,6 +11,7 @@ import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import type { PoolRow } from '../../types'
 
 const { Spacing } = SizesAndSpaces
+type PoolType = NonNullable<PoolRow['poolType']>
 
 const poolTypeClassifications: Record<PoolType, 'stable' | 'volatile'> = {
   main: 'stable',

--- a/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
+++ b/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
@@ -28,7 +28,7 @@ type PoolColumnOptions = Omit<PoolColumn, 'id' | 'header'>
 
 const columnHelper = createColumnHelper<PoolRow>()
 
-// TanStack requires an accessorFn for sorting controls, even when it's a computed value rather than a direct property; manualSorting leaves ordering to the v2 pools API.
+// TanStack requires an accessorFn for sorting controls, even when it's a computed value rather than a direct property; manualSorting leaves ordering to the v2 pools API on full networks.
 const serverSortableAccessor = () => 0
 
 const createTooltip = (id: keyof typeof POOL_TITLES, body: ReactNode): Tooltip => ({
@@ -53,78 +53,85 @@ const accessor = (
     header: POOL_TITLES[id],
   })
 
-export const POOL_COLUMNS = [
-  accessor(PoolColumnId.PoolName, 'name', {
-    cell: PoolTitleCell,
-    meta: { tooltip: createTooltip(PoolColumnId.PoolName, <PoolHeaderTooltipContent />) },
-  }),
-  accessor(PoolColumnId.NetApy, serverSortableAccessor, {
-    cell: ({ row }) => <NetApyCell pool={row.original} />,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.NetApy, <NetApyHeaderTooltipContent />),
-    },
-  }),
-  accessor(PoolColumnId.BaseApy, 'baseDailyApr', {
-    cell: BaseApyCell,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.BaseApy, <BaseApyHeaderTooltipContent />),
-    },
-    sortUndefined: 'last',
-  }),
-  accessor(PoolColumnId.WeeklyBaseApy, 'baseWeeklyApr', {
-    cell: WeeklyBaseApyCell,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.WeeklyBaseApy, <BaseApyHeaderTooltipContent weekly />),
-    },
-    sortUndefined: 'last',
-  }),
-  accessor(PoolColumnId.CrvApy, serverSortableAccessor, {
-    cell: ({ row }) => <CrvApyCell pool={row.original} />,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.CrvApy, <CrvApyHeaderTooltipContent />),
-    },
-  }),
-  accessor(PoolColumnId.RewardsApy, serverSortableAccessor, {
-    cell: ({ row }) => <RewardsApyCell pool={row.original} />,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.RewardsApy, <RewardsApyHeaderTooltipContent />),
-    },
-  }),
-  display(PoolColumnId.Points, {
-    cell: ({ row }) => <PointsCell pool={row.original} />,
-    enableSorting: false,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.Points, <PointsHeaderTooltipContent />),
-    },
-  }),
-  accessor(PoolColumnId.Volume, 'tradingVolume24h', {
-    cell: UsdCell,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.Volume, <VolumeHeaderTooltipContent />),
-    },
-    sortUndefined: 'last',
-  }),
-  accessor(PoolColumnId.Tvl, 'tvlUsd', {
-    cell: UsdCell,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.Tvl, <TvlHeaderTooltipContent />),
-    },
-    sortUndefined: 'last',
-  }),
-  accessor(PoolColumnId.Age, 'creationDate', {
-    cell: AgeCell,
-    meta: {
-      type: 'numeric',
-      tooltip: createTooltip(PoolColumnId.Age, <AgeHeaderTooltipContent />),
-    },
-    sortUndefined: 'last',
-  }),
-] satisfies PoolColumn[]
+const createPoolColumns = ({ isLite }: { isLite: boolean }) =>
+  [
+    accessor(PoolColumnId.PoolName, 'name', {
+      cell: PoolTitleCell,
+      meta: { tooltip: createTooltip(PoolColumnId.PoolName, <PoolHeaderTooltipContent />) },
+    }),
+    accessor(PoolColumnId.NetApy, serverSortableAccessor, {
+      cell: ({ row }) => <NetApyCell pool={row.original} />,
+      enableSorting: !isLite,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.NetApy, <NetApyHeaderTooltipContent />),
+      },
+    }),
+    accessor(PoolColumnId.BaseApy, 'baseDailyApr', {
+      cell: BaseApyCell,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.BaseApy, <BaseApyHeaderTooltipContent />),
+      },
+      sortUndefined: 'last',
+    }),
+    accessor(PoolColumnId.WeeklyBaseApy, 'baseWeeklyApr', {
+      cell: WeeklyBaseApyCell,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.WeeklyBaseApy, <BaseApyHeaderTooltipContent weekly />),
+      },
+      sortUndefined: 'last',
+    }),
+    accessor(PoolColumnId.CrvApy, serverSortableAccessor, {
+      cell: ({ row }) => <CrvApyCell pool={row.original} />,
+      enableSorting: !isLite,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.CrvApy, <CrvApyHeaderTooltipContent />),
+      },
+    }),
+    accessor(PoolColumnId.RewardsApy, serverSortableAccessor, {
+      cell: ({ row }) => <RewardsApyCell pool={row.original} />,
+      enableSorting: !isLite,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.RewardsApy, <RewardsApyHeaderTooltipContent />),
+      },
+    }),
+    display(PoolColumnId.Points, {
+      cell: ({ row }) => <PointsCell pool={row.original} />,
+      enableSorting: false,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.Points, <PointsHeaderTooltipContent />),
+      },
+    }),
+    accessor(PoolColumnId.Volume, 'tradingVolume24h', {
+      cell: UsdCell,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.Volume, <VolumeHeaderTooltipContent />),
+      },
+      sortUndefined: 'last',
+    }),
+    accessor(PoolColumnId.Tvl, 'tvlUsd', {
+      cell: UsdCell,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.Tvl, <TvlHeaderTooltipContent />),
+      },
+      sortUndefined: 'last',
+    }),
+    accessor(PoolColumnId.Age, 'creationDate', {
+      cell: AgeCell,
+      meta: {
+        type: 'numeric',
+        tooltip: createTooltip(PoolColumnId.Age, <AgeHeaderTooltipContent />),
+      },
+      sortUndefined: 'last',
+    }),
+  ] satisfies PoolColumn[]
+
+export const POOL_COLUMNS = createPoolColumns({ isLite: false })
+export const LITE_POOL_COLUMNS = createPoolColumns({ isLite: true })

--- a/apps/main/src/dex/features/pool-list/columns/column.options.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.options.ts
@@ -10,8 +10,8 @@ const createVisibility = ({ isLite }: { isLite: boolean }): VisibilityGroup<Pool
       {
         label: POOL_TITLES[PoolColumnId.NetApy],
         columns: [PoolColumnId.NetApy],
-        active: !isLite,
-        enabled: !isLite,
+        active: true,
+        enabled: true,
       },
       {
         label: POOL_TITLES[PoolColumnId.BaseApy],
@@ -29,7 +29,7 @@ const createVisibility = ({ isLite }: { isLite: boolean }): VisibilityGroup<Pool
         label: POOL_TITLES[PoolColumnId.CrvApy],
         columns: [PoolColumnId.CrvApy],
         active: false,
-        enabled: !isLite,
+        enabled: true,
       },
       {
         label: POOL_TITLES[PoolColumnId.RewardsApy],
@@ -47,8 +47,8 @@ const createVisibility = ({ isLite }: { isLite: boolean }): VisibilityGroup<Pool
       {
         label: POOL_TITLES[PoolColumnId.Volume],
         columns: [PoolColumnId.Volume],
-        active: true,
-        enabled: true,
+        active: !isLite,
+        enabled: !isLite,
       },
       {
         label: POOL_TITLES[PoolColumnId.Tvl],
@@ -60,7 +60,7 @@ const createVisibility = ({ isLite }: { isLite: boolean }): VisibilityGroup<Pool
         label: POOL_TITLES[PoolColumnId.Age],
         columns: [PoolColumnId.Age],
         active: false,
-        enabled: true,
+        enabled: !isLite,
       },
     ],
   },

--- a/apps/main/src/dex/features/pool-list/components/LegacyPoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/LegacyPoolExpandedPanel.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react'
 import { CampaignRewardsRow } from '@/dex/components/CampaignRewardsRow'
 import { TableCellRewardsOthers } from '@/dex/components/TableCellRewardsOthers'
 import { useNetworkFromUrl } from '@/dex/hooks/useChainId'
-import type { Chain } from '@curvefi/prices-api'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -41,7 +40,7 @@ export const LegacyPoolExpandedPanel: ExpandedPanelComponent<LegacyPoolRow> = ({
     network,
   } = poolData
   const { data: campaigns } = useCampaignsByAddress({
-    blockchainId: network as Chain,
+    blockchainId: network,
     address: address as Address,
   })
   const { volume, tvl, rewards } = poolData

--- a/apps/main/src/dex/features/pool-list/hooks/useLegacyHasPoolRewards.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/useLegacyHasPoolRewards.ts
@@ -1,6 +1,5 @@
 import { sum } from 'lodash'
 import type { RewardsApy } from '@/dex/types/main.types'
-import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { useCampaignsByAddress } from '@ui-kit/entities/campaigns'
 import type { LegacyPoolRow } from '../types'
@@ -9,7 +8,7 @@ export const hasLegacyCrvRewards = (rewards: RewardsApy | undefined) => sum(rewa
 
 export const useLegacyHasPoolRewards = (rewards: RewardsApy | undefined, poolData: LegacyPoolRow) => {
   const { data: campaigns } = useCampaignsByAddress({
-    blockchainId: poolData.network as Chain,
+    blockchainId: poolData.network,
     address: poolData?.pool?.address as Address,
   })
 

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsGlobalFilter.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsGlobalFilter.ts
@@ -1,0 +1,23 @@
+import type { FuseOptionKey } from 'fuse.js'
+import { cleanValue, useFuzzyFilterFn } from '@ui-kit/hooks/useFuzzySearch'
+import type { PoolRow } from '../types'
+
+const POOL_SEARCH_KEYS = [
+  'name',
+  { name: 'symbols', getFn: ({ coins }) => cleanValue(coins.map(({ symbol }) => symbol)) },
+  {
+    name: 'addresses',
+    getFn: ({ address, gauge, gauges, coins }) => [
+      ...new Set([
+        address,
+        ...(gauge ? [gauge.address] : []),
+        ...gauges.map(({ address }) => address),
+        ...coins.map(({ address }) => address),
+      ]),
+    ],
+  },
+] satisfies FuseOptionKey<PoolRow>[]
+
+/** Client-side search filter for the new pools list. */
+export const usePoolsGlobalFilterFn = (data: readonly PoolRow[], filterValue: string) =>
+  useFuzzyFilterFn(data, filterValue, POOL_SEARCH_KEYS)

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
@@ -21,7 +21,7 @@ const POOL_SORT_BY = {
 type PoolSortableColumn = keyof typeof POOL_SORT_BY
 
 const SORT_QUERY_FIELD = 'sort'
-const LITE_SORT_COLUMNS = new Set<string>([PoolColumnId.PoolName, PoolColumnId.Volume, PoolColumnId.Tvl])
+const LITE_SORT_COLUMNS = new Set<PoolColumnId>([PoolColumnId.PoolName, PoolColumnId.Tvl])
 
 type ColumnSort = { id: PoolSortableColumn; desc: boolean }
 export type PoolsSorting = [ColumnSort]
@@ -36,7 +36,7 @@ const LITE_SORT_OPTIONS = SORT_OPTIONS.filter(({ id }) => LITE_SORT_COLUMNS.has(
 
 const getPoolsSorting = (sorting: SortingState, defaultSort: SortingState, isLite: boolean): PoolsSorting => {
   const sort = [...sorting, ...defaultSort].find(
-    ({ id }) => Object.hasOwn(POOL_SORT_BY, id) && (!isLite || LITE_SORT_COLUMNS.has(id)),
+    ({ id }) => Object.hasOwn(POOL_SORT_BY, id) && (!isLite || LITE_SORT_COLUMNS.has(id as PoolColumnId)),
   )
 
   return sort ? [{ id: sort.id as PoolSortableColumn, desc: sort.desc }] : [{ id: PoolColumnId.Tvl, desc: true }]

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
@@ -18,7 +18,7 @@ const POOL_SORT_BY = {
 type PoolSortableColumn = keyof typeof POOL_SORT_BY
 
 const SORT_QUERY_FIELD = 'sort'
-const LITE_SORT_COLUMNS = new Set<string>([PoolColumnId.PoolName, PoolColumnId.Volume, PoolColumnId.Tvl])
+const LITE_SORT_COLUMNS = new Set<PoolColumnId>([PoolColumnId.PoolName, PoolColumnId.Tvl])
 
 type ColumnSort = { id: PoolSortableColumn; desc: boolean }
 export type PoolsSorting = [ColumnSort]
@@ -33,7 +33,7 @@ const LITE_SORT_OPTIONS = SORT_OPTIONS.filter(({ id }) => LITE_SORT_COLUMNS.has(
 
 const getPoolsSorting = (sorting: SortingState, defaultSort: SortingState, isLite: boolean): PoolsSorting => {
   const sort = [...sorting, ...defaultSort].find(
-    ({ id }) => Object.hasOwn(POOL_SORT_BY, id) && (!isLite || LITE_SORT_COLUMNS.has(id)),
+    ({ id }) => Object.hasOwn(POOL_SORT_BY, id) && (!isLite || LITE_SORT_COLUMNS.has(id as PoolColumnId)),
   )
 
   return sort ? [{ id: sort.id as PoolSortableColumn, desc: sort.desc }] : [{ id: PoolColumnId.Tvl, desc: true }]

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
@@ -1,5 +1,14 @@
 import { useCallback } from 'react'
-import { resetLitePoolList, resetPoolList, useLitePoolList, usePoolList } from '@/dex/queries/pool-list.query'
+import {
+  resetLitePoolChains,
+  resetLitePoolList,
+  resetPoolChains,
+  resetPoolList,
+  useLitePoolChains,
+  useLitePoolList,
+  usePoolChains,
+  usePoolList,
+} from '@/dex/queries/pool-list.query'
 import type { NetworkConfig } from '@/dex/types/main.types'
 import { getPath } from '@/dex/utils/utilsRouter'
 import type {
@@ -11,12 +20,19 @@ import type {
 import type { Address } from '@primitives/address.utils'
 import { useCampaigns, type CampaignRewards } from '@ui-kit/entities/campaigns'
 import { DEX_ROUTES } from '@ui-kit/shared/routes'
-import { useMappedQuery } from '@ui-kit/types/util'
+import { q, useMappedQuery } from '@ui-kit/types/util'
 import { isVyperVulnerablePool } from '../alerts'
 import type { PoolsApiParams } from '../filters/utils'
 import type { PoolRow, PoolRowData } from '../types'
 import { POOLS_PAGE_SIZE } from './usePoolsPagination'
 import { usePoolsUserHasPosition } from './usePoolsUserHasPosition'
+
+class UnsupportedPoolListError extends Error {
+  constructor(readonly chainId: number) {
+    super(`The pool list is not supported on chain ${chainId}`)
+    this.name = 'UnsupportedPoolListError'
+  }
+}
 
 /** Maps Prices API pool data into the source-independent pool-list model. */
 const poolToRowData = (pool: V2Pool): PoolRowData => ({
@@ -123,6 +139,17 @@ export const usePoolsTable = ({
   sortDirection: PoolSortDirection
 }) => {
   const { chainId, id: blockchainId, isLite } = network
+
+  /** Network support */
+  const litePoolChainsQuery = useLitePoolChains({}, isLite)
+  const fullPoolChainsQuery = usePoolChains({}, !isLite)
+  const poolListSupportQuery = useMappedQuery(
+    isLite ? litePoolChainsQuery : fullPoolChainsQuery,
+    useCallback(poolChains => poolChains.some(poolChain => poolChain.chainId === chainId), [chainId]),
+  )
+  const isSupported = poolListSupportQuery.data ?? false
+
+  // Preferable we'd only enable these queries when the network is supported, but that in itself is not yet supported.
   const hasUserPoolPosition = usePoolsUserHasPosition(chainId)
   const { data: campaignsByAddress } = useCampaigns({ blockchainId })
 
@@ -139,8 +166,8 @@ export const usePoolsTable = ({
 
   /** Lite pools */
   const litePoolListParams = { chainId }
-  const litePoolListQuery = useLitePoolList(litePoolListParams, isLite)
-  const liteTableQuery = useMappedQuery(
+  const litePoolListQuery = useLitePoolList(litePoolListParams, isLite && isSupported)
+  const litePoolListTableQuery = useMappedQuery(
     litePoolListQuery,
     useCallback(({ pools }) => pools.map(pool => toPoolRow(litePoolToRowData(pool))), [toPoolRow]),
   )
@@ -155,17 +182,33 @@ export const usePoolsTable = ({
     sortBy,
     sortDirection,
   }
-  const poolListQuery = usePoolList(poolListParams, !isLite)
-  const fullTableQuery = useMappedQuery(
+  const poolListQuery = usePoolList(poolListParams, !isLite && isSupported)
+  const poolListTableQuery = useMappedQuery(
     poolListQuery,
     useCallback(({ pools }) => pools.map(pool => toPoolRow(poolToRowData(pool))), [toPoolRow]),
   )
 
-  const tableQuery = isLite ? liteTableQuery : fullTableQuery
+  const tableQuery = poolListSupportQuery.data
+    ? isLite
+      ? litePoolListTableQuery
+      : poolListTableQuery
+    : q({
+        data: undefined,
+        isLoading: poolListSupportQuery.isLoading,
+        error: poolListSupportQuery.data === false ? new UnsupportedPoolListError(chainId) : poolListSupportQuery.error,
+      })
 
   return {
-    isFetching: isLite ? litePoolListQuery.isFetching : poolListQuery.isFetching,
-    onReload: () => (isLite ? resetLitePoolList(litePoolListParams) : resetPoolList(poolListParams)),
+    isFetching: isLite
+      ? litePoolChainsQuery.isFetching || litePoolListQuery.isFetching
+      : fullPoolChainsQuery.isFetching || poolListQuery.isFetching,
+    onReload: () =>
+      Promise.all([
+        resetPoolChains({}),
+        resetLitePoolChains({}),
+        resetLitePoolList(litePoolListParams),
+        resetPoolList(poolListParams),
+      ]),
     pageCount: isLite ? 1 : (poolListQuery.data?.pageCount ?? -1),
     userHasPositions: tableQuery.data?.some(({ hasPosition }) => hasPosition),
     tableQuery,

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
@@ -1,42 +1,112 @@
 import { useCallback } from 'react'
-import { resetPoolList, usePoolList } from '@/dex/queries/pool-list.query'
+import { resetLitePoolList, resetPoolList, useLitePoolList, usePoolList } from '@/dex/queries/pool-list.query'
 import type { NetworkConfig } from '@/dex/types/main.types'
 import { getPath } from '@/dex/utils/utilsRouter'
-import type { Chain } from '@curvefi/prices-api'
 import type {
+  LitePool,
   SortDirection as PoolSortDirection,
-  V2PoolSortField as PoolSortField,
   V2Pool,
+  V2PoolSortField as PoolSortField,
 } from '@curvefi/prices-api/pools'
+import type { Address } from '@primitives/address.utils'
 import { useCampaigns, type CampaignRewards } from '@ui-kit/entities/campaigns'
 import { DEX_ROUTES } from '@ui-kit/shared/routes'
 import { useMappedQuery } from '@ui-kit/types/util'
 import { isVyperVulnerablePool } from '../alerts'
 import type { PoolsApiParams } from '../filters/utils'
-import type { PoolRow } from '../types'
+import type { PoolRow, PoolRowData } from '../types'
 import { POOLS_PAGE_SIZE } from './usePoolsPagination'
 import { usePoolsUserHasPosition } from './usePoolsUserHasPosition'
 
-type PoolsCampaignsByAddress = Record<string, CampaignRewards[]>
-
-const getPoolsCampaigns = (campaignsByAddress: PoolsCampaignsByAddress | undefined, poolAddress: string) =>
-  campaignsByAddress?.[poolAddress.toLocaleLowerCase()] ?? []
-
-const getPoolListItem = (
-  network: NetworkConfig,
-  pool: V2Pool,
-  hasPosition: PoolRow['hasPosition'],
-  campaignsByAddress?: PoolsCampaignsByAddress,
-): PoolRow => ({
-  ...pool,
-  campaigns: getPoolsCampaigns(campaignsByAddress, pool.address),
-  hasPosition,
-  hasVyperVulnerability: isVyperVulnerablePool(network.chainId, pool.address),
-  network: network.id,
-  url: getPath({ network: network.id }, `${DEX_ROUTES.PAGE_POOLS}/${pool.address}/deposit`),
+/** Maps Prices API pool data into the source-independent pool-list model. */
+const poolToRowData = (pool: V2Pool): PoolRowData => ({
+  address: pool.address,
+  baseDailyApr: pool.baseDailyApr ?? undefined,
+  baseWeeklyApr: pool.baseWeeklyApr ?? undefined,
+  coins: pool.coins,
+  creationDate: pool.creationDate ?? undefined,
+  crvApr: pool.crvApr ?? undefined,
+  crvAprBoosted: pool.crvAprBoosted ?? undefined,
+  extraRewardsApr: pool.extraRewardsApr.map(({ address, apr, name, symbol }) => ({
+    address: address ?? undefined,
+    apr,
+    name: name ?? undefined,
+    symbol: symbol ?? undefined,
+  })),
+  gauge: pool.gauge ?? undefined,
+  gauges: pool.gauges,
+  isMetapool: pool.isMetapool ?? false,
+  name: pool.name,
+  poolType: pool.poolType ?? undefined,
+  tradeableCoins: pool.tradeableCoins.map(({ address, symbol }) => ({ address, symbol })),
+  tradingVolume24h: pool.tradingVolume24h,
+  tvlUsd: pool.tvlUsd ?? undefined,
 })
 
-/** Fetches the current pool page and maps API rows into table rows. */
+/** Maps API2's Lite pool shape into the source-independent pool-list model. */
+const litePoolToRowData = (pool: LitePool): PoolRowData => {
+  const gauges = [
+    ...new Set([pool.gaugeAddress, pool.rootGaugeAddress].filter((address): address is Address => address != null)),
+  ].map(address => ({ address, isKilled: pool.gaugeIsKilled ?? false }))
+  const coins = (pool.coins ?? []).map(coin => ({ address: coin.address, symbol: coin.symbol ?? '' }))
+
+  return {
+    address: pool.address,
+    baseDailyApr: undefined,
+    baseWeeklyApr: undefined,
+    coins,
+    creationDate: undefined,
+    crvApr: pool.gaugeCrvApr?.[0],
+    crvAprBoosted: pool.gaugeCrvApr?.[1],
+    extraRewardsApr: (pool.gaugeExtraRewards ?? []).flatMap(reward =>
+      reward.apr == null
+        ? []
+        : [
+            {
+              address: reward.tokenAddress,
+              apr: reward.apr,
+              decimals: Number(reward.decimals),
+              name: reward.name,
+              price: reward.tokenPrice,
+              symbol: reward.symbol,
+            },
+          ],
+    ),
+    gauge: gauges[0],
+    gauges,
+    isMetapool: pool.isMetaPool,
+    name: pool.name ?? '',
+    poolType: undefined,
+    tradeableCoins: coins,
+    tradingVolume24h: undefined,
+    tvlUsd: pool.tvl,
+  }
+}
+
+/** Enriches a pool from the API into a fully fledged table row with all necessary data. */
+const enrichPoolRow = (
+  pool: PoolRowData,
+  {
+    chainId,
+    blockchainId,
+    hasPosition,
+    campaignsByAddress,
+  }: {
+    chainId: number
+    blockchainId: string
+    hasPosition: PoolRow['hasPosition']
+    campaignsByAddress?: Record<string, CampaignRewards[]>
+  },
+): PoolRow => ({
+  ...pool,
+  campaigns: campaignsByAddress?.[pool.address.toLocaleLowerCase()] ?? [],
+  hasPosition,
+  hasVyperVulnerability: isVyperVulnerablePool(chainId, pool.address),
+  network: blockchainId,
+  url: getPath({ network: blockchainId }, `${DEX_ROUTES.PAGE_POOLS}/${pool.address}/deposit`),
+})
+
+/** Fetches the selected pool-list source and maps its API rows into table rows. */
 export const usePoolsTable = ({
   filters,
   network,
@@ -52,10 +122,32 @@ export const usePoolsTable = ({
   sortBy: PoolSortField
   sortDirection: PoolSortDirection
 }) => {
-  const hasUserPoolPosition = usePoolsUserHasPosition(network.chainId)
-  const { data: campaignsByAddress } = useCampaigns({ blockchainId: network.networkId as Chain })
+  const { chainId, id: blockchainId, isLite } = network
+  const hasUserPoolPosition = usePoolsUserHasPosition(chainId)
+  const { data: campaignsByAddress } = useCampaigns({ blockchainId })
+
+  const toPoolRow = useCallback(
+    (poolData: PoolRowData) =>
+      enrichPoolRow(poolData, {
+        chainId,
+        blockchainId,
+        hasPosition: hasUserPoolPosition(poolData.address),
+        campaignsByAddress,
+      }),
+    [chainId, blockchainId, campaignsByAddress, hasUserPoolPosition],
+  )
+
+  /** Lite pools */
+  const litePoolListParams = { chainId }
+  const litePoolListQuery = useLitePoolList(litePoolListParams, isLite)
+  const liteTableQuery = useMappedQuery(
+    litePoolListQuery,
+    useCallback(({ pools }) => pools.map(pool => toPoolRow(litePoolToRowData(pool))), [toPoolRow]),
+  )
+
+  /** Normal network pools */
   const poolListParams = {
-    chainId: network.chainId,
+    chainId,
     page,
     pageSize: POOLS_PAGE_SIZE,
     searchString: searchText || undefined,
@@ -63,22 +155,18 @@ export const usePoolsTable = ({
     sortBy,
     sortDirection,
   }
-  const poolListQuery = usePoolList(poolListParams)
-  const { data: poolList, isFetching } = poolListQuery
-
-  const tableQuery = useMappedQuery(
+  const poolListQuery = usePoolList(poolListParams, !isLite)
+  const fullTableQuery = useMappedQuery(
     poolListQuery,
-    useCallback(
-      ({ pools }) =>
-        pools.map(pool => getPoolListItem(network, pool, hasUserPoolPosition(pool.address), campaignsByAddress)),
-      [campaignsByAddress, hasUserPoolPosition, network],
-    ),
+    useCallback(({ pools }) => pools.map(pool => toPoolRow(poolToRowData(pool))), [toPoolRow]),
   )
 
+  const tableQuery = isLite ? liteTableQuery : fullTableQuery
+
   return {
-    isFetching,
-    onReload: () => resetPoolList(poolListParams),
-    pageCount: poolList?.pageCount ?? -1,
+    isFetching: isLite ? litePoolListQuery.isFetching : poolListQuery.isFetching,
+    onReload: () => (isLite ? resetLitePoolList(litePoolListParams) : resetPoolList(poolListParams)),
+    pageCount: isLite ? 1 : (poolListQuery.data?.pageCount ?? -1),
     userHasPositions: tableQuery.data?.some(({ hasPosition }) => hasPosition),
     tableQuery,
   }

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
@@ -1,16 +1,18 @@
 import { useCallback } from 'react'
-import { resetPoolList, usePoolList } from '@/dex/queries/pool-list.query'
+import { resetLitePoolList, resetPoolList, useLitePoolList, usePoolList } from '@/dex/queries/pool-list.query'
 import type { NetworkConfig } from '@/dex/types/main.types'
 import { getPath } from '@/dex/utils/utilsRouter'
-import type { Chain } from '@curvefi/prices-api'
 import type {
+  LitePool,
   SortDirection as PoolSortDirection,
   V2PoolSortField as PoolSortField,
-  V2Pool,
 } from '@curvefi/prices-api/pools'
+import type { Address } from '@primitives/address.utils'
+import { maybe } from '@primitives/objects.utils'
 import { useCampaigns, type CampaignRewards } from '@ui-kit/entities/campaigns'
 import { DEX_ROUTES } from '@ui-kit/shared/routes'
 import { useMappedQuery } from '@ui-kit/types/util'
+import { apyToApr, AVERAGE_CATEGORIES } from '@ui-kit/utils'
 import { isVyperVulnerablePool } from '../alerts'
 import type { PoolsApiParams } from '../filters/utils'
 import type { PoolRow } from '../types'
@@ -18,25 +20,70 @@ import { POOLS_PAGE_SIZE } from './usePoolsPagination'
 import { usePoolsUserHasPosition } from './usePoolsUserHasPosition'
 
 type PoolsCampaignsByAddress = Record<string, CampaignRewards[]>
+type PoolListData = Omit<PoolRow, 'campaigns' | 'hasPosition' | 'hasVyperVulnerability' | 'network' | 'url'>
 
-const getPoolsCampaigns = (campaignsByAddress: PoolsCampaignsByAddress | undefined, poolAddress: string) =>
-  campaignsByAddress?.[poolAddress.toLocaleLowerCase()] ?? []
+const POOL_COMPOUND_WINDOW = AVERAGE_CATEGORIES['dex.poolYield.compoundRate'].window
 
-const getPoolListItem = (
+// TODO: Temporary API2 APY-to-APR compatibility adapter for the beta pool list.
+// Remove when PoolRow and yield cells consume APY directly before beta graduation.
+const apyToPoolApr = (apy: number | null | undefined) => apyToApr(apy, POOL_COMPOUND_WINDOW)
+
+/** Maps API2's Lite pool shape into the source-independent pool-list model. */
+const litePoolToPool = (pool: LitePool): PoolListData => {
+  const gauges = [
+    ...new Set([pool.gaugeAddress, pool.rootGaugeAddress].filter((address): address is Address => address != null)),
+  ].map(address => ({ address, isKilled: pool.gaugeIsKilled ?? false }))
+
+  return {
+    address: pool.address,
+    baseDailyApr: null,
+    baseWeeklyApr: null,
+    coins: (pool.coins ?? []).map((coin, poolIndex) => ({
+      address: coin.address,
+      decimals: Number(coin.decimals),
+      poolIndex,
+      symbol: coin.symbol ?? '',
+    })),
+    creationDate: null,
+    crvApr: apyToPoolApr(pool.gaugeCrvApy?.[0]),
+    crvAprBoosted: apyToPoolApr(pool.gaugeCrvApy?.[1]),
+    extraRewardsApr: (pool.gaugeExtraRewards ?? []).flatMap(
+      reward =>
+        maybe(apyToPoolApr(reward.apy), apr => [
+          {
+            address: reward.tokenAddress,
+            apr,
+            decimals: Number(reward.decimals),
+            name: reward.name,
+            price: reward.tokenPrice,
+            symbol: reward.symbol,
+          },
+        ]) ?? [],
+    ),
+    gauge: gauges[0] ?? null,
+    gauges,
+    isMetapool: pool.isMetaPool,
+    name: pool.name ?? '',
+    poolType: null,
+    tvlUsd: pool.tvl,
+  }
+}
+
+const apiPoolToRow = (
   network: NetworkConfig,
-  pool: V2Pool,
+  pool: PoolListData,
   hasPosition: PoolRow['hasPosition'],
   campaignsByAddress?: PoolsCampaignsByAddress,
 ): PoolRow => ({
   ...pool,
-  campaigns: getPoolsCampaigns(campaignsByAddress, pool.address),
+  campaigns: campaignsByAddress?.[pool.address.toLocaleLowerCase()] ?? [],
   hasPosition,
   hasVyperVulnerability: isVyperVulnerablePool(network.chainId, pool.address),
   network: network.id,
   url: getPath({ network: network.id }, `${DEX_ROUTES.PAGE_POOLS}/${pool.address}/deposit`),
 })
 
-/** Fetches the current pool page and maps API rows into table rows. */
+/** Fetches the selected pool-list source and maps its API rows into table rows. */
 export const usePoolsTable = ({
   filters,
   network,
@@ -53,7 +100,21 @@ export const usePoolsTable = ({
   sortDirection: PoolSortDirection
 }) => {
   const hasUserPoolPosition = usePoolsUserHasPosition(network.chainId)
-  const { data: campaignsByAddress } = useCampaigns({ blockchainId: network.networkId as Chain })
+  const { data: campaignsByAddress } = useCampaigns({ blockchainId: network.networkId })
+
+  const litePoolListParams = { chainId: network.chainId }
+  const litePoolListQuery = useLitePoolList(litePoolListParams, network.isLite)
+  const liteTableQuery = useMappedQuery(
+    litePoolListQuery,
+    useCallback(
+      ({ pools }) =>
+        pools.map(pool =>
+          apiPoolToRow(network, litePoolToPool(pool), hasUserPoolPosition(pool.address), campaignsByAddress),
+        ),
+      [campaignsByAddress, hasUserPoolPosition, network],
+    ),
+  )
+
   const poolListParams = {
     chainId: network.chainId,
     page,
@@ -63,22 +124,22 @@ export const usePoolsTable = ({
     sortBy,
     sortDirection,
   }
-  const poolListQuery = usePoolList(poolListParams)
-  const { data: poolList, isFetching } = poolListQuery
-
-  const tableQuery = useMappedQuery(
+  const poolListQuery = usePoolList(poolListParams, !network.isLite)
+  const fullTableQuery = useMappedQuery(
     poolListQuery,
     useCallback(
       ({ pools }) =>
-        pools.map(pool => getPoolListItem(network, pool, hasUserPoolPosition(pool.address), campaignsByAddress)),
+        pools.map(pool => apiPoolToRow(network, pool, hasUserPoolPosition(pool.address), campaignsByAddress)),
       [campaignsByAddress, hasUserPoolPosition, network],
     ),
   )
 
+  const tableQuery = network.isLite ? liteTableQuery : fullTableQuery
+
   return {
-    isFetching,
-    onReload: () => resetPoolList(poolListParams),
-    pageCount: poolList?.pageCount ?? -1,
+    isFetching: network.isLite ? litePoolListQuery.isFetching : poolListQuery.isFetching,
+    onReload: () => (network.isLite ? resetLitePoolList(litePoolListParams) : resetPoolList(poolListParams)),
+    pageCount: network.isLite ? 1 : (poolListQuery.data?.pageCount ?? -1),
     userHasPositions: tableQuery.data?.some(({ hasPosition }) => hasPosition),
     tableQuery,
   }

--- a/apps/main/src/dex/features/pool-list/index.tsx
+++ b/apps/main/src/dex/features/pool-list/index.tsx
@@ -1,5 +1,4 @@
 import { useNetworkFromUrl } from '@/dex/hooks/useChainId'
-import { usePoolChains } from '@/dex/queries/pool-list.query'
 import { useDexPoolListV2 } from '@ui-kit/hooks/useFeatureFlags'
 import { ListPageWrapper } from '@ui-kit/widgets/ListPageWrapper'
 import { LegacyPoolsTable } from './LegacyPoolsTable'
@@ -8,24 +7,10 @@ import { PoolsTable } from './PoolsTable'
 export const PoolsList = () => {
   const network = useNetworkFromUrl()
   const isBetaPoolListEnabled = useDexPoolListV2()
-  const shouldLoadSupportedPoolChains = Boolean(isBetaPoolListEnabled && network && !network.isLite)
-  const { data: supportedPoolChains, isLoading } = usePoolChains({}, shouldLoadSupportedPoolChains)
-  /**
-   * Prices API v2 does not cover every full DEX network that's supplied by the curve-api.
-   * Unsupported: Moonbeam, Kava, Avalanche, Celo, Aurora, X-Layer, zkSync, Mantle.
-   */
-  const isSupported = network?.isLite ? true : supportedPoolChains?.some(({ chainId }) => chainId === network?.chainId)
-  const isPoolListReady = network?.isLite ? true : !isLoading
 
   return (
     <ListPageWrapper>
-      {network &&
-        (!isBetaPoolListEnabled || isPoolListReady) &&
-        (isBetaPoolListEnabled && isSupported ? (
-          <PoolsTable network={network} />
-        ) : (
-          <LegacyPoolsTable network={network} />
-        ))}
+      {network && (isBetaPoolListEnabled ? <PoolsTable network={network} /> : <LegacyPoolsTable network={network} />)}
     </ListPageWrapper>
   )
 }

--- a/apps/main/src/dex/features/pool-list/index.tsx
+++ b/apps/main/src/dex/features/pool-list/index.tsx
@@ -8,17 +8,19 @@ import { PoolsTable } from './PoolsTable'
 export const PoolsList = () => {
   const network = useNetworkFromUrl()
   const isBetaPoolListEnabled = useDexPoolListV2()
-  const { data: supportedPoolChains, isLoading } = usePoolChains({}, isBetaPoolListEnabled)
+  const shouldLoadSupportedPoolChains = Boolean(isBetaPoolListEnabled && network && !network.isLite)
+  const { data: supportedPoolChains, isLoading } = usePoolChains({}, shouldLoadSupportedPoolChains)
   /**
    * Prices API v2 does not cover every full DEX network that's supplied by the curve-api.
    * Unsupported: Moonbeam, Kava, Avalanche, Celo, Aurora, X-Layer, zkSync, Mantle.
    */
-  const isSupported = supportedPoolChains?.some(({ chainId }) => chainId === network?.chainId)
+  const isSupported = network?.isLite ? true : supportedPoolChains?.some(({ chainId }) => chainId === network?.chainId)
+  const isPoolListReady = network?.isLite ? true : !isLoading
 
   return (
     <ListPageWrapper>
       {network &&
-        (!isBetaPoolListEnabled || !isLoading) &&
+        (!isBetaPoolListEnabled || isPoolListReady) &&
         (isBetaPoolListEnabled && isSupported ? (
           <PoolsTable network={network} />
         ) : (

--- a/apps/main/src/dex/features/pool-list/types.ts
+++ b/apps/main/src/dex/features/pool-list/types.ts
@@ -1,16 +1,60 @@
 import type { PoolData, RewardsApy, NetworkConfig } from '@/dex/types/main.types'
 import type { INetworkName } from '@curvefi/api/lib/interfaces'
-import type { V2Pool } from '@curvefi/prices-api/pools'
+import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 
-export type PoolRow = V2Pool & {
+type PoolRowGauge = {
+  address: Address
+  isKilled: boolean
+}
+
+type PoolRowToken = {
+  address: Address
+  symbol: string
+}
+
+type PoolRowExtraReward = {
+  address: Address | undefined
+  apr: number
+  name: string | undefined
+  symbol: string | undefined
+}
+
+type PoolRowType =
+  'main' | 'crypto' | 'factory' | 'factory_crypto' | 'crvusd' | 'factory_tricrypto' | 'stableswapng' | 'twocryptong'
+
+/** Normalized pool data shared by all pool-list API adapters. */
+export type PoolRowData = {
+  address: Address
+  baseDailyApr: number | undefined
+  baseWeeklyApr: number | undefined
+  coins: PoolRowToken[]
+  creationDate: number | undefined
+  crvApr: number | undefined
+  crvAprBoosted: number | undefined
+  extraRewardsApr: PoolRowExtraReward[]
+  gauge: PoolRowGauge | undefined
+  gauges: PoolRowGauge[]
+  isMetapool: boolean
+  name: string
+  poolType: PoolRowType | undefined
+  tradeableCoins: PoolRowToken[]
+  tradingVolume24h: number | undefined
+  tvlUsd: number | undefined
+}
+
+/** Additional pool context not in the main pool data (contextual information sourced with external sources) */
+type PoolRowContext = {
   campaigns: CampaignRewards[]
   hasPosition: boolean | undefined
   hasVyperVulnerability: boolean | undefined
   network: NetworkConfig['id']
   url: string
 }
+
+/** Source-independent view model containing only data consumed by the pools table. */
+export type PoolRow = PoolRowData & PoolRowContext
 
 export type LegacyPoolTag =
   'btc' | 'crypto' | 'kava' | 'eth' | 'usd' | 'others' | 'user' | 'crvusd' | 'tricrypto' | 'stableng' | 'cross-chain'

--- a/apps/main/src/dex/features/pool-list/types.ts
+++ b/apps/main/src/dex/features/pool-list/types.ts
@@ -4,7 +4,27 @@ import type { V2Pool } from '@curvefi/prices-api/pools'
 import type { Decimal } from '@primitives/decimal.utils'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 
-export type PoolRow = V2Pool & {
+type PoolListData = Pick<
+  V2Pool,
+  | 'address'
+  | 'baseDailyApr'
+  | 'baseWeeklyApr'
+  | 'coins'
+  | 'crvApr'
+  | 'crvAprBoosted'
+  | 'extraRewardsApr'
+  | 'gauge'
+  | 'gauges'
+  | 'isMetapool'
+  | 'poolType'
+  | 'tvlUsd'
+> & {
+  creationDate?: V2Pool['creationDate']
+  name: string
+  tradingVolume24h?: V2Pool['tradingVolume24h'] | null
+}
+
+export type PoolRow = PoolListData & {
   campaigns: CampaignRewards[]
   hasPosition: boolean | undefined
   hasVyperVulnerability: boolean | undefined

--- a/apps/main/src/dex/queries/pool-list.query.ts
+++ b/apps/main/src/dex/queries/pool-list.query.ts
@@ -1,4 +1,10 @@
-import { listLitePools, listPoolChains, listPools, type ListPoolsParams } from '@curvefi/prices-api/pools'
+import {
+  listLitePoolChains,
+  listLitePools,
+  listPoolChains,
+  listPools,
+  type ListPoolsParams,
+} from '@curvefi/prices-api/pools'
 import { createValidationSuite, EmptyValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys, type ChainQuery } from '@ui-kit/lib/model'
 import { chainValidationGroup } from '@ui-kit/lib/model/query/chain-validation'
@@ -82,9 +88,16 @@ export const { reset: resetLitePoolList, useQuery: useLitePoolList } = queryFact
   category: 'dex.pools',
 })
 
-export const { useQuery: usePoolChains } = queryFactory({
+export const { reset: resetPoolChains, useQuery: usePoolChains } = queryFactory({
   queryKey: () => ['listPoolChains'] as const,
   queryFn: () => listPoolChains(),
+  validationSuite: EmptyValidationSuite,
+  category: 'dex.network',
+})
+
+export const { reset: resetLitePoolChains, useQuery: useLitePoolChains } = queryFactory({
+  queryKey: () => ['listLitePoolChains'] as const,
+  queryFn: () => listLitePoolChains(),
   validationSuite: EmptyValidationSuite,
   category: 'dex.network',
 })

--- a/apps/main/src/dex/queries/pool-list.query.ts
+++ b/apps/main/src/dex/queries/pool-list.query.ts
@@ -1,4 +1,4 @@
-import { listPoolChains, listPools, type ListPoolsParams } from '@curvefi/prices-api/pools'
+import { listLitePools, listPoolChains, listPools, type ListPoolsParams } from '@curvefi/prices-api/pools'
 import { createValidationSuite, EmptyValidationSuite, type FieldsOf } from '@ui-kit/lib'
 import { queryFactory, rootKeys, type ChainQuery } from '@ui-kit/lib/model'
 import { chainValidationGroup } from '@ui-kit/lib/model/query/chain-validation'
@@ -70,6 +70,16 @@ export const { reset: resetPoolList, useQuery: usePoolList } = queryFactory({
   validationSuite: createValidationSuite(chainValidationGroup),
   category: 'dex.pools',
   keepPreviousData: true,
+})
+
+type LitePoolListQuery = ChainQuery
+type LitePoolListParams = FieldsOf<LitePoolListQuery>
+
+export const { reset: resetLitePoolList, useQuery: useLitePoolList } = queryFactory({
+  queryKey: ({ chainId }: LitePoolListParams) => [...rootKeys.chain({ chainId }), 'listLitePools'] as const,
+  queryFn: (params: LitePoolListQuery) => listLitePools(params),
+  validationSuite: createValidationSuite(chainValidationGroup),
+  category: 'dex.pools',
 })
 
 export const { useQuery: usePoolChains } = queryFactory({

--- a/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
+++ b/packages/curve-ui-kit/src/entities/campaigns/campaigns.ts
@@ -1,6 +1,5 @@
 import memoizee from 'memoizee'
 import { useCallback } from 'react'
-import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { fromEntries, notFalsy, objectKeys } from '@primitives/objects.utils'
 import { type QueriesResults, useQueries } from '@tanstack/react-query'
@@ -44,7 +43,7 @@ export const combineCampaigns = memoizee((campaigns: (Campaigns | undefined)[], 
   )
 })
 
-type UseCampaignsOptions = { blockchainId?: Chain; enabled?: boolean }
+type UseCampaignsOptions = { blockchainId?: string; enabled?: boolean }
 
 type CampaignQueries = [
   ReturnType<typeof getCampaignsExternalOptions>,

--- a/packages/curve-ui-kit/src/hooks/useFuzzySearch.ts
+++ b/packages/curve-ui-kit/src/hooks/useFuzzySearch.ts
@@ -1,10 +1,10 @@
-import Fuse from 'fuse.js'
+import Fuse, { type FuseOptionKey } from 'fuse.js'
 import { get, partition } from 'lodash'
 import { useMemo } from 'react'
 import type { FilterFn, Row } from '@tanstack/react-table'
 
 /** Replace ₮ with T so users don't need the special character to find Tether markets */
-const cleanValue = <T>(value: T): T =>
+export const cleanValue = <T>(value: T): T =>
   (Array.isArray(value) ? value.map(cleanValue) : typeof value === 'string' ? value.replace(/₮/g, 'T') : value) as T
 
 /** Don't search for "0x" or "0xA", it's too broad */
@@ -35,10 +35,10 @@ const splitSearchTerms = (input: string) => {
  *
  * @param data        The dataset to index. Should be referentially stable (e.g. from `useMemo`).
  * @param filterValue The raw search string entered by the user.
- * @param keys        Dot-path keys to index (both text and address fields).
+ * @param keys        Dot-path keys or custom key extractors to index (both text and address fields).
  * @returns A `Set` of matching items, or `null` if there is no active filter.
  */
-function useFuseResultSet<T>(data: readonly T[], filterValue: string, keys: string[]) {
+function useFuseResultSet<T>(data: readonly T[], filterValue: string, keys: readonly FuseOptionKey<T>[]) {
   const fuse = useMemo(
     () =>
       new Fuse(data, {
@@ -48,7 +48,7 @@ function useFuseResultSet<T>(data: readonly T[], filterValue: string, keys: stri
         minMatchCharLength: 2,
         threshold: 0.01,
         getFn: (obj, path) => cleanValue(get(obj, path)) as string,
-        keys,
+        keys: [...keys],
       }),
     [data, keys],
   )
@@ -79,7 +79,11 @@ function useFuseResultSet<T>(data: readonly T[], filterValue: string, keys: stri
 }
 
 /** Returns a stable {@link FilterFn} backed by Fuse.js, for use as TanStack Table's `globalFilterFn`. */
-export function useFuzzyFilterFn<T>(data: readonly T[], filterValue: string, keys: string[]): FilterFn<T> {
+export function useFuzzyFilterFn<T>(
+  data: readonly T[],
+  filterValue: string,
+  keys: readonly FuseOptionKey<T>[],
+): FilterFn<T> {
   const resultSet = useFuseResultSet(data, filterValue, keys)
   return useMemo(() => (row: Row<T>) => !resultSet || resultSet.has(row.original), [resultSet])
 }
@@ -88,7 +92,7 @@ export function useFuzzyFilterFn<T>(data: readonly T[], filterValue: string, key
  * Returns a filtered copy of `data` using Fuse.js fuzzy search.
  * Use this outside of TanStack Table (e.g. token selectors, dropdowns).
  */
-export function useFuzzySearch<T>(data: readonly T[], filterValue: string, keys: string[]) {
+export function useFuzzySearch<T>(data: readonly T[], filterValue: string, keys: readonly FuseOptionKey<T>[]) {
   const resultSet = useFuseResultSet(data, filterValue, keys)
   return useMemo(() => (resultSet ? data.filter(item => resultSet.has(item)) : data), [data, resultSet])
 }

--- a/packages/curve-ui-kit/src/themes/design/1_sizes_spaces.ts
+++ b/packages/curve-ui-kit/src/themes/design/1_sizes_spaces.ts
@@ -291,7 +291,7 @@ export const SizesAndSpaces = {
     connectWallet: '50rem', // 800px
     actionCard: '28rem', // 448px
     candleAndBandChart: '68.75rem', // 1100px, switches to column from row when charts start to become to small next to eachother
-    emptyStateCard: '27.5rem', // 440px
+    emptyStateCard: '35rem', // 560px
     tooltip: '27.5rem', // 440px
     chartTooltip: { mobile: '16.4rem', tablet: '20.5rem' }, // 264px/328px
     sliderInput: {

--- a/packages/curve-ui-kit/src/utils/rates.spec.ts
+++ b/packages/curve-ui-kit/src/utils/rates.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { aprToApy, apyToApr } from './rates'
+
+describe('apyToApr', () => {
+  it.each([null, undefined])('preserves a nullish APY value', apy => {
+    expect(apyToApr(apy)).toBeNull()
+  })
+
+  it('preserves zero', () => {
+    expect(apyToApr(0)).toBe(0)
+  })
+
+  it.each([
+    { apr: 1, compoundingDays: 1 },
+    { apr: 10, compoundingDays: 7 },
+    { apr: 250, compoundingDays: 30 },
+  ])('reverses APR compounding for $apr% APR every $compoundingDays days', ({ apr, compoundingDays }) => {
+    const apy = aprToApy(apr, compoundingDays)
+
+    expect(apyToApr(apy, compoundingDays)).toBeCloseTo(apr, 10)
+  })
+
+  it('uses the same default compounding window as aprToApy', () => {
+    expect(apyToApr(aprToApy(10))).toBeCloseTo(10, 10)
+  })
+})

--- a/packages/curve-ui-kit/src/utils/rates.ts
+++ b/packages/curve-ui-kit/src/utils/rates.ts
@@ -41,3 +41,19 @@ export function aprToApy(
 
   return (Math.pow(compoundedRate, periods) - 1) * 100
 }
+
+// TODO: Temporary API2 APY-to-APR compatibility adapter for the beta pool list.
+// Remove when PoolRow and yield cells consume APY directly before beta graduation.
+export function apyToApr(apyPercentage: number, compoundingDays?: number): number
+export function apyToApr(apyPercentage: number | null | undefined, compoundingDays?: number): number | null
+export function apyToApr(
+  apyPercentage: number | null | undefined,
+  compoundingDays = AVERAGE_CATEGORIES['llamalend.compoundRate'].window,
+): number | null {
+  if (apyPercentage == null) return null
+
+  const periods = DAYS_PER_YEAR / compoundingDays
+  const periodicRate = Math.pow(1 + apyPercentage / 100, 1 / periods) - 1
+
+  return periodicRate * periods * 100
+}

--- a/packages/prices-api/src/pools/index.ts
+++ b/packages/prices-api/src/pools/index.ts
@@ -6,6 +6,8 @@ import * as Schema from './schema'
 
 export type * from './schema'
 
+const LITE_POOLS_HOST = 'https://api2.curve.finance'
+
 export async function getPools(chain: Chain, options?: Options) {
   const host = getHost(options)
   const response = await fetch(`${host}/v1/chains/${chain}`)
@@ -25,6 +27,13 @@ export async function listPoolChains(options?: Options) {
   const response = await fetch(`${host}/v2/pools/chains/`)
 
   return Schema.listPoolChainsResponse.parse(response)
+}
+
+export async function listLitePools({ chainId }: { chainId: number }, options?: Options) {
+  const host = options?.host ?? LITE_POOLS_HOST
+  const response = await fetch(`${host}/get_pools/${chainId}`, { signal: options?.signal })
+
+  return Schema.listLitePoolsResponse.parse(response)
 }
 
 export type ListPoolsParams = {

--- a/packages/prices-api/src/pools/index.ts
+++ b/packages/prices-api/src/pools/index.ts
@@ -29,6 +29,13 @@ export async function listPoolChains(options?: Options) {
   return Schema.listPoolChainsResponse.parse(response)
 }
 
+export async function listLitePoolChains(options?: Options) {
+  const host = options?.host ?? LITE_POOLS_HOST
+  const response = await fetch(`${host}/get_platforms`, { signal: options?.signal })
+
+  return Schema.listLitePoolChainsResponse.parse(response)
+}
+
 export async function listLitePools({ chainId }: { chainId: number }, options?: Options) {
   const host = options?.host ?? LITE_POOLS_HOST
   const response = await fetch(`${host}/get_pools/${chainId}`, { signal: options?.signal })

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -326,17 +326,91 @@ const v2PoolChain = z
   })
   .transform(camelizeKeys)
 
-export const getPoolsResponse = z
+const litePoolCoin = z
   .object({
-    chain,
-    total: poolTotals,
-    data: z.array(pool),
+    address,
+    usd_price: z.number().nullable().optional(),
+    decimals: z.string().nullable().optional(),
+    is_base_pool_lp_token: z.boolean().default(false),
+    symbol: z.string().nullable().optional(),
+    pool_balance: z.string().nullable().optional(),
   })
-  .transform(({ chain, total, data }) => ({
-    chain,
-    totals: total,
-    pools: data,
-  }))
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraRewardApyData = z
+  .object({
+    is_reward_still_active: z.boolean(),
+    token_price: z.number().nullable().optional(),
+    rate: z.number(),
+    total_supply: z.number(),
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraRewardMetaData = z
+  .object({
+    rate: z.string(),
+    period_finish: z.number(),
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraReward = z
+  .object({
+    gauge_address: address,
+    token_address: address,
+    token_price: z.number().nullable().optional(),
+    name: z.string(),
+    symbol: z.string(),
+    decimals: z.string(),
+    apy_data: litePoolGaugeExtraRewardApyData,
+    apy: z.number().nullable().optional(),
+    meta_data: litePoolGaugeExtraRewardMetaData,
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeData = z
+  .object({
+    working_supply: z.string().nullable().optional(),
+    total_supply: z.string().nullable().optional(),
+    gauge_relative_weight: z.string().nullable().optional(),
+    gauge_future_relative_weight: z.string().nullable().optional(),
+    get_gauge_weight: z.string().nullable().optional(),
+    inflation_rate: z.number().nullable().optional(),
+  })
+  .transform(camelizeKeys)
+
+const litePool = z
+  .object({
+    id: z.string(),
+    chain_id: z.number(),
+    address,
+    registry_id: z.string(),
+    name: z.string().nullable().optional(),
+    symbol: z.string().nullable().optional(),
+    total_supply: z.string().nullable().optional(),
+    factory: z.boolean().nullable().optional(),
+    tvl: z.number().default(0),
+    coins: z.array(litePoolCoin).optional(),
+    price_oracles: z.array(z.union([z.number(), z.string(), z.null()])).optional(),
+    virtual_price: z.union([z.number(), z.string(), z.null()]).optional(),
+    amplification_coefficient: z.string().nullable().optional(),
+    implementation_address: address.nullable().optional(),
+    lp_token_address: address.nullable().optional(),
+    lp_token_price: z.number().nullable().optional(),
+    is_meta_pool: z.boolean().default(false),
+    is_broken: z.boolean().default(false),
+    gauge_address: address.nullable().optional(),
+    root_gauge_address: address.nullable().optional(),
+    gauge_crv_apy: z.array(z.number()).nullable().optional(),
+    gauge_extra_rewards: z.array(litePoolGaugeExtraReward).optional(),
+    gauge_is_killed: z.boolean().nullable().optional(),
+    gauge_has_crv: z.boolean().nullable().optional(),
+    gauge_data: litePoolGaugeData.nullable().optional(),
+  })
+  .transform(camelizeKeys)
+
+export const getPoolsResponse = z
+  .object({ chain, total: poolTotals, data: z.array(pool) })
+  .transform(({ chain, total, data }) => ({ chain, totals: total, pools: data }))
 
 export const getPoolResponse = pool
 export const listPoolsResponse = z
@@ -353,17 +427,27 @@ export const listPoolsResponse = z
     pools,
   }))
 
-export const listPoolRegistriesResponse = z
-  .object({
-    data: z.array(v2PoolRegistry),
-  })
-  .transform(({ data }) => data)
+export const listPoolRegistriesResponse = z.object({ data: z.array(v2PoolRegistry) }).transform(({ data }) => data)
+export const listPoolChainsResponse = z.object({ data: z.array(v2PoolChain) }).transform(({ data }) => data)
 
-export const listPoolChainsResponse = z
+export const listLitePoolsResponse = z
   .object({
-    data: z.array(v2PoolChain),
+    success: z.boolean(),
+    data: z
+      .object({
+        pool_data: z.array(litePool).optional(),
+        tvl: z.number().default(0),
+      })
+      .transform(camelizeKeys),
+    generated_time_ms: z.number(),
   })
-  .transform(({ data }) => data)
+  .transform(camelizeKeys)
+  .transform(({ data, generatedTimeMs }) => ({
+    pools: data.poolData ?? [],
+    totalTvl: data.tvl,
+    generatedTimeMs,
+  }))
+
 export const getVolumeResponse = z.object({ data: z.array(volume) }).transform(({ data }) => data)
 export const getTvlResponse = z.object({ data: z.array(tvl) }).transform(({ data }) => data)
 
@@ -421,11 +505,7 @@ export const getPoolLiquidityEventsResponse = z
   }))
 
 export const getPoolSnapshotsResponse = z
-  .object({
-    chain: z.string(),
-    address: z.string(),
-    data: z.array(poolSnapshot),
-  })
+  .object({ chain: z.string(), address: z.string(), data: z.array(poolSnapshot) })
   .transform(({ data }) => data)
 
 export const getPoolMetadataResponse = z
@@ -463,6 +543,11 @@ export type V2Gauge = z.infer<typeof v2Gauge>
 export type V2Pool = z.infer<typeof v2Pool>
 export type V2PoolRegistry = z.infer<typeof v2PoolRegistry>
 export type V2PoolChain = z.infer<typeof v2PoolChain>
+export type LitePoolCoin = z.infer<typeof litePoolCoin>
+export type LitePoolGaugeExtraReward = z.infer<typeof litePoolGaugeExtraReward>
+export type LitePoolGaugeData = z.infer<typeof litePoolGaugeData>
+export type LitePool = z.infer<typeof litePool>
+export type ListLitePoolsResponse = z.infer<typeof listLitePoolsResponse>
 export type Volume = z.infer<typeof volume>
 export type Tvl = z.infer<typeof tvl>
 export type TradeToken = z.infer<typeof tradeToken>

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -330,12 +330,8 @@ export type V2PoolSortField = z.infer<typeof v2PoolSortField>
 
 export type SortDirection = z.infer<typeof sortDirection>
 
-const v2PoolChain = z
-  .object({
-    chain_id: z.number(),
-    name: z.string(),
-  })
-  .transform(camelizeKeys)
+const v2PoolChain = z.object({ chain_id: z.number(), name: z.string() }).transform(camelizeKeys)
+const litePoolChain = z.object({ chain_id: z.number(), name: z.string() }).transform(camelizeKeys)
 
 const litePoolCoin = z
   .object({
@@ -440,6 +436,22 @@ export const listPoolsResponse = z
 
 export const listPoolRegistriesResponse = z.object({ data: z.array(v2PoolRegistry) }).transform(({ data }) => data)
 export const listPoolChainsResponse = z.object({ data: z.array(v2PoolChain) }).transform(({ data }) => data)
+
+export const listLitePoolChainsResponse = z
+  .object({
+    success: z.boolean(),
+    data: z.object({
+      platforms: z.record(z.string(), z.array(z.string())),
+      platforms_metadata: z.record(z.string(), litePoolChain),
+    }),
+    generated_time_ms: z.number(),
+  })
+  .transform(({ data: { platforms, platforms_metadata: platformMetadata } }) =>
+    Object.keys(platforms).flatMap(platform => {
+      const metadata = platformMetadata[platform]
+      return metadata ? [metadata] : []
+    }),
+  )
 
 export const listLitePoolsResponse = z
   .object({
@@ -554,6 +566,8 @@ export type V2Gauge = z.infer<typeof v2Gauge>
 export type V2Pool = z.infer<typeof v2Pool>
 export type V2PoolRegistry = z.infer<typeof v2PoolRegistry>
 export type V2PoolChain = z.infer<typeof v2PoolChain>
+export type LitePoolChain = z.infer<typeof litePoolChain>
+export type ListLitePoolChainsResponse = z.infer<typeof listLitePoolChainsResponse>
 export type LitePoolCoin = z.infer<typeof litePoolCoin>
 export type LitePoolGaugeExtraReward = z.infer<typeof litePoolGaugeExtraReward>
 export type LitePoolGaugeData = z.infer<typeof litePoolGaugeData>

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -337,17 +337,91 @@ const v2PoolChain = z
   })
   .transform(camelizeKeys)
 
-export const getPoolsResponse = z
+const litePoolCoin = z
   .object({
-    chain,
-    total: poolTotals,
-    data: z.array(pool),
+    address,
+    usd_price: z.number().nullable().optional(),
+    decimals: z.string().nullable().optional(),
+    is_base_pool_lp_token: z.boolean().default(false),
+    symbol: z.string().nullable().optional(),
+    pool_balance: z.string().nullable().optional(),
   })
-  .transform(({ chain, total, data }) => ({
-    chain,
-    totals: total,
-    pools: data,
-  }))
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraRewardAprData = z
+  .object({
+    is_reward_still_active: z.boolean(),
+    token_price: z.number().nullable().optional(),
+    rate: z.number(),
+    total_supply: z.number(),
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraRewardMetaData = z
+  .object({
+    rate: z.string(),
+    period_finish: z.number(),
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeExtraReward = z
+  .object({
+    gauge_address: address,
+    token_address: address,
+    token_price: z.number().nullable().optional(),
+    name: z.string(),
+    symbol: z.string(),
+    decimals: z.string(),
+    apr_data: litePoolGaugeExtraRewardAprData,
+    apr: z.number().nullable().optional(),
+    meta_data: litePoolGaugeExtraRewardMetaData,
+  })
+  .transform(camelizeKeys)
+
+const litePoolGaugeData = z
+  .object({
+    working_supply: z.string().nullable().optional(),
+    total_supply: z.string().nullable().optional(),
+    gauge_relative_weight: z.string().nullable().optional(),
+    gauge_future_relative_weight: z.string().nullable().optional(),
+    get_gauge_weight: z.string().nullable().optional(),
+    inflation_rate: z.number().nullable().optional(),
+  })
+  .transform(camelizeKeys)
+
+const litePool = z
+  .object({
+    id: z.string(),
+    chain_id: z.number(),
+    address,
+    registry_id: z.string(),
+    name: z.string().nullable().optional(),
+    symbol: z.string().nullable().optional(),
+    total_supply: z.string().nullable().optional(),
+    factory: z.boolean().nullable().optional(),
+    tvl: z.number().default(0),
+    coins: z.array(litePoolCoin).optional(),
+    price_oracles: z.array(z.union([z.number(), z.string(), z.null()])).optional(),
+    virtual_price: z.union([z.number(), z.string(), z.null()]).optional(),
+    amplification_coefficient: z.string().nullable().optional(),
+    implementation_address: address.nullable().optional(),
+    lp_token_address: address.nullable().optional(),
+    lp_token_price: z.number().nullable().optional(),
+    is_meta_pool: z.boolean().default(false),
+    is_broken: z.boolean().default(false),
+    gauge_address: address.nullable().optional(),
+    root_gauge_address: address.nullable().optional(),
+    gauge_crv_apr: z.array(z.number()).nullable().optional(),
+    gauge_extra_rewards: z.array(litePoolGaugeExtraReward).optional(),
+    gauge_is_killed: z.boolean().nullable().optional(),
+    gauge_has_crv: z.boolean().nullable().optional(),
+    gauge_data: litePoolGaugeData.nullable().optional(),
+  })
+  .transform(camelizeKeys)
+
+export const getPoolsResponse = z
+  .object({ chain, total: poolTotals, data: z.array(pool) })
+  .transform(({ chain, total, data }) => ({ chain, totals: total, pools: data }))
 
 export const getPoolResponse = pool
 export const listPoolsResponse = z
@@ -364,17 +438,27 @@ export const listPoolsResponse = z
     pools,
   }))
 
-export const listPoolRegistriesResponse = z
-  .object({
-    data: z.array(v2PoolRegistry),
-  })
-  .transform(({ data }) => data)
+export const listPoolRegistriesResponse = z.object({ data: z.array(v2PoolRegistry) }).transform(({ data }) => data)
+export const listPoolChainsResponse = z.object({ data: z.array(v2PoolChain) }).transform(({ data }) => data)
 
-export const listPoolChainsResponse = z
+export const listLitePoolsResponse = z
   .object({
-    data: z.array(v2PoolChain),
+    success: z.boolean(),
+    data: z
+      .object({
+        pool_data: z.array(litePool).optional(),
+        tvl: z.number().default(0),
+      })
+      .transform(camelizeKeys),
+    generated_time_ms: z.number(),
   })
-  .transform(({ data }) => data)
+  .transform(camelizeKeys)
+  .transform(({ data, generatedTimeMs }) => ({
+    pools: data.poolData ?? [],
+    totalTvl: data.tvl,
+    generatedTimeMs,
+  }))
+
 export const getVolumeResponse = z.object({ data: z.array(volume) }).transform(({ data }) => data)
 export const getTvlResponse = z.object({ data: z.array(tvl) }).transform(({ data }) => data)
 
@@ -432,11 +516,7 @@ export const getPoolLiquidityEventsResponse = z
   }))
 
 export const getPoolSnapshotsResponse = z
-  .object({
-    chain: z.string(),
-    address: z.string(),
-    data: z.array(poolSnapshot),
-  })
+  .object({ chain: z.string(), address: z.string(), data: z.array(poolSnapshot) })
   .transform(({ data }) => data)
 
 export const getPoolMetadataResponse = z
@@ -474,6 +554,11 @@ export type V2Gauge = z.infer<typeof v2Gauge>
 export type V2Pool = z.infer<typeof v2Pool>
 export type V2PoolRegistry = z.infer<typeof v2PoolRegistry>
 export type V2PoolChain = z.infer<typeof v2PoolChain>
+export type LitePoolCoin = z.infer<typeof litePoolCoin>
+export type LitePoolGaugeExtraReward = z.infer<typeof litePoolGaugeExtraReward>
+export type LitePoolGaugeData = z.infer<typeof litePoolGaugeData>
+export type LitePool = z.infer<typeof litePool>
+export type ListLitePoolsResponse = z.infer<typeof listLitePoolsResponse>
 export type Volume = z.infer<typeof volume>
 export type Tvl = z.infer<typeof tvl>
 export type TradeToken = z.infer<typeof tradeToken>

--- a/packages/prices-api/tests/endpoints/pools.test.ts
+++ b/packages/prices-api/tests/endpoints/pools.test.ts
@@ -9,6 +9,7 @@ runEndpointCases('pools', [
   endpointCase('getPools', () => pools.getPools(chainSeed(), requestOptions)),
   endpointCase('getPool', () => pools.getPool(poolSeed().chain, poolSeed().poolAddress, requestOptions)),
   endpointCase('listPoolChains', () => pools.listPoolChains(requestOptions)),
+  endpointCase('listLitePools', () => pools.listLitePools({ chainId: 4663 })),
   endpointCase('listPools', () => pools.listPools({ chainId: 1, pagination: 2 }, requestOptions)),
   endpointCase('listPoolRegistries', () => pools.listPoolRegistries({ chainId: 1 }, requestOptions)),
   endpointCase('getVolume', () => pools.getVolume(poolSeed().chain, poolSeed().poolAddress, requestOptions)),

--- a/packages/prices-api/tests/endpoints/pools.test.ts
+++ b/packages/prices-api/tests/endpoints/pools.test.ts
@@ -9,6 +9,7 @@ runEndpointCases('pools', [
   endpointCase('getPools', () => pools.getPools(chainSeed(), requestOptions)),
   endpointCase('getPool', () => pools.getPool(poolSeed().chain, poolSeed().poolAddress, requestOptions)),
   endpointCase('listPoolChains', () => pools.listPoolChains(requestOptions)),
+  endpointCase('listLitePoolChains', () => pools.listLitePoolChains()),
   endpointCase('listLitePools', () => pools.listLitePools({ chainId: 4663 })),
   endpointCase('listPools', () => pools.listPools({ chainId: 1, pagination: 2 }, requestOptions)),
   endpointCase('listPoolRegistries', () => pools.listPoolRegistries({ chainId: 1 }, requestOptions)),

--- a/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
+++ b/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
@@ -6,7 +6,6 @@ import { CampaignTooltipContent } from '@/dex/features/pool-list/cells/RewardIco
 import { RewardsApyTooltipContent } from '@/dex/features/pool-list/cells/RewardsApyTooltipContent'
 import { aprToPoolApy } from '@/dex/features/pool-list/cells/utils'
 import type { PoolRow } from '@/dex/features/pool-list/types'
-import { fromDate } from '@curvefi/prices-api/timestamp'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 
@@ -31,7 +30,6 @@ const USDC = {
 } as const
 const EXTRA_REWARD = {
   ...BOLD,
-  price: 1,
   apr: 2,
 } satisfies PoolRow['extraRewardsApr'][number]
 
@@ -60,26 +58,14 @@ const BOLD_APR_CAMPAIGN: CampaignRewards = {
   symbol: BOLD.symbol,
 }
 
-const createPool = (overrides: Partial<PoolRow> = {}): PoolRow => ({
-  chainId: 1,
+const createPool = (): PoolRow => ({
   name: 'BOLD/USDC Pool',
   address: POOL_ADDRESS,
-  creationDate: fromDate(new Date('2025-05-18T19:37:59.000Z')),
-  poolType: 'stableswapng',
-  isMetapool: false,
-  basePool: null,
-  tvlUsd: 1_000_000,
-  tradingVolume24h: 100_000,
-  tradingFee24h: 1_000,
-  liquidityVolume24h: 90_000,
-  liquidityFee24h: 900,
   coins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
   baseDailyApr: 10,
-  baseWeeklyApr: 20,
   crvApr: 5,
   crvAprBoosted: 12.5,
   extraRewardsApr: [EXTRA_REWARD],
-  vyperVersion: null,
   gauge: { address: GAUGE_ADDRESS, isKilled: false },
   gauges: [{ address: GAUGE_ADDRESS, isKilled: false }],
   campaigns: [BOLD_CAMPAIGN, BOLD_APR_CAMPAIGN],
@@ -87,7 +73,6 @@ const createPool = (overrides: Partial<PoolRow> = {}): PoolRow => ({
   hasVyperVulnerability: false,
   network: 'ethereum',
   url: `/dex/ethereum/pools/${POOL_ADDRESS}/deposit`,
-  ...overrides,
 })
 
 const mountContent = (content: ReactElement) =>

--- a/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
+++ b/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
@@ -6,7 +6,6 @@ import { CampaignTooltipContent } from '@/dex/features/pool-list/cells/RewardIco
 import { RewardsApyTooltipContent } from '@/dex/features/pool-list/cells/RewardsApyTooltipContent'
 import { aprToPoolApy } from '@/dex/features/pool-list/cells/utils'
 import type { PoolRow } from '@/dex/features/pool-list/types'
-import { fromDate } from '@curvefi/prices-api/timestamp'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import type { CampaignRewards } from '@ui-kit/entities/campaigns'
 
@@ -30,9 +29,10 @@ const USDC = {
   decimals: 6,
 } as const
 const EXTRA_REWARD = {
-  ...BOLD,
-  price: 1,
+  address: BOLD.address,
   apr: 2,
+  name: BOLD.name,
+  symbol: BOLD.symbol,
 } satisfies PoolRow['extraRewardsApr'][number]
 
 const BOLD_CAMPAIGN: CampaignRewards = {
@@ -60,35 +60,28 @@ const BOLD_APR_CAMPAIGN: CampaignRewards = {
   symbol: BOLD.symbol,
 }
 
-const createPool = (overrides: Partial<PoolRow> = {}): PoolRow => ({
-  chainId: 1,
+const createPool = (): PoolRow => ({
   name: 'BOLD/USDC Pool',
   address: POOL_ADDRESS,
-  creationDate: fromDate(new Date('2025-05-18T19:37:59.000Z')),
-  poolType: 'stableswapng',
-  isMetapool: false,
-  basePool: null,
-  tvlUsd: 1_000_000,
-  tradingVolume24h: 100_000,
-  tradingFee24h: 1_000,
-  liquidityVolume24h: 90_000,
-  liquidityFee24h: 900,
   coins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
   tradeableCoins: [BOLD, USDC].map((token, poolIndex) => ({ poolIndex, ...token })),
   baseDailyApr: 10,
-  baseWeeklyApr: 20,
+  baseWeeklyApr: undefined,
+  creationDate: undefined,
   crvApr: 5,
   crvAprBoosted: 12.5,
   extraRewardsApr: [EXTRA_REWARD],
-  vyperVersion: null,
   gauge: { address: GAUGE_ADDRESS, isKilled: false },
   gauges: [{ address: GAUGE_ADDRESS, isKilled: false }],
   campaigns: [BOLD_CAMPAIGN, BOLD_APR_CAMPAIGN],
   hasPosition: false,
   hasVyperVulnerability: false,
+  isMetapool: false,
   network: 'ethereum',
+  poolType: undefined,
+  tradingVolume24h: undefined,
+  tvlUsd: undefined,
   url: `/dex/ethereum/pools/${POOL_ADDRESS}/deposit`,
-  ...overrides,
 })
 
 const mountContent = (content: ReactElement) =>

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -71,9 +71,9 @@ const OPTIONAL_FULL_COLUMNS = [
   PoolColumnId.Age,
 ]
 
-const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.Volume, PoolColumnId.Tvl]
-const OPTIONAL_LITE_COLUMNS = [PoolColumnId.RewardsApy, PoolColumnId.Points, PoolColumnId.Age]
-const FULL_ONLY_COLUMNS = [PoolColumnId.NetApy, PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.CrvApy]
+const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.NetApy, PoolColumnId.Tvl]
+const OPTIONAL_LITE_COLUMNS = [PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points]
+const FULL_ONLY_COLUMNS = [PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.Volume, PoolColumnId.Age]
 
 describe('V2 pool-list columns', () => {
   beforeEach(() => {
@@ -160,6 +160,8 @@ describe('V2 pool-list columns', () => {
     visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
 
     expectHeaderOrder(DEFAULT_LITE_COLUMNS)
+    cy.get('[data-testid="btn-open-filters-dex-pools"]').should('not.exist')
+    cy.get('[data-testid="dex-pool-filters-collapsible"]').should('not.exist')
 
     cy.get('[data-testid="btn-visibility-settings"]').click()
     for (const columnId of OPTIONAL_LITE_COLUMNS) {
@@ -173,16 +175,45 @@ describe('V2 pool-list columns', () => {
     showV2PoolColumns(OPTIONAL_LITE_COLUMNS)
     expectHeaderOrder([
       PoolColumnId.PoolName,
+      PoolColumnId.NetApy,
+      PoolColumnId.CrvApy,
       PoolColumnId.RewardsApy,
       PoolColumnId.Points,
-      PoolColumnId.Volume,
       PoolColumnId.Tvl,
-      PoolColumnId.Age,
     ])
-    getV2PoolCell(V2_POOL_FIXTURES.lite.address, PoolColumnId.Age)
-      .find('[data-testid="pool-age"]')
-      // The fixture is four minutes old, which the shared formatter groups into its under-five-minute state.
-      .should('have.text', 'just now')
+  })
+
+  it('searches and sorts every Lite pool locally without refetching or applying the default TVL filter', () => {
+    visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
+
+    cy.get('@dex-v2-pool-chains.all').should('have.length', 0)
+    cy.get('@dex-v2-pools.all').should('have.length', 0)
+    getV2PoolRow(V2_POOL_FIXTURES.liteLowTvl.address).should('be.visible')
+
+    const getSearch = () => cy.get('[data-testid="table-text-search-dex-pool-list"]').find('input')
+    for (const query of [
+      'Taiko Lite',
+      V2_POOL_FIXTURES.lite.address,
+      V2_POOL_FIXTURES.lite.gauge_address!,
+      V2_POOL_FIXTURES.lite.root_gauge_address!,
+      'USDC',
+      V2_POOL_FIXTURES.lite.coins[0].address,
+      'USDT',
+    ]) {
+      getSearch().clear({ scrollBehavior: false }).type(query, { scrollBehavior: false })
+      cy.get('[data-testid^="data-table-row-"]').should('have.length', 1)
+      getV2PoolRow(V2_POOL_FIXTURES.lite.address).should('be.visible')
+    }
+
+    getSearch().clear({ scrollBehavior: false })
+    cy.get('[data-testid^="data-table-row-"]').should('have.length', 2)
+
+    cy.get(`[data-testid="data-table-header-${PoolColumnId.Tvl}"]`).click()
+    cy.get('[data-testid^="data-table-row-"]')
+      .first()
+      .find(`[data-testid="market-link-${V2_POOL_FIXTURES.liteLowTvl.address}"]`)
+      .should('exist')
+    cy.get('@dex-v2-lite-pools.all').should('have.length', 1)
   })
 
   it('classifies representative pool types and adds status badges', () => {

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -70,9 +70,9 @@ const OPTIONAL_FULL_COLUMNS = [
   PoolColumnId.Age,
 ]
 
-const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.Volume, PoolColumnId.Tvl]
-const OPTIONAL_LITE_COLUMNS = [PoolColumnId.RewardsApy, PoolColumnId.Points, PoolColumnId.Age]
-const FULL_ONLY_COLUMNS = [PoolColumnId.NetApy, PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.CrvApy]
+const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.NetApy, PoolColumnId.Tvl]
+const OPTIONAL_LITE_COLUMNS = [PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points]
+const FULL_ONLY_COLUMNS = [PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.Volume, PoolColumnId.Age]
 
 describe('V2 pool-list columns', () => {
   beforeEach(() => {
@@ -153,6 +153,8 @@ describe('V2 pool-list columns', () => {
     visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
 
     expectHeaderOrder(DEFAULT_LITE_COLUMNS)
+    cy.get('[data-testid="btn-open-filters-dex-pools"]').should('not.exist')
+    cy.get('[data-testid="dex-pool-filters-collapsible"]').should('not.exist')
 
     cy.get('[data-testid="btn-visibility-settings"]').click()
     for (const columnId of OPTIONAL_LITE_COLUMNS) {
@@ -166,16 +168,35 @@ describe('V2 pool-list columns', () => {
     showV2PoolColumns(OPTIONAL_LITE_COLUMNS)
     expectHeaderOrder([
       PoolColumnId.PoolName,
+      PoolColumnId.NetApy,
+      PoolColumnId.CrvApy,
       PoolColumnId.RewardsApy,
       PoolColumnId.Points,
-      PoolColumnId.Volume,
       PoolColumnId.Tvl,
-      PoolColumnId.Age,
     ])
-    getV2PoolCell(V2_POOL_FIXTURES.lite.address, PoolColumnId.Age)
-      .find('[data-testid="pool-age"]')
-      // The fixture is four minutes old, which the shared formatter groups into its under-five-minute state.
-      .should('have.text', 'just now')
+  })
+
+  it('searches and sorts every Lite pool locally without refetching or applying the default TVL filter', () => {
+    visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
+
+    cy.get('@dex-v2-pool-chains.all').should('have.length', 0)
+    cy.get('@dex-v2-pools.all').should('have.length', 0)
+    getV2PoolRow(V2_POOL_FIXTURES.liteLowTvl.address).should('be.visible')
+
+    const search = cy.get('[data-testid="table-text-search-dex-pool-list"]').find('input')
+    search.type(V2_POOL_FIXTURES.lite.name!)
+    cy.get('[data-testid^="data-table-row-"]').should('have.length', 1)
+    getV2PoolRow(V2_POOL_FIXTURES.lite.address).should('be.visible')
+
+    search.clear()
+    cy.get('[data-testid^="data-table-row-"]').should('have.length', 2)
+
+    cy.get(`[data-testid="data-table-header-${PoolColumnId.Tvl}"]`).click()
+    cy.get('[data-testid^="data-table-row-"]')
+      .first()
+      .find(`[data-testid="market-link-${V2_POOL_FIXTURES.liteLowTvl.address}"]`)
+      .should('exist')
+    cy.get('@dex-v2-lite-pools.all').should('have.length', 1)
   })
 
   it('classifies representative pool types and adds status badges', () => {

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -74,6 +74,13 @@ const OPTIONAL_FULL_COLUMNS = [
 const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.NetApy, PoolColumnId.Tvl]
 const OPTIONAL_LITE_COLUMNS = [PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points]
 const FULL_ONLY_COLUMNS = [PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.Volume, PoolColumnId.Age]
+const LITE_SORTABLE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.Tvl]
+const LITE_NON_SORTABLE_COLUMNS = [
+  PoolColumnId.NetApy,
+  PoolColumnId.CrvApy,
+  PoolColumnId.RewardsApy,
+  PoolColumnId.Points,
+]
 
 describe('V2 pool-list columns', () => {
   beforeEach(() => {
@@ -181,6 +188,13 @@ describe('V2 pool-list columns', () => {
       PoolColumnId.Points,
       PoolColumnId.Tvl,
     ])
+
+    for (const columnId of LITE_SORTABLE_COLUMNS) {
+      getColumnHeader(columnId).find(`[data-testid^="icon-sort-${columnId}-"]`).should('exist')
+    }
+    for (const columnId of LITE_NON_SORTABLE_COLUMNS) {
+      getColumnHeader(columnId).find(`[data-testid^="icon-sort-${columnId}-"]`).should('not.exist')
+    }
   })
 
   it('searches and sorts every Lite pool locally without refetching or applying the default TVL filter', () => {

--- a/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
@@ -30,7 +30,13 @@ const FULL_NETWORK_CAMPAIGN_IDS = [
   'pool-points-campaign-4',
 ] as const
 
-const LITE_METRIC_IDS = ['pool-volume', 'pool-tvl', 'pool-rewards-apy', 'pool-points-campaign-0', 'pool-age'] as const
+const LITE_METRIC_IDS = [
+  'pool-net-apy',
+  'pool-tvl',
+  'pool-rewards-apy',
+  'pool-crv-apy',
+  'pool-points-campaign-0',
+] as const
 
 const expectMetricOrder = (address: string, expectedIds: readonly string[]) => {
   getV2PoolExpandedPanel(address)
@@ -83,7 +89,6 @@ describe('V2 pool-list mobile panels', () => {
     visitAndExpand(address, 'taiko')
 
     expectMetricOrder(address, LITE_METRIC_IDS)
-    expectCampaignRowsToBeLinks(address, ['pool-points-campaign-0'])
   })
 
   it('does not create a campaign metric when campaign data is unavailable', () => {

--- a/tests/cypress/e2e/dex/pool-list-v2/network-support.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/network-support.cy.ts
@@ -1,0 +1,45 @@
+import { setupDexPoolListV2Mocks } from '@cy/support/helpers/dex-pool-list-v2-mocks'
+import { DESKTOP_VIEWPORT } from '@cy/support/helpers/dex-pools-list-v2.helpers'
+import { API_LOAD_TIMEOUT } from '@cy/support/ui'
+import { Chain } from '@ui-kit/utils/network'
+
+const visitPoolList = (network: string, supportAlias: `@${string}`) => {
+  cy.viewport(...DESKTOP_VIEWPORT)
+  cy.visitWithoutTestConnector(`dex/${network}/pools/`)
+  cy.wait('@dex-v2-platforms', API_LOAD_TIMEOUT)
+  cy.wait('@dex-v2-prices-chains', API_LOAD_TIMEOUT)
+  cy.wait(supportAlias, API_LOAD_TIMEOUT)
+}
+
+const expectUnsupportedPoolList = () => {
+  cy.contains('Unable to retrieve pool list').should('be.visible')
+  cy.contains('The pool list is not supported on chain').should('be.visible')
+}
+
+describe('V2 pool-list network support', () => {
+  beforeEach(setupDexPoolListV2Mocks)
+
+  it('shows the table error state without fetching pools for an unsupported full network', () => {
+    cy.intercept(
+      { method: 'GET', hostname: 'prices.curve.finance', pathname: '/v2/pools/chains/' },
+      { body: { data: [] } },
+    ).as('dex-v2-unsupported-pool-chains')
+
+    visitPoolList('ethereum', '@dex-v2-unsupported-pool-chains')
+
+    expectUnsupportedPoolList()
+    cy.get('@dex-v2-pools.all').should('have.length', 0)
+  })
+
+  it('shows the table error state without fetching pools for an unsupported Lite network', () => {
+    cy.intercept(
+      { method: 'GET', hostname: 'api2.curve.finance', pathname: `/get_pools/${Chain.Celo}` },
+      { statusCode: 503 },
+    ).as('dex-v2-unexpected-lite-pools')
+
+    visitPoolList('celo', '@dex-v2-lite-pool-chains')
+
+    expectUnsupportedPoolList()
+    cy.get('@dex-v2-unexpected-lite-pools.all').should('have.length', 0)
+  })
+})

--- a/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
@@ -103,12 +103,17 @@ describe('V2 pool-list yields', () => {
       .and('not.contain.text', '5,000+%')
   })
 
-  it('combines Lite-network APR and points campaigns', () => {
+  it('combines Lite-network API2 APRs with campaign APRs and points', () => {
     const { address } = V2_POOL_FIXTURES.lite
     visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
-    showV2PoolColumns([PoolColumnId.RewardsApy, PoolColumnId.Points])
+    showV2PoolColumns([PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points])
 
+    getV2PoolCell(address, PoolColumnId.NetApy).find('[data-testid="pool-net-apy"]').should('have.text', '13.32%')
     getV2PoolCell(address, PoolColumnId.RewardsApy).should('contain.text', '8.20%')
+    getV2PoolCell(address, PoolColumnId.CrvApy).within(() => {
+      cy.get('[data-testid="pool-crv-apy-unboosted"]').should('have.text', '5.12%')
+      cy.get('[data-testid="pool-crv-apy-boosted"]').should('have.text', '13.30%')
+    })
     getV2PoolCell(address, PoolColumnId.Points).find(POINTS_BADGE).should('have.text', 'TP')
   })
 })

--- a/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/yields.cy.ts
@@ -103,12 +103,17 @@ describe('V2 pool-list yields', () => {
       .and('not.contain.text', '5,000+%')
   })
 
-  it('combines Lite-network APR and points campaigns', () => {
+  it('combines Lite-network API2 APYs with APR and points campaigns', () => {
     const { address } = V2_POOL_FIXTURES.lite
     visitV2PoolList({ network: 'taiko', viewport: DESKTOP_VIEWPORT })
-    showV2PoolColumns([PoolColumnId.RewardsApy, PoolColumnId.Points])
+    showV2PoolColumns([PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points])
 
+    getV2PoolCell(address, PoolColumnId.NetApy).find('[data-testid="pool-net-apy"]').should('have.text', '13.32%')
     getV2PoolCell(address, PoolColumnId.RewardsApy).should('contain.text', '8.20%')
+    getV2PoolCell(address, PoolColumnId.CrvApy).within(() => {
+      cy.get('[data-testid="pool-crv-apy-unboosted"]').should('have.text', '5.12%')
+      cy.get('[data-testid="pool-crv-apy-boosted"]').should('have.text', '13.30%')
+    })
     getV2PoolCell(address, PoolColumnId.Points).find(POINTS_BADGE).should('have.text', 'TP')
   })
 })

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -436,9 +436,20 @@ const getPoolSortValue = (pool: V2PoolFixture, sortBy: string | null) => {
 const mockPoolChains = () =>
   cy.intercept(
     { method: 'GET', hostname: 'prices.curve.finance', pathname: '/v2/pools/chains/' },
+    { body: { data: [{ chain_id: Chain.Ethereum, name: 'ethereum' }] } },
+  )
+
+const mockLitePoolChains = () =>
+  cy.intercept(
+    { method: 'GET', hostname: 'api2.curve.finance', pathname: '/get_platforms' },
     {
       body: {
-        data: [{ chain_id: Chain.Ethereum, name: 'ethereum' }],
+        success: true,
+        data: {
+          platforms: { taiko: [] },
+          platforms_metadata: { taiko: { chain_id: Chain.Taiko, name: 'Taiko' } },
+        },
+        generated_time_ms: V2_POOL_FIXTURE_NOW,
       },
     },
   )
@@ -562,6 +573,7 @@ export const setupDexPoolListV2Mocks = () => {
     req.reply({ statusCode: 503, body: { error: `Unexpected API2 pool-list request: ${req.url}` } })
   })
   mockPoolChains().as('dex-v2-pool-chains')
+  mockLitePoolChains().as('dex-v2-lite-pool-chains')
   mockPoolList().as('dex-v2-pools')
   mockLitePoolList().as('dex-v2-lite-pools')
   mockPlatforms().as('dex-v2-platforms')

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -43,6 +43,36 @@ type RawV2Pool = {
 
 type V2PoolFixture = RawV2Pool & { network: V2PoolNetwork }
 
+type RawLitePool = {
+  id: string
+  chain_id: number
+  address: Address
+  registry_id: string
+  name: string | null
+  tvl: number
+  coins: {
+    address: Address
+    decimals?: string | null
+    symbol?: string | null
+  }[]
+  gauge_address?: Address | null
+  gauge_crv_apy?: number[] | null
+  gauge_extra_rewards?: {
+    gauge_address: Address
+    token_address: Address
+    name: string
+    symbol: string
+    decimals: string
+    apy_data: {
+      is_reward_still_active: boolean
+      rate: number
+      total_supply: number
+    }
+    apy?: number | null
+    meta_data: { rate: string; period_finish: number }
+  }[]
+}
+
 const address = (suffix: string): Address => `0x${suffix.padStart(40, '0')}`
 const EXTRA_REWARD_ADDRESS = address('3001')
 const ALERT_TOKEN_ADDRESS: Address = '0xeb4c2781e4eba804ce9a9803c67d0893436bb27d'
@@ -71,6 +101,19 @@ const createCoins = (network: V2PoolNetwork): RawV2Pool['coins'] => [
   },
 ]
 
+const createLiteCoins = (): RawLitePool['coins'] => [
+  {
+    address: address('4001'),
+    decimals: '6',
+    symbol: 'USDC',
+  },
+  {
+    address: address('4002'),
+    decimals: '6',
+    symbol: 'USDT',
+  },
+]
+
 const extraReward = (apr: number, symbol = 'RWD'): RawV2Pool['extra_rewards_apr'][number] => ({
   address: EXTRA_REWARD_ADDRESS,
   symbol,
@@ -78,6 +121,24 @@ const extraReward = (apr: number, symbol = 'RWD'): RawV2Pool['extra_rewards_apr'
   decimals: 18,
   price: 1,
   apr,
+})
+
+const liteExtraReward = (
+  apy: number,
+  symbol = 'LITE',
+): NonNullable<RawLitePool['gauge_extra_rewards']>[number] => ({
+  gauge_address: address('2007'),
+  token_address: EXTRA_REWARD_ADDRESS,
+  name: `${symbol} reward`,
+  symbol,
+  decimals: '18',
+  apy_data: {
+    is_reward_still_active: true,
+    rate: 1,
+    total_supply: 1,
+  },
+  apy,
+  meta_data: { rate: '1', period_finish: V2_POOL_FIXTURE_NOW_SECONDS + YEAR_SECONDS },
 })
 
 const createPoolFixture = ({
@@ -110,7 +171,22 @@ const createPoolFixture = ({
   network,
 })
 
-export const V2_POOL_FIXTURES = {
+const createLitePoolFixture = ({
+  address: poolAddress,
+  name,
+  ...overrides
+}: Pick<RawLitePool, 'address' | 'name'> & Partial<RawLitePool>): RawLitePool => ({
+  id: `factory_stable_ng-${poolAddress.slice(-4)}`,
+  chain_id: Chain.Taiko,
+  address: poolAddress,
+  registry_id: 'factory_stable_ng',
+  name,
+  tvl: 10_000,
+  coins: createLiteCoins(),
+  ...overrides,
+})
+
+const FULL_V2_POOL_FIXTURES = {
   showcase: createPoolFixture({
     address: '0x6c5ff8dce52be77b4ece6b51996018f0c1713ba9',
     name: 'V2 Rewards Showcase',
@@ -181,23 +257,34 @@ export const V2_POOL_FIXTURES = {
     trading_volume_24h: 0,
     tvl_usd: 0,
   }),
-  lite: createPoolFixture({
-    address: address('1007'),
-    name: 'V2 Taiko Lite',
-    network: 'taiko',
-    pool_type: 'stableswapng',
-    base_daily_apr: 10,
-    base_weekly_apr: 20,
-    crv_apr: 5,
-    crv_apr_boosted: 12.5,
-    extra_rewards_apr: [extraReward(2, 'LITE')],
-    gauges: [{ address: address('2007'), is_killed: false }],
-  }),
 } as const satisfies Record<string, V2PoolFixture>
+
+const LITE_POOL_SHOWCASE = createLitePoolFixture({
+  address: address('1007'),
+  name: 'V2 Taiko Lite',
+  tvl: 10_000_000,
+  gauge_address: address('2007'),
+  gauge_crv_apy: [5.12, 13.3],
+  gauge_extra_rewards: [liteExtraReward(2.02)],
+})
+
+const LITE_POOL_LOW_TVL = createLitePoolFixture({
+  address: address('1009'),
+  name: 'V2 Low TVL',
+  tvl: 1,
+})
+
+const LITE_POOL_FIXTURES = [LITE_POOL_SHOWCASE, LITE_POOL_LOW_TVL]
+
+export const V2_POOL_FIXTURES = {
+  ...FULL_V2_POOL_FIXTURES,
+  lite: LITE_POOL_SHOWCASE,
+  liteLowTvl: LITE_POOL_LOW_TVL,
+} as const
 
 type MerklOpportunityParams = {
   identifier: string
-  pool: V2PoolFixture
+  pool: Pick<RawLitePool | V2PoolFixture, 'address' | 'chain_id' | 'name'>
   apr: number
   symbol: string
   platform: string
@@ -223,7 +310,7 @@ const createMerklOpportunity = ({
   tags: [platform],
   chain: {
     id: pool.chain_id,
-    name: pool.network === 'ethereum' ? 'Ethereum' : 'Taiko',
+    name: pool.chain_id === Number(Chain.Ethereum) ? 'Ethereum' : 'Taiko',
   },
   rewardsRecord: {
     breakdowns: [
@@ -328,10 +415,7 @@ const mockPoolChains = () =>
     { method: 'GET', hostname: 'prices.curve.finance', pathname: '/v2/pools/chains/' },
     {
       body: {
-        data: [
-          { chain_id: Chain.Ethereum, name: 'ethereum' },
-          { chain_id: Chain.Taiko, name: 'taiko' },
-        ],
+        data: [{ chain_id: Chain.Ethereum, name: 'ethereum' }],
       },
     },
   )
@@ -346,7 +430,7 @@ const mockPoolList = () =>
     const sortBy = url.searchParams.get('sort_by')
     const sortDirection = url.searchParams.get('sort_direction') === 'asc' ? 'asc' : 'desc'
     const matching = orderBy(
-      Object.values(V2_POOL_FIXTURES)
+      Object.values(FULL_V2_POOL_FIXTURES)
         .filter(pool => pool.chain_id === chainId)
         .filter(
           pool =>
@@ -369,6 +453,21 @@ const mockPoolList = () =>
       },
     })
   })
+
+const mockLitePoolList = () =>
+  cy.intercept(
+    { method: 'GET', hostname: 'api2.curve.finance', pathname: `/get_pools/${Chain.Taiko}` },
+    {
+      body: {
+        success: true,
+        data: {
+          pool_data: LITE_POOL_FIXTURES,
+          tvl: LITE_POOL_FIXTURES.reduce((total, pool) => total + pool.tvl, 0),
+        },
+        generated_time_ms: V2_POOL_FIXTURE_NOW,
+      },
+    },
+  )
 
 const mockPlatforms = () =>
   cy.intercept(
@@ -436,8 +535,12 @@ export const setupDexPoolListV2Mocks = () => {
   cy.intercept({ method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ }, req => {
     req.reply({ statusCode: 503, body: { error: `Unexpected V2 pool-list request: ${req.url}` } })
   })
+  cy.intercept({ method: 'GET', hostname: 'api2.curve.finance', pathname: /^\/get_pools\/\d+$/ }, req => {
+    req.reply({ statusCode: 503, body: { error: `Unexpected API2 pool-list request: ${req.url}` } })
+  })
   mockPoolChains().as('dex-v2-pool-chains')
   mockPoolList().as('dex-v2-pools')
+  mockLitePoolList().as('dex-v2-lite-pools')
   mockPlatforms().as('dex-v2-platforms')
   mockBootstrapRequests()
   mockMerklOpportunities()

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -46,6 +46,37 @@ type RawV2Pool = {
 
 type V2PoolFixture = RawV2Pool & { network: V2PoolNetwork }
 
+type RawLitePool = {
+  id: string
+  chain_id: number
+  address: Address
+  registry_id: string
+  name: string | null
+  tvl: number
+  coins: {
+    address: Address
+    decimals?: string | null
+    symbol?: string | null
+  }[]
+  gauge_address?: Address | null
+  root_gauge_address?: Address | null
+  gauge_crv_apr?: number[] | null
+  gauge_extra_rewards?: {
+    gauge_address: Address
+    token_address: Address
+    name: string
+    symbol: string
+    decimals: string
+    apr_data: {
+      is_reward_still_active: boolean
+      rate: number
+      total_supply: number
+    }
+    apr?: number | null
+    meta_data: { rate: string; period_finish: number }
+  }[]
+}
+
 const address = (suffix: string): Address => `0x${suffix.padStart(40, '0')}`
 const EXTRA_REWARD_ADDRESS = address('3001')
 const ALERT_TOKEN_ADDRESS: Address = '0xeb4c2781e4eba804ce9a9803c67d0893436bb27d'
@@ -74,6 +105,19 @@ const createCoins = (network: V2PoolNetwork): RawV2Pool['coins'] => [
   },
 ]
 
+const createLiteCoins = (): RawLitePool['coins'] => [
+  {
+    address: address('4001'),
+    decimals: '6',
+    symbol: 'USDC',
+  },
+  {
+    address: address('4002'),
+    decimals: '6',
+    symbol: 'USD₮',
+  },
+]
+
 const extraReward = (apr: number, symbol = 'RWD'): RawV2Pool['extra_rewards_apr'][number] => ({
   address: EXTRA_REWARD_ADDRESS,
   symbol,
@@ -81,6 +125,21 @@ const extraReward = (apr: number, symbol = 'RWD'): RawV2Pool['extra_rewards_apr'
   decimals: 18,
   price: 1,
   apr,
+})
+
+const liteExtraReward = (apr: number, symbol = 'LITE'): NonNullable<RawLitePool['gauge_extra_rewards']>[number] => ({
+  gauge_address: address('2007'),
+  token_address: EXTRA_REWARD_ADDRESS,
+  name: `${symbol} reward`,
+  symbol,
+  decimals: '18',
+  apr_data: {
+    is_reward_still_active: true,
+    rate: 1,
+    total_supply: 1,
+  },
+  apr,
+  meta_data: { rate: '1', period_finish: V2_POOL_FIXTURE_NOW_SECONDS + YEAR_SECONDS },
 })
 
 const createPoolFixture = ({
@@ -114,7 +173,22 @@ const createPoolFixture = ({
   network,
 })
 
-export const V2_POOL_FIXTURES = {
+const createLitePoolFixture = ({
+  address: poolAddress,
+  name,
+  ...overrides
+}: Pick<RawLitePool, 'address' | 'name'> & Partial<RawLitePool>): RawLitePool => ({
+  id: `factory_stable_ng-${poolAddress.slice(-4)}`,
+  chain_id: Chain.Taiko,
+  address: poolAddress,
+  registry_id: 'factory_stable_ng',
+  name,
+  tvl: 10_000,
+  coins: createLiteCoins(),
+  ...overrides,
+})
+
+const FULL_V2_POOL_FIXTURES = {
   showcase: createPoolFixture({
     address: '0x6c5ff8dce52be77b4ece6b51996018f0c1713ba9',
     name: 'V2 Rewards Showcase',
@@ -188,23 +262,39 @@ export const V2_POOL_FIXTURES = {
     trading_volume_24h: 0,
     tvl_usd: 0,
   }),
-  lite: createPoolFixture({
-    address: address('1007'),
-    name: 'V2 Taiko Lite',
-    network: 'taiko',
-    pool_type: 'stableswapng',
-    base_daily_apr: 10,
-    base_weekly_apr: 20,
-    crv_apr: 5,
-    crv_apr_boosted: 12.5,
-    extra_rewards_apr: [extraReward(2, 'LITE')],
-    gauges: [{ address: address('2007'), is_killed: false }],
-  }),
 } as const satisfies Record<string, V2PoolFixture>
+
+const LITE_POOL_SHOWCASE = createLitePoolFixture({
+  address: address('1007'),
+  name: 'V2 Taiko Lite',
+  tvl: 10_000_000,
+  gauge_address: address('2007'),
+  root_gauge_address: address('2017'),
+  gauge_crv_apr: [5, 12.5],
+  gauge_extra_rewards: [liteExtraReward(2)],
+})
+
+const LITE_POOL_LOW_TVL = createLitePoolFixture({
+  address: '0x9999999999999999999999999999999999999999',
+  name: 'V2 Low TVL',
+  tvl: 1,
+  coins: [
+    { address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', decimals: '18', symbol: 'WETH' },
+    { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', decimals: '18', symbol: 'TAIKO' },
+  ],
+})
+
+const LITE_POOL_FIXTURES = [LITE_POOL_SHOWCASE, LITE_POOL_LOW_TVL]
+
+export const V2_POOL_FIXTURES = {
+  ...FULL_V2_POOL_FIXTURES,
+  lite: LITE_POOL_SHOWCASE,
+  liteLowTvl: LITE_POOL_LOW_TVL,
+} as const
 
 type MerklOpportunityParams = {
   identifier: string
-  pool: V2PoolFixture
+  pool: Pick<RawLitePool | V2PoolFixture, 'address' | 'chain_id' | 'name'>
   apr: number
   symbol: string
   platform: string
@@ -230,7 +320,7 @@ const createMerklOpportunity = ({
   tags: [platform],
   chain: {
     id: pool.chain_id,
-    name: pool.network === 'ethereum' ? 'Ethereum' : 'Taiko',
+    name: pool.chain_id === Number(Chain.Ethereum) ? 'Ethereum' : 'Taiko',
   },
   rewardsRecord: {
     breakdowns: [
@@ -348,10 +438,7 @@ const mockPoolChains = () =>
     { method: 'GET', hostname: 'prices.curve.finance', pathname: '/v2/pools/chains/' },
     {
       body: {
-        data: [
-          { chain_id: Chain.Ethereum, name: 'ethereum' },
-          { chain_id: Chain.Taiko, name: 'taiko' },
-        ],
+        data: [{ chain_id: Chain.Ethereum, name: 'ethereum' }],
       },
     },
   )
@@ -366,7 +453,7 @@ const mockPoolList = () =>
     const sortBy = url.searchParams.get('sort_by')
     const sortDirection = url.searchParams.get('sort_direction') === 'asc' ? 'asc' : 'desc'
     const matching = orderBy(
-      Object.values(V2_POOL_FIXTURES)
+      Object.values(FULL_V2_POOL_FIXTURES)
         .filter(pool => pool.chain_id === chainId)
         .filter(
           pool =>
@@ -389,6 +476,21 @@ const mockPoolList = () =>
       },
     })
   })
+
+const mockLitePoolList = () =>
+  cy.intercept(
+    { method: 'GET', hostname: 'api2.curve.finance', pathname: `/get_pools/${Chain.Taiko}` },
+    {
+      body: {
+        success: true,
+        data: {
+          pool_data: LITE_POOL_FIXTURES,
+          tvl: LITE_POOL_FIXTURES.reduce((total, pool) => total + pool.tvl, 0),
+        },
+        generated_time_ms: V2_POOL_FIXTURE_NOW,
+      },
+    },
+  )
 
 const mockPlatforms = () =>
   cy.intercept(
@@ -456,8 +558,12 @@ export const setupDexPoolListV2Mocks = () => {
   cy.intercept({ method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ }, req => {
     req.reply({ statusCode: 503, body: { error: `Unexpected V2 pool-list request: ${req.url}` } })
   })
+  cy.intercept({ method: 'GET', hostname: 'api2.curve.finance', pathname: /^\/get_pools\/\d+$/ }, req => {
+    req.reply({ statusCode: 503, body: { error: `Unexpected API2 pool-list request: ${req.url}` } })
+  })
   mockPoolChains().as('dex-v2-pool-chains')
   mockPoolList().as('dex-v2-pools')
+  mockLitePoolList().as('dex-v2-lite-pools')
   mockPlatforms().as('dex-v2-platforms')
   mockBootstrapRequests()
   mockMerklOpportunities()

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -20,8 +20,12 @@ export const visitV2PoolList = ({
   cy.visitWithoutTestConnector(`dex/${network}/pools/`)
   cy.wait('@dex-v2-platforms', API_LOAD_TIMEOUT)
   cy.wait(['@dex-v2-prices-chains'], API_LOAD_TIMEOUT)
-  cy.wait('@dex-v2-pool-chains', API_LOAD_TIMEOUT)
-  cy.wait('@dex-v2-pools', API_LOAD_TIMEOUT)
+  if (network === 'taiko') {
+    cy.wait('@dex-v2-lite-pools', API_LOAD_TIMEOUT)
+  } else {
+    cy.wait('@dex-v2-pool-chains', API_LOAD_TIMEOUT)
+    cy.wait('@dex-v2-pools', API_LOAD_TIMEOUT)
+  }
   cy.wait('@dex-v2-merkl-curve', API_LOAD_TIMEOUT)
 
   if (!isMobile && network === 'ethereum') {
@@ -57,8 +61,7 @@ export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
   cy.get('body').click(0, 0)
 }
 
-export const getV2PoolExpandedPanel = (address: string) =>
-  getV2PoolRow(address).next('tr').find('[data-testid="pool-age-value"]').should('be.visible').closest('tr')
+export const getV2PoolExpandedPanel = (address: string) => getV2PoolRow(address).next('tr').should('be.visible')
 
 export const expandV2PoolRow = (address: string) => {
   getV2PoolRow(address).find('[data-testid="expand-icon"]').click()

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -21,6 +21,7 @@ export const visitV2PoolList = ({
   cy.wait('@dex-v2-platforms', API_LOAD_TIMEOUT)
   cy.wait(['@dex-v2-prices-chains'], API_LOAD_TIMEOUT)
   if (network === 'taiko') {
+    cy.wait('@dex-v2-lite-pool-chains', API_LOAD_TIMEOUT)
     cy.wait('@dex-v2-lite-pools', API_LOAD_TIMEOUT)
   } else {
     cy.wait('@dex-v2-pool-chains', API_LOAD_TIMEOUT)


### PR DESCRIPTION
Adds support (in beta mode) for lite networks in the new pools list. 

Main idea is to have the table have its own (normalized) view model and map both pool list responses of Prices API and Lite API into that view model. Prices API and Lite API are both only invoked depending on if the network is lite or not, and if the chain is actually supported by the new API. Thus, the fallback to legacy for unsupported chains has been removed and we show an error message instead.

Lite networks don't support server-side pagination, filtering and sorting, so it all happens client-side on a single giant page (like the legacy pool list, basically). There's also no base APYs and Volume column support (yet). Sorting Net APY, CRV APY and Rewards APY for Lite is not yet supported either.

The following networks are expected to not be supported: Aurora, Moonbeam, Mega Testnet, Neon (Testnet)
The following networks will work in the future but not now: Celo