### PR TITLE
refactor: move loan action settings into forms

### DIFF
--- a/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
@@ -1,5 +1,4 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
-import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useBorrowMoreExpectedCollateral } from '@/llamalend/queries/borrow-more/borrow-more-expected-collateral.query'
 import { useBorrowMoreFutureLeverage } from '@/llamalend/queries/borrow-more/borrow-more-future-leverage.query'
@@ -30,12 +29,10 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   values: { slippage, userCollateral, debt },
   tokens: { collateralToken, borrowToken },
   networks,
-  onSlippageChange,
   leverageEnabled,
   form,
   controllerAddress,
   marketType,
-  routes,
   priceImpact,
 }: {
   params: BorrowMoreParams<ChainId>
@@ -44,10 +41,8 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   networks: NetworkDict<ChainId>
   controllerAddress: Address | undefined
   marketType: MarketType
-  onSlippageChange: (newSlippage: Decimal) => void
   leverageEnabled: boolean | undefined
   form: UseFormReturn<BorrowMoreForm>
-  routes: MarketRoutes | undefined
   priceImpact: QueryProp<PriceImpact | Decimal | null>
 }) {
   const isOpen = form.isTouched('userCollateral', 'userBorrowed', 'debt')
@@ -90,9 +85,7 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
           (prevCollateral, { totalCollateral }) => maybes([totalCollateral, prevCollateral], decimalSum),
         ),
         expected: expectedCollateralQuery,
-        routes,
         slippage,
-        onSlippageChange,
         priceImpact,
         collateralDelta,
       })}

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -2,6 +2,7 @@ import { type ChangeEvent, useCallback } from 'react'
 import { LEVERAGE, LoanPreset } from '@/llamalend/constants'
 import { getMaxBorrowAmount } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
+import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
@@ -90,9 +91,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           collateralToken={collateralToken}
           borrowToken={borrowToken}
           networks={networks}
-          routes={routes}
           priceImpact={priceImpact}
-          onSlippageChange={value => updateForm({ slippage: value })}
         />
       }
       data-testid="create-loan-form"
@@ -139,12 +138,21 @@ export const CreateLoanForm = <ChainId extends IChainId>({
         />
       </Stack>
       {isLeverageSupported && (
-        <LeverageInput
-          checked={values.leverageEnabled}
-          leverage={leverage}
-          onToggle={toggleLeverage}
-          maxLeverage={maxLeverage.data}
-        />
+        <Stack>
+          <LeverageInput
+            checked={values.leverageEnabled}
+            leverage={leverage}
+            onToggle={toggleLeverage}
+            maxLeverage={maxLeverage.data}
+          />
+          {values.leverageEnabled && (
+            <LoanActionSettings
+              slippage={values.slippage}
+              onSlippageChange={slippage => updateForm({ slippage })}
+              routes={routes}
+            />
+          )}
+        </Stack>
       )}
       <LoanPresetSelector preset={preset} setPreset={setPreset} setRange={setRange}>
         <Collapse in={preset === LoanPreset.Custom}>

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -145,13 +145,12 @@ export const CreateLoanForm = <ChainId extends IChainId>({
             onToggle={toggleLeverage}
             maxLeverage={maxLeverage.data}
           />
-          {values.leverageEnabled && (
-            <LoanActionSettings
-              slippage={values.slippage}
-              onSlippageChange={slippage => updateForm({ slippage })}
-              routes={routes}
-            />
-          )}
+          <LoanActionSettings
+            show={values.leverageEnabled}
+            slippage={values.slippage}
+            onSlippageChange={slippage => updateForm({ slippage })}
+            routes={routes}
+          />
         </Stack>
       )}
       <LoanPresetSelector preset={preset} setPreset={setPreset} setRange={setRange}>

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
@@ -1,4 +1,3 @@
-import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useCreateLoanIsApproved } from '@/llamalend/queries/create-loan/create-loan-approved.query'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
@@ -27,8 +26,6 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
   collateralToken,
   borrowToken,
   networks,
-  routes,
-  onSlippageChange,
   form,
   priceImpact,
 }: {
@@ -39,8 +36,6 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
   collateralToken: Token | undefined
   borrowToken: Token | undefined
   networks: NetworkDict<ChainId>
-  routes: MarketRoutes | undefined
-  onSlippageChange: (newSlippage: Decimal) => void
   form: UseFormReturn<CreateLoanForm>
   priceImpact: QueryProp<PriceImpact | Decimal | null>
 }) => {
@@ -64,10 +59,8 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
       prevDebt={constQ('0')}
       {...getLeverageInfoFields({
         leverageEnabled,
-        routes,
         collateralDelta: userCollateral,
         slippage,
-        onSlippageChange,
         priceImpact,
         leverageValue: mapQuery(expectedCollateral, data => data.leverage),
         prevLeverageValue: constQ('0'),

--- a/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LoanPresetSelector.tsx
@@ -41,7 +41,7 @@ export const LoanPresetSelector = ({
         onChange={useCallback(
           (_: MouseEvent<HTMLElement>, p: LoanPreset) => {
             setPreset(p)
-            setRange(PRESET_RANGES[p])
+            if (p !== LoanPreset.Custom) setRange(PRESET_RANGES[p])
           },
           [setPreset, setRange],
         )}

--- a/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js'
 import { useMemo } from 'react'
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
-import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import { calculateReturnToWallet } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
@@ -90,9 +89,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   values: { slippage, stateCollateral, userCollateral, userBorrowed, isFull },
   tokens: { collateralToken, borrowToken },
   networks,
-  onSlippageChange,
   showLeverage,
-  routes,
   form,
   prices,
   prevPrices,
@@ -104,9 +101,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   values: RepayFormData
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
   networks: NetworkDict<ChainId>
-  onSlippageChange: (newSlippage: Decimal) => void
   showLeverage: boolean | undefined
-  routes: MarketRoutes | undefined
   form: UseFormReturn<RepayFormData>
   prices?: QueryProp<Range<Decimal> | null>
   prevPrices?: QueryProp<Range<Decimal> | null>
@@ -163,10 +158,8 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
           isFull ? decimal(0) : decimal(new BigNumber(prev).minus(stateCollateral ?? '0')),
         ),
         expected: useRepayExpectedBorrowed(params, isOpen),
-        routes,
         // routeImage: useRepayRouteImage(params, isOpen),
         slippage,
-        onSlippageChange,
         priceImpact,
         collateralDelta: userCollateral,
       })}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/ClosePositionInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/ClosePositionInfoList.tsx
@@ -8,7 +8,6 @@ import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { usePrevLoanState } from '@/llamalend/widgets/action-card/hooks/usePrevLoanState'
 import { LoanActionInfoList } from '@/llamalend/widgets/action-card/LoanActionInfoList'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import type { Decimal } from '@primitives/decimal.utils'
 import { constQ, q } from '@ui-kit/types/util'
 
 type ClosePositionInfoListProps = {
@@ -17,7 +16,6 @@ type ClosePositionInfoListProps = {
   chainId: LlamaChainId
   networks: NetworkDict<LlamaChainId>
   values: CloseLoanMutation
-  onSlippageChange: (newSlippage: Decimal) => void
 }
 
 export function ClosePositionInfoList({
@@ -26,14 +24,11 @@ export function ClosePositionInfoList({
   tokens: { borrowToken, collateralToken },
   networks,
   values: { slippage },
-  onSlippageChange,
 }: ClosePositionInfoListProps) {
   const params = { chainId, marketId, userAddress: useConnection().address, slippage }
   return (
     <LoanActionInfoList
       isOpen
-      slippage={slippage}
-      onSlippageChange={onSlippageChange}
       gas={q(useCloseEstimateGas(networks, params))}
       debt={constQ('0')}
       collateral={constQ('0')}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
@@ -2,6 +2,7 @@ import { useClosePositionForm } from '@/llamalend/features/manage-liquidation/ho
 import { ClosePositionInfoList } from '@/llamalend/features/manage-liquidation/ui/ClosePositionInfoList'
 import { useMarketContext } from '@/llamalend/features/market-context'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
+import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import TableCell from '@mui/material/TableCell'
 import { FormButton } from '@ui-kit/features/forms'
@@ -49,7 +50,6 @@ export const ClosePositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
           chainId={network.chainId}
           networks={networks}
           values={values}
-          onSlippageChange={slippage => form.update({ slippage })}
         />
       }
     >
@@ -73,6 +73,7 @@ export const ClosePositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
           )
         }
       />
+      <LoanActionSettings slippage={values.slippage} onSlippageChange={slippage => form.update({ slippage })} />
       {missing != null && borrowedBalance != null && +missing > 0 ? (
         <AlertAdditionalDebtToken debtTokenSymbol={debtTokenSymbol} missing={missing} balance={borrowedBalance} />
       ) : (

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -144,13 +144,12 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
             onToggle={onLeverageToggle}
             maxLeverage={max.maxLeverage.data}
           />
-          {values.leverageEnabled && (
-            <LoanActionSettings
-              slippage={values.slippage}
-              onSlippageChange={slippage => updateForm({ slippage })}
-              routes={routes}
-            />
-          )}
+          <LoanActionSettings
+            show={values.leverageEnabled}
+            slippage={values.slippage}
+            onSlippageChange={slippage => updateForm({ slippage })}
+            routes={routes}
+          />
         </Stack>
       )}
       <HighPriceImpactAlert

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -5,6 +5,7 @@ import { LeverageInput } from '@/llamalend/features/borrow/components/LeverageIn
 import type { UserCollateralEvents } from '@/llamalend/features/user-position-history/hooks/useUserCollateralEvents'
 import { getMaxBorrowAmount } from '@/llamalend/llama.utils'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
+import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
@@ -83,9 +84,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           values={values}
           tokens={{ collateralToken, borrowToken }}
           networks={networks}
-          routes={routes}
           marketType={marketType}
-          onSlippageChange={value => updateForm({ slippage: value })}
           leverageEnabled={values.leverageEnabled}
           priceImpact={priceImpact}
         />
@@ -138,12 +137,21 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
         />
       </Stack>
       {isLeverageSupported && (
-        <LeverageInput
-          checked={values.leverageEnabled}
-          leverage={leverage}
-          onToggle={onLeverageToggle}
-          maxLeverage={max.maxLeverage.data}
-        />
+        <Stack>
+          <LeverageInput
+            checked={values.leverageEnabled}
+            leverage={leverage}
+            onToggle={onLeverageToggle}
+            maxLeverage={max.maxLeverage.data}
+          />
+          {values.leverageEnabled && (
+            <LoanActionSettings
+              slippage={values.slippage}
+              onSlippageChange={slippage => updateForm({ slippage })}
+              routes={routes}
+            />
+          )}
+        </Stack>
       )}
       <HighPriceImpactAlert
         priceImpact={priceImpact}

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -145,7 +145,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
             maxLeverage={max.maxLeverage.data}
           />
           <LoanActionSettings
-            show={values.leverageEnabled}
+            show={values.leverageEnabled === true}
             slippage={values.slippage}
             onSlippageChange={slippage => updateForm({ slippage })}
             routes={routes}

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -10,6 +10,7 @@ import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useRepayPrices } from '@/llamalend/queries/repay/repay-prices.query'
 import { isRepayLeveraged } from '@/llamalend/queries/repay/repay-query.helpers'
 import { useUserPrices } from '@/llamalend/queries/user'
+import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -143,9 +144,7 @@ export const RepayForm = <ChainId extends IChainId>({
           values={values}
           tokens={{ collateralToken, borrowToken }}
           networks={networks}
-          onSlippageChange={value => updateForm({ slippage: value })}
           showLeverage={showLeverage}
-          routes={routes}
           prices={q(useRepayPrices(params, !isInSoftLiquidation))} // when in soft liquidation, the prices do not change
           prevPrices={q(useUserPrices(params))}
           priceImpact={priceImpact}
@@ -187,6 +186,13 @@ export const RepayForm = <ChainId extends IChainId>({
           )
         }
       />
+      {showLeverage && (
+        <LoanActionSettings
+          slippage={values.slippage}
+          onSlippageChange={slippage => updateForm({ slippage })}
+          routes={routes}
+        />
+      )}
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(max.expected)} slippageType={LEVERAGE} />
       {isInSoftLiquidation && <AlertRepayDebtToIncreaseHealth />}
       <FormButton

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -186,13 +186,12 @@ export const RepayForm = <ChainId extends IChainId>({
           )
         }
       />
-      {showLeverage && (
-        <LoanActionSettings
-          slippage={values.slippage}
-          onSlippageChange={slippage => updateForm({ slippage })}
-          routes={routes}
-        />
-      )}
+      <LoanActionSettings
+        show={showLeverage}
+        slippage={values.slippage}
+        onSlippageChange={slippage => updateForm({ slippage })}
+        routes={routes}
+      />
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(max.expected)} slippageType={LEVERAGE} />
       {isInSoftLiquidation && <AlertRepayDebtToIncreaseHealth />}
       <FormButton

--- a/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanActionInfoList.tsx
@@ -1,6 +1,5 @@
 import { LEVERAGE } from '@/llamalend/constants'
 import { getHealthValueColor } from '@/llamalend/features/market-position-details'
-import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import { ReturnToWalletActionInfo } from '@/llamalend/widgets/action-card/ReturnToWalletActionInfo'
 import { SmallLiquidationRangeChart } from '@/llamalend/widgets/small-liquidation-range-chart/SmallLiquidationRangeChart'
 import Stack from '@mui/material/Stack'
@@ -8,7 +7,6 @@ import { useTheme } from '@mui/material/styles'
 import { Decimal } from '@primitives/decimal.utils'
 import { maybe, notFalsy } from '@primitives/objects.utils'
 import { useShowNetRate } from '@ui-kit/hooks/useLocalStorage'
-import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate, type TxGasInfo } from '@ui-kit/shared/ui/ActionInfo'
 import { Tooltip } from '@ui-kit/shared/ui/Tooltip'
@@ -19,8 +17,6 @@ import {
   getPriceImpactPercent,
   type PriceImpact,
 } from '@ui-kit/widgets/DetailPageLayout/price-impact.util'
-import { RouteProvidersAccordion } from '@ui-kit/widgets/RouteProvider'
-import { SlippageToleranceActionInfo } from '@ui-kit/widgets/SlippageSettings'
 import { ActionInfoCollapse } from './ActionInfoCollapse'
 import { useShouldShowNetRate } from './hooks/useShouldShowNetRate'
 import { ACTION_INFO_GROUP_SX, formatAmount, formatLeverage } from './info-actions.helpers'
@@ -55,18 +51,16 @@ export type LoanActionInfoListProps = {
   leverageTotalCollateral?: QueryProp<Decimal | null>
   priceImpact?: QueryProp<PriceImpact | Decimal | null>
   slippage?: Decimal
-  onSlippageChange?: (newSlippage: Decimal) => void
   collateralSymbol?: string
   borrowSymbol?: string
   /** Whether to show leverage-related fields (leverage value, leverage collateral...) */
   leverageEnabled?: boolean
-  routes?: MarketRoutes
 }
 
 /**
- * List with action infos about the loan (like health, borrow APR, LTV, net borrow APR, estimated gas, slippage)
+ * List with action infos about the loan (like health, borrow APR, LTV, net borrow APR, estimated gas)
  * By default, the action info are hidden. They are visible when the isOpen prop is true.
- * When leverage is enabled, leverage-specific infos and slippage settings are also included.
+ * When leverage is enabled, leverage-specific infos are also included.
  */
 export const LoanActionInfoList = ({
   isOpen,
@@ -98,13 +92,10 @@ export const LoanActionInfoList = ({
   leverageTotalCollateral,
   priceImpact,
   slippage,
-  onSlippageChange,
   collateralSymbol,
   borrowSymbol,
   leverageEnabled,
-  routes,
 }: LoanActionInfoListProps) => {
-  const [isRoutesOpen, , , toggleRoutes] = useSwitch(false)
   const { label: priceImpactLabel, color: priceImpactColor } = getPriceImpactDisplay(priceImpact, {
     slippage,
     slippageType: LEVERAGE,
@@ -277,14 +268,6 @@ export const LoanActionInfoList = ({
       )}
 
       <Stack>
-        {slippage && onSlippageChange && (
-          <SlippageToleranceActionInfo
-            maxSlippage={slippage}
-            type={LEVERAGE}
-            onChanged={({ leverage }) => onSlippageChange(leverage)}
-            size="small"
-          />
-        )}
         {priceImpact && (
           <ActionInfo
             label={priceImpactLabel}
@@ -309,7 +292,6 @@ export const LoanActionInfoList = ({
             testId="borrow-exchange-rate"
           />
         )}
-        {routes && <RouteProvidersAccordion isExpanded={isRoutesOpen} onToggle={toggleRoutes} {...routes} />}
         <ActionInfoGasEstimate gas={gas} isApproved={isApproved?.data} />
       </Stack>
     </ActionInfoCollapse>

--- a/apps/main/src/llamalend/widgets/action-card/LoanActionSettings.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanActionSettings.tsx
@@ -1,5 +1,6 @@
 import { LEVERAGE } from '@/llamalend/constants'
 import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
+import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useSwitch } from '@ui-kit/hooks/useSwitch'
@@ -14,27 +15,31 @@ export const LoanActionSettings = ({
   slippage,
   onSlippageChange,
   routes,
+  show = true,
 }: {
   slippage: Decimal | undefined
   onSlippageChange: (newSlippage: Decimal) => void
   routes?: MarketRoutes
+  show?: boolean
 }) => {
   const [isRoutesOpen, , , toggleRoutes] = useSwitch(false)
 
   return (
-    <Stack
-      data-testid="loan-action-settings"
-      sx={{ backgroundColor: t => t.design.Layer[2].Fill, border: borderStyle, padding: Spacing.xs }}
-    >
-      {slippage && (
-        <SlippageToleranceActionInfo
-          maxSlippage={slippage}
-          type={LEVERAGE}
-          onChanged={({ leverage }) => onSlippageChange(leverage)}
-          size="small"
-        />
-      )}
-      {routes && <RouteProvidersAccordion isExpanded={isRoutesOpen} onToggle={toggleRoutes} {...routes} />}
-    </Stack>
+    <Collapse in={show}>
+      <Stack
+        data-testid="loan-action-settings"
+        sx={{ backgroundColor: t => t.design.Layer[2].Fill, border: borderStyle, padding: Spacing.xs }}
+      >
+        {slippage && (
+          <SlippageToleranceActionInfo
+            maxSlippage={slippage}
+            type={LEVERAGE}
+            onChanged={({ leverage }) => onSlippageChange(leverage)}
+            size="small"
+          />
+        )}
+        {routes && <RouteProvidersAccordion isExpanded={isRoutesOpen} onToggle={toggleRoutes} {...routes} />}
+      </Stack>
+    </Collapse>
   )
 }

--- a/apps/main/src/llamalend/widgets/action-card/LoanActionSettings.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanActionSettings.tsx
@@ -1,0 +1,40 @@
+import { LEVERAGE } from '@/llamalend/constants'
+import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
+import Stack from '@mui/material/Stack'
+import type { Decimal } from '@primitives/decimal.utils'
+import { useSwitch } from '@ui-kit/hooks/useSwitch'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { borderStyle } from '@ui-kit/utils'
+import { RouteProvidersAccordion } from '@ui-kit/widgets/RouteProvider'
+import { SlippageToleranceActionInfo } from '@ui-kit/widgets/SlippageSettings'
+
+const { Spacing } = SizesAndSpaces
+
+export const LoanActionSettings = ({
+  slippage,
+  onSlippageChange,
+  routes,
+}: {
+  slippage: Decimal | undefined
+  onSlippageChange: (newSlippage: Decimal) => void
+  routes?: MarketRoutes
+}) => {
+  const [isRoutesOpen, , , toggleRoutes] = useSwitch(false)
+
+  return (
+    <Stack
+      data-testid="loan-action-settings"
+      sx={{ backgroundColor: t => t.design.Layer[2].Fill, border: borderStyle, padding: Spacing.xs }}
+    >
+      {slippage && (
+        <SlippageToleranceActionInfo
+          maxSlippage={slippage}
+          type={LEVERAGE}
+          onChanged={({ leverage }) => onSlippageChange(leverage)}
+          size="small"
+        />
+      )}
+      {routes && <RouteProvidersAccordion isExpanded={isRoutesOpen} onToggle={toggleRoutes} {...routes} />}
+    </Stack>
+  )
+}

--- a/apps/main/src/llamalend/widgets/action-card/hooks/getLeverageInfoFields.ts
+++ b/apps/main/src/llamalend/widgets/action-card/hooks/getLeverageInfoFields.ts
@@ -1,4 +1,3 @@
-import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import { isPositionLeveraged } from '@/llamalend/llama.utils'
 import { calculateLeverageCollateral } from '@/llamalend/widgets/action-card/info-actions.helpers'
 import type { LoanActionInfoListProps } from '@/llamalend/widgets/action-card/LoanActionInfoList'
@@ -17,18 +16,14 @@ type LeverageInfoFieldsOptions = {
   leverageTotalCollateral: QueryProp<Decimal | null>
   expected?: Query<{ avgPrice?: Decimal }>
   priceImpact?: Query<PriceImpact | Decimal | null>
-  routes?: MarketRoutes | undefined
   slippage?: Decimal
-  onSlippageChange?: (newSlippage: Decimal) => void
   collateralDelta: Decimal | undefined // only used when leverage is disabled, otherwise `leverageTotalCollateral` is used
 }
 
 export const getLeverageInfoFields = ({
   leverageEnabled,
-  routes,
   collateralDelta,
   slippage,
-  onSlippageChange,
   priceImpact,
   leverageValue,
   prevLeverageValue,
@@ -55,9 +50,7 @@ export const getLeverageInfoFields = ({
           leverageTotalCollateral,
           ...(leverageEnabled && {
             exchangeRate: expected && mapQuery(expected, data => data.avgPrice ?? null),
-            routes,
             slippage,
-            onSlippageChange,
             priceImpact: priceImpact && q(priceImpact),
           }),
         }

--- a/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
+++ b/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
@@ -6,9 +6,13 @@ import { IS_DEVELOPMENT } from '@ui-kit/utils'
 import type { FieldValues, UseFormReturn } from './form.types'
 import { FormContext } from './useFormContext'
 
-export type FormProviderProps<T extends FieldValues> = UseFormReturn<T> & { children: ReactNode }
+export type FormProviderProps<T extends FieldValues> = UseFormReturn<T> & {
+  children: ReactNode
+  showFormState?: boolean // Show the development-only form state accordion.
+}
 export const FormProvider = <T extends FieldValues>({
   children,
+  showFormState = true,
   handleSubmit,
   reset,
   watchValues,
@@ -59,7 +63,7 @@ export const FormProvider = <T extends FieldValues>({
       )}
     >
       {children}
-      {IS_DEVELOPMENT && (
+      {IS_DEVELOPMENT && showFormState && (
         <Accordion title={t`Form state`} ghost size="extraSmall">
           <AccordionDetails>
             <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>

--- a/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
+++ b/packages/curve-ui-kit/src/features/forms/FormProvider.tsx
@@ -8,11 +8,11 @@ import { FormContext } from './useFormContext'
 
 export type FormProviderProps<T extends FieldValues> = UseFormReturn<T> & {
   children: ReactNode
-  showFormState?: boolean // Show the development-only form state accordion.
+  hideFormState?: boolean // Hide the development-only form state accordion.
 }
 export const FormProvider = <T extends FieldValues>({
   children,
-  showFormState = true,
+  hideFormState = false,
   handleSubmit,
   reset,
   watchValues,
@@ -63,7 +63,7 @@ export const FormProvider = <T extends FieldValues>({
       )}
     >
       {children}
-      {IS_DEVELOPMENT && showFormState && (
+      {IS_DEVELOPMENT && !hideFormState && (
         <Accordion title={t`Form state`} ghost size="extraSmall">
           <AccordionDetails>
             <pre style={{ whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>

--- a/packages/curve-ui-kit/src/widgets/DetailPageLayout/CheckboxField.tsx
+++ b/packages/curve-ui-kit/src/widgets/DetailPageLayout/CheckboxField.tsx
@@ -33,7 +33,7 @@ export const CheckboxField = ({
       sx={{
         justifyContent: 'space-between',
         gap: Spacing.sm,
-        alignItems: 'start',
+        alignItems: 'center',
         flexWrap: 'wrap',
       }}
     >

--- a/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
+++ b/packages/curve-ui-kit/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
@@ -89,7 +89,7 @@ export const RouteProvidersAccordion = ({
         expanded={isExpanded}
         toggle={onToggle}
       >
-        <Stack sx={{ paddingBlock: Spacing.sm, gap: Spacing.sm }}>
+        <Stack sx={{ gap: Spacing.sm }}>
           <Stack>
             <Stack direction="row" sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
               <Typography variant="headingXsBold" color="textSecondary">

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
@@ -37,7 +37,7 @@ export const SlippageSettingsModal = ({
     current: currentSlippage,
   })
   return (
-    <FormProvider {...form}>
+    <FormProvider {...form} showFormState={false}>
       <ModalDialog
         open={isOpen}
         onClose={onClose}

--- a/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
+++ b/packages/curve-ui-kit/src/widgets/SlippageSettings/SlippageSettingsModal.tsx
@@ -37,7 +37,7 @@ export const SlippageSettingsModal = ({
     current: currentSlippage,
   })
   return (
-    <FormProvider {...form} showFormState={false}>
+    <FormProvider {...form} hideFormState>
       <ModalDialog
         open={isOpen}
         onClose={onClose}

--- a/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
+++ b/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import type { MarketRoutes } from '@/llamalend/hooks/useMarketRoutes'
 import { LoanActionInfoList } from '@/llamalend/widgets/action-card/LoanActionInfoList'
+import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
 import { mockedWagmiConfig } from '@cy/support/helpers/llamalend/test-wagmi.helpers'
 import { allViewports } from '@cy/support/ui'
@@ -59,20 +60,20 @@ allViewports().forEach(([width, height, viewport]) => {
       it(`has consistent heights ${label}`, () => {
         cy.mount(
           <ComponentTestWrapper config={mockedWagmiConfig}>
-            <LoanActionInfoList
-              isOpen
-              prevHealth={q({ data: '12.4', ...{ isLoading, error } })} // make sure `->` doesn't change the line height
-              health={q({ data: '123.4', ...{ isLoading, error, ...state } })}
-              oraclePrice={q({ data: '123.4', ...{ isLoading, error, ...state } })}
-              exchangeRate={q({ data: '123.4', ...{ isLoading, error, ...state } })}
-              gas={q({ data: { estGasCostUsd: '123.4' }, ...{ isLoading, error, ...state } })}
-              rates={q({ data: { borrowApr: '123.4' }, ...{ isLoading, error, ...state } })}
-              slippage="123.4"
-              onSlippageChange={noop}
-              collateralSymbol="wstETH"
-              borrowSymbol="crvUSD"
-              routes={routes}
-            />
+            <>
+              <LoanActionSettings slippage="123.4" onSlippageChange={noop} routes={routes} />
+              <LoanActionInfoList
+                isOpen
+                prevHealth={q({ data: '12.4', ...{ isLoading, error } })} // make sure `->` doesn't change the line height
+                health={q({ data: '123.4', ...{ isLoading, error, ...state } })}
+                oraclePrice={q({ data: '123.4', ...{ isLoading, error, ...state } })}
+                exchangeRate={q({ data: '123.4', ...{ isLoading, error, ...state } })}
+                gas={q({ data: { estGasCostUsd: '123.4' }, ...{ isLoading, error, ...state } })}
+                rates={q({ data: { borrowApr: '123.4' }, ...{ isLoading, error, ...state } })}
+                collateralSymbol="wstETH"
+                borrowSymbol="crvUSD"
+              />
+            </>
           </ComponentTestWrapper>,
         )
 

--- a/tests/cypress/support/helpers/llamalend/borrow-more.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/borrow-more.helpers.ts
@@ -67,6 +67,7 @@ export function checkBorrowMoreDetailsLoaded({
   cy.get('[data-testid="loan-form-errors"]').should('not.exist')
   if (leverageEnabled) {
     getActionValue('borrow-price-impact').should('include', '%')
+    cy.get('[data-testid="loan-action-settings"] [data-testid="borrow-slippage"]').should('be.visible')
     getActionValue('borrow-slippage').should('include', '%')
   }
 }

--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -137,7 +137,6 @@ export function checkLoanDetailsLoaded({
     getActionValue('borrow-slippage').should('include', '%')
   } else {
     cy.get('[data-testid="borrow-price-impact-value"]', LOAD_TIMEOUT).should('not.exist')
-    cy.get('[data-testid="loan-action-settings"]', LOAD_TIMEOUT).should('not.exist')
   }
 
   if (expectError) {
@@ -162,6 +161,7 @@ export const checkLeverageCheckbox = ({
   if (hasLeverage) {
     cy.get('[data-testid="leverage-checkbox"]').should('be.visible')
     cy.get('[data-testid="leverage-checkbox"] input').should(leverageEnabled ? 'be.checked' : 'not.be.checked')
+    if (!leverageEnabled) cy.get('[data-testid="loan-action-settings"]').should('not.be.visible')
   } else {
     cy.get('[data-testid="leverage-checkbox"]').should('not.exist')
   }

--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -133,10 +133,11 @@ export function checkLoanDetailsLoaded({
 
   if (leverageEnabled) {
     getActionValue('borrow-price-impact').should('include', '%')
+    cy.get('[data-testid="loan-action-settings"] [data-testid="borrow-slippage"]').should('be.visible')
     getActionValue('borrow-slippage').should('include', '%')
   } else {
     cy.get('[data-testid="borrow-price-impact-value"]', LOAD_TIMEOUT).should('not.exist')
-    cy.get('[data-testid="borrow-slippage-value"]', LOAD_TIMEOUT).should('not.exist')
+    cy.get('[data-testid="loan-action-settings"]', LOAD_TIMEOUT).should('not.exist')
   }
 
   if (expectError) {
@@ -167,7 +168,7 @@ export const checkLeverageCheckbox = ({
 }
 
 export const waitForRoutesLoaded = ({ submitButtonTestId }: { submitButtonTestId: string }) => {
-  cy.get('[data-testid="route-provider-accordion"]').click()
+  cy.get('[data-testid="loan-action-settings"] [data-testid="route-provider-accordion"]').click()
   cy.wait('@routerRoutes', LOAD_TIMEOUT)
   cy.get('[data-testid="refresh-button"]').should('be.enabled')
   cy.get(`[data-testid="${submitButtonTestId}"]`, LOAD_TIMEOUT).should('be.enabled')

--- a/tests/cypress/support/helpers/llamalend/repay-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/repay-loan.helpers.ts
@@ -51,6 +51,7 @@ export function checkRepayDetailsLoaded({
   hasApi?: boolean
 }) {
   cy.get('[data-testid="borrow-leverage-info-list"]', LOAD_TIMEOUT).should(leverageEnabled ? 'be.visible' : 'not.exist')
+  cy.get('[data-testid="loan-action-settings"]', LOAD_TIMEOUT).should(leverageEnabled ? 'be.visible' : 'not.exist')
   getActionValue('borrow-price-range', ...notFalsy(!isPriceChanged && 'previous')).should(
     'match',
     /(\d(\.\d+)?) - (\d(\.\d+)?)/,

--- a/tests/cypress/support/helpers/llamalend/repay-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/repay-loan.helpers.ts
@@ -51,7 +51,7 @@ export function checkRepayDetailsLoaded({
   hasApi?: boolean
 }) {
   cy.get('[data-testid="borrow-leverage-info-list"]', LOAD_TIMEOUT).should(leverageEnabled ? 'be.visible' : 'not.exist')
-  cy.get('[data-testid="loan-action-settings"]', LOAD_TIMEOUT).should(leverageEnabled ? 'be.visible' : 'not.exist')
+  cy.get('[data-testid="loan-action-settings"]', LOAD_TIMEOUT).should(leverageEnabled ? 'be.visible' : 'not.be.visible')
   getActionValue('borrow-price-range', ...notFalsy(!isPriceChanged && 'previous')).should(
     'match',
     /(\d(\.\d+)?) - (\d(\.\d+)?)/,

--- a/tests/cypress/support/helpers/llamalend/soft-liquidation.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/soft-liquidation.helpers.ts
@@ -17,6 +17,7 @@ const getResetPositionWalletInput = () =>
   cy.get('[data-testid="reset-position-input-user-borrowed"] input[type="text"]', LOAD_TIMEOUT)
 
 export function checkClosePositionDetailsLoaded({ debt }: { debt: Decimal }) {
+  cy.get('[data-testid="loan-action-settings"] [data-testid="borrow-slippage"]').should('be.visible')
   cy.get('[data-testid="outstanding-debt"]').invoke('text').should('match', DECIMAL_REGEX) // first check the number is displayed before converting to number
   cy.get('[data-testid="outstanding-debt"]')
     .invoke('text')


### PR DESCRIPTION
- move slippage and route provider controls into the forms
- show and hide leverage settings with a transition
- preserve the selected range when switching to the custom loan preset

<img width="472" height="445" alt="Screenshot 2026-08-18 at 09 06 41" src="https://github.com/user-attachments/assets/cf39632b-b788-4141-817b-19fd45b2fef1" />
