### PR TITLE
feat: configure stable market leverage slippage

### DIFF
--- a/apps/main/src/llamalend/markets.constants.ts
+++ b/apps/main/src/llamalend/markets.constants.ts
@@ -405,10 +405,30 @@ type MarketLeverageConfig = { slippage?: Decimal }
 
 export const MARKET_LEVERAGE: PartialRecord<number, Record<Address, MarketLeverageConfig>> = {
   [Chain.Ethereum]: {
-    // sDOLA-crvUSD v2
-    '0xC77d97cF01737EB7aCE46cAb7cd9F60eC51a40c0': { slippage: SLIPPAGE.stable.default },
     // syrupUSDC-crvUSD
     '0x2fb54c8eae57767A9A509A395b9C4FA0702e2675': { slippage: SLIPPAGE.stable.default },
+    // sfrxUSD-crvUSD v2
+    '0x3cD4d86a2c65e57ce4b4121b67E2D2224BA41bbe': { slippage: SLIPPAGE.stable.default },
+    // sDOLA-crvUSD v2
+    '0xC77d97cF01737EB7aCE46cAb7cd9F60eC51a40c0': { slippage: SLIPPAGE.stable.default },
+    // sreUSD-crvUSD
+    '0x4F79Fe450a2BAF833E8f50340BD230f5A3eCaFe9': { slippage: SLIPPAGE.stable.default },
+    // fxSAVE-crvUSD
+    '0x8035b16053560b3C351b665b10f6C7dBDb6A1E05': { slippage: SLIPPAGE.stable.default },
+    // sUSDS-crvUSD
+    '0x2dA313f6DCEE04BA46466E100c4656618E5d3dDd': { slippage: SLIPPAGE.stable.default },
+    // sfrxUSD-crvUSD
+    '0x3DE37c38739dFb83b7A902842bF5393040f7BF50': { slippage: SLIPPAGE.stable.default },
+    // sUSDe-crvUSD
+    '0xB536FEa3a01c95Dd09932440eC802A75410139D6': { slippage: SLIPPAGE.stable.default },
+  },
+  [Chain.Optimism]: {
+    // wstETH-WETH v2
+    '0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9': { slippage: SLIPPAGE.stable.default },
+  },
+  [Chain.Fraxtal]: {
+    // sfrxUSD-crvUSD
+    '0xB4EbF87A474569d8eB7f7182B4beBD8aE79ae675': { slippage: SLIPPAGE.stable.default },
   },
 }
 

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/slippage.utils.ts
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/slippage.utils.ts
@@ -40,5 +40,5 @@ export const SLIPPAGE: Record<
 > = {
   stable: slippage('0.03', t`Stableswap slippage`, t`Used when the route only goes through stableswap pools`),
   crypto: slippage('0.1', t`Cryptoswap slippage`, t`Used when the route goes through at least one cryptoswap pool`),
-  leverage: slippage('0.5', t`Leverage slippage`, t`Used when leveraging on llamalend`),
+  leverage: slippage('0.2', t`Leverage slippage`, t`Used when leveraging on llamalend`),
 }

--- a/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
+++ b/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
@@ -10,6 +10,7 @@ import type { BaseConfig } from '@ui/utils'
 import { q } from '@ui-kit/types/util'
 import { mockRoutes } from '@ui-kit/widgets/RouteProvider/route.mock'
 import { SlippageToleranceActionInfo } from '@ui-kit/widgets/SlippageSettings'
+import { SLIPPAGE } from '@ui-kit/widgets/SlippageSettings/slippage.utils'
 
 const getHeight = (testId: string, subelement?: string) =>
   cy
@@ -104,7 +105,7 @@ describe('market slippage settings', () => {
     cy.get('@onChanged').should('not.have.been.called')
 
     cy.get('[data-testid="slippage-settings-button"]').click()
-    cy.get('[data-testid="slippage-radio-group"] [value="0.5"]').click()
+    cy.get(`[data-testid="slippage-radio-group"] [value="${SLIPPAGE.leverage.default}"]`).click()
     cy.get('[data-testid="slippage-save-button"]').click()
     cy.get('@onChanged').should('have.been.calledOnce')
   })

--- a/tests/cypress/component/llamalend/market-constants.cy.tsx
+++ b/tests/cypress/component/llamalend/market-constants.cy.tsx
@@ -36,10 +36,10 @@ const mountMarketAlert = ({
 
 const ALL_MARKET_ALERTS = recordValues(MARKETS_ALERTS)
 const ALL_DEPRECATED_LLAMAS = recordValues(DEPRECATED_LLAMAS)
-const STABLE_LEVERAGE_MARKETS = [
-  '0xC77d97cF01737EB7aCE46cAb7cd9F60eC51a40c0',
-  '0x2fb54c8eae57767A9A509A395b9C4FA0702e2675',
-] as const
+const STABLE_LEVERAGE_MARKETS = {
+  [Chain.Ethereum]: ['0x2fb54c8eae57767A9A509A395b9C4FA0702e2675', '0xC77d97cF01737EB7aCE46cAb7cd9F60eC51a40c0'],
+  [Chain.Optimism]: ['0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9'],
+} as const
 
 /** Get a list of all alerts for each market type, and chain */
 const ALERT_CASES = recordEntries(MARKETS_ALERTS).flatMap(([marketType, marketAlerts]) =>
@@ -90,8 +90,10 @@ describe('llama market constants', () => {
   })
 
   it('gets the configured market slippage with a leverage fallback', () => {
-    for (const controllerAddress of STABLE_LEVERAGE_MARKETS) {
-      expect(getMarketLeverageSlippage(Chain.Ethereum, controllerAddress)).to.eq(SLIPPAGE.stable.default)
+    for (const [chainId, controllerAddresses] of recordEntries(STABLE_LEVERAGE_MARKETS)) {
+      for (const controllerAddress of controllerAddresses) {
+        expect(getMarketLeverageSlippage(Number(chainId), controllerAddress)).to.eq(SLIPPAGE.stable.default)
+      }
     }
     expect(getMarketLeverageSlippage(Chain.Ethereum, zeroAddress)).to.eq(SLIPPAGE.leverage.default)
   })


### PR DESCRIPTION
- add stable slippage to stable pair markets
- default non-stable pair with `0.2%` slippage 