### PR TITLE
test: cover health details states

### DIFF
--- a/apps/main/src/llamalend/features/market-position-details/health/HealthAndBufferBar.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/health/HealthAndBufferBar.tsx
@@ -82,11 +82,13 @@ export const HealthAndBufferBar = ({
   const { data, isLoading } = mapQuery(query, getValue)
   const percentage = getPercentage(data)
   const label = type === 'health' ? maybe(state, state => HEALTH_LABEL[state]) : undefined
+  const testId = `health-details-${type === 'liquidationBuffer' ? 'liquidation-buffer' : type}-bar`
 
   return (
     <WithSkeleton loading={isLoading} variant="rectangular" width="100%" height={Height.healthBar[size]}>
       <Tooltip title={tooltip.title} body={tooltip.body}>
         <Stack
+          data-testid={testId}
           sx={{
             height: Height.healthBar[size],
             backgroundColor: theme => theme.design.Color.Neutral[300],
@@ -96,6 +98,7 @@ export const HealthAndBufferBar = ({
           }}
         >
           <Box
+            data-testid={`${testId}-fill`}
             sx={{
               height: '100%',
               width: `${percentage}%`,
@@ -105,6 +108,7 @@ export const HealthAndBufferBar = ({
           />
           {label && (
             <Badge
+              data-testid={`${testId}-badge`}
               size={BADGE_SIZE_BY_BAR_SIZE[size]}
               color={state === 'hardLiquidation' ? 'alert' : 'warning'}
               label={label}

--- a/apps/main/src/llamalend/features/market-position-details/health/HealthDetails.stories.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/health/HealthDetails.stories.tsx
@@ -5,8 +5,8 @@ import { maybes } from '@primitives/objects.utils'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { QueryData } from '@ui-kit/lib/queries/types'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
-import { q } from '@ui-kit/types/util'
-import { decimalDiv, decimalMultiply, decimalSum, ZERO } from '@ui-kit/utils'
+import { constQ, q } from '@ui-kit/types/util'
+import { decimalDiv, decimalMultiply, decimalSum } from '@ui-kit/utils'
 import { HealthDetails } from './HealthDetails'
 
 const { Spacing } = SizesAndSpaces
@@ -18,28 +18,19 @@ type HealthDetailsStoryProps = {
   isLoading?: boolean
 }
 
-const getHealthQuery = ({ health, liquidationBuffer, isLoading }: HealthDetailsStoryProps) =>
-  q<QueryData<typeof useUserHealthValues>>({
-    data: maybes([health, liquidationBuffer], (h, lb) => {
-      const healthNotFull = decimalMultiply(decimalDiv(lb, '100'), DISCOUNT_GAP)
-      return {
-        health: h,
-        healthFactor: decimalSum('1', decimalDiv(h, '100')),
-        healthNotFull,
-        liquidationBuffer: lb,
-        debug: {
-          healthFull: decimalSum(h, healthNotFull),
-          healthNotFull,
-          loanDiscount: DISCOUNT_GAP,
-          liquidationDiscount: ZERO,
-          discountGap: DISCOUNT_GAP,
-          healthDelta: h,
-        },
-      }
-    }),
-    isLoading: isLoading ?? false,
-    error: null,
-  })
+const getHealthQuery = ({ health, liquidationBuffer, isLoading }: HealthDetailsStoryProps) => {
+  const data = maybes([health, liquidationBuffer], (h, lb) => {
+    const healthNotFull = decimalMultiply(decimalDiv(lb, '100'), DISCOUNT_GAP)
+    return {
+      health: h,
+      healthFactor: decimalSum('1', decimalDiv(h, '100')),
+      healthNotFull,
+      liquidationBuffer: lb,
+    }
+  }) satisfies QueryData<typeof useUserHealthValues> | undefined
+
+  return isLoading ? q({ data, isLoading: true, error: null }) : constQ(data)
+}
 
 const HealthDetailsStory = (props: HealthDetailsStoryProps) => <HealthDetails healthQuery={getHealthQuery(props)} />
 

--- a/apps/main/src/llamalend/features/market-position-details/health/HealthDetails.tsx
+++ b/apps/main/src/llamalend/features/market-position-details/health/HealthDetails.tsx
@@ -30,6 +30,7 @@ export const HealthDetails = ({ healthQuery }: { healthQuery: HealthQuery }) => 
           <Metric
             category="llamalend.positionHealth"
             label={HEALTH_TOOLTIP.shortTitle}
+            testId="health-details-health-metric"
             value={mapQuery(healthQuery, data => data.healthFactor)}
             valueOptions={{
               abbreviate: false,
@@ -47,6 +48,7 @@ export const HealthDetails = ({ healthQuery }: { healthQuery: HealthQuery }) => 
           <Metric
             category="llamalend.positionLiquidationBuffer"
             label={LIQUIDATION_BUFFER_TOOLTIP.shortTitle}
+            testId="health-details-liquidation-buffer-metric"
             value={mapQuery(healthQuery, data => data.liquidationBuffer)}
             notional={mapQuery(healthQuery, data => t`(${formatNumber(data.healthNotFull, 'percent.value')} of debt)`)}
             valueOptions={{

--- a/apps/main/src/llamalend/queries/user/user-health.query.ts
+++ b/apps/main/src/llamalend/queries/user/user-health.query.ts
@@ -13,6 +13,20 @@ import { useUserDiscounts } from './user-discounts.query'
 
 type UserHealthParams = UserMarketParams & { isFull: boolean }
 type UserHealthQuery = UserMarketQuery & { isFull: boolean }
+type UserHealthValues = {
+  health: Decimal
+  healthFactor: Decimal
+  healthNotFull: Decimal
+  liquidationBuffer: Decimal | undefined
+  debug?: {
+    healthFull: Decimal
+    healthNotFull: Decimal
+    healthDelta: Decimal
+    loanDiscount: Decimal
+    liquidationDiscount: Decimal
+    discountGap: Decimal
+  }
+}
 
 /**
  * Query to get the user's health in a market.
@@ -49,7 +63,7 @@ export const useUserHealthValues = (params: UserMarketParams) => {
   return {
     data: maybes(
       [healthFull.data, healthNotFull.data, discounts.data],
-      (full, notFull, { loanDiscount, liquidationDiscount }) => {
+      (full, notFull, { loanDiscount, liquidationDiscount }): UserHealthValues => {
         const discountGap = decimalMinus(loanDiscount, liquidationDiscount)
         const healthDelta = decimalMinus(full, notFull)
         // Clamping at zero because separate RPC calls can resolve from different blocks and return a negative delta

--- a/tests/cypress/component/llamalend/health-details.cy.tsx
+++ b/tests/cypress/component/llamalend/health-details.cy.tsx
@@ -1,0 +1,208 @@
+import { HealthDetails } from '@/llamalend/features/market-position-details/health/HealthDetails'
+import type { HealthQuery } from '@/llamalend/queries/user/user-health.query'
+import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
+import type { Decimal } from '@primitives/decimal.utils'
+import { lightTheme } from '@ui-kit/themes'
+import { constQ } from '@ui-kit/types/util'
+import { decimalDiv, decimalMultiply, decimalSum } from '@ui-kit/utils'
+
+const { design } = lightTheme()
+const DISCOUNT_GAP: Decimal = '3'
+
+const hexToRgb = (value: string) => {
+  const parsed = Number.parseInt(value.replace('#', ''), 16)
+  return `rgb(${(parsed >> 16) & 255}, ${(parsed >> 8) & 255}, ${parsed & 255})`
+}
+
+const checkBarWidth =
+  (expectedPercentage: number) =>
+  ([fill]: JQuery<HTMLElement>) => {
+    const fillWidth = fill.getBoundingClientRect().width
+    const barWidth = fill.parentElement!.getBoundingClientRect().width
+    // Allow half a pixel for browser subpixel rounding.
+    expect(fillWidth).to.be.closeTo((barWidth * expectedPercentage) / 100, 0.5)
+  }
+
+const getHealthQuery = (health: Decimal, liquidationBuffer: Decimal): HealthQuery => {
+  const healthNotFull = decimalMultiply(decimalDiv(liquidationBuffer, '100'), DISCOUNT_GAP)
+
+  return constQ({
+    health,
+    healthFactor: decimalSum('1', decimalDiv(health, '100')),
+    healthNotFull,
+    liquidationBuffer,
+  })
+}
+
+const mountHealthDetails = (health: Decimal, liquidationBuffer: Decimal) =>
+  cy.mount(
+    <ComponentTestWrapper>
+      <HealthDetails healthQuery={getHealthQuery(health, liquidationBuffer)} />
+    </ComponentTestWrapper>,
+  )
+
+type HealthDetailsTestCase = {
+  title: string
+  health: Decimal
+  liquidationBuffer: Decimal
+  expected: {
+    healthFactor: string
+    healthColor: string
+    healthBarWidth: number
+    liquidationBuffer: string
+    debtNotional: string
+    liquidationBufferColor: string
+    liquidationBufferBarWidth: number
+    badge?: 'Soft Liquidation' | 'Hard Liquidation'
+  }
+}
+
+const testCases: HealthDetailsTestCase[] = [
+  {
+    title: 'renders pristine health',
+    health: '426.9',
+    liquidationBuffer: '108',
+    expected: {
+      healthFactor: '5.27',
+      healthColor: design.Layer.Feedback.Info,
+      healthBarWidth: 100,
+      liquidationBuffer: '108%',
+      debtNotional: '(3.24% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Info,
+      liquidationBufferBarWidth: 100,
+    },
+  },
+  {
+    title: 'renders good health',
+    health: '24.1',
+    liquidationBuffer: '110',
+    expected: {
+      healthFactor: '1.24',
+      healthColor: design.Layer.Feedback.Success,
+      healthBarWidth: 24.1,
+      liquidationBuffer: '110%',
+      debtNotional: '(3.30% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Info,
+      liquidationBufferBarWidth: 100,
+    },
+  },
+  {
+    title: 'renders caution health',
+    health: '7.9',
+    liquidationBuffer: '110',
+    expected: {
+      healthFactor: '1.079',
+      healthColor: design.Layer.Feedback.Caution,
+      healthBarWidth: 7.9,
+      liquidationBuffer: '110%',
+      debtNotional: '(3.30% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Info,
+      liquidationBufferBarWidth: 100,
+    },
+  },
+  {
+    title: 'renders tight health',
+    health: '4.9',
+    liquidationBuffer: '110',
+    expected: {
+      healthFactor: '1.049',
+      healthColor: design.Layer.Feedback.Error,
+      healthBarWidth: 4.9,
+      liquidationBuffer: '110%',
+      debtNotional: '(3.30% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Info,
+      liquidationBufferBarWidth: 100,
+    },
+  },
+  {
+    title: 'renders soft liquidation with a risky buffer',
+    health: '0',
+    liquidationBuffer: '22.5',
+    expected: {
+      healthFactor: '1.00',
+      healthColor: design.Layer.Feedback.Error,
+      healthBarWidth: 0,
+      liquidationBuffer: '22.50%',
+      debtNotional: '(0.68% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Warning,
+      liquidationBufferBarWidth: 22.5,
+      badge: 'Soft Liquidation',
+    },
+  },
+  {
+    title: 'renders soft liquidation with a critical buffer',
+    health: '0',
+    liquidationBuffer: '2.4',
+    expected: {
+      healthFactor: '1.00',
+      healthColor: design.Layer.Feedback.Error,
+      healthBarWidth: 0,
+      liquidationBuffer: '2.40%',
+      debtNotional: '(0.07% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Error,
+      liquidationBufferBarWidth: 2.4,
+      badge: 'Soft Liquidation',
+    },
+  },
+  {
+    title: 'renders the hard liquidation threshold',
+    health: '0',
+    liquidationBuffer: '0',
+    expected: {
+      healthFactor: '1.00',
+      healthColor: design.Layer.Feedback.Error,
+      healthBarWidth: 0,
+      liquidationBuffer: '0%',
+      debtNotional: '(0% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Error,
+      liquidationBufferBarWidth: 0,
+      badge: 'Hard Liquidation',
+    },
+  },
+  {
+    title: 'renders a position beyond liquidation',
+    health: '0',
+    liquidationBuffer: '-20',
+    expected: {
+      healthFactor: '1.00',
+      healthColor: design.Layer.Feedback.Error,
+      healthBarWidth: 0,
+      liquidationBuffer: '-20%',
+      debtNotional: '(-0.60% of debt)',
+      liquidationBufferColor: design.Layer.Feedback.Error,
+      liquidationBufferBarWidth: 0,
+      badge: 'Hard Liquidation',
+    },
+  },
+]
+
+describe('Health details', () => {
+  testCases.forEach(({ title, health, liquidationBuffer, expected }) => {
+    it(title, () => {
+      mountHealthDetails(health, liquidationBuffer)
+
+      cy.get('[data-testid="health-details-health-metric-value"]')
+        .should('have.text', expected.healthFactor)
+        .find('p')
+        .should('have.css', 'color', hexToRgb(expected.healthColor))
+      cy.get('[data-testid="health-details-health-bar-fill"]')
+        .should('have.css', 'background-color', hexToRgb(expected.healthColor))
+        .then(checkBarWidth(expected.healthBarWidth))
+
+      cy.get('[data-testid="health-details-liquidation-buffer-metric-value"]').should(
+        'have.text',
+        expected.liquidationBuffer,
+      )
+      cy.get('[data-testid="health-details-liquidation-buffer-metric"]').should('contain.text', expected.debtNotional)
+      cy.get('[data-testid="health-details-liquidation-buffer-bar-fill"]')
+        .should('have.css', 'background-color', hexToRgb(expected.liquidationBufferColor))
+        .then(checkBarWidth(expected.liquidationBufferBarWidth))
+
+      if (expected.badge) {
+        cy.get('[data-testid="health-details-health-bar-badge"]').should('have.text', expected.badge)
+      } else {
+        cy.get('[data-testid="health-details-health-bar-badge"]').should('not.exist')
+      }
+    })
+  })
+})


### PR DESCRIPTION
- add test coverage for health metrics, colors, bar widths, and liquidation badges
- make query debugs optional 