### PR TITLE
fix: truncate wei conversion

### DIFF
--- a/packages/curve-ui-kit/src/utils/decimal.spec.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.spec.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { describe, expect, it } from 'vitest'
-import { amount, decimal, decimalSqrt } from './decimal'
+import { amount, decimal, decimalSqrt, toWei } from './decimal'
 
 describe('decimal', () => {
   it('handles basic, normal numbers', () => {
@@ -90,5 +90,11 @@ describe('decimalSqrt', () => {
 
   it('rejects negative numbers', () => {
     expect(() => decimalSqrt('-1')).toThrow('Cannot calculate square root of a negative Decimal: -1')
+  })
+})
+
+describe('toWei', () => {
+  it('truncates precision beyond the token decimals', () => {
+    expect(toWei('58.0208027707242457906', 18)).toBe('58020802770724245790')
   })
 })

--- a/packages/curve-ui-kit/src/utils/decimal.ts
+++ b/packages/curve-ui-kit/src/utils/decimal.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'bignumber.js'
-import { formatUnits, parseUnits } from 'viem'
+import { formatUnits } from 'viem'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
 import { maybe } from '@primitives/objects.utils'
 
@@ -71,5 +71,11 @@ export const decimalDiv = (first: Decimal, second: Decimal) =>
 export const decimalPercent = (part: Decimal, total: Decimal): Decimal =>
   +total ? decimalMultiply(decimalDiv(part, total), '100') : '0'
 
-export const toWei = (n: string, decimals: number) => decimal(parseUnits(n || '0', decimals))!
+// Viem parseUnits rounds excess decimals, but we must truncate to match llamalend.js transaction amounts.
+export const toWei = (n: string, decimals: number) =>
+  decimal(
+    BigNumber(n || '0')
+      .shiftedBy(decimals)
+      .integerValue(BigNumber.ROUND_DOWN),
+  )!
 export const fromWei = (n: string, decimals: number) => decimal(formatUnits(BigInt(n), decimals))!


### PR DESCRIPTION
- truncate instead of rounding wei conversion

This was causing errors because llamalend.j truncates and we were rouding