### PR TITLE
refactor: remove legacy query types

### DIFF
--- a/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
+++ b/apps/main/src/dex/components/PagePool/Withdraw/components/FormWithdraw.tsx
@@ -1,8 +1,7 @@
 import lodash from 'lodash'
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { styled, css } from 'styled-components'
-import { useConnection, type Config } from 'wagmi'
-import { useConfig } from 'wagmi'
+import { css, styled } from 'styled-components'
+import { type Config, useConfig, useConnection } from 'wagmi'
 import { AlertFormError } from '@/dex/components/AlertFormError'
 import { AlertSlippage } from '@/dex/components/AlertSlippage'
 import { DetailInfoEstGas } from '@/dex/components/DetailInfoEstGas'
@@ -284,25 +283,21 @@ export const FormWithdraw = ({
   const estUsdAmountTotalReceive = useMemo(() => {
     if (formValues.selected === 'token') {
       const foundCoinWithAmount = formValues.amounts.find(a => Number(a.value) > 0)
-
-      if (foundCoinWithAmount && !lodash.isUndefined(usdRates[foundCoinWithAmount.tokenAddress])) {
+      if (foundCoinWithAmount && usdRates?.[foundCoinWithAmount.tokenAddress] != null) {
         const { value, tokenAddress } = foundCoinWithAmount
-        const usdRate = usdRates[tokenAddress]
-        if (usdRate && !lodash.isNaN(usdRate)) {
-          return (Number(usdRate) * Number(value)).toString()
+        const usdRate = usdRates?.[tokenAddress]
+        if (usdRate) {
+          return (usdRate * Number(value)).toString()
         }
       }
     } else if (formValues.selected === 'lpToken' || formValues.selected === 'imbalance') {
-      const amounts = formValues.amounts.filter(a => Number(a.value) > 0)
-      let usdAmountTotal = 0
-
-      amounts.forEach(a => {
-        const usdRate = usdRates[a.tokenAddress]
-        if (usdRate && !lodash.isNaN(usdRate)) {
-          usdAmountTotal += Number(a.value) * Number(usdRate)
-        }
-      })
-      return usdAmountTotal.toString()
+      return lodash
+        .sum(
+          formValues.amounts
+            .filter(({ tokenAddress, value }) => Number(value) > 0 && usdRates?.[tokenAddress])
+            .map(({ tokenAddress, value }) => Number(usdRates?.[tokenAddress]) * Number(value)),
+        )
+        .toString()
     }
 
     return ''

--- a/apps/main/src/llamalend/hooks/useHealthQueries.ts
+++ b/apps/main/src/llamalend/hooks/useHealthQueries.ts
@@ -2,13 +2,12 @@ import type { Decimal } from '@primitives/decimal.utils'
 import { maybes } from '@primitives/objects.utils'
 import { useQueries } from '@tanstack/react-query'
 import type { UseQueryOptions } from '@tanstack/react-query'
-import { combineQueriesMeta } from '@ui-kit/lib/queries/combine'
-import type { QueryResultsArray } from '@ui-kit/lib/queries/types'
+import { combineQueryState } from '@ui-kit/lib/queries/combine'
+import type { Query } from '@ui-kit/types/util'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type QueryKey = any // disable typecheck for this as we accept any query key
 type HealthQueryOptions = UseQueryOptions<Decimal, Error, Decimal, QueryKey>
-type HealthQueryResults = QueryResultsArray<readonly HealthQueryOptions[]>
 
 /**
  * Docs courtesy of Saint Rat:
@@ -36,9 +35,9 @@ type HealthQueryResults = QueryResultsArray<readonly HealthQueryOptions[]>
  *   In or below soft-liq healthFull = healthNotFull, above soft-liq healthFull > healthNotFull
  *   When healthNotFull is below 0, the user is in soft-liq and we should return the corresponding metric.
  */
-const combineHealth = ([healthFull, healthNotFull]: HealthQueryResults) => ({
-  data: maybes([healthFull.data, healthNotFull.data], (full, notFull) => (+notFull < 0 ? notFull : full)),
-  ...combineQueriesMeta([healthFull, healthNotFull]),
+const combineHealth = ([healthFull, healthNotFull]: Query<Decimal>[]) => ({
+  data: maybes([healthFull?.data, healthNotFull?.data], (full, notFull) => (+notFull < 0 ? notFull : full)),
+  ...combineQueryState(healthFull, healthNotFull),
 })
 
 /**
@@ -47,7 +46,4 @@ const combineHealth = ([healthFull, healthNotFull]: HealthQueryResults) => ({
  * @returns Combined health query result.
  */
 export const useHealthQueries = (getOptions: (isFull: boolean) => HealthQueryOptions) =>
-  useQueries({
-    queries: [true, false].map(getOptions),
-    combine: combineHealth,
-  })
+  useQueries({ queries: [true, false].map(getOptions), combine: combineHealth })

--- a/apps/main/src/llamalend/hooks/useHealthQueries.ts
+++ b/apps/main/src/llamalend/hooks/useHealthQueries.ts
@@ -35,7 +35,7 @@ type HealthQueryOptions = UseQueryOptions<Decimal, Error, Decimal, QueryKey>
  *   In or below soft-liq healthFull = healthNotFull, above soft-liq healthFull > healthNotFull
  *   When healthNotFull is below 0, the user is in soft-liq and we should return the corresponding metric.
  */
-const combineHealth = ([healthFull, healthNotFull]: Query<Decimal>[]) => ({
+const combineHealth = ([healthFull, healthNotFull]: [Query<Decimal>, Query<Decimal>]) => ({
   data: maybes([healthFull?.data, healthNotFull?.data], (full, notFull) => (+notFull < 0 ? notFull : full)),
   ...combineQueryState(healthFull, healthNotFull),
 })
@@ -46,4 +46,4 @@ const combineHealth = ([healthFull, healthNotFull]: Query<Decimal>[]) => ({
  * @returns Combined health query result.
  */
 export const useHealthQueries = (getOptions: (isFull: boolean) => HealthQueryOptions) =>
-  useQueries({ queries: [true, false].map(getOptions), combine: combineHealth })
+  useQueries({ queries: [getOptions(true), getOptions(false)], combine: combineHealth })

--- a/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
+++ b/apps/main/src/llamalend/hooks/useSolvencyMarket.ts
@@ -5,9 +5,9 @@ import type { Address } from '@primitives/address.utils'
 import { maybes } from '@primitives/objects.utils'
 import type { QueriesResults } from '@tanstack/react-query'
 import { useQueries } from '@tanstack/react-query'
-import { RESOLVED_QUERY_RESULT } from '@ui-kit/lib/queries'
-import { combineQueriesMeta } from '@ui-kit/lib/queries/combine'
+import { combineQueryState } from '@ui-kit/lib/queries/combine'
 import { MarketType } from '@ui-kit/types/market'
+import { DISABLED_Q } from '@ui-kit/types/util'
 import { calculateMarketSolvency, createGetBadDebtMarket } from '../llama.utils'
 import { getBadDebtLendMarketsOptions } from '../queries/market/market-bad-debt.query'
 import { getLendingVaultsOptions } from '../queries/market-list/lending-vaults'
@@ -40,9 +40,7 @@ export const useSolvencyMarket = (
     ),
     combine: useCallback(
       (results: QueriesResults<SolvencyMarketsQueries>) => {
-        if (!isEnabled) {
-          return RESOLVED_QUERY_RESULT
-        }
+        if (!isEnabled) return DISABLED_Q
         const [lendingVaults, badDebtLendMarkets] = results
         const getLendMarketBadDebt = createGetBadDebtMarket(badDebtLendMarkets.data)
 
@@ -62,7 +60,7 @@ export const useSolvencyMarket = (
           })
 
         return {
-          ...combineQueriesMeta(results),
+          ...combineQueryState(...results),
           data: maybes([solvencyPercent, badDebtUsd], (solvencyPercent, badDebtUsd) => ({
             solvencyPercent,
             badDebtUsd,

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -25,10 +25,10 @@ import { useQueries } from '@tanstack/react-query'
 import { type CampaignRewards, combineCampaigns } from '@ui-kit/entities/campaigns'
 import { getCampaignsExternalOptions } from '@ui-kit/entities/campaigns/campaigns-external'
 import { getCampaignsMarketsMerklOptions } from '@ui-kit/entities/campaigns/campaigns-markets-merkl'
-import { combineQueryState, RESOLVED_QUERY_RESULT } from '@ui-kit/lib'
+import { combineQueryState } from '@ui-kit/lib'
 import { CRVUSD_ROUTES, getInternalUrl, LEND_ROUTES } from '@ui-kit/shared/routes'
 import { type ExtraIncentive, MarketType, MarketVersion, MarketRateType } from '@ui-kit/types/market'
-import type { Query } from '@ui-kit/types/util'
+import { DISABLED_Q, type Query } from '@ui-kit/types/util'
 import { decimal, decimalDiv } from '@ui-kit/utils'
 import { DEPRECATED_LLAMAS, NO_LEVERAGE_LEND } from '../../markets.constants'
 import { getBadDebtLendMarketsOptions, getBadDebtMintMarketsOptions } from '../market/market-bad-debt.query'
@@ -422,7 +422,7 @@ export const useLlamaMarkets = ({ userAddress, enableDeprecatedMarkets }: LlamaM
     ),
     combine: useCallback(
       (results: QueriesResults<LlamaMarketsQueries>): Query<LlamaMarketsResult> => {
-        if (!enabled) return RESOLVED_QUERY_RESULT // used in the header, only run when llamalend is selected
+        if (!enabled) return DISABLED_Q // used in the header, only run when llamalend is selected
         const [
           lendingVaults,
           mintMarkets,

--- a/apps/main/src/llamalend/queries/market/market-overview.query.ts
+++ b/apps/main/src/llamalend/queries/market/market-overview.query.ts
@@ -4,7 +4,7 @@ import type { Chain } from '@curvefi/prices-api'
 import type { Address } from '@primitives/address.utils'
 import { maybe, maybes } from '@primitives/objects.utils'
 import { type QueriesResults, useQueries } from '@tanstack/react-query'
-import { combineQueriesMeta } from '@ui-kit/lib/queries/combine'
+import { combineQueryState } from '@ui-kit/lib/queries/combine'
 import { MarketType } from '@ui-kit/types/market'
 import { q } from '@ui-kit/types/util'
 import { TIME_FRAMES } from '@ui-kit/utils'
@@ -52,7 +52,7 @@ export const useMarketOverview = ({
           )
 
           return {
-            ...combineQueriesMeta(results),
+            ...combineQueryState(...results),
             data: maybe(marketOverview, ({ createdAt, totalBorrowers }) => ({
               deployedDays: Math.floor((Date.now() - createdAt) / TIME_FRAMES.DAY_MS),
               totalBorrowers,

--- a/packages/evm-ui/src/entities/campaigns/campaigns.ts
+++ b/packages/evm-ui/src/entities/campaigns/campaigns.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import type { Address } from '@primitives/address.utils'
 import { fromEntries, notFalsy, objectKeys } from '@primitives/objects.utils'
 import { type QueriesResults, useQueries } from '@tanstack/react-query'
-import { combineQueriesMeta } from '@ui-kit/lib'
+import { combineQueryState } from '@ui-kit/lib'
 import { useMappedQuery } from '@ui-kit/types/util'
 import { getCampaignsExternalOptions } from './campaigns-external'
 import { getCampaignsMarketsMerklOptions } from './campaigns-markets-merkl'
@@ -80,7 +80,7 @@ export const useCampaigns = ({ blockchainId }: UseCampaignsOptions = {}) =>
     queries,
     combine: useCallback(
       ([external, merklPools, merklMarkets]: QueriesResults<CampaignQueries>) => ({
-        ...combineQueriesMeta([external, merklPools, merklMarkets]),
+        ...combineQueryState(external, merklPools, merklMarkets),
         // Combine campaigns with an optional network filter
         data: combineCampaigns([external.data, merklPools.data, merklMarkets.data], blockchainId),
       }),

--- a/packages/evm-ui/src/hooks/useTokenBalance.ts
+++ b/packages/evm-ui/src/hooks/useTokenBalance.ts
@@ -3,11 +3,12 @@ import { useCallback, useMemo } from 'react'
 import { type Address, erc20Abi, ethAddress, formatUnits, isAddressEqual } from 'viem'
 import { useBalance, useConfig, useReadContracts } from 'wagmi'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useQueries, type UseQueryResult } from '@tanstack/react-query'
+import { useQueries } from '@tanstack/react-query'
 import { combineQueriesToObject, type FieldsOf } from '@ui-kit/lib'
 import { queryClient } from '@ui-kit/lib/api'
 import { type ChainQuery, type UserQuery } from '@ui-kit/lib/model'
 import { QUERY_CATEGORIES } from '@ui-kit/lib/model/query/query-categories'
+import type { Query } from '@ui-kit/types/util'
 import { uniqAddresses } from '@ui-kit/utils'
 import { DEFAULT_DECIMALS } from '@ui-kit/utils/units'
 import type { Config, GetBalanceReturnType, ReadContractsReturnType } from '@wagmi/core'
@@ -186,7 +187,7 @@ export function useTokenBalances(
       [config, chainId, userAddress, uniqueAddresses, isEnabled],
     ),
     combine: useCallback(
-      (results: UseQueryResult[]) => combineQueriesToObject(results as UseQueryResult<Decimal>[], uniqueAddresses),
+      (results: Query<unknown>[]) => combineQueriesToObject<Decimal>(results as Query<Decimal>[], uniqueAddresses),
       [uniqueAddresses],
     ),
   })

--- a/packages/evm-ui/src/lib/queries/combine.ts
+++ b/packages/evm-ui/src/lib/queries/combine.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react'
 import type { Decimal } from '@primitives/decimal.utils'
-import type { UseQueryOptions } from '@tanstack/react-query'
-import { Query, QueryProp } from '@ui-kit/types/util'
+import { notFalsy } from '@primitives/objects.utils'
+import { q, Query, QueryProp } from '@ui-kit/types/util'
 import { decimalMin } from '@ui-kit/utils/decimal'
-import { type PartialQueryResult, QueryResultsArray } from './types'
 
 export const combineQueryState = (...queries: (Query<unknown> | undefined)[]) =>
   ({
@@ -42,24 +41,18 @@ export const useCombinedQueries = <const TQueries extends Queries, TResult>(
     ...combineQueryState(...queries),
   }) as QueryProp<TResult>
 
-/** Combines the metadata of multiple queries into a single object. */
-export const combineQueriesMeta = (results: PartialQueryResult<unknown>[]) => ({
-  isLoading: results.some(result => result.isLoading),
-  isPending: results.some(result => result.isPending),
-  isError: results.some(result => result.isError),
-  isFetching: results.some(result => result.isFetching),
-  error: results.find(result => result.error)?.error ?? null,
-})
-
-/** Combines the data and metadata of multiple queries into a single object. */
-export const combineQueriesToObject = <TData, K extends string[]>(
-  results: QueryResultsArray<UseQueryOptions<TData, Error, TData, unknown[]>[]>,
-  keys: K,
-) => ({
-  // Using flatMap instead of map + filter(Boolean), because it's not correctly erasing | undefined from the Record value type
-  data: Object.fromEntries(results.flatMap(({ data }, index) => (data == null ? [] : [[keys[index], data]]))),
-  ...combineQueriesMeta(results),
-})
+/** Combines multiple queries into a query whose data is keyed by the matching key list. */
+export const combineQueriesToObject = <TData, K extends string = string>(results: Query<TData>[], keys: readonly K[]) =>
+  q<Record<K, TData>>({
+    data: (results.some(({ data }) => data != null)
+      ? Object.fromEntries(
+          notFalsy(...results.map(({ data }, index) => data != null && ([keys[index], data] as const))),
+        )
+      : results.some(({ data }) => data === null)
+        ? null
+        : undefined) as Record<K, TData> | undefined,
+    ...combineQueryState(...results),
+  })
 
 /**
  * Returns the minimum value from multiple queries returning Decimal values.

--- a/packages/evm-ui/src/lib/queries/combine.ts
+++ b/packages/evm-ui/src/lib/queries/combine.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import type { Decimal } from '@primitives/decimal.utils'
-import { notFalsy } from '@primitives/objects.utils'
+import { fromEntries, notFalsy } from '@primitives/objects.utils'
 import { q, Query, QueryProp } from '@ui-kit/types/util'
 import { decimalMin } from '@ui-kit/utils/decimal'
 
@@ -44,13 +44,9 @@ export const useCombinedQueries = <const TQueries extends Queries, TResult>(
 /** Combines multiple queries into a query whose data is keyed by the matching key list. */
 export const combineQueriesToObject = <TData, K extends string = string>(results: Query<TData>[], keys: readonly K[]) =>
   q<Record<K, TData>>({
-    data: (results.some(({ data }) => data != null)
-      ? Object.fromEntries(
-          notFalsy(...results.map(({ data }, index) => data != null && ([keys[index], data] as const))),
-        )
-      : results.some(({ data }) => data === null)
-        ? null
-        : undefined) as Record<K, TData> | undefined,
+    data: results.some(({ data }) => data != null)
+      ? fromEntries(notFalsy(...results.map(({ data }, index) => data != null && ([keys[index], data] as const))))
+      : undefined,
     ...combineQueryState(...results),
   })
 

--- a/packages/evm-ui/src/lib/queries/config.ts
+++ b/packages/evm-ui/src/lib/queries/config.ts
@@ -1,9 +1,0 @@
-const createQueryStatus = ({ value }: { value: boolean }) => ({ isLoading: value, isPending: value, isFetching: value })
-
-const QUERY_SUCCESS_BASE = { isError: false, data: undefined, error: null }
-
-// Simulates a successful query that has resolved and is idle.
-export const RESOLVED_QUERY_RESULT = {
-  ...createQueryStatus({ value: false }),
-  ...QUERY_SUCCESS_BASE,
-} as const

--- a/packages/evm-ui/src/lib/queries/index.ts
+++ b/packages/evm-ui/src/lib/queries/index.ts
@@ -1,3 +1,2 @@
 export * from './types'
 export * from './combine'
-export * from './config'

--- a/packages/evm-ui/src/lib/queries/types.ts
+++ b/packages/evm-ui/src/lib/queries/types.ts
@@ -1,20 +1,7 @@
-import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type QueryOptionsArray = readonly UseQueryOptions<any, any, any, any>[]
+import type { UseQueryOptions } from '@tanstack/react-query'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type QueryOptionsData<T> = T extends UseQueryOptions<infer TData, any, any, any> ? TData : never
-
-export type QueryResultsArray<T extends QueryOptionsArray> = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [K in keyof T]: T[K] extends UseQueryOptions<infer TData, any, any, any> ? UseQueryResult<TData> : never
-}
-
-export type PartialQueryResult<T> = Pick<
-  UseQueryResult<T>,
-  'data' | 'isLoading' | 'isPending' | 'isError' | 'isFetching' | 'error'
->
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFunction = (...args: any[]) => any


### PR DESCRIPTION
- Remove legacy helpers `createQueryStatus`, `QUERY_SUCCESS_BASE`, `RESOLVED_QUERY_RESULT`, `combineQueriesMeta`, `PartialQueryResult`. Use `combineQueryState` instead.
- Update `combineQueriesToObject` to use `Query<Record<K, TData>>` instead.