### PR TITLE
fix: only show max boost if not zero and deviates from total

### DIFF
--- a/apps/main/src/dex/features/pool-information/components/yield-breakdown/FooterRow.tsx
+++ b/apps/main/src/dex/features/pool-information/components/yield-breakdown/FooterRow.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 import TableCell from '@mui/material/TableCell'
 import Typography from '@mui/material/Typography'
-import { maybe } from '@primitives/objects.utils'
 import type { Column } from '@tanstack/react-table'
 import { t } from '@ui-kit/lib/i18n'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
@@ -13,7 +12,7 @@ const { Spacing } = SizesAndSpaces
 
 type FooterRowProps = {
   visibleColumns: Column<YieldBreakdownRow, unknown>[]
-  maxBoostTotal: number | undefined
+  maxBoostTotal: number
   total: number
 }
 
@@ -29,11 +28,11 @@ const footerCellByColumnId: Record<YieldBreakdownColumnId, (props: FooterCellPro
   [YieldBreakdownColumnId.Apy]: ({ columnId, maxBoostTotal, total }: FooterCellProps) => (
     <TableCell key={columnId} sx={{ paddingInline: Spacing.md, paddingBlock: Spacing.sm, textAlign: 'right' }}>
       <Typography variant="tableCellMBold">{formatNumber(total, 'percent.rate')}</Typography>
-      {maybe(maxBoostTotal, x => (
+      {maxBoostTotal && maxBoostTotal != total && (
         <Typography variant="tableCellSRegular" color="textSecondary">
-          {t`Max boost ${formatNumber(x, 'percent.rate')}`}
+          {t`Max boost ${formatNumber(maxBoostTotal, 'percent.rate')}`}
         </Typography>
-      ))}
+      )}
     </TableCell>
   ),
 }

--- a/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
+++ b/apps/main/src/dex/features/pool-information/hooks/useYieldBreakdown.tsx
@@ -148,7 +148,7 @@ export const useYieldBreakdown = ({
   const total = useMemo(() => sum(rows.map(row => row.apy)), [rows])
 
   return {
-    maxBoostTotal: maybe(crvApyRange, ({ unboostedApy, maximumApy }) => total - unboostedApy + maximumApy),
+    maxBoostTotal: maybe(crvApyRange, ({ unboostedApy, maximumApy }) => total - unboostedApy + maximumApy) ?? 0,
     total,
     rows,
   }


### PR DESCRIPTION
Hides the max boost label if it doesn't deviate from the normal total (eg there's no crv emissions with boost!)

**Before**
<img width="1291" height="272" alt="image" src="https://github.com/user-attachments/assets/f3d6a5b6-6ae0-402b-9b8c-ddf013ea274f" />

**After**
<img width="1282" height="254" alt="image" src="https://github.com/user-attachments/assets/97255e29-cbd4-41d4-bafe-0bc7605139ae" />

The API tells us the type of `crvApyRange` is
```ts
{
    unboostedApy: number;
    maximumApy: number;
} | undefined
```
But that doesn't mean it can't be `{ unboostedApy: 0, maximumApy: 0 }`. Hence to prevent further confusion I made the type `number` by defaulting to `0` if it's `undefined` rather than keeping the possibility of both `undefined` and `0`. This way you can easily check if it's non-zero rather than having to check for both in `FooterRow`.