### PR TITLE
chore: fix pool table row expansion flakyness

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/DataTable/ExpansionRow.tsx
@@ -33,18 +33,11 @@ export function ExpansionRow<T extends TableItem>({
   const { render, onExited, expanded } = useRowExpansion(row)
   const { Body, Actions } = expandedPanel
 
-  const [testId, setTestId] = useState<string | null>(null)
-
   return (
     render && (
-      <TableRow data-testid={testId}>
+      <TableRow data-testid={expanded ? 'data-table-expansion-row' : undefined}>
         <TableCell colSpan={colSpan} sx={{ padding: 0 }}>
-          <Collapse
-            in={expanded}
-            onEntered={() => setTestId('data-table-expansion-row')}
-            onExit={() => setTestId(null)}
-            onExited={onExited}
-          >
+          <Collapse in={expanded} onExited={onExited}>
             <Stack direction="column" sx={{ gap: Spacing.md, paddingBlockStart: Spacing.md }}>
               <Stack sx={{ gap: Spacing.md, paddingInline: Spacing.md }}>
                 <Body row={row} table={table} />


### PR DESCRIPTION
I'm not exactly sure *why*, but the row expansion using Collapse non-deterministically fails, and I suspect the culprit to be the transition. This is a test-only problem, so I'm trying to see if attaching the `data-table-expansion-row` value for `data-testid` without depending on the animation state fixes the flakyness.