### PR TITLE
fix: improve form error alerts

### DIFF
--- a/packages/curve-ui-kit/src/hooks/useCopyToClipboard.ts
+++ b/packages/curve-ui-kit/src/hooks/useCopyToClipboard.ts
@@ -10,6 +10,7 @@ const getTitle = (copyText: string, title: string | undefined) =>
 type CopyToClipboardWithToastOptions = {
   copyText: string | undefined
   confirmationText?: string
+  confirmationMessage?: string
   failureText?: string
   testId?: string
 }
@@ -17,6 +18,7 @@ type CopyToClipboardWithToastOptions = {
 export const copyToClipboardWithToast = async ({
   copyText,
   confirmationText,
+  confirmationMessage,
   failureText = t`Failed to copy to clipboard`,
   testId = 'copy-confirmation',
 }: CopyToClipboardWithToastOptions) => {
@@ -25,7 +27,12 @@ export const copyToClipboardWithToast = async ({
   const copied = await copyToClipboard(copyText)
   showToast(
     copied
-      ? { message: copyText, severity: 'info', title: getTitle(copyText, confirmationText), testId }
+      ? {
+          message: confirmationMessage ?? copyText,
+          severity: 'info',
+          title: getTitle(copyText, confirmationText),
+          testId,
+        }
       : { severity: 'error', title: failureText, testId },
   )
 }
@@ -33,12 +40,14 @@ export const copyToClipboardWithToast = async ({
 export const useCopyToClipboard = ({
   copyText,
   confirmationText,
+  confirmationMessage,
   testId,
 }: {
   copyText: string | undefined
   confirmationText?: string
+  confirmationMessage?: string
   testId?: string
 }) =>
   useCallback(() => {
-    void copyToClipboardWithToast({ copyText, confirmationText, testId })
-  }, [copyText, confirmationText, testId])
+    void copyToClipboardWithToast({ copyText, confirmationText, confirmationMessage, testId })
+  }, [copyText, confirmationText, confirmationMessage, testId])

--- a/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
+++ b/packages/curve-ui-kit/src/shared/ui/CopyIconButton.tsx
@@ -5,9 +5,10 @@ import { CopyIcon } from '@ui-kit/shared/icons/CopyIcon'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
 
 type CopyIconButtonProps = {
-  copyText: string
+  copyText: string | undefined
   label: string
   confirmationText: string
+  confirmationMessage?: string
   children?: ReactNode
 } & IconButtonProps
 
@@ -15,12 +16,17 @@ export const CopyIconButton = ({
   copyText,
   label,
   confirmationText,
+  confirmationMessage,
   children = <CopyIcon />,
   size = 'extraSmall',
   ...iconProps
 }: CopyIconButtonProps) => (
   <Tooltip title={label} placement="top">
-    <IconButton size={size} {...iconProps} onClick={useCopyToClipboard({ copyText, confirmationText })}>
+    <IconButton
+      size={size}
+      {...iconProps}
+      onClick={useCopyToClipboard({ copyText, confirmationText, confirmationMessage })}
+    >
       {children}
     </IconButton>
   </Tooltip>

--- a/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
+++ b/packages/curve-ui-kit/src/themes/components/mui-alert.tsx
@@ -37,7 +37,6 @@ export const defineMuiAlert = (
         flexGrow: 1,
         textWrapStyle: 'pretty',
         ...handleBreakpoints({
-          paddingInlineEnd: Spacing.sm,
           paddingBlockStart: Spacing.sm,
           paddingBlockEnd: Spacing.xs,
         }),
@@ -97,6 +96,14 @@ export const defineMuiAlert = (
         height: IconSize.sm,
       }),
     },
+    action: handleBreakpoints({
+      marginInlineStart: Spacing.xs,
+      marginInlineEnd: 0,
+      paddingInlineStart: 0,
+      paddingInlineEnd: 0,
+      paddingBlockStart: Spacing.sm,
+      paddingBlockEnd: Spacing.xs,
+    }),
   },
 })
 

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.stories.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.stories.tsx
@@ -1,11 +1,11 @@
+import { range } from '@primitives/objects.utils'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { FormAlerts } from './FormAlerts'
 
 const LONG_ERROR = new Error(
-  Array.from(
-    { length: 20 },
-    (_, index) => `Transaction error detail ${index}: reverted call data 0x${index.toString(16).padStart(8, '0')}`,
-  ).join(' '),
+  range(20)
+    .map(index => `Transaction error detail ${index}: reverted call data 0x${index.toString(16).padStart(8, '0')}`)
+    .join(' '),
 )
 
 const meta: Meta<typeof FormAlerts> = {

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.stories.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FormAlerts } from './FormAlerts'
+
+const LONG_ERROR = new Error(
+  Array.from(
+    { length: 20 },
+    (_, index) => `Transaction error detail ${index}: reverted call data 0x${index.toString(16).padStart(8, '0')}`,
+  ).join(' '),
+)
+
+const meta: Meta<typeof FormAlerts> = {
+  title: 'UI Kit/Widgets/Detail Page/Form Alerts',
+  component: FormAlerts,
+  args: { formErrors: [], handledErrors: [] },
+  decorators: [Story => <div style={{ width: 'min(480px, 100vw)' }}>{Story()}</div>],
+}
+
+type Story = StoryObj<typeof FormAlerts>
+
+export const Default: Story = {
+  args: { error: new Error('Transaction reverted') },
+}
+
+export const ValidationErrors: Story = {
+  args: {
+    formErrors: [
+      ['collateral', 'Collateral amount exceeds your balance'],
+      ['debt', 'Debt amount is below the minimum'],
+    ],
+  },
+}
+
+export const RejectedTransaction: Story = {
+  args: { error: new Error('User rejected the request') },
+}
+
+export const LongSubmissionError: Story = {
+  args: { error: LONG_ERROR },
+}
+
+export const ValidationAndSubmissionErrors: Story = {
+  args: {
+    error: new Error('Unable to estimate gas'),
+    formErrors: [['debt', 'Enter a valid debt amount']],
+  },
+}
+
+export default meta

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react'
+import CloseIcon from '@mui/icons-material/Close'
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { ErrorReportModal } from '@ui-kit/features/report-error'
 import { usePreviousValue } from '@ui-kit/hooks/usePreviousValue'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
+import { CopyIconButton } from '@ui-kit/shared/ui/CopyIconButton'
 import { WithSkeleton } from '@ui-kit/shared/ui/WithSkeleton'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { type QueryProp } from '@ui-kit/types/util'
@@ -34,7 +38,10 @@ const { Spacing } = SizesAndSpaces
 
 export const FormAlerts = <Field extends string>({ error, formErrors, handledErrors }: FormAlertProps<Field>) => {
   const [isReportOpen, openReportModal, closeReportModal] = useSwitch(false)
+  const [dismissedError, setDismissedError] = useState<Error | null>(null)
   const unhandledErrors = formErrors.filter(([field]) => !handledErrors.includes(field))
+  const visibleError = error === dismissedError ? null : error
+  const errorMessage = visibleError ? getErrorMessage(visibleError) : ''
   return (
     <>
       {unhandledErrors.length > 0 && (
@@ -45,19 +52,46 @@ export const FormAlerts = <Field extends string>({ error, formErrors, handledErr
           ))}
         </Alert>
       )}
-      {error && (
+      {visibleError && (
         <Alert
           variant="outlined"
           severity="error"
           sx={{ overflowWrap: 'anywhere' /* break anywhere as there is often JSON in the error breaking the design */ }}
           data-testid="loan-alert-error"
+          action={
+            <IconButton
+              color="ghost"
+              size="extraSmall"
+              title={t`Dismiss error`}
+              aria-label={t`Dismiss error`}
+              data-testid="dismiss-loan-alert-error"
+              onClick={() => setDismissedError(visibleError)}
+            >
+              <CloseIcon />
+            </IconButton>
+          }
         >
           <AlertTitle>{t`An error occurred`}</AlertTitle>
           <Stack sx={{ gap: Spacing.xs, width: '100%' }}>
-            <span>{getErrorMessage(error)}</span>
-            <Button color="ghost" size="extraSmall" sx={{ alignSelf: 'flex-end' }} onClick={openReportModal}>
-              {t`Submit error report`}
-            </Button>
+            <Box
+              component="span"
+              data-testid="loan-alert-error-message"
+              sx={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 5, overflow: 'hidden' }}
+            >
+              {errorMessage}
+            </Box>
+            <Stack direction="row" sx={{ alignSelf: 'flex-end', alignItems: 'center', gap: Spacing.xxs }}>
+              <CopyIconButton
+                copyText={errorMessage}
+                label={t`Copy error message`}
+                confirmationText={t`Error message copied to clipboard`}
+                color="ghost"
+                data-testid="copy-loan-alert-error"
+              />
+              <Button color="ghost" size="extraSmall" onClick={openReportModal}>
+                {t`Submit error report`}
+              </Button>
+            </Stack>
           </Stack>
         </Alert>
       )}

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/FormAlerts.tsx
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
+import { maybe } from '@primitives/objects.utils'
 import { ErrorReportModal } from '@ui-kit/features/report-error'
 import { usePreviousValue } from '@ui-kit/hooks/usePreviousValue'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
@@ -40,8 +41,8 @@ export const FormAlerts = <Field extends string>({ error, formErrors, handledErr
   const [isReportOpen, openReportModal, closeReportModal] = useSwitch(false)
   const [dismissedError, setDismissedError] = useState<Error | null>(null)
   const unhandledErrors = formErrors.filter(([field]) => !handledErrors.includes(field))
-  const visibleError = error === dismissedError ? null : error
-  const errorMessage = visibleError ? getErrorMessage(visibleError) : ''
+  const visibleError = error !== dismissedError && error
+  const errorMessage = maybe(visibleError, getErrorMessage)
   return (
     <>
       {unhandledErrors.length > 0 && (
@@ -63,7 +64,6 @@ export const FormAlerts = <Field extends string>({ error, formErrors, handledErr
               color="ghost"
               size="extraSmall"
               title={t`Dismiss error`}
-              aria-label={t`Dismiss error`}
               data-testid="dismiss-loan-alert-error"
               onClick={() => setDismissedError(visibleError)}
             >
@@ -85,6 +85,7 @@ export const FormAlerts = <Field extends string>({ error, formErrors, handledErr
                 copyText={errorMessage}
                 label={t`Copy error message`}
                 confirmationText={t`Error message copied to clipboard`}
+                confirmationMessage="" // confirmation title is enough
                 color="ghost"
                 data-testid="copy-loan-alert-error"
               />

--- a/tests/cypress/component/form-alerts.cy.tsx
+++ b/tests/cypress/component/form-alerts.cy.tsx
@@ -1,0 +1,32 @@
+import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
+import { FormAlerts } from '@ui-kit/widgets/DetailPageLayout/FormAlerts'
+
+const ERROR_MESSAGE = Array.from({ length: 20 }, (_, index) => `Transaction error detail ${index}`).join(' ')
+
+describe('FormAlerts', () => {
+  beforeEach(() => {
+    cy.window().then(({ navigator }) => cy.stub(navigator.clipboard, 'writeText').as('writeText'))
+    cy.mount(
+      <ComponentTestWrapper>
+        <FormAlerts error={new Error(ERROR_MESSAGE)} formErrors={[]} handledErrors={[]} />
+      </ComponentTestWrapper>,
+    )
+  })
+
+  it('truncates and copies submission errors', () => {
+    cy.get('[data-testid="loan-alert-error-message"]')
+      .should('have.css', '-webkit-line-clamp', '5')
+      .and('have.css', 'overflow', 'hidden')
+    cy.contains('button', 'Submit error report').should('be.visible')
+    cy.get('[data-testid="copy-loan-alert-error"]').should('be.visible')
+    cy.get('[data-testid="dismiss-loan-alert-error"]').should('be.visible')
+
+    cy.get('[data-testid="copy-loan-alert-error"]').click()
+    cy.get('@writeText').should('have.been.calledOnceWith', ERROR_MESSAGE)
+  })
+
+  it('dismisses submission errors', () => {
+    cy.get('[data-testid="dismiss-loan-alert-error"]').click()
+    cy.get('[data-testid="loan-alert-error"]').should('not.exist')
+  })
+})

--- a/tests/cypress/component/form-alerts.cy.tsx
+++ b/tests/cypress/component/form-alerts.cy.tsx
@@ -23,6 +23,7 @@ describe('FormAlerts', () => {
 
     cy.get('[data-testid="copy-loan-alert-error"]').click()
     cy.get('@writeText').should('have.been.calledOnceWith', ERROR_MESSAGE)
+    cy.get('[data-testid="copy-confirmation"]').should('not.contain.text', ERROR_MESSAGE)
   })
 
   it('dismisses submission errors', () => {


### PR DESCRIPTION
- dismissible form alert boxes
- add copy button for the content of the error
- add 5 line clamp to the form alert so the message is truncated

<img width="533" height="179" alt="Screenshot 2026-08-12 at 16 10 31" src="https://github.com/user-attachments/assets/cef30c70-e3d5-4f9f-ab22-43f284d8b3ae" />
