### PR TITLE
fix: max debt error

### DIFF
--- a/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/hooks/useCreateLoanForm.tsx
@@ -37,7 +37,7 @@ const userDefaultValues = {
 } satisfies Partial<CreateLoanForm>
 
 const validation = createLoanQueryValidationSuite({
-  debtRequired: false,
+  debtRequired: true,
   skipMarketValidation: true, // given separately to the mutation
   collateralRequired: true,
 })

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,8 +8,8 @@
     "hoistingLimits": "dependencies"
   },
   "scripts": {
-    "lint": "eslint --cache --cache-location ../../.cache/eslint/tests --cache-strategy content .",
-    "lint:fix": "eslint --cache --cache-location ../../.cache/eslint/tests --cache-strategy content . --fix",
+    "lint": "eslint --cache --cache-location ../.cache/eslint/tests --cache-strategy content .",
+    "lint:fix": "eslint --cache --cache-location ../.cache/eslint/tests --cache-strategy content . --fix",
     "typecheck": "tsc --tsBuildInfoFile ../.cache/typecheck/tests.tsbuildinfo",
     "test": "vitest run",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
- `debtRequired: false` was introduced when form validation was split from submit validation, making the form less strict than submit.
- That mismatch allows Borrow to be clickable before `maxDebt` is ready, then submit validation throws the max-debt error.
- Setting `debtRequired: true` realigns form and submit validation, so Borrow stays disabled until `maxDebt` is calculated.