### PR TITLE
fix: prevent slippage modal form submissions

### DIFF
--- a/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/ModalDialog.tsx
@@ -85,7 +85,17 @@ type ModalDialogProps = {
  * so that we can keep the form submission in the footer.
  */
 const Form = ({ onSubmit, ...props }: ModalFormProps) => (
-  <form {...props} onSubmit={onSubmit ? event => void onSubmit(event) : undefined} />
+  <form
+    {...props}
+    onSubmit={
+      onSubmit
+        ? event => {
+            event.stopPropagation()
+            void onSubmit(event)
+          }
+        : undefined
+    }
+  />
 )
 
 export const ModalDialog = ({

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageFormField.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageFormField.tsx
@@ -88,8 +88,7 @@ export const SlippageFormField = ({
         decimalGreaterThan(min, value) && (
           <Alert severity="warning" variant="outlined">
             <AlertTitle>{t`Low ${type} slippage selected!`}</AlertTitle>
-            {t`Your transaction may fail if price moves slightly. Consider increasing slippage if it doesn't go through.`}{' '}
-            {t`Min. slippage is ${formatNumber(min, 'percent.rate')}`}
+            {t`Your transaction may fail if price moves slightly. Consider increasing slippage if it doesn't go through.`}
           </Alert>
         )
       )}

--- a/tests/cypress/component/slippage-settings.cy.tsx
+++ b/tests/cypress/component/slippage-settings.cy.tsx
@@ -1,0 +1,26 @@
+import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
+import { SlippageToleranceActionInfo } from '@ui-kit/widgets/SlippageSettings/SlippageToleranceActionInfo'
+
+describe('Slippage settings', () => {
+  it('does not submit an enclosing form when saving', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+
+    cy.mount(
+      <ComponentTestWrapper>
+        <form
+          onSubmit={event => {
+            event.preventDefault()
+            onSubmit()
+          }}
+        >
+          <SlippageToleranceActionInfo maxSlippage="0.5" type="leverage" />
+        </form>
+      </ComponentTestWrapper>,
+    )
+
+    cy.get('[data-testid="slippage-settings-button"]').click()
+    cy.get('[data-testid="slippage-radio-group"] [value="1"]').click()
+    cy.get('[data-testid="slippage-save-button"]').click()
+    cy.get('@onSubmit').should('not.have.been.called')
+  })
+})


### PR DESCRIPTION
- this prevent the slippage modal from propagating form submissions (ex: slippage modal llamalend form's with leverage)