### PR TITLE
fix: buffer leveraged max borrow amount

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useCallback } from 'react'
 import { LEVERAGE, LoanPreset } from '@/llamalend/constants'
+import { getMaxBorrowAmount } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
@@ -113,7 +114,11 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           blockchainId={network.id}
           name="debt"
           form={form}
-          max={{ ...q(maxDebt), fieldName: 'maxDebt' }}
+          max={{
+            ...q(maxDebt),
+            fieldName: 'maxDebt',
+            onMax: maxDebt => getMaxBorrowAmount(maxDebt, values.leverageEnabled),
+          }}
           hideBalance
           testId="borrow-debt-input"
           network={network}
@@ -124,7 +129,10 @@ export const CreateLoanForm = <ChainId extends IChainId>({
               tooltip={t`Max borrow`}
               symbol={borrowToken?.symbol}
               balance={q(maxDebt)}
-              onClick={useCallback(() => updateForm({ debt: values.maxDebt }), [updateForm, values.maxDebt])}
+              onClick={useCallback(
+                () => updateForm({ debt: getMaxBorrowAmount(values.maxDebt, values.leverageEnabled) }),
+                [updateForm, values.leverageEnabled, values.maxDebt],
+              )}
               buttonTestId="borrow-set-debt-to-max"
             />
           }

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -3,6 +3,7 @@ import { LEVERAGE } from '@/llamalend/constants'
 import { BorrowMoreLoanInfoList } from '@/llamalend/features/borrow/components/BorrowMoreLoanInfoList'
 import { LeverageInput } from '@/llamalend/features/borrow/components/LeverageInput'
 import type { UserCollateralEvents } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
+import { getMaxBorrowAmount } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
@@ -68,6 +69,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
     (event: ChangeEvent<HTMLInputElement>) => updateForm({ leverageEnabled: event.target.checked, routeId: undefined }),
     [updateForm],
   )
+  const getMaxDebt = (maxDebt?: Decimal) => getMaxBorrowAmount(maxDebt, values.leverageEnabled)
 
   return (
     <Form
@@ -119,7 +121,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           blockchainId={network.id}
           name="debt"
           form={form}
-          max={{ ...max.debt, fieldName: max.debt.field }}
+          max={{ ...max.debt, fieldName: max.debt.field, onMax: getMaxDebt }}
           testId="borrow-more-input-debt"
           network={network}
           hideBalance
@@ -130,7 +132,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
               tooltip={t`Max available to borrow`}
               symbol={borrowToken?.symbol}
               balance={max.debt}
-              onClick={() => updateForm({ debt: max.debt.data })}
+              onClick={() => updateForm({ debt: getMaxDebt(max.debt.data) })}
             />
           }
         />

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -95,7 +95,7 @@ export const isRouterRequired = (
   type: 'zapV2' | 'V0' | 'deleverage' | 'unleveragedMint' | 'unleveragedLend' | 'unleveraged',
 ) => type == 'zapV2'
 
-const LEVERAGED_MAX_BORROW_RATIO = '0.995'
+const LEVERAGED_MAX_BORROW_RATIO = '0.99999' // -0.001%
 
 /** Leaves a buffer below the quoted maximum to account for leverage quote changes before execution. */
 export const getMaxBorrowAmount = (maxDebt: Decimal | undefined, leverageEnabled: boolean | undefined) =>

--- a/apps/main/src/llamalend/llama.utils.ts
+++ b/apps/main/src/llamalend/llama.utils.ts
@@ -95,6 +95,12 @@ export const isRouterRequired = (
   type: 'zapV2' | 'V0' | 'deleverage' | 'unleveragedMint' | 'unleveragedLend' | 'unleveraged',
 ) => type == 'zapV2'
 
+const LEVERAGED_MAX_BORROW_RATIO = '0.995'
+
+/** Leaves a buffer below the quoted maximum to account for leverage quote changes before execution. */
+export const getMaxBorrowAmount = (maxDebt: Decimal | undefined, leverageEnabled: boolean | undefined) =>
+  maxDebt && leverageEnabled ? decimalMultiply(maxDebt, LEVERAGED_MAX_BORROW_RATIO) : maxDebt
+
 export const hasGauge = (market: MarketTemplate) =>
   market instanceof LendMarketTemplate && market.addresses.gauge !== zeroAddress
 

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -131,10 +131,7 @@ export const LoanFormTokenInput = <
     },
     [name, onValueChange, updateForm],
   )
-  const onMaxBalance = useCallback(
-    (v?: Decimal) => onBalance(onMax ? onMax(v) : v),
-    [onBalance, onMax],
-  )
+  const onMaxBalance = useCallback((v?: Decimal) => onBalance(onMax ? onMax(v) : v), [onBalance, onMax])
   return (
     <LargeTokenInput
       name={name}

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -29,7 +29,10 @@ export type LoanFormTokenInputProps<
    * Optional max-value query for this field, including loading and error state.
    * When present, it also carries an optional related max-field name whose errors should be reflected here.
    */
-  max?: QueryProp<Decimal> & { fieldName: TMaxFieldName }
+  max?: QueryProp<Decimal> & {
+    fieldName: TMaxFieldName
+    onMax?: NonNullable<LargeTokenInputProps['maxBalance']>['onMax']
+  }
   name: TFieldName
   form: UseFormReturn<TFieldValues> // the form, used to set the value and get errors
   testId: string
@@ -145,7 +148,7 @@ export const LoanFormTokenInput = <
       balance={q({ data: value, isLoading: value == null, error: error ?? null })}
       onBalance={onBalance}
       {...(!hideBalance && { walletBalance })}
-      maxBalance={max && { chips: 'range', balance: max }}
+      maxBalance={max && { chips: 'range', balance: max, onMax: max.onMax }}
       inputBalanceUsd={decimal(usdRate && usdRate * +(value ?? 0))}
       message={errorMessage ? undefined : message}
       disabled={disabled}

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -118,6 +118,7 @@ export const LoanFormTokenInput = <
 
   const errors = formErrors as PartialRecord<FieldPath<TFieldValues>, Error>
   const maxFieldName = max?.fieldName
+  const onMax = max?.onMax
   const relatedMaxFieldError = max?.data && maxFieldName && errors[maxFieldName]
   const error = name in touchedFields ? (errors[name] ?? max?.error ?? relatedMaxFieldError) : balanceError
   const value = getValue(name)
@@ -129,6 +130,10 @@ export const LoanFormTokenInput = <
       onValueChange?.(v)
     },
     [name, onValueChange, updateForm],
+  )
+  const onMaxBalance = useCallback(
+    (v?: Decimal) => onBalance(onMax ? onMax(v) : v),
+    [onBalance, onMax],
   )
   return (
     <LargeTokenInput
@@ -154,7 +159,7 @@ export const LoanFormTokenInput = <
       disabled={disabled}
     >
       {maxMessage && !errorMessage && <HelperMessage onNumberClick={onBalance} message={maxMessage} />}
-      {errorMessage && <HelperMessage message={errorMessage} onNumberClick={onBalance} isError />}
+      {errorMessage && <HelperMessage message={errorMessage} onNumberClick={onMaxBalance} isError />}
     </LargeTokenInput>
   )
 }

--- a/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
@@ -35,14 +35,23 @@ type InputChip = {
   label: string
   /** The function that returns the new input amount, possibly based on the max balance. */
   newBalance: (() => void) | ((maxBalance?: Decimal) => Decimal | undefined)
+  /** Whether the chip selects the maximum balance. */
+  isMax?: boolean
 }
+
+const [MIN_PERCENTAGE, MAX_PERCENTAGE] = [0, 100]
+
+/** Splits a maximum percentage into evenly spaced percentage steps. */
+const createPercentageSteps = (maxPercentage: number, count = 4) =>
+  Array.from({ length: count }, (_, i) => ((i + 1) * maxPercentage) / count)
 
 type ChipsPreset = 'max' | 'range'
 const CHIPS_PRESETS: Record<ChipsPreset, InputChip[]> = {
-  max: [{ label: t`Max`, newBalance: maxBalance => maxBalance }],
-  range: [25, 50, 75, 100].map(p => ({
+  max: [{ label: t`Max`, newBalance: maxBalance => maxBalance, isMax: true }],
+  range: createPercentageSteps(MAX_PERCENTAGE).map(p => ({
     label: `${p}%`,
     newBalance: maxBalance => maxBalance && calculateNewBalance(maxBalance, `${p}`),
+    isMax: p === MAX_PERCENTAGE,
   })),
 }
 
@@ -88,6 +97,8 @@ export type LargeTokenInputProps = {
     showSlider?: boolean
     /** Custom or preset chips to show. */
     chips?: ChipsPreset | InputChip[]
+    /** Optional override for the amount selected by a Max-style chip. */
+    onMax?: (maxBalance?: Decimal) => Decimal | undefined
   }
 
   /** Optional usd value of the balance given as input. */
@@ -167,8 +178,6 @@ const calculateNewPercentage = (newBalance: Decimal, max: Decimal) =>
 /** Converts two decimals to BigNumber for comparison */
 const bigNumEquals = (a?: Decimal, b?: Decimal) => a == b || (a != null && b != null && new BigNumber(a).isEqualTo(b))
 
-const [MIN_PERCENTAGE, MAX_PERCENTAGE] = [0, 100]
-
 export const LargeTokenInput = ({
   ref,
   tokenSelector,
@@ -195,6 +204,7 @@ export const LargeTokenInput = ({
   })
 
   const chips = typeof maxBalance?.chips === 'string' ? CHIPS_PRESETS[maxBalance.chips] : maxBalance?.chips
+  const onMax = maxBalance?.onMax
   const showChips = !!chips?.length
   const { data: maxBalanceValue, isLoading: maxBalanceLoading, error: maxBalanceError } = toQuery(maxBalance?.balance)
   const showSlider = !!maxBalance?.showSlider && maxBalanceValue != null
@@ -327,7 +337,8 @@ export const LargeTokenInput = ({
                       data-testid={!chipDisabled && `input-chip-${chip.label}`}
                       disabled={chipDisabled}
                       toggle={() => {
-                        const newBalance = chip.newBalance(maxBalanceValue)
+                        const newBalance =
+                          chip.isMax && onMax ? onMax(maxBalanceValue) : chip.newBalance(maxBalanceValue)
                         if (newBalance !== undefined) {
                           handleBalanceChange(newBalance)
                         }


### PR DESCRIPTION
- apply a `99.999%` of the max borrowable when leveraging when clicking the max borrowable or 100% chip, so that if the max debt changes in the meantime it doesn't throw validation errors