### PR TITLE
feat: add pool historical base rate chart

### DIFF
--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
@@ -37,8 +37,8 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
 
   const poolPriceApi = usePoolPricesApi({ blockchainId: network, poolAddress })
 
-  const poolTokens = mapQuery(poolPriceApi, pool => pool.coins)
-  const { liquidityColumnVisibility } = usePoolActivityVisibility({ poolTokens: poolTokens.data ?? [] })
+  const { data: poolTokens = [] } = mapQuery(poolPriceApi, pool => pool.coins)
+  const { liquidityColumnVisibility } = usePoolActivityVisibility({ poolTokens })
 
   const poolLiquidityEvents = usePoolLiquidityEvents({
     chain: network,
@@ -61,14 +61,14 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
           providerUrl: scanAddressPath(networkConfig, event.provider),
           txUrl: scanTxPath(networkConfig, event.txHash),
           network,
-          poolTokens: poolTokens.data ?? [],
+          poolTokens,
         })),
       [network, networkConfig, poolTokens],
     ),
   )
 
   const liquidityColumns = useMemo(
-    () => createPoolLiquidityColumns({ blockchainId: network, poolTokens: poolTokens.data ?? [] }),
+    () => createPoolLiquidityColumns({ blockchainId: network, poolTokens }),
     [network, poolTokens],
   )
 

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityEventsConfig.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useNetworkByChain } from '@/dex/entities/networks'
 import { usePoolLiquidityEvents } from '@/dex/entities/pool-liquidity.query'
-import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import { usePoolPricesApi } from '@/dex/queries/pools-prices-api.query'
 import { ChainId } from '@/dex/types/main.types'
 import { getBlockchainId } from '@curvefi/prices-api'
 import { scanAddressPath, scanTxPath } from '@legacy-ui/utils'
@@ -17,7 +17,7 @@ import { useCurve } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
 import { useCombinedQueries } from '@ui-kit/lib/queries/combine'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { fakeLoadingQ } from '@ui-kit/types/util'
+import { fakeLoadingQ, mapQuery } from '@ui-kit/types/util'
 import { getPageCount } from '@ui-kit/utils'
 
 type UsePoolActivityProps = {
@@ -35,13 +35,10 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
   const network = getBlockchainId(networkConfig?.id)
   const { pagination, onPaginationChange, apiPage } = useManualPagination()
 
-  const poolPriceApi = usePoolsPricesApi({ blockchainId: network })
-  const { data: pricesApiPoolsMapper } = poolPriceApi
-  const poolTokens = useMemo(
-    () => pricesApiPoolsMapper?.[poolAddress]?.coins ?? [],
-    [pricesApiPoolsMapper, poolAddress],
-  )
-  const { liquidityColumnVisibility } = usePoolActivityVisibility({ poolTokens })
+  const poolPriceApi = usePoolPricesApi({ blockchainId: network, poolAddress })
+
+  const poolTokens = mapQuery(poolPriceApi, pool => pool.coins)
+  const { liquidityColumnVisibility } = usePoolActivityVisibility({ poolTokens: poolTokens.data ?? [] })
 
   const poolLiquidityEvents = usePoolLiquidityEvents({
     chain: network,
@@ -64,14 +61,14 @@ export const usePoolActivityEventsConfig = ({ chainId, poolAddress }: UsePoolAct
           providerUrl: scanAddressPath(networkConfig, event.provider),
           txUrl: scanTxPath(networkConfig, event.txHash),
           network,
-          poolTokens,
+          poolTokens: poolTokens.data ?? [],
         })),
       [network, networkConfig, poolTokens],
     ),
   )
 
   const liquidityColumns = useMemo(
-    () => createPoolLiquidityColumns({ blockchainId: network, poolTokens }),
+    () => createPoolLiquidityColumns({ blockchainId: network, poolTokens: poolTokens.data ?? [] }),
     [network, poolTokens],
   )
 

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
@@ -37,8 +37,8 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
 
   const poolPriceApi = usePoolPricesApi({ blockchainId: network, poolAddress })
 
-  const poolTokens = mapQuery(poolPriceApi, pool => pool.coins)
-  const { tradesColumnVisibility } = usePoolActivityVisibility({ poolTokens: poolTokens.data ?? [] })
+  const { data: poolTokens = [] } = mapQuery(poolPriceApi, pool => pool.coins)
+  const { tradesColumnVisibility } = usePoolActivityVisibility({ poolTokens })
 
   const poolTrades = usePoolTrades({
     chain: network,

--- a/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
+++ b/apps/main/src/dex/components/OhlcAndActivityComp/hooks/usePoolActivityTradesConfig.ts
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useNetworkByChain } from '@/dex/entities/networks'
 import { usePoolTrades } from '@/dex/entities/pool-trades.query'
-import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import { usePoolPricesApi } from '@/dex/queries/pools-prices-api.query'
 import { ChainId } from '@/dex/types/main.types'
 import { getBlockchainId } from '@curvefi/prices-api'
 import { scanAddressPath, scanTxPath } from '@legacy-ui/utils'
@@ -17,7 +17,7 @@ import { useCurve } from '@ui-kit/features/connect-wallet'
 import { t } from '@ui-kit/lib/i18n'
 import { useCombinedQueries } from '@ui-kit/lib/queries/combine'
 import { getTableOptions, useTable } from '@ui-kit/shared/ui/DataTable/data-table.utils'
-import { fakeLoadingQ } from '@ui-kit/types/util'
+import { fakeLoadingQ, mapQuery } from '@ui-kit/types/util'
 import { getPageCount } from '@ui-kit/utils'
 
 type UsePoolActivityProps = {
@@ -35,13 +35,10 @@ export const usePoolActivityTradesConfig = ({ chainId, poolAddress }: UsePoolAct
   const { isHydrated } = useCurve()
   const { pagination, onPaginationChange, apiPage } = useManualPagination()
 
-  const poolPriceApi = usePoolsPricesApi({ blockchainId: network })
-  const { data: pricesApiPoolsMapper } = poolPriceApi
-  const poolTokens = useMemo(
-    () => pricesApiPoolsMapper?.[poolAddress]?.coins ?? [],
-    [pricesApiPoolsMapper, poolAddress],
-  )
-  const { tradesColumnVisibility } = usePoolActivityVisibility({ poolTokens })
+  const poolPriceApi = usePoolPricesApi({ blockchainId: network, poolAddress })
+
+  const poolTokens = mapQuery(poolPriceApi, pool => pool.coins)
+  const { tradesColumnVisibility } = usePoolActivityVisibility({ poolTokens: poolTokens.data ?? [] })
 
   const poolTrades = usePoolTrades({
     chain: network,

--- a/apps/main/src/dex/components/PagePool/components/ManagePoolLink.tsx
+++ b/apps/main/src/dex/components/PagePool/components/ManagePoolLink.tsx
@@ -1,6 +1,6 @@
 import { ROUTE } from '@/dex/constants'
 import { useNetworkByChain } from '@/dex/entities/networks'
-import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import { usePoolPricesApi } from '@/dex/queries/pools-prices-api.query'
 import type { Chain } from '@curvefi/prices-api'
 import Button from '@mui/material/Button'
 import { t } from '@ui-kit/lib/i18n'
@@ -15,8 +15,7 @@ const hasRefuelMethod = (poolMethods?: string[]) => poolMethods?.includes('donat
 
 export const ManagePoolLink = ({ chainId, poolAddress }: { chainId: number; poolAddress: string | undefined }) => {
   const { data: network } = useNetworkByChain({ chainId })
-  const { data: pricesApiPoolsMapper } = usePoolsPricesApi({ blockchainId: network?.networkId as Chain })
-  const pricesApiPoolData = poolAddress ? pricesApiPoolsMapper?.[poolAddress] : undefined
+  const { data: pricesApiPoolData } = usePoolPricesApi({ blockchainId: network?.networkId as Chain, poolAddress })
 
   return (
     poolAddress != null &&

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -17,7 +17,7 @@ import { UserPosition } from '@/dex/features/user-position'
 import { usePoolAlert } from '@/dex/hooks/usePoolAlert'
 import { usePoolIdByAddressOrId } from '@/dex/hooks/usePoolIdByAddressOrId'
 import { useTokensMapper } from '@/dex/hooks/useTokensMapper'
-import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import { usePoolPricesApi } from '@/dex/queries/pools-prices-api.query'
 import { useStore } from '@/dex/store/useStore'
 import { getChainPoolIdActiveKey } from '@/dex/utils'
 import { getPath } from '@/dex/utils/utilsRouter'
@@ -70,10 +70,8 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
 
   const { data: network } = useNetworkByChain({ chainId: rChainId })
   const { networkId, isLite, pricesApi } = network
-  const { data: pricesApiPoolsMapper } = usePoolsPricesApi({ blockchainId: networkId as Chain })
   const poolAddress = poolData?.pool.address as Address
-
-  const pricesApiPoolData = poolData && pricesApiPoolsMapper?.[poolData.pool.address]
+  const { data: pricesApiPoolData } = usePoolPricesApi({ blockchainId: networkId as Chain, poolAddress })
 
   const fetchPoolStats = useStore(state => state.pools.fetchPoolStats)
   usePageVisibleInterval(() => {

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -12,6 +12,7 @@ import { useGaugeManager, useGaugeRewardsDistributors } from '@/dex/entities/gau
 import { useNetworkByChain } from '@/dex/entities/networks'
 import { AdvancedDetails } from '@/dex/features/advanced-details'
 import { PoolInformation } from '@/dex/features/pool-information'
+import { PoolHistoricalBaseRateChart } from '@/dex/features/PoolHistoricalBaseRateChart'
 import { UserPosition } from '@/dex/features/user-position'
 import { usePoolAlert } from '@/dex/hooks/usePoolAlert'
 import { usePoolIdByAddressOrId } from '@/dex/hooks/usePoolIdByAddressOrId'
@@ -212,6 +213,7 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
         {!isLite && pricesApiPoolData && pricesApi && (
           <OhlcAndActivityComp rChainId={rChainId} poolAddress={poolAddress} pricesApiPoolData={pricesApiPoolData} />
         )}
+        {pricesApi && <PoolHistoricalBaseRateChart blockchainId={networkId} poolAddress={poolAddress} />}
         <PoolInformation
           curve={curve}
           routerParams={routerParams}

--- a/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
+++ b/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
@@ -28,7 +28,7 @@ import {
 import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { mapQuery } from '@ui-kit/types/util'
-import { formatNumber, TIME_OPTION_MS } from '@ui-kit/utils'
+import { decimal, formatNumber, TIME_OPTION_MS } from '@ui-kit/utils'
 
 const { Height, Spacing } = SizesAndSpaces
 
@@ -152,7 +152,7 @@ export const PoolHistoricalBaseRateChart = ({
             series={series}
             visibleSeries={visibleSeries}
             xTickFormatter={value => formatDate(value)}
-            yTickFormatter={value => formatNumber(+value, 'percent.value')}
+            yTickFormatter={value => formatNumber(decimal(value), 'percent.value')}
             yPaddingRatio={0.05}
             renderTooltip={({ datum, visibleSeries: activeSeries }) => (
               <ChartTooltipShell title={formatDate(datum.timestamp, 'long')}>

--- a/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
+++ b/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react'
+import type { Address } from 'viem'
+import { usePoolSnapshots } from '@/dex/entities/pool-snapshots.query'
+import { aprToPoolApy } from '@/dex/features/pool-list/cells/utils'
+import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import type { Chain } from '@curvefi/prices-api'
+import { formatDate } from '@legacy-ui/utils'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import CardHeader from '@mui/material/CardHeader'
+import Stack from '@mui/material/Stack'
+import { useTheme } from '@mui/material/styles'
+import { maybe } from '@primitives/objects.utils'
+import { t } from '@ui-kit/lib/i18n'
+import { type TimeOption, timeOptions } from '@ui-kit/lib/model/query/time-option-validation'
+import {
+  CHART_LINE_DASH_PATTERNS,
+  ChartFooter,
+  ChartStateWrapper,
+  ChartTooltipSeriesGroup,
+  ChartTooltipSeriesRow,
+  ChartTooltipShell,
+  EChartsLineChart,
+  type LegendItem,
+  type LineSeriesConfig,
+  SelectTimeOption,
+} from '@ui-kit/shared/ui/Chart'
+import { Metric } from '@ui-kit/shared/ui/Metric'
+import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { mapQuery } from '@ui-kit/types/util'
+import { formatNumber, TIME_OPTION_MS } from '@ui-kit/utils'
+
+const { Height, Spacing } = SizesAndSpaces
+
+const METRIC_CATEGORY = 'dex.poolInformation'
+
+type BaseRateSeriesKey = 'dailyBaseApy' | 'weeklyBaseApy'
+type BaseRateChartPoint = {
+  timestamp: number
+  dailyBaseApy: number | undefined
+  weeklyBaseApy: number | undefined
+}
+
+const SERIES_CONFIG = [
+  { key: 'dailyBaseApy', label: t`Daily Base APY` },
+  { key: 'weeklyBaseApy', label: t`Weekly Base APY`, dash: CHART_LINE_DASH_PATTERNS.tight },
+] as const
+
+export const PoolHistoricalBaseRateChart = ({
+  blockchainId,
+  poolAddress,
+}: {
+  blockchainId: string
+  poolAddress: Address
+}) => {
+  const [timeOption, setTimeOption] = useState<TimeOption>('1M')
+  const [visibleSeries, setVisibleSeries] = useState<BaseRateSeriesKey[]>(() => SERIES_CONFIG.map(({ key }) => key))
+
+  const chain = blockchainId as Chain
+  const [end] = useState(() => Math.floor(Date.now() / 1000))
+  const snapshots = usePoolSnapshots({
+    chain,
+    poolAddress,
+    start: end - TIME_OPTION_MS[timeOption] / 1000,
+    end,
+    unit: 'day',
+  })
+
+  const ratePoints = mapQuery(snapshots, snapshots =>
+    snapshots.toReversed().map(snapshot => ({
+      timestamp: snapshot.timestamp,
+      dailyBaseApy: maybe(snapshot.baseDailyApr, apr => aprToPoolApy(apr * 100)) ?? undefined,
+      weeklyBaseApy: maybe(snapshot.baseWeeklyApr, apr => aprToPoolApy(apr * 100)) ?? undefined,
+    })),
+  )
+
+  // Current metric values are based on pool list data to avoid mismatches, and is also updated more frequently than snapshots
+  const currentPool = mapQuery(usePoolsPricesApi({ blockchainId: chain }), pools => pools[poolAddress.toLowerCase()])
+
+  const {
+    design: { Color },
+  } = useTheme()
+
+  const seriesColors: Record<BaseRateSeriesKey, string> = useMemo(
+    () => ({ dailyBaseApy: Color.Primary[500], weeklyBaseApy: Color.Secondary[500] }),
+    [Color.Primary, Color.Secondary],
+  )
+
+  const series: LineSeriesConfig<BaseRateSeriesKey>[] = useMemo(
+    () => SERIES_CONFIG.map(({ key, label, ...config }) => ({ key, label, color: seriesColors[key], ...config })),
+    [seriesColors],
+  )
+
+  const legendSets: LegendItem[] = useMemo(
+    () =>
+      SERIES_CONFIG.map(({ key, label, ...config }) => ({
+        label,
+        line: { lineStroke: seriesColors[key], ...config },
+        toggled: visibleSeries.includes(key),
+        onToggle: () =>
+          setVisibleSeries(previous =>
+            previous.includes(key) ? previous.filter(seriesKey => seriesKey !== key) : [...previous, key],
+          ),
+      })),
+    [seriesColors, visibleSeries],
+  )
+
+  return (
+    <Card size="small">
+      <CardHeader
+        title={t`Historical Base Rate`}
+        action={
+          <SelectTimeOption
+            options={timeOptions}
+            activeOption={timeOption}
+            setActiveOption={setTimeOption}
+            isLoading={snapshots.isLoading}
+          />
+        }
+      />
+      <CardContent component={Stack} sx={{ gap: Spacing.md }}>
+        <Stack
+          sx={{
+            display: 'grid',
+            gap: Spacing.xl,
+            gridTemplateColumns: { mobile: 'repeat(2, 1fr)', tablet: 'repeat(5, 1fr)' },
+          }}
+        >
+          <Metric
+            category={METRIC_CATEGORY}
+            label={t`Current daily base APY`}
+            value={mapQuery(currentPool, pool => aprToPoolApy(pool.baseDailyApr * 100))}
+            valueOptions={{ unit: 'percentage' }}
+          />
+          <Metric
+            category={METRIC_CATEGORY}
+            label={t`Current weekly base APY`}
+            value={mapQuery(currentPool, pool => aprToPoolApy(pool.baseWeeklyApr * 100))}
+            valueOptions={{ unit: 'percentage' }}
+          />
+        </Stack>
+        <ChartStateWrapper
+          height={Height.shortChart}
+          isLoading={ratePoints.isLoading}
+          error={ratePoints.error}
+          errorMessage={t`Unable to fetch historical base rate data.`}
+        >
+          <EChartsLineChart<BaseRateChartPoint, BaseRateSeriesKey, 'timestamp'>
+            data={ratePoints.data ?? []}
+            height={Height.shortChart}
+            xKey="timestamp"
+            series={series}
+            visibleSeries={visibleSeries}
+            xTickFormatter={value => formatDate(value)}
+            yTickFormatter={value => formatNumber(+value, 'percent.value')}
+            yPaddingRatio={0.05}
+            renderTooltip={({ datum, visibleSeries: activeSeries }) => (
+              <ChartTooltipShell title={formatDate(datum.timestamp, 'long')}>
+                <ChartTooltipSeriesGroup>
+                  {activeSeries.map(activeSeriesItem => (
+                    <ChartTooltipSeriesRow
+                      key={activeSeriesItem.key}
+                      label={activeSeriesItem.label}
+                      lineColor={activeSeriesItem.color}
+                      dash={activeSeriesItem.dash}
+                      value={formatNumber(datum[activeSeriesItem.key], 'percent.value')}
+                    />
+                  ))}
+                </ChartTooltipSeriesGroup>
+              </ChartTooltipShell>
+            )}
+          />
+        </ChartStateWrapper>
+        <ChartFooter legendSets={legendSets} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
+++ b/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import type { Address } from 'viem'
 import { usePoolSnapshots } from '@/dex/entities/pool-snapshots.query'
 import { aprToPoolApy } from '@/dex/features/pool-list/cells/utils'
-import { usePoolsPricesApi } from '@/dex/queries/pools-prices-api.query'
+import { usePoolPricesApi } from '@/dex/queries/pools-prices-api.query'
 import type { Chain } from '@curvefi/prices-api'
 import { formatDate } from '@legacy-ui/utils'
 import Card from '@mui/material/Card'
@@ -75,7 +75,7 @@ export const PoolHistoricalBaseRateChart = ({
   )
 
   // Current metric values are based on pool list data to avoid mismatches, and is also updated more frequently than snapshots
-  const currentPool = mapQuery(usePoolsPricesApi({ blockchainId: chain }), pools => pools[poolAddress.toLowerCase()])
+  const currentPool = usePoolPricesApi({ blockchainId: chain, poolAddress })
 
   const {
     design: { Color },

--- a/apps/main/src/dex/queries/pools-prices-api.query.ts
+++ b/apps/main/src/dex/queries/pools-prices-api.query.ts
@@ -1,7 +1,9 @@
+import { isAddress, type Address } from 'viem'
 import { getPools } from '@curvefi/prices-api/pools'
-import { fromEntries } from '@primitives/objects.utils'
+import { fromEntries, maybe } from '@primitives/objects.utils'
 import { queryFactory, rootKeys, type ChainNameParams, type ChainNameQuery } from '@ui-kit/lib/model'
 import { pricesApiChainValidationSuite } from '@ui-kit/lib/model/query/prices-chain-validation'
+import { mapQuery } from '@ui-kit/types/util'
 
 export const { useQuery: usePoolsPricesApi } = queryFactory({
   queryKey: ({ blockchainId }: ChainNameParams) =>
@@ -13,3 +15,11 @@ export const { useQuery: usePoolsPricesApi } = queryFactory({
   validationSuite: pricesApiChainValidationSuite,
   category: 'dex.pools',
 })
+
+export const usePoolPricesApi = ({
+  blockchainId,
+  poolAddress,
+}: ChainNameParams & { poolAddress: string | undefined }) =>
+  mapQuery(usePoolsPricesApi({ blockchainId }, isAddress(poolAddress as Address, { strict: false })), pools =>
+    maybe(poolAddress, poolAddress => pools[poolAddress.toLowerCase()]),
+  )

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -30,7 +30,7 @@ import { Metric } from '@ui-kit/shared/ui/Metric'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
 import { MarketRateType } from '@ui-kit/types/market'
 import { fallbackQ, mapQuery, q, useMappedQuery } from '@ui-kit/types/util'
-import { formatNumber, TIME_OPTION_MS } from '@ui-kit/utils'
+import { decimal, formatNumber, TIME_OPTION_MS } from '@ui-kit/utils'
 import { AVERAGE_WINDOW_DAYS, calculateAverageRates, hasFullTimeWindow } from '@ui-kit/utils/averageRates'
 import { useMarketContext } from '../features/market-context'
 import { MarketCardHeader } from './MarketCardHeader'
@@ -264,7 +264,7 @@ export const MarketHistoricalRatesChart = ({ rateMode }: MarketHistoricalRatesCh
             series={series}
             visibleSeries={visibleSeries}
             xTickFormatter={(value: RateChartPoint['timestamp'] | string) => formatDate(value)}
-            yTickFormatter={value => formatNumber(+value, { unit: 'percentage', abbreviate: false, decimals: 2 })}
+            yTickFormatter={value => formatNumber(decimal(value), 'percent.value')}
             yPaddingRatio={0.05}
             renderTooltip={HistoricalRatesTooltip}
           />

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -192,7 +192,7 @@ const poolLiquidityEvent = z
 
 const poolSnapshot = z
   .object({
-    timestamp: z.number(),
+    timestamp,
     a: z.number().nullable(),
     fee: z.number().nullable(),
     admin_fee: z.number().nullable(),


### PR DESCRIPTION
Adds a new historical base rate chart to the pool page if it's supported by the prices API.

<img width="1069" height="388" alt="image" src="https://github.com/user-attachments/assets/217c1d92-3a1d-4b2f-b654-79ace4c46cea" />
