### PR TITLE
fix: use correct number formatter category for oracle price and price per share

### DIFF
--- a/apps/main/src/llamalend/features/market-advanced-information/MarketParameterRows.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketParameterRows.tsx
@@ -28,14 +28,13 @@ export const MarketPricesRows = ({ chainId, marketId, enablePricePerShare, apiMa
         labelTooltip={{
           title: t`The price source that determines your collateral value, health, and when your position moves toward soft liquidation.`,
         }}
-        value={mapQuery(oraclePrice, data => formatNumber(data, { abbreviate: false, fallback: '-' }))}
-        valueTooltip={formatNumber(oraclePrice.data, { decimals: 5, abbreviate: false, fallback: '-' })}
+        value={mapQuery(oraclePrice, data => formatNumber(data, 'pool.parameter'))}
       />
       {enablePricePerShare && marketId && (
         <ActionInfo
           testId="market-price-per-share"
           label={t`Price per share`}
-          value={mapQuery(pricePerShare, data => formatNumber(data, { decimals: 5, abbreviate: false, fallback: '-' }))}
+          value={mapQuery(pricePerShare, data => formatNumber(data, 'pool.parameter'))}
         />
       )}
     </>


### PR DESCRIPTION
This was by request, as both parameters may lack precision in a few use cases.

<img width="515" height="87" alt="image" src="https://github.com/user-attachments/assets/5d5bad0b-e3a5-43bf-8a99-546f2d017354" />
