### PR TITLE
chore: revert status propagation

### DIFF
--- a/apps/router-api/src/routes/routes.ts
+++ b/apps/router-api/src/routes/routes.ts
@@ -1,6 +1,5 @@
 import type { FastifyRequest } from 'fastify'
 import lodash from 'lodash'
-import { FetchError } from '@primitives/fetch.utils'
 import { handleTimeout } from '@primitives/objects.utils'
 import { type RouterRouteResponse } from '@primitives/router.utils'
 import { buildCurveRouteResponse } from '../curve-router/curve-router'
@@ -11,7 +10,7 @@ import { buildZeroExRouteResponse } from '../zeroex-router/zeroex-router'
 import { type RoutesQuery } from './routes.schemas'
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
-const { minBy, partition } = lodash // bundler crashes when using new-style imports
+const { partition } = lodash // bundler crashes when using new-style imports
 const ROUTE_TIMEOUT = 30_000 // 30 seconds
 
 const routers = {
@@ -24,22 +23,6 @@ const routers = {
 const sortRoutes = (a: RouterRouteResponse, b: RouterRouteResponse) =>
   decimalCompare(decimalMax(...b.amountOut) ?? '0', decimalMax(...a.amountOut) ?? '0') ||
   (a.priceImpact ?? 100) - (b.priceImpact ?? 100)
-
-function handleFailures(failures: PromiseRejectedResult[], router: string[]) {
-  const reasons = failures.map((f): unknown => f.reason)
-  const fetchError = minBy(
-    reasons.filter((reason): reason is FetchError => reason instanceof FetchError),
-    'status',
-  )
-  if (fetchError) {
-    const { body, status: status } = fetchError
-    return status >= 400 && status < 500 && status !== 403 && body
-      ? { status, data: body } // propagate body and status for 4xx, except 403 (forbidden)
-      : { status: status >= 500 ? 502 : 500, data: `Upstream failed with status ${status}` }
-  }
-  if (reasons.length === 1) throw reasons[0]
-  throw new Error(`Failed to calculate route for ${router.join(', ')}: ${reasons.join('; ')}`)
-}
 
 /**
  * Handles the routes request. Returns the best routes for the given parameters.
@@ -64,11 +47,14 @@ export const getRoutes = async (request: FastifyRequest<{ Querystring: RoutesQue
 
   failures.forEach(res => request.log.error({ message: 'route calculation failed', error: res.reason }))
   if (!successes.length) {
-    return handleFailures(failures, router)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation before enabling this rule.
+    const reasons = failures.map(f => f.reason)
+    if (reasons.length === 1) throw reasons[0]
+    throw new Error(`Failed to calculate route for ${router.join(', ')}: ${reasons.join('; ')}`)
   }
 
   // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
   const result = successes.flatMap(p => p.value).sort(sortRoutes)
   request.log.info({ message: 'route calculated', query, result })
-  return { status: 200, data: result }
+  return result
 }

--- a/apps/router-api/src/server.ts
+++ b/apps/router-api/src/server.ts
@@ -6,8 +6,5 @@ export const createRouterApiServer = (env = process.env) =>
   createApiServer({ serviceName: 'router-api', env }).get<{ Querystring: RoutesQuery }>(
     ROUTES_PATH,
     RoutesOpts,
-    async (request, reply) => {
-      const { status, data } = await getRoutes(request)
-      return reply.code(status).send(data)
-    },
+    getRoutes,
   )

--- a/apps/router-api/src/zeroex-router/zeroex-router.ts
+++ b/apps/router-api/src/zeroex-router/zeroex-router.ts
@@ -5,7 +5,7 @@ import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { FetchError, fetchJson } from '@primitives/fetch.utils'
 import { assert, maybe, notFalsy } from '@primitives/objects.utils'
-import type { RouteStep, RouterRouteResponse } from '@primitives/router.utils'
+import type { RouterRouteResponse, RouteStep } from '@primitives/router.utils'
 import {
   calculateFeePercentage,
   combineFeePercentages,
@@ -18,14 +18,11 @@ import type { ZeroExQuoteRequest, ZeroExQuoteResponse } from './zeroex.types'
 const { ZEROEX_API_URL = 'https://api.0x.org', ZEROEX_API_KEY } = process.env
 const PROTOCOL = '0x' as const
 
-async function getZeroExQuote({ chainId, ...params }: ZeroExQuoteRequest) {
-  const quote = await fetchJson<ZeroExQuoteResponse>(
+const getZeroExQuote = async ({ chainId, ...params }: ZeroExQuoteRequest) =>
+  await fetchJson<ZeroExQuoteResponse>(
     `${ZEROEX_API_URL}/swap/allowance-holder/quote?${new URLSearchParams({ ...params, chainId: `${chainId}` })}`,
     { headers: { '0x-api-key': assert(ZEROEX_API_KEY, 'Missing 0x API KEY'), '0x-version': 'v2' } },
   )
-  assert(quote.liquidityAvailable, `0x quote error - no liquidity available`)
-  return quote
-}
 
 /**
  * Normalizes 0x volume fees into one effective percentage.
@@ -89,9 +86,12 @@ export const buildZeroExRouteResponse = async (
       swapFeeToken: sellToken,
     })),
   }
-  const { buyAmount, fees, route, sellAmount, transaction } = await getZeroExQuote(params).catch(error =>
-    logZeroExError(error, log, params),
-  )
+  const quote = await getZeroExQuote(params).catch(error => logZeroExError(error, log, params))
+  if (!quote?.liquidityAvailable) {
+    log.info({ message: '0x quote returned no liquidity', params, quote })
+    return []
+  }
+  const { buyAmount, fees, route, sellAmount, transaction } = quote
   const { data, gas, to, value } = transaction
   return [
     {

--- a/apps/router-api/test/integration/routes-mocked.test.ts
+++ b/apps/router-api/test/integration/routes-mocked.test.ts
@@ -1,11 +1,14 @@
 import type { FastifyInstance } from 'fastify'
 import { zeroAddress } from 'viem'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
-import { createRouterApiServer } from '../../src/server'
 
 describe('GET routes mocked unit tests', () => {
   let server: FastifyInstance
-  beforeAll(() => (server = createRouterApiServer()))
+  beforeAll(async () => {
+    process.env.ZEROEX_API_KEY = 'test'
+    const { createRouterApiServer } = await import('../../src/server')
+    server = createRouterApiServer()
+  })
   afterEach(() => vi.unstubAllGlobals())
   afterAll(() => server.close())
 
@@ -19,50 +22,27 @@ describe('GET routes mocked unit tests', () => {
     route: [],
   }
 
-  it.each([
-    {
-      label: 'preserves upstream 4xx statuses',
-      router: ['enso'],
-      fetchStatuses: [429],
-      expectedStatus: 429,
-      expectedBody: 'Upstream response',
-    },
-    {
-      label: 'maps upstream 5xx statuses to 502',
-      router: ['enso'],
-      fetchStatuses: [503],
-      expectedStatus: 502,
-      expectedBody: 'Upstream failed with status 503',
-    },
-    {
-      label: 'returns the lowest mapped status when all requested routers fail',
-      router: ['enso', 'curve-solver'],
-      fetchStatuses: [429, 503],
-      expectedStatus: 429,
-      expectedBody: 'Upstream response',
-    },
-  ])('$label', async ({ router, fetchStatuses, expectedStatus, expectedBody }) => {
+  it('returns an empty response when 0x has no liquidity', async () => {
     vi.stubGlobal(
       'fetch',
-      // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
-      vi.fn<typeof fetch>(() => Promise.resolve(new Response('Upstream response', { status: fetchStatuses.shift() }))),
+      vi.fn<typeof fetch>(() => Promise.resolve(Response.json({ liquidityAvailable: false }))),
     )
 
-    const { body, statusCode } = await server.inject({
+    const { json, statusCode } = await server.inject({
       url: '/api/router/v1/routes',
       query: {
         chainId: '1',
         tokenIn: [zeroAddress],
         tokenOut: [zeroAddress],
         amountIn: ['1000000000'],
-        router,
+        router: ['0x'],
         userAddress: zeroAddress,
         zapAddress: zeroAddress,
       },
     })
 
-    expect(statusCode).toBe(expectedStatus)
-    expect(body).equals(expectedBody)
+    expect(statusCode).toBe(200)
+    expect(json()).toEqual([])
   })
 
   // TODO: test 0x slippage and fees


### PR DESCRIPTION
 - instead, we should only return 4xx responses for known errors
 - this partially reverts #2820
 - handle 0x routes with no liquidity