### PR TITLE
fix: remove min chart length of 2 before fuzzy search kicks in

### DIFF
--- a/packages/evm-ui/src/hooks/useFuzzySearch.ts
+++ b/packages/evm-ui/src/hooks/useFuzzySearch.ts
@@ -45,7 +45,6 @@ function useFuseResultSet<T>(data: readonly T[], filterValue: string, keys: read
         ignoreLocation: true,
         ignoreDiacritics: true,
         isCaseSensitive: false,
-        minMatchCharLength: 2,
         threshold: 0.01,
         getFn: (obj, path) => cleanValue(get(obj, path)) as string,
         keys: [...keys],


### PR DESCRIPTION
Fixes fuzzy search not kicking in when you're searching with just 1 character. This was a deliberate choice made by previous devs since the genesis of Curve front-end, but I don't see a need for it anymore.

**Before**
<img width="472" height="395" alt="image" src="https://github.com/user-attachments/assets/36055eed-39dd-449a-948a-ea5882600794" />

**After**
<img width="481" height="771" alt="image" src="https://github.com/user-attachments/assets/c48d95f5-1a25-4064-861d-b680e2820897" />
