### PR TITLE
fix: wstETH-ETH market test

### DIFF
--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -86,9 +86,9 @@ export const LOAN_TEST_MARKETS = {
       collateralAddress: '0x1f32b1c2345538c0c6f582fcb022739c4a194ebb', // wstETH
       controllerAddress: '0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9',
       collateral: '1',
-      borrow: '0.05',
-      borrowMore: '0.01',
-      repay: '0.02',
+      borrow: '0.01',
+      borrowMore: '0.005',
+      repay: '0.005',
       chainId: Chain.Optimism,
       path: '/lend/optimism/markets/0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9',
       hasLeverage: true,


### PR DESCRIPTION
- [the market](https://www.curve.finance/lend/optimism/markets/0x745422BF49f3F6e4A8E12E4abD19339E7910F8C9/vault) currently has low liquidity and the max borrow was 0.04, so e2e tests were failing

<img width="973" height="136" alt="Screenshot From 2026-08-22 11-57-24" src="https://github.com/user-attachments/assets/6100bac3-0252-4538-b544-d65abbf9f838" />
