### PR TITLE
chore: form skeleton height improvements

### DIFF
--- a/packages/evm-ui/src/widgets/DetailPageLayout/FormSkeleton.tsx
+++ b/packages/evm-ui/src/widgets/DetailPageLayout/FormSkeleton.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography'
 import { noop } from '@tanstack/react-query'
 import { BUTTON_FORM_SIZE } from '@ui-kit/features/forms/constants'
 import { t } from '@ui-kit/lib/i18n'
-import { HelperMessage, LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
+import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
 import { FormContent } from './FormContent'
 import { FormTabs } from './FormTabs'
 
@@ -29,9 +29,7 @@ export const FormSkeleton = () => (
                 tokenSelector={<Typography variant="bodyMBold">{t`Token`}</Typography>}
                 walletBalance={{ balance: '0', symbol: t`Token` }}
                 inputBalanceUsd="0"
-              >
-                <HelperMessage message={t`Loading`} />
-              </LargeTokenInput>
+              />
             </Skeleton>
             <Button loading disabled fullWidth size={BUTTON_FORM_SIZE} />
           </FormContent>

--- a/packages/evm-ui/src/widgets/DetailPageLayout/FormSkeleton.tsx
+++ b/packages/evm-ui/src/widgets/DetailPageLayout/FormSkeleton.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography'
 import { noop } from '@tanstack/react-query'
 import { BUTTON_FORM_SIZE } from '@ui-kit/features/forms/constants'
 import { t } from '@ui-kit/lib/i18n'
-import { LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
+import { HelperMessage, LargeTokenInput } from '@ui-kit/shared/ui/LargeTokenInput'
 import { FormContent } from './FormContent'
 import { FormTabs } from './FormTabs'
 
@@ -14,14 +14,24 @@ export const FormSkeleton = () => (
     menu={[
       {
         value: 'tab',
-        label: <Skeleton width={100} />,
+        label: (
+          <Skeleton variant="rectangular" width={100}>
+            <Typography variant="buttonTabsM">{t`Loading`}</Typography>
+          </Skeleton>
+        ),
         component: () => (
           <FormContent>
-            <Skeleton width="100%">
-              <LargeTokenInput name="loading" onBalance={noop} message={t`Loading`} />
-            </Skeleton>
-            <Skeleton width="100%">
-              <Typography variant="buttonM">{t`Loading form...`}</Typography>
+            <Skeleton variant="rectangular" width="100%">
+              <LargeTokenInput
+                name="loading"
+                onBalance={noop}
+                label={t`Loading`}
+                tokenSelector={<Typography variant="bodyMBold">{t`Token`}</Typography>}
+                walletBalance={{ balance: '0', symbol: t`Token` }}
+                inputBalanceUsd="0"
+              >
+                <HelperMessage message={t`Loading`} />
+              </LargeTokenInput>
             </Skeleton>
             <Button loading disabled fullWidth size={BUTTON_FORM_SIZE} />
           </FormContent>

--- a/tests/cypress/component/form-skeleton.cy.tsx
+++ b/tests/cypress/component/form-skeleton.cy.tsx
@@ -1,0 +1,82 @@
+import { DepositForm } from '@/llamalend/features/supply/components/DepositForm'
+import { MockLoanTestWrapper } from '@cy/support/helpers/llamalend/MockLoanTestWrapper'
+import { createDepositScenario } from '@cy/support/helpers/llamalend/supply/supply-test-scenarios.helpers'
+import {
+  llamaNetworks,
+  resetLlamaTestContext,
+  setGasInfo,
+  setLlamaApi,
+} from '@cy/support/helpers/llamalend/test-context.helpers'
+import Stack from '@mui/material/Stack'
+import { t } from '@ui-kit/lib/i18n'
+import { FormSkeleton } from '@ui-kit/widgets/DetailPageLayout/FormSkeleton'
+import { type FormTab, FormTabs } from '@ui-kit/widgets/DetailPageLayout/FormTabs'
+
+type DepositTabsParams = Record<string, never>
+
+const depositMenu = [
+  {
+    value: 'deposit',
+    label: t`Deposit`,
+    component: (props: DepositTabsParams) => <DepositForm networks={llamaNetworks} {...props} />,
+  },
+] satisfies FormTab<DepositTabsParams>[]
+
+const HEIGHT_TOLERANCE = 1
+
+const getHeight = (selector: string) =>
+  cy
+    .get(selector)
+    .should('be.visible')
+    .then($element => $element[0].getBoundingClientRect().height)
+
+const shouldMatchHeight = (actualSelector: string, skeletonSelector: string) => {
+  getHeight(skeletonSelector).then(skeletonHeight =>
+    getHeight(actualSelector).should(actualHeight =>
+      expect(actualHeight).to.be.closeTo(skeletonHeight, HEIGHT_TOLERANCE),
+    ),
+  )
+}
+
+describe('FormSkeleton', () => {
+  beforeEach(resetLlamaTestContext)
+
+  it('matches the layout heights of a one-input deposit form', () => {
+    const { llamaApi, market } = createDepositScenario({
+      chainId: 1,
+      approved: true,
+    })
+
+    setLlamaApi(llamaApi)
+    setGasInfo({ chainId: 1, networks: llamaNetworks })
+
+    cy.mount(
+      <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
+        <Stack>
+          <Stack data-testid="skeleton-form">
+            <FormSkeleton />
+          </Stack>
+          <Stack data-testid="actual-form">
+            <FormTabs params={{}} menu={depositMenu} />
+          </Stack>
+        </Stack>
+      </MockLoanTestWrapper>,
+    )
+
+    cy.get('[data-testid="actual-form"] [data-testid="supply-deposit-input"]').should('be.visible')
+
+    shouldMatchHeight(
+      '[data-testid="actual-form"] [data-testid="tab-deposit"]',
+      '[data-testid="skeleton-form"] [data-testid="tab-tab"]',
+    )
+    shouldMatchHeight(
+      '[data-testid="actual-form"] [data-testid="supply-deposit-input"]',
+      '[data-testid="skeleton-form"] .MuiCard-root .MuiSkeleton-rectangular',
+    )
+    shouldMatchHeight(
+      '[data-testid="actual-form"] [data-testid="supply-deposit-submit-button"]',
+      '[data-testid="skeleton-form"] .MuiCardContent-root > button.MuiButton-root',
+    )
+    shouldMatchHeight('[data-testid="actual-form"] .MuiCard-root', '[data-testid="skeleton-form"] .MuiCard-root')
+  })
+})


### PR DESCRIPTION
- update the height of the form skeleton to match the simplest forms (a single input and a submit button)
- make sure the tab title and the token input match the expected sizes
- add component test