### PR TITLE
fix: omit zero enso fee parameters

### DIFF
--- a/apps/router-api/src/enso-router/enso-router.ts
+++ b/apps/router-api/src/enso-router/enso-router.ts
@@ -66,7 +66,11 @@ export const buildEnsoRouteResponse = async (
     ...(minAmountOut
       ? { minAmountOut }
       : slippage != null && { slippage: new BigNumber(slippage).times(100).toString() }),
-    ...maybe(ROUTER_FEE_RECEIVER_BY_CHAIN_ID[chainId], feeReceiver => ({ fee: ROUTER_FEE_BPS, feeReceiver })),
+    ...maybe(
+      // Enso rejects an explicit fee=0, so omit fee parameters when fees are disabled.
+      ROUTER_FEE_BPS === '0' ? undefined : ROUTER_FEE_RECEIVER_BY_CHAIN_ID[chainId],
+      feeReceiver => ({ fee: ROUTER_FEE_BPS, feeReceiver }),
+    ),
   })}`
 
   // Enso API is documented to return an array of routes, but in practice it returns a single object

--- a/apps/router-api/test/integration/routes-mocked.test.ts
+++ b/apps/router-api/test/integration/routes-mocked.test.ts
@@ -92,5 +92,7 @@ describe('GET routes mocked unit tests', () => {
     expect(statusCode).toBe(200)
     expect(url.searchParams.get('slippage')).toBe(expectedSlippage)
     expect(url.searchParams.has('minAmountOut')).toBe(false)
+    expect(url.searchParams.has('fee')).toBe(false)
+    expect(url.searchParams.has('feeReceiver')).toBe(false)
   })
 })


### PR DESCRIPTION
Enso appears to have tightened its validation to reject explicit `fee=0`, so we now omit fee and feeReceiver when fees are disabled.