### PR TITLE
Prioritize owned tokens in selector search

### DIFF
--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -548,7 +548,6 @@ export const QuickSwap = ({
               tokens={tokens}
               balances={balances}
               tokenPrices={tokenPrices}
-              disableMyTokens
               onToken={({ address: toAddress }) => {
                 const fromAddress =
                   toAddress === searchedParams.fromAddress ? searchedParams.toAddress : searchedParams.fromAddress

--- a/packages/evm-ui/src/features/select-token/search-ordering.spec.ts
+++ b/packages/evm-ui/src/features/select-token/search-ordering.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { orderSearchTokens } from './search-ordering'
+import type { TokenOption } from './types'
+
+const token = (address: `0x${string}`, symbol: string, volume?: number): TokenOption => ({ address, symbol, volume })
+
+describe('orderSearchTokens', () => {
+  it('puts owned tokens ahead of higher-volume unowned tokens', () => {
+    const owned = token('0xowned', 'OWN', 1)
+    const unowned = token('0xunowned', 'HIGH', 1_000)
+
+    expect(orderSearchTokens([unowned, owned], { balances: { [owned.address]: 1 } })).toEqual([[owned], [unowned]])
+  })
+
+  it('orders owned tokens by USD value, raw balance, symbol, then address', () => {
+    const tokens = [
+      token('0x3', 'ZED'),
+      token('0x2', 'ALPHA'),
+      token('0x1', 'ALPHA'),
+      token('0x4', 'VALUE'),
+      token('0x5', 'RAW'),
+    ]
+
+    expect(
+      orderSearchTokens(tokens, {
+        balances: { '0x1': 2, '0x2': 2, '0x3': 2, '0x4': 1, '0x5': 3 },
+        tokenPrices: { '0x1': 1, '0x2': 1, '0x3': 1, '0x4': 3, '0x5': 0.5 },
+      })[0],
+    ).toEqual([tokens[3], tokens[2], tokens[1], tokens[0], tokens[4]])
+  })
+
+  it('keeps dust and unpriced positive balances in the owned group', () => {
+    const dust = token('0xdust', 'DUST')
+    const unpriced = token('0xunpriced', 'UNPRICED')
+    const unowned = token('0xunowned', 'VOLUME', 100)
+
+    expect(
+      orderSearchTokens([unowned, dust, unpriced], { balances: { [dust.address]: 0.0001, [unpriced.address]: 2 } }),
+    ).toEqual([[unpriced, dust], [unowned]])
+  })
+
+  it('orders remaining tokens by volume, then alphabetically and address for missing values', () => {
+    const tokens = [
+      token('0x2', 'ALPHA'),
+      token('0x1', 'ALPHA'),
+      token('0xzed', 'ZED'),
+      token('0xhigh', 'HIGH', 2),
+      token('0xlow', 'LOW', 1),
+    ]
+
+    expect(orderSearchTokens(tokens, {})[1]).toEqual([tokens[3], tokens[4], tokens[1], tokens[0], tokens[2]])
+  })
+
+  it('falls back to volume ordering without wallet data and does not duplicate tokens', () => {
+    const tokens = [token('0xb', 'B', 1), token('0xa', 'A', 2)]
+    const [owned, remaining] = orderSearchTokens(tokens, {})
+
+    expect(owned).toEqual([])
+    expect(remaining).toEqual([tokens[1], tokens[0]])
+    expect(new Set([...owned, ...remaining])).toHaveLength(tokens.length)
+  })
+})

--- a/packages/evm-ui/src/features/select-token/search-ordering.ts
+++ b/packages/evm-ui/src/features/select-token/search-ordering.ts
@@ -1,0 +1,35 @@
+import type { TokenOption } from './types'
+
+type SearchOrderingOptions = {
+  balances?: Record<string, string | number | undefined>
+  tokenPrices?: Record<string, number | undefined>
+}
+
+const value = (number: string | number | undefined) => Number(number) || 0
+
+const bySymbolAndAddress = (a: TokenOption, b: TokenOption) =>
+  a.symbol.localeCompare(b.symbol) || a.address.localeCompare(b.address)
+
+/** Sorts searched token matches into owned and remaining groups. */
+export const orderSearchTokens = (
+  tokens: readonly TokenOption[],
+  { balances, tokenPrices }: SearchOrderingOptions,
+): [TokenOption[], TokenOption[]] => {
+  const owned = tokens.filter(token => value(balances?.[token.address]) > 0)
+  const remaining = tokens.filter(token => value(balances?.[token.address]) === 0)
+
+  // eslint-disable-next-line local/no-mutable-array-methods -- Sorting copies created above.
+  owned.sort((a, b) => {
+    const aBalance = value(balances?.[a.address])
+    const bBalance = value(balances?.[b.address])
+    return (
+      value(tokenPrices?.[b.address]) * bBalance - value(tokenPrices?.[a.address]) * aBalance ||
+      bBalance - aBalance ||
+      bySymbolAndAddress(a, b)
+    )
+  })
+  // eslint-disable-next-line local/no-mutable-array-methods -- Sorting copies created above.
+  remaining.sort((a, b) => value(b.volume) - value(a.volume) || bySymbolAndAddress(a, b))
+
+  return [owned, remaining]
+}

--- a/packages/evm-ui/src/features/select-token/ui/modal/TokenList.tsx
+++ b/packages/evm-ui/src/features/select-token/ui/modal/TokenList.tsx
@@ -10,6 +10,7 @@ import { useSwitch } from '@ui-kit/hooks/useSwitch'
 import { t } from '@ui-kit/lib/i18n'
 import { SearchField } from '@ui-kit/shared/ui/SearchField'
 import { SizesAndSpaces } from '@ui-kit/themes/design/1_sizes_spaces'
+import { orderSearchTokens } from '../../search-ordering'
 import type { TokenOption as Option } from '../../types'
 import { ErrorAlert } from './ErrorAlert'
 import { FavoriteTokens } from './FavoriteTokens'
@@ -65,11 +66,16 @@ export const TokenList = ({
   const showFavorites = !!favorites?.length && !search
 
   const tokensSearched = useFuzzySearch(tokens, search, ['symbol', 'address'])
+  const [searchedMyTokens, searchedAllTokens] = useMemo(
+    () =>
+      disableSorting || !search ? [undefined, undefined] : orderSearchTokens(tokensSearched, { balances, tokenPrices }),
+    [disableSorting, search, tokensSearched, balances, tokenPrices],
+  )
 
   /**
    * Filters and sorts tokens that the user owns (has a balance > 0).
    *
-   * When disableSorting is false, tokens are sorted by:
+   * Outside of search, when disableSorting is false, tokens are sorted by:
    * 1. USD value of balance (highest first)
    * 2. Raw token balance (highest first) as a tiebreaker
    *
@@ -77,6 +83,8 @@ export const TokenList = ({
    */
   const myTokens = useMemo(() => {
     if (disableMyTokens) return []
+
+    if (searchedMyTokens) return searchedMyTokens
 
     const balanceTokens = tokensSearched.filter(token => +(balances?.[token.address] ?? 0) > 0)
 
@@ -94,7 +102,7 @@ export const TokenList = ({
     }
 
     return balanceTokens
-  }, [disableMyTokens, tokensSearched, disableSorting, balances, tokenPrices])
+  }, [disableMyTokens, searchedMyTokens, tokensSearched, disableSorting, balances, tokenPrices])
 
   /**
    * Filters tokens to show only those with significant value.
@@ -132,6 +140,9 @@ export const TokenList = ({
    * This keeps the UI clean while ensuring all tokens remain accessible.
    */
   const allTokens = useMemo(() => {
+    if (searchedAllTokens)
+      return disableMyTokens ? [...(searchedMyTokens ?? []), ...searchedAllTokens] : searchedAllTokens
+
     const allTokensBase = notFalsy(
       disableMyTokens ? tokensSearched : tokensSearched.filter(token => +(balances?.[token.address] ?? 0) === 0),
 
@@ -145,7 +156,17 @@ export const TokenList = ({
       ? allTokensBase
       : // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
         allTokensBase.sort((a, b) => (b.volume ?? 0) - (a.volume ?? 0) || a.symbol.localeCompare(b.symbol))
-  }, [disableMyTokens, tokensSearched, showPreviewMy, myTokens, disableSorting, balances, previewMy])
+  }, [
+    disableMyTokens,
+    searchedMyTokens,
+    searchedAllTokens,
+    tokensSearched,
+    showPreviewMy,
+    myTokens,
+    disableSorting,
+    balances,
+    previewMy,
+  ])
 
   /**
    * Filters tokens to show in the preview of "All tokens" section.
@@ -176,7 +197,7 @@ export const TokenList = ({
             balances={balances}
             tokenPrices={tokenPrices}
             disabledTokens={disabledTokens}
-            preview={previewMy}
+            preview={search ? myTokens : previewMy}
             showAllLabel={t`Show dust`}
             isLoading={isLoading}
             onShowAll={closeShowPreviewMy}
@@ -189,7 +210,7 @@ export const TokenList = ({
             balances={balances}
             tokenPrices={tokenPrices}
             disabledTokens={disabledTokens}
-            preview={previewAll}
+            preview={search ? allTokens : previewAll}
             isLoading={isLoading}
             onShowAll={closeShowPreviewAll}
             onToken={onToken}


### PR DESCRIPTION
## Objective

Make token-selector search results surface tokens the connected wallet owns before discovery-oriented results.

## Changes

- Add internal search-only ordering: positive balance, USD value, raw balance, then symbol/address; unowned matches then use Curve 24h volume and symbol/address.
- Keep empty-search browse behavior and `disableSorting` unchanged.
- Enable this behavior for Swap Buy by removing its `disableMyTokens` opt-out.

## Verification

- Focused `evm-ui` Vitest coverage
- `evm-ui` typecheck and lint
- Cypress component coverage delegated to GitHub Actions
