### PR TITLE
chore: not falsy lint rule

### DIFF
--- a/.eslint/use-not-falsy-pattern.rule.mjs
+++ b/.eslint/use-not-falsy-pattern.rule.mjs
@@ -1,0 +1,316 @@
+import ts from 'typescript'
+
+const EXPRESSION_WRAPPERS = new Set([
+  'ChainExpression',
+  'ParenthesizedExpression',
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSTypeAssertion',
+])
+
+const unwrap = node => (EXPRESSION_WRAPPERS.has(node?.type) ? unwrap(node.expression) : node)
+const propertyName = node =>
+  node.property.type === 'Identifier' && !node.computed
+    ? node.property.name
+    : node.computed && node.property.type === 'Literal' && typeof node.property.value === 'string'
+      ? node.property.value
+      : null
+const unionMembers = type => (type.isUnion() ? type.types : [type])
+const isBoundedArrayLiteral = node =>
+  node.type === 'ArrayExpression' &&
+  node.elements.length > 0 &&
+  node.elements.every(element => element && element.type !== 'SpreadElement')
+const isFilterLength = node => {
+  while (EXPRESSION_WRAPPERS.has(node.parent?.type)) node = node.parent
+  return (
+    node.parent?.type === 'MemberExpression' && node.parent.object === node && propertyName(node.parent) === 'length'
+  )
+}
+
+const bigintLiteralIsZero = type => {
+  const value = typeof type.value === 'object' ? type.value.base10Value : `${type.value}`
+  return /^[-+]?0+$/.test(value)
+}
+
+const containsTypeParameter = type =>
+  !!(type.flags & ts.TypeFlags.TypeParameter) ||
+  ((type.isUnion() || type.isIntersection()) && type.types.some(containsTypeParameter))
+
+/** True only for types whose runtime values cannot be falsy. */
+const isDefinitelyTruthy = (checker, type) => {
+  if (!type || containsTypeParameter(type)) return false
+  const falsyTypes = [
+    checker.getFalseType(),
+    checker.getStringLiteralType(''),
+    checker.getNumberLiteralType(0),
+    checker.getBigIntLiteralType({ negative: false, base10Value: '0' }),
+    checker.getNullType(),
+    checker.getUndefinedType(),
+  ]
+  // A branded primitive can exclude its falsy literal structurally without doing so at runtime.
+  if (
+    type.isIntersection() &&
+    falsyTypes.some(falsy => type.types.some(member => checker.isTypeAssignableTo(falsy, member)))
+  )
+    return false
+  return falsyTypes.every(falsy => !checker.isTypeAssignableTo(falsy, type))
+}
+
+const isObviouslyTruthyExpression = node =>
+  [
+    'ArrayExpression',
+    'ArrowFunctionExpression',
+    'ClassExpression',
+    'FunctionExpression',
+    'NewExpression',
+    'ObjectExpression',
+  ].includes(unwrap(node).type)
+
+/** Broad primitives do not make an unbounded receiver a compaction signal. */
+const containsExplicitFalsy = type => {
+  if (!type || type.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.TypeParameter)) return false
+  if (type.isUnion()) return type.types.some(containsExplicitFalsy)
+  if (type.isIntersection()) return false
+  if (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void)) return true
+  if (type.flags & ts.TypeFlags.BooleanLiteral) return type.intrinsicName === 'false'
+  if (type.flags & ts.TypeFlags.StringLiteral) return type.value.length === 0
+  if (type.flags & ts.TypeFlags.NumberLiteral) return type.value === 0 || Number.isNaN(type.value)
+  if (type.flags & ts.TypeFlags.BigIntLiteral) return bigintLiteralIsZero(type)
+  return false
+}
+
+const nullishMask = type =>
+  unionMembers(type).reduce(
+    (mask, member) =>
+      mask |
+      (member.flags & ts.TypeFlags.Null ? 1 : 0) |
+      (member.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void) ? 2 : 0),
+    0,
+  )
+
+const isObjectsUtilsImport = source =>
+  source === '@primitives/objects.utils' || source === './objects.utils' || source.endsWith('/objects.utils')
+
+/** Reports safe, high-signal manual falsy compaction. */
+export const useNotFalsyPatternRule = {
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Prefer `notFalsy` for safe, intentional falsy compaction' },
+    messages: {
+      compact: 'Use `notFalsy(...)` instead of filtering falsy values manually.',
+      compactThenFilter: 'Compact with `notFalsy(...)` before applying the remaining filter predicate.',
+      conditional: 'Use `notFalsy(...)` instead of conditionally producing a singleton array.',
+      redundant: '`notFalsy(...)` already removes falsy values; remove this filter.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode
+    const services = sourceCode.parserServices
+    if (!services?.program || !services.esTreeNodeToTSNodeMap) return {}
+
+    const checker = services.program.getTypeChecker()
+    const inObjectsUtils = context.filename
+      .replaceAll('\\', '/')
+      .toLowerCase()
+      .endsWith('/packages/primitives/src/objects.utils.ts')
+
+    const findVariable = (node, name) => {
+      for (let scope = sourceCode.getScope(node); scope; scope = scope.upper) {
+        const variable = scope.set?.get(name)
+        if (variable) return variable
+      }
+    }
+    const isGlobal = (node, name) => {
+      const variable = findVariable(node, name)
+      return !variable || variable.defs.length === 0
+    }
+    const getType = node => checker.getTypeAtLocation(services.esTreeNodeToTSNodeMap.get(node))
+    const getElementType = receiver => {
+      const type = getType(receiver)
+      const isArray = member => {
+        const apparent = checker.getApparentType(member)
+        return checker.isArrayType(apparent) || checker.isTupleType(apparent)
+      }
+      return unionMembers(type).every(isArray) ? checker.getIndexTypeOfType(type, ts.IndexKind.Number) : undefined
+    }
+
+    const isReference = node => {
+      node = unwrap(node)
+      return node.type === 'Identifier' || node.type === 'ThisExpression'
+    }
+    const sameExpression = (left, right) => sourceCode.getText(unwrap(left)) === sourceCode.getText(unwrap(right))
+
+    /** `true` means the test is true exactly when value is truthy; `false` means the inverse. */
+    const truthinessPolarity = (test, value) => {
+      test = unwrap(test)
+      value = unwrap(value)
+      if (isReference(value) && sameExpression(test, value)) return true
+      if (test.type === 'UnaryExpression' && test.operator === '!') {
+        const inner = truthinessPolarity(test.argument, value)
+        return inner === undefined ? undefined : !inner
+      }
+      if (
+        test.type === 'CallExpression' &&
+        !test.optional &&
+        test.arguments.length === 1 &&
+        test.callee.type === 'Identifier' &&
+        test.callee.name === 'Boolean' &&
+        isGlobal(test.callee, 'Boolean') &&
+        isReference(value) &&
+        sameExpression(test.arguments[0], value)
+      )
+        return true
+    }
+
+    const flattenAnd = node => {
+      node = unwrap(node)
+      return node.type === 'LogicalExpression' && node.operator === '&&'
+        ? [...flattenAnd(node.left), ...flattenAnd(node.right)]
+        : [node]
+    }
+    const nullishGuardMask = (node, parameterName) => {
+      node = unwrap(node)
+      if (node.type !== 'BinaryExpression' || !['!=', '!=='].includes(node.operator)) return 0
+      const left = unwrap(node.left)
+      const right = unwrap(node.right)
+      const compared =
+        left.type === 'Identifier' && left.name === parameterName
+          ? right
+          : right.type === 'Identifier' && right.name === parameterName
+            ? left
+            : undefined
+      if (!compared) return 0
+      const isNull = compared.type === 'Literal' && compared.value === null
+      const isUndefined =
+        compared.type === 'Identifier' && compared.name === 'undefined' && isGlobal(compared, 'undefined')
+      if (!isNull && !isUndefined) return 0
+      return node.operator === '!=' ? 3 : isNull ? 1 : 2
+    }
+
+    const classifyCallback = (callback, elementType) => {
+      if (
+        callback.type !== 'ArrowFunctionExpression' ||
+        callback.async ||
+        callback.params.length !== 1 ||
+        callback.params[0].type !== 'Identifier' ||
+        callback.body.type === 'BlockStatement'
+      )
+        return undefined
+
+      const parameter = callback.params[0]
+      const operands = flattenAnd(callback.body)
+      let guardCount = truthinessPolarity(operands[0], parameter) === true ? 1 : 0
+      if (!guardCount) {
+        const required = nullishMask(elementType)
+        let removed = 0
+        for (const operand of operands) {
+          const mask = nullishGuardMask(operand, parameter.name)
+          if (!mask) break
+          removed |= mask
+          guardCount++
+          if ((removed & required) === required) break
+        }
+        if (
+          !required ||
+          (removed & required) !== required ||
+          !isDefinitelyTruthy(checker, checker.getNonNullableType(elementType))
+        )
+          return undefined
+      }
+      return guardCount < operands.length ? 'compound' : 'direct'
+    }
+
+    const isGlobalBoolean = node => node.type === 'Identifier' && node.name === 'Boolean' && isGlobal(node, 'Boolean')
+    const importDefinition = node =>
+      node.type === 'Identifier'
+        ? findVariable(node, node.name)?.defs.find(
+            definition =>
+              definition.type === 'ImportBinding' &&
+              definition.parent.type === 'ImportDeclaration' &&
+              definition.parent.importKind !== 'type' &&
+              isObjectsUtilsImport(definition.parent.source.value),
+          )
+        : undefined
+    const isImportedNotFalsyCall = node => {
+      if (node.type !== 'CallExpression') return false
+      if (node.callee.type === 'Identifier') {
+        const definition = importDefinition(node.callee)
+        return (
+          definition?.node.type === 'ImportSpecifier' &&
+          definition.node.importKind !== 'type' &&
+          (definition.node.imported.name === 'notFalsy' || definition.node.imported.value === 'notFalsy')
+        )
+      }
+      if (node.callee.type !== 'MemberExpression' || propertyName(node.callee) !== 'notFalsy') return false
+      const object = unwrap(node.callee.object)
+      return importDefinition(object)?.node.type === 'ImportNamespaceSpecifier'
+    }
+    const isOwnImplementation = node => {
+      if (!inObjectsUtils) return false
+      for (let parent = node.parent; parent; parent = parent.parent)
+        if (parent.type === 'VariableDeclarator')
+          return parent.id.type === 'Identifier' && parent.id.name === 'notFalsy'
+      return false
+    }
+
+    const conditionalParts = node => {
+      const consequentEmpty = node.consequent.type === 'ArrayExpression' && node.consequent.elements.length === 0
+      const alternateEmpty = node.alternate.type === 'ArrayExpression' && node.alternate.elements.length === 0
+      if (consequentEmpty === alternateEmpty) return undefined
+      const included = consequentEmpty ? node.alternate : node.consequent
+      if (
+        included.type !== 'ArrayExpression' ||
+        included.elements.length !== 1 ||
+        !included.elements[0] ||
+        included.elements[0].type === 'SpreadElement'
+      )
+        return undefined
+      return { element: included.elements[0], includeOnTestTrue: !consequentEmpty }
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.optional ||
+          node.callee.type !== 'MemberExpression' ||
+          node.callee.optional ||
+          propertyName(node.callee) !== 'filter' ||
+          node.arguments.length !== 1 ||
+          isFilterLength(node)
+        )
+          return
+
+        const receiver = node.callee.object
+        const arrayLiteral = unwrap(receiver)
+        if (arrayLiteral.type === 'ArrayExpression' && !isBoundedArrayLiteral(arrayLiteral)) return
+        const elementType = getElementType(receiver)
+        if (!elementType) return
+
+        const callback = unwrap(node.arguments[0])
+        if (isGlobalBoolean(callback) && isOwnImplementation(node)) return
+        if (isGlobalBoolean(callback) && isImportedNotFalsyCall(arrayLiteral)) {
+          context.report({ node, messageId: 'redundant' })
+          return
+        }
+        if (!isBoundedArrayLiteral(arrayLiteral) && !containsExplicitFalsy(elementType)) return
+
+        const predicate = isGlobalBoolean(callback) ? 'direct' : classifyCallback(callback, elementType)
+        if (predicate) context.report({ node, messageId: predicate === 'compound' ? 'compactThenFilter' : 'compact' })
+      },
+
+      ConditionalExpression(node) {
+        const parts = conditionalParts(node)
+        if (!parts) return
+        const polarity = truthinessPolarity(node.test, parts.element)
+        const sameTruthyValue = polarity !== undefined && polarity === parts.includeOnTestTrue
+        if (
+          sameTruthyValue ||
+          isObviouslyTruthyExpression(parts.element) ||
+          isDefinitelyTruthy(checker, getType(parts.element))
+        )
+          context.report({ node, messageId: 'conditional' })
+      },
+    }
+  },
+}

--- a/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
+++ b/apps/main/src/dex/components/PageCreatePool/TokensInPool/SelectTokenButton.tsx
@@ -22,6 +22,7 @@ import { Checkbox } from '@legacy-ui/Checkbox'
 import { SpinnerWrapper, Spinner } from '@legacy-ui/Spinner'
 import { Chip } from '@legacy-ui/Typography'
 import type { Address } from '@primitives/address.utils'
+import { notFalsy } from '@primitives/objects.utils'
 
 type Props = {
   curve: CurveApi
@@ -91,7 +92,7 @@ export const SelectTokenButton = ({
         chain: blockchainId,
         address: token.address as Address,
         symbol: token.symbol,
-        label: [token.basePool && 'Base pool', token.userAddedToken && 'User added'].filter(Boolean).join(' - '),
+        label: notFalsy(token.basePool && 'Base pool', token.userAddedToken && 'User added').join(' - '),
         volume: token.volume,
       })),
     [filteredResults, blockchainId],

--- a/apps/main/src/dex/components/PagePool/index.tsx
+++ b/apps/main/src/dex/components/PagePool/index.tsx
@@ -34,6 +34,7 @@ import { REFRESH_INTERVAL } from '@evm-ui/utils'
 import { DetailPageLayout } from '@evm-ui/widgets/DetailPageLayout/DetailPageLayout'
 import { FormMargins } from '@evm-ui/widgets/DetailPageLayout/FormTabs'
 import { AlertBox } from '@legacy-ui/AlertBox'
+import { notFalsy } from '@primitives/objects.utils'
 import { PoolAlertBanner } from '../PoolAlertBanner'
 
 const DEFAULT_SEED: Seed = { isSeed: null, loaded: false }
@@ -115,7 +116,7 @@ export const Transfer = (pageTransferProps: PageTransferProps) => {
       { value: 'deposit', label: t`Deposit` },
       { value: 'withdraw', label: t`Withdraw` },
       { value: 'swap', label: t`Swap` },
-      ...(isAvailableManageGauge ? [{ value: 'manage-gauge' as const, label: t`Gauge` }] : []),
+      ...notFalsy(isAvailableManageGauge && { value: 'manage-gauge' as const, label: t`Gauge` }),
     ],
     [isAvailableManageGauge],
   )

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -51,7 +51,7 @@ import { scanTxPath } from '@legacy-ui/utils'
 import Stack from '@mui/material/Stack'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
-import { assert, maybe, maybes } from '@primitives/objects.utils'
+import { assert, maybe, maybes, notFalsy } from '@primitives/objects.utils'
 import type { RouterRouteResponse } from '@primitives/router.utils'
 
 const { Spacing } = SizesAndSpaces
@@ -137,10 +137,7 @@ export const QuickSwap = ({
   }, [curve, blacklist, userAddress])
 
   const tokens = useMemo(
-    () =>
-      Object.values(tokensMapper ?? {})
-        .filter(token => !!token)
-        .map(toTokenOption(network?.networkId)),
+    () => notFalsy(...Object.values(tokensMapper ?? {})).map(toTokenOption(network?.networkId)),
     // eslint-disable-next-line @eslint-react/exhaustive-deps
     [tokensMapperStr, network?.networkId],
   )

--- a/apps/main/src/dex/features/add-gauge-reward-token/ui/TokenSelector.tsx
+++ b/apps/main/src/dex/features/add-gauge-reward-token/ui/TokenSelector.tsx
@@ -6,13 +6,14 @@ import { useNetworkByChain } from '@/dex/entities/networks'
 import type { AddRewardFormValues } from '@/dex/features/add-gauge-reward-token/types'
 import { FlexItemToken, SubTitle } from '@/dex/features/add-gauge-reward-token/ui'
 import { useTokensMapper } from '@/dex/hooks/useTokensMapper'
-import { ChainId, Token } from '@/dex/types/main.types'
+import { ChainId } from '@/dex/types/main.types'
 import { toTokenOption } from '@/dex/utils'
 import { useCurve } from '@evm-ui/features/connect-wallet'
 import { useFormContext } from '@evm-ui/features/forms'
 import { TokenList, TokenSelector as TokenSelectorUIKit } from '@evm-ui/features/select-token'
 import { useSwitch } from '@evm-ui/hooks/useSwitch'
 import { t } from '@evm-ui/lib/i18n'
+import { notFalsy } from '@primitives/objects.utils'
 
 export const TokenSelector = ({
   chainId,
@@ -40,10 +41,9 @@ export const TokenSelector = ({
 
   const filteredTokens = useMemo(
     () =>
-      Object.values(tokensMapper)
+      notFalsy(...Object.values(tokensMapper))
         .filter(
-          (token): token is Token =>
-            !!token &&
+          token =>
             // Roman: "There are calculation errors for coins with small decimals, including USDC. Though, new cross chain gauges are good with it, so it depends which gauge do you ask"
             // I fixed it here: https://github.com/curvefi/curve-xchain-factory/blob/3e03f19d49826cad7c1e84829b35cc34955b046e/contracts/implementations/ChildGauge.vy#L117
             token.decimals == 18 &&

--- a/apps/main/src/dex/features/deposit-gauge-reward/ui/AmountTokenInput.tsx
+++ b/apps/main/src/dex/features/deposit-gauge-reward/ui/AmountTokenInput.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/dex/features/deposit-gauge-reward/ui/styled'
 import { useTokensMapper } from '@/dex/hooks/useTokensMapper'
 import { useStore } from '@/dex/store/useStore'
-import { ChainId, Token } from '@/dex/types/main.types'
+import { ChainId } from '@/dex/types/main.types'
 import { toTokenOption } from '@/dex/utils'
 import { useFormContext } from '@evm-ui/features/forms'
 import { TokenList, type TokenOption, TokenSelector } from '@evm-ui/features/select-token'
@@ -27,6 +27,7 @@ import { useTokenUsdRates } from '@evm-ui/lib/model/entities/token-usd-rate'
 import { formatNumber } from '@evm-ui/utils'
 import { InputDebounced, InputMaxBtn } from '@legacy-ui/InputComp'
 import { FlexContainer } from '@legacy-ui/styled-containers'
+import { notFalsy } from '@primitives/objects.utils'
 
 export const AmountTokenInput = ({ chainId, poolId }: { chainId: ChainId; poolId: string }) => {
   const { update: updateForm, formState, watchValue } = useFormContext<DepositRewardFormValues>()
@@ -60,11 +61,9 @@ export const AmountTokenInput = ({ chainId, poolId }: { chainId: ChainId; poolId
       .filter(([_, distributor]) => isAddressEqual(distributor as Address, signerAddress))
       .map(([tokenId]) => tokenId)
 
-    return Object.values(tokensMapper)
-      .filter(
-        (token): token is Token =>
-          !!token &&
-          activeRewardTokens.some(rewardToken => isAddressEqual(rewardToken as Address, token.address as Address)),
+    return notFalsy(...Object.values(tokensMapper))
+      .filter(token =>
+        activeRewardTokens.some(rewardToken => isAddressEqual(rewardToken as Address, token.address as Address)),
       )
       .map(toTokenOption(networkId))
   }, [isPendingRewardDistributors, rewardDistributors, signerAddress, tokensMapper, networkId])

--- a/apps/main/src/dex/features/manage-pool/components/RefuelPricesChart.tsx
+++ b/apps/main/src/dex/features/manage-pool/components/RefuelPricesChart.tsx
@@ -25,7 +25,7 @@ import { useMappedQuery } from '@evm-ui/types/util'
 import { formatNumber } from '@evm-ui/utils'
 import Grid from '@mui/material/Grid'
 import { useTheme } from '@mui/material/styles'
-import { DEFAULT_DECIMALS, maybe } from '@primitives/objects.utils'
+import { DEFAULT_DECIMALS, maybe, notFalsy } from '@primitives/objects.utils'
 import { REFUEL_TIMESERIES_PAGE_SIZE, RefuelTimeSeriesData, useRefuelTimeseries } from '../queries/timeseries.query'
 
 const { Spacing } = SizesAndSpaces
@@ -48,7 +48,7 @@ const formatPrice = (value: number | null | undefined) =>
   formatNumber(value, { abbreviate: false, decimals: 6, fallback: '-' })
 
 // Helper functions and filters that don't type check nicely when inlined
-const toExportPoint = (time: number, value: number | null) => (value == null ? [] : [{ time, value }])
+const toExportPoint = (time: number, value: number | null) => notFalsy(value != null && { time, value })
 const isFinitePrice = (value: number | null): value is number => value != null && Number.isFinite(value)
 const getLatestMetric = (values: (number | null | undefined)[]) =>
   values.findLast((value): value is number => value != null && Number.isFinite(value))

--- a/apps/main/src/dex/features/pool-list/chips/LegacyPoolsChips.tsx
+++ b/apps/main/src/dex/features/pool-list/chips/LegacyPoolsChips.tsx
@@ -24,7 +24,7 @@ const getFilterGroups = ({ isConnected }: { isConnected: boolean }) =>
       { key: 'stableng' as const, label: t`Stable NG` },
       { key: 'cross-chain' as const, label: t`Cross-chain` },
     ],
-    ...(isConnected ? [[{ key: 'user' as const, label: t`My Pools` }]] : []),
+    ...notFalsy(isConnected && [{ key: 'user' as const, label: t`My Pools` }]),
   ] satisfies { key: LegacyPoolTag | null; label: string }[][]
 
 export type LegacyPoolsChipsProps = FilterProps<LegacyPoolColumnId> & {

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsGlobalFilter.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsGlobalFilter.ts
@@ -1,5 +1,6 @@
 import type { FuseOptionKey } from 'fuse.js'
 import { cleanValue, useFuzzyFilterFn } from '@evm-ui/hooks/useFuzzySearch'
+import { notFalsy } from '@primitives/objects.utils'
 import type { PoolRow } from '../types'
 
 const POOL_SEARCH_KEYS = [
@@ -10,7 +11,7 @@ const POOL_SEARCH_KEYS = [
     getFn: ({ address, gauge, gauges, coins }) => [
       ...new Set([
         address,
-        ...(gauge ? [gauge.address] : []),
+        ...notFalsy(gauge?.address),
         ...gauges.map(({ address }) => address),
         ...coins.map(({ address }) => address),
       ]),

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
@@ -20,7 +20,7 @@ import type {
 import { useCampaigns, type CampaignRewards } from '@evm-ui/entities/campaigns'
 import { DEX_ROUTES } from '@evm-ui/shared/routes'
 import { q, useMappedQuery } from '@evm-ui/types/util'
-import type { Address } from '@primitives/address.utils'
+import { notFalsy } from '@primitives/objects.utils'
 import { isVyperVulnerablePool } from '../alerts'
 import type { PoolsApiParams } from '../filters/utils'
 import type { PoolRow, PoolRowData } from '../types'
@@ -61,9 +61,10 @@ const poolToRowData = (pool: V2Pool): PoolRowData => ({
 
 /** Maps API2's Lite pool shape into the source-independent pool-list model. */
 const litePoolToRowData = (pool: LitePool): PoolRowData => {
-  const gauges = [
-    ...new Set([pool.gaugeAddress, pool.rootGaugeAddress].filter((address): address is Address => address != null)),
-  ].map(address => ({ address, isKilled: pool.gaugeIsKilled ?? false }))
+  const gauges = [...new Set(notFalsy(pool.gaugeAddress, pool.rootGaugeAddress))].map(address => ({
+    address,
+    isKilled: pool.gaugeIsKilled ?? false,
+  }))
   const coins = (pool.coins ?? []).map(coin => ({ address: coin.address, symbol: coin.symbol ?? '' }))
 
   return {
@@ -75,18 +76,16 @@ const litePoolToRowData = (pool: LitePool): PoolRowData => {
     crvApr: pool.gaugeCrvApr?.[0],
     crvAprBoosted: pool.gaugeCrvApr?.[1],
     extraRewardsApr: (pool.gaugeExtraRewards ?? []).flatMap(reward =>
-      reward.apr == null
-        ? []
-        : [
-            {
-              address: reward.tokenAddress,
-              apr: reward.apr,
-              decimals: Number(reward.decimals),
-              name: reward.name,
-              price: reward.tokenPrice,
-              symbol: reward.symbol,
-            },
-          ],
+      notFalsy(
+        reward.apr != null && {
+          address: reward.tokenAddress,
+          apr: reward.apr,
+          decimals: Number(reward.decimals),
+          name: reward.name,
+          price: reward.tokenPrice,
+          symbol: reward.symbol,
+        },
+      ),
     ),
     gauge: gauges[0],
     gauges,

--- a/apps/main/src/dex/widgets/manage-gauge/ui/ManageGauge.tsx
+++ b/apps/main/src/dex/widgets/manage-gauge/ui/ManageGauge.tsx
@@ -8,6 +8,7 @@ import { ChainId } from '@/dex/types/main.types'
 import { t } from '@evm-ui/lib/i18n'
 import { TabsSwitcher, type TabOption } from '@evm-ui/shared/ui/Tabs/TabsSwitcher'
 import { FormContent } from '@evm-ui/widgets/DetailPageLayout/FormContent'
+import { notFalsy } from '@primitives/objects.utils'
 
 export const ManageGauge = ({ poolId, chainId }: { poolId: string; chainId: ChainId }) => {
   const { address: signerAddress } = useConnection()
@@ -29,10 +30,11 @@ export const ManageGauge = ({ poolId, chainId }: { poolId: string; chainId: Chai
 
   type Tab = 'add_reward' | 'deposit_reward'
   const tabs: TabOption<Tab>[] = useMemo(
-    () => [
-      ...(isGaugeManager ? [{ value: 'add_reward' as const, label: t`Add Reward` }] : []),
-      ...(isRewardsDistributor ? [{ value: 'deposit_reward' as const, label: t`Deposit Reward` }] : []),
-    ],
+    () =>
+      notFalsy<TabOption<Tab>>(
+        isGaugeManager && { value: 'add_reward', label: t`Add Reward` },
+        isRewardsDistributor && { value: 'deposit_reward', label: t`Deposit Reward` },
+      ),
     [isGaugeManager, isRewardsDistributor],
   )
 

--- a/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
+++ b/apps/main/src/llamalend/features/bands-chart/chartOptions.ts
@@ -1,5 +1,6 @@
 import { formatChartAxisNumber } from '@evm-ui/shared/ui/Chart'
 import { Duration } from '@evm-ui/themes/design/0_primitives'
+import { notFalsy } from '@primitives/objects.utils'
 import { generateOracleReferenceLines, generateRangeBoundaryLines, type HorizontalLine } from './horizontalLines'
 import type {
   BandsChartOption,
@@ -526,16 +527,15 @@ export const getChartOptions = (
         generateOracleReferenceLines(oraclePrice, xStart, xEnd, palette),
         CHART_LAYER.oracleLine,
       )
-      const oracleLineSeries = nativeOracleMarkLine
-        ? [
-            createNativeOracleLineSeries(
-              'Oracle Price Line',
-              outlineSeriesData,
-              CHART_LAYER.oracleLine,
-              nativeOracleMarkLine,
-            ),
-          ]
-        : []
+      const oracleLineSeries = notFalsy(
+        nativeOracleMarkLine &&
+          createNativeOracleLineSeries(
+            'Oracle Price Line',
+            outlineSeriesData,
+            CHART_LAYER.oracleLine,
+            nativeOracleMarkLine,
+          ),
+      )
 
       return [
         ...currentRangeAreaSeries,

--- a/apps/main/src/llamalend/hooks/useMarketRoutes.ts
+++ b/apps/main/src/llamalend/hooks/useMarketRoutes.ts
@@ -18,7 +18,7 @@ import type { BaseConfig } from '@legacy-ui/utils'
 import { Address } from '@primitives/address.utils'
 import { toArray } from '@primitives/array.utils'
 import { Decimal } from '@primitives/decimal.utils'
-import { maybe, recordValues } from '@primitives/objects.utils'
+import { maybe, notFalsy, recordValues } from '@primitives/objects.utils'
 import { type RouteProvider, type RouterRouteResponse } from '@primitives/router.utils'
 import type { QueryKey } from '@tanstack/react-query'
 
@@ -117,10 +117,11 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
     () =>
       chosenRouter && queries[chosenRouter].enabled
         ? (queries[chosenRouter].data ?? undefined)
-        : recordValues(queries)
-            .filter(q => q.enabled)
-            .map(q => q.data)
-            .filter((q): q is RouteResponse => !!q)
+        : notFalsy(
+            ...recordValues(queries)
+              .filter(q => q.enabled)
+              .map(q => q.data),
+          )
             // eslint-disable-next-line local/no-mutable-array-methods -- Existing violation before creating this rule.
             .sort(sortRoutes)[0],
     // eslint-disable-next-line @eslint-react/exhaustive-deps

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-health.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-health.query.ts
@@ -7,6 +7,7 @@ import type { BorrowMoreParams, BorrowMoreQuery } from '@/llamalend/queries/vali
 import { borrowMoreValidationSuite } from '@/llamalend/queries/validation/borrow-more.validation'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import type { Decimal } from '@primitives/decimal.utils'
+import { notFalsy } from '@primitives/objects.utils'
 
 export const { useQuery: useBorrowMoreHealth, invalidate: invalidateBorrowMoreHealth } = queryFactory({
   queryKey: ({
@@ -59,5 +60,7 @@ export const { useQuery: useBorrowMoreHealth, invalidate: invalidateBorrowMoreHe
   category: 'llamalend.borrowMore',
   validationSuite: borrowMoreValidationSuite({ debtRequired: true, leverageRequired: false, maxDebtRequired: false }),
   dependencies: params =>
-    isLeverageBorrowMore(params.marketId, params.leverageEnabled) ? [getBorrowMoreExpectedCollateralKey(params)] : [],
+    notFalsy(
+      isLeverageBorrowMore(params.marketId, params.leverageEnabled) && getBorrowMoreExpectedCollateralKey(params),
+    ),
 })

--- a/apps/main/src/llamalend/queries/market-list/llama-market-positions.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-market-positions.ts
@@ -52,7 +52,7 @@ export const useUserLlamaPositions = ({ userAddress }: { userAddress: Address | 
       const [userMints, hasMinted] = groupAddressesByChain(userMintMarkets, MINT_CHAINS)
       const userSuppliesByChain = fromEntries(
         zip(LEND_CHAINS, userSuppliedMarkets).flatMap(([chain, { data }]) =>
-          notFalsy(data != null && ([chain, data] as const)),
+          notFalsy(data && ([chain, data] as const)),
         ),
       )
       const hasSupplied = userSuppliedMarkets.some(query => recordValues(query.data ?? {}).length)

--- a/apps/main/src/llamalend/queries/market-list/llama-market-positions.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-market-positions.ts
@@ -51,7 +51,9 @@ export const useUserLlamaPositions = ({ userAddress }: { userAddress: Address | 
       const [userBorrows, hasBorrowed] = groupAddressesByChain(userLendingVaults, LEND_CHAINS)
       const [userMints, hasMinted] = groupAddressesByChain(userMintMarkets, MINT_CHAINS)
       const userSuppliesByChain = fromEntries(
-        zip(LEND_CHAINS, userSuppliedMarkets).flatMap(([chain, { data }]) => (data == null ? [] : [[chain, data]])),
+        zip(LEND_CHAINS, userSuppliedMarkets).flatMap(([chain, { data }]) =>
+          notFalsy(data != null && ([chain, data] as const)),
+        ),
       )
       const hasSupplied = userSuppliedMarkets.some(query => recordValues(query.data ?? {}).length)
       const userHasPositions =

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import storybook from 'eslint-plugin-storybook'
 import unusedImports from 'eslint-plugin-unused-imports'
 import tseslint from 'typescript-eslint'
 import { useMaybePatternRule } from './.eslint/use-maybe-pattern.rule.mjs'
+import { useNotFalsyPatternRule } from './.eslint/use-not-falsy-pattern.rule.mjs'
 import { stableHookCallbacksRule } from './.eslint/stable-hook-callbacks.rule.mjs'
 import { noDoubleNegativeRule } from './.eslint/no-double-negative.rule.mjs'
 import { noJsxStringLiteralBracesRule } from './.eslint/no-jsx-string-literal-braces.rule.mjs'
@@ -57,6 +58,7 @@ const config = [
       local: {
         rules: {
           'use-maybe-pattern': useMaybePatternRule,
+          'use-not-falsy-pattern': useNotFalsyPatternRule,
           'stable-hook-callbacks': stableHookCallbacksRule,
           'no-double-negative': noDoubleNegativeRule,
           'no-jsx-string-literal-braces': noJsxStringLiteralBracesRule,
@@ -94,6 +96,7 @@ const config = [
       'local/no-redundant-ternary': 'error',
       'local/no-router-navigate-on-click': 'error',
       'local/no-single-line-named-functions': 'error',
+      'local/use-not-falsy-pattern': 'error',
 
       'object-shorthand': 'warn',
       'arrow-body-style': ['error', 'as-needed'],

--- a/packages/evm-ui/src/entities/campaigns/campaigns.ts
+++ b/packages/evm-ui/src/entities/campaigns/campaigns.ts
@@ -30,10 +30,7 @@ export const combineCampaigns = memoizee((campaigns: (Campaigns | undefined)[], 
   return fromEntries(
     [...allAddresses]
       .map(address => {
-        const allRewards = campaigns
-          .filter((record): record is Campaigns => record !== undefined)
-          .flatMap(record => record[address] || [])
-
+        const allRewards = notFalsy(...campaigns.flatMap(record => record?.[address]))
         const filteredRewards = network ? allRewards.filter(r => r.network === network) : allRewards
 
         return [address, filteredRewards] as const

--- a/packages/evm-ui/src/features/candle-chart/CandleChart.tsx
+++ b/packages/evm-ui/src/features/candle-chart/CandleChart.tsx
@@ -4,7 +4,7 @@ import { sortBy } from 'lodash'
 import { useEffect, useRef, useCallback, useMemo, type RefObject } from 'react'
 import { CHART_LINE_WIDTHS } from '@evm-ui/shared/ui/Chart/chart.utils'
 import { Box } from '@mui/material'
-import { maybes } from '@primitives/objects.utils'
+import { maybes, notFalsy } from '@primitives/objects.utils'
 import { useLatestValueRef } from '../../hooks/useLatestValueRef'
 import { PRICE_SCALE_MARGINS } from './constants'
 import { createLiquidationRangeSeries } from './custom-series/liquidationRangeSeries'
@@ -37,15 +37,17 @@ const normalizeLiquidationRangePoints = (range?: LlammaLiquididationRange | null
   range.price2?.forEach(({ time, value }) => assignPoint(time, 'lower', value))
 
   const orderedPoints = sortBy(
-    Array.from(
-      pointMap,
-      ([time, { upper, lower }]) =>
-        maybes([upper, lower], (...points) => ({
-          time,
-          upper: Math.max(...points),
-          lower: Math.min(...points),
-        })) ?? null,
-    ).filter(point => point !== null),
+    notFalsy(
+      ...Array.from(
+        pointMap,
+        ([time, { upper, lower }]) =>
+          maybes([upper, lower], (...points) => ({
+            time,
+            upper: Math.max(...points),
+            lower: Math.min(...points),
+          })) ?? null,
+      ),
+    ),
     point => point.time,
   )
 

--- a/packages/evm-ui/src/hooks/useActiveSection.ts
+++ b/packages/evm-ui/src/hooks/useActiveSection.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useLayoutStore } from '@evm-ui/features/layout'
 import { useLocation, useNavigate } from '@evm-ui/hooks/router'
 import { useResizeObserver } from '@evm-ui/hooks/useResizeObserver'
+import { notFalsy } from '@primitives/objects.utils'
 import { useRouterState } from '@tanstack/react-router'
 
 /** Height in pixels of the viewport band used to determine the active section. */
@@ -61,9 +62,7 @@ export const useActiveSection = <T extends string>(sections: readonly Section<T>
     const section = sections.find(({ value }) => value === hash)
     // The target may render after TanStack Router's initial hash scroll attempt.
     const target = section && document.getElementById(section.value)
-    const elements = sections
-      .map(({ value }) => document.getElementById(value))
-      .filter((element): element is HTMLElement => element != null)
+    const elements = notFalsy(...sections.map(({ value }) => document.getElementById(value)))
     if (target && getActiveSection<T>(elements, activationTop) !== section.value) {
       scrollSpyHashRef.current = section.value
       target.scrollIntoView()
@@ -71,9 +70,7 @@ export const useActiveSection = <T extends string>(sections: readonly Section<T>
   }, [activationTop, hash, sections])
 
   useEffect(() => {
-    const elements = sections
-      .map(({ value }) => document.getElementById(value))
-      .filter((element): element is HTMLElement => element != null)
+    const elements = notFalsy(...sections.map(({ value }) => document.getElementById(value)))
     if (!elements.length) return
 
     const updateActiveSection = () => {

--- a/packages/evm-ui/src/lib/model/query/factory.ts
+++ b/packages/evm-ui/src/lib/model/query/factory.ts
@@ -6,7 +6,7 @@ import { QUERY_CATEGORIES, type QueryCategory } from '@evm-ui/lib/model/query/qu
 import { FieldName, FieldsOf, validate } from '@evm-ui/lib/validation'
 import { formatTimeDiff } from '@evm-ui/utils/time'
 import { FetchError } from '@primitives/fetch.utils'
-import { isEmpty } from '@primitives/objects.utils'
+import { isEmpty, notFalsy } from '@primitives/objects.utils'
 import {
   type DefaultError,
   type FetchQueryOptions,
@@ -98,7 +98,7 @@ async function runQuery<TKey extends QueryKey, TData, TQuery>(
     const start = new Date()
     if (!disableLog) logQuery(queryKey)
     const data = await queryFn(getParamsFromQueryKey(queryKey))
-    if (!disableLog) logSuccess(queryKey, formatTimeDiff(start), ...[data ? [data] : []])
+    if (!disableLog) logSuccess(queryKey, formatTimeDiff(start), notFalsy(data))
     return data
   } catch (error) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Existing violation before enabling this rule.

--- a/packages/evm-ui/src/utils/decimal.ts
+++ b/packages/evm-ui/src/utils/decimal.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { formatUnits } from 'viem'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
-import { maybe } from '@primitives/objects.utils'
+import { maybe, notFalsy } from '@primitives/objects.utils'
 
 export const ZERO: Decimal = '0'
 
@@ -40,11 +40,10 @@ export const decimalMax = (...data: Decimal[]) =>
   data.length ? (BigNumber.max(...data).toFixed() as Decimal) : undefined
 
 export const decimalSum = (...data: (Decimal | undefined)[]): Decimal =>
-  data.filter(d => d != null).reduce((sum, value) => new BigNumber(sum).plus(value).toFixed() as Decimal, '0')
+  notFalsy(...data).reduce((sum, value) => new BigNumber(sum).plus(value).toFixed() as Decimal, '0')
 
 export const decimalMinus = (first: Decimal, ...rest: (Decimal | undefined)[]): Decimal =>
-  rest
-    .filter(d => d != null)
+  notFalsy(...rest)
     .reduce((acc, value) => acc.minus(value), new BigNumber(first))
     .toFixed() as Decimal
 

--- a/packages/evm-ui/src/utils/dom.ts
+++ b/packages/evm-ui/src/utils/dom.ts
@@ -1,3 +1,5 @@
+import { notFalsy } from '@primitives/objects.utils'
+
 /**
  * Check if the target has a parent with the given class name.
  * Optionally, you can specify a tag name to stop the search at.
@@ -16,4 +18,4 @@ export function hasParentWithClass(target: EventTarget, className: string, { unt
   return false
 }
 
-export const classNames = (...items: (string | false | undefined | null)[]): string => items.filter(Boolean).join(' ')
+export const classNames = (...items: (string | false | undefined | null)[]): string => notFalsy(...items).join(' ')

--- a/packages/evm-ui/src/utils/mui.ts
+++ b/packages/evm-ui/src/utils/mui.ts
@@ -1,5 +1,6 @@
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import type { SxProps as MuiSx, Theme } from '@mui/material/styles'
+import { notFalsy } from '@primitives/objects.utils'
 
 const { BorderWidth } = SizesAndSpaces
 
@@ -12,7 +13,7 @@ type SxStyleObject = Exclude<SxProps, ((theme: Theme) => unknown) | readonly unk
  */
 export const applySxProps = (...sx: (SxProps | false | null | undefined)[]): SxProps =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Existing violation before enabling this rule.
-  sx.flatMap(s => (Array.isArray(s) ? s : s ? [s] : []))
+  sx.flatMap(s => (Array.isArray(s) ? s : notFalsy(s)))
 
 /**
  * Selects every direct child that has a previous sibling. This is useful for applying styles between children, such as

--- a/packages/evm-ui/src/utils/number.ts
+++ b/packages/evm-ui/src/utils/number.ts
@@ -1,4 +1,5 @@
 import type { Amount } from '@primitives/decimal.utils'
+import { notFalsy } from '@primitives/objects.utils'
 import { getUnitOptions, type Unit } from './units'
 
 // Sometimes API returns overflowed USD values. Don't show them!
@@ -369,7 +370,7 @@ export function formatNumber(value: Amount | MissingAmount, options: NumberForma
   const isNegative = decomposed.mainValue.startsWith('-')
   const sign = isNegative ? '-' : ''
   const mainValue = isNegative ? decomposed.mainValue.slice(1) : decomposed.mainValue
-  return [sign, decomposed.prefix, mainValue, decomposed.scaleSuffix, decomposed.suffix].filter(Boolean).join('')
+  return notFalsy(sign, decomposed.prefix, mainValue, decomposed.scaleSuffix, decomposed.suffix).join('')
 }
 
 /**

--- a/packages/evm-ui/src/widgets/Header/Header.tsx
+++ b/packages/evm-ui/src/widgets/Header/Header.tsx
@@ -6,6 +6,7 @@ import { isChinese, t } from '@evm-ui/lib/i18n'
 import { type AppName, getInternalUrl, PAGE_INTEGRATIONS, PAGE_LEGAL, routeToPage } from '@evm-ui/shared/routes'
 import { Toast } from '@evm-ui/widgets/Toast'
 import { EXTERNAL_LINKS } from '@legacy-ui/utils'
+import { notFalsy } from '@primitives/objects.utils'
 import { DesktopHeader } from './DesktopHeader'
 import { MobileHeader } from './MobileHeader'
 import { HeaderProps, NavigationSection } from './types'
@@ -42,7 +43,7 @@ const getSections = (currentApp: AppName, networkId: string): NavigationSection[
       { href: getInternalUrl(currentApp, networkId, PAGE_LEGAL), label: t`Legal` },
       { href: getInternalUrl(currentApp, networkId, PAGE_INTEGRATIONS), label: t`Integrations` },
       { href: EXTERNAL_LINKS.brand.assets, label: t`Branding` },
-      ...(isChinese() ? [{ href: EXTERNAL_LINKS.curve.chinese.wiki, label: t`Wiki` }] : []),
+      ...notFalsy(isChinese() && { href: EXTERNAL_LINKS.curve.chinese.wiki, label: t`Wiki` }),
     ],
   },
   {

--- a/packages/external-rewards/src/index.ts
+++ b/packages/external-rewards/src/index.ts
@@ -28,6 +28,7 @@ export type RewardsAction = 'supply' | 'borrow' | 'lp'
 
 const parsedCampaignsJsons = campaignsJsons as Record<string, Campaign>
 
+// eslint-disable-next-line local/use-not-falsy-pattern
 export const campaigns = campaignList
   .map(({ campaign }) => {
     const campaignName = campaign.split('.')?.[0]

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4'
+import { notFalsy } from '@primitives/objects.utils'
 import { address, camelizeKeys, chain, sortDirection, timestamp } from '../schemas'
 
 const rawCoin = z.object({
@@ -447,10 +448,7 @@ export const listLitePoolChainsResponse = z
     generated_time_ms: z.number(),
   })
   .transform(({ data: { platforms, platforms_metadata: platformMetadata } }) =>
-    Object.keys(platforms).flatMap(platform => {
-      const metadata = platformMetadata[platform]
-      return metadata ? [metadata] : []
-    }),
+    Object.keys(platforms).flatMap(platform => notFalsy(platformMetadata[platform])),
   )
 
 export const listLitePoolsResponse = z

--- a/packages/prices-api/tests/catalog.ts
+++ b/packages/prices-api/tests/catalog.ts
@@ -48,9 +48,7 @@ const formatEndpointCatalogStatus = (status: EndpointCatalogStatus) =>
     status.missing.length && `missing: ${status.missing.join(', ')}`,
     status.staleCases.length && `stale cases: ${status.staleCases.join(', ')}`,
     status.staleExclusions.length && `stale exclusions: ${status.staleExclusions.join(', ')}`,
-  )
-    .filter(Boolean)
-    .join('; ')
+  ).join('; ')
 
 /** Returns a memoized skip reason for live tests when the endpoint catalog is stale. */
 export const getEndpointCatalogSkipReason = (() => {

--- a/packages/prices-api/tests/seeds.ts
+++ b/packages/prices-api/tests/seeds.ts
@@ -1,6 +1,7 @@
 /** Discovers reproducible live endpoint parameters for schema tests. */
 import { beforeAll } from 'vitest'
 import type { Address } from '@primitives/address.utils'
+import { notFalsy } from '@primitives/objects.utils'
 import type { Chain, Options } from '../src'
 import * as chains from '../src/chains'
 import * as crvusd from '../src/crvusd'
@@ -212,9 +213,9 @@ export const getSavingsUserSeed = once(async () => {
   const firstPage = await savings.getEvents(1, requestOptions)
   const page = randomPage(firstPage.count, perPage, 50)
   const response = page === 1 ? firstPage : await savings.getEvents(page, requestOptions)
-  const users = response.events
-    .flatMap(event => [event.owner, event.sender, event.receiver])
-    .filter((value): value is Address => value !== undefined && isAddress(value))
+  const users = notFalsy(...response.events.flatMap(event => [event.owner, event.sender, event.receiver])).filter(
+    (value): value is Address => isAddress(value),
+  )
 
   return randomItem(users, `savings.getEvents(${page}) address user`)
 })

--- a/tests/cypress/support/helpers/dex-pool-list-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-mocks.ts
@@ -5,7 +5,7 @@ import { oneAddress, oneFloat } from '@cy/support/generators'
 import { oneToken } from '@cy/support/helpers/tokens'
 import { Chain, requireBlockchainId } from '@evm-ui/utils/network'
 import type { Address } from '@primitives/address.utils'
-import { range } from '@primitives/objects.utils'
+import { notFalsy, range } from '@primitives/objects.utils'
 
 const MOCK_CHAIN_IDS = [Chain.Ethereum, Chain.Arbitrum] as const
 type MockChainId = (typeof MOCK_CHAIN_IDS)[number]
@@ -101,76 +101,69 @@ type MockPool = ReturnType<typeof createPool>
 
 // Hardcode known pools where tests need exact search text, or a real address because
 // generated addresses do not resolve on the pool detail page.
-const createMockPools = (chainId: MockChainId): MockPool[] => [
-  ...(chainId === Chain.Ethereum
-    ? [
+const createMockPools = (chainId: MockChainId): MockPool[] =>
+  notFalsy(
+    chainId === Chain.Ethereum && {
+      ...createPool({
+        address: SearchPool.address,
+        chainId,
+        index: POOL_COUNT,
+        name: SearchPool.name,
+        poolType: 'main',
+      }),
+      coins: [
         {
-          ...createPool({
-            address: SearchPool.address,
-            chainId,
-            index: POOL_COUNT,
-            name: SearchPool.name,
-            poolType: 'main',
-          }),
-          coins: [
-            {
-              pool_index: 0,
-              symbol: 'DAI',
-              address: '0x6b175474e89094c44da98b954eedeac495271d0f' as Address,
-              name: 'Dai Stablecoin',
-              decimals: 18,
-            },
-            {
-              pool_index: 1,
-              symbol: 'USDC',
-              address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Address,
-              name: 'USD Coin',
-              decimals: 6,
-            },
-            {
-              pool_index: 2,
-              symbol: 'USDT',
-              address: '0xdac17f958d2ee523a2206206994597c13d831ec7' as Address,
-              name: 'Tether USD',
-              decimals: 6,
-            },
-          ],
+          pool_index: 0,
+          symbol: 'DAI',
+          address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          name: 'Dai Stablecoin',
+          decimals: 18,
         },
-      ]
-    : []),
-  ...(chainId === Chain.Arbitrum
-    ? [
         {
-          ...createPool({
-            address: DEX_POOL_LIST_NAVIGATION_POOL.address,
-            chainId,
-            index: POOL_COUNT + 1,
-            name: DEX_POOL_LIST_NAVIGATION_POOL.name,
-            poolType: 'main',
-          }),
-          tvl_usd: onePriorityPoolUsdValue(),
-          trading_volume_24h: onePriorityPoolUsdValue(),
-          coins: [
-            {
-              pool_index: 0,
-              symbol: 'USDC',
-              address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8' as Address,
-              name: 'USD Coin',
-              decimals: 6,
-            },
-            {
-              pool_index: 1,
-              symbol: 'USDT',
-              address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9' as Address,
-              name: 'Tether USD',
-              decimals: 6,
-            },
-          ],
+          pool_index: 1,
+          symbol: 'USDC',
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          name: 'USD Coin',
+          decimals: 6,
         },
-      ]
-    : []),
-  ...range(POOL_COUNT).map(index => createPool({ chainId, index })),
-]
+        {
+          pool_index: 2,
+          symbol: 'USDT',
+          address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+          name: 'Tether USD',
+          decimals: 6,
+        },
+      ],
+    },
+    chainId === Chain.Arbitrum && {
+      ...createPool({
+        address: DEX_POOL_LIST_NAVIGATION_POOL.address,
+        chainId,
+        index: POOL_COUNT + 1,
+        name: DEX_POOL_LIST_NAVIGATION_POOL.name,
+        poolType: 'main',
+      }),
+      tvl_usd: onePriorityPoolUsdValue(),
+      trading_volume_24h: onePriorityPoolUsdValue(),
+      coins: [
+        {
+          pool_index: 0,
+          symbol: 'USDC',
+          address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+          name: 'USD Coin',
+          decimals: 6,
+        },
+        {
+          pool_index: 1,
+          symbol: 'USDT',
+          address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+          name: 'Tether USD',
+          decimals: 6,
+        },
+      ],
+    },
+    ...range(POOL_COUNT).map(index => createPool({ chainId, index })),
+  )
 
 const MOCK_POOLS = MOCK_CHAIN_IDS.flatMap(createMockPools)
 

--- a/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
@@ -3,6 +3,7 @@ import type { Address } from 'viem'
 import { oneAddress } from '@cy/support/generators'
 import { CRVUSD_ADDRESS, decimalDiv, decimalMinus, decimalMultiply, decimalSum } from '@evm-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
+import { notFalsy } from '@primitives/objects.utils'
 import { createMockLlamaApi, TEST_ADDRESS, TEST_TX_HASH } from '../mock-loan-test-data'
 import {
   createMockLendMarket,
@@ -529,9 +530,9 @@ export const createClaimScenario = ({
       otherRewardsButtonDisabled: claimableRewards.every(({ amount }) => Number(amount) <= 0),
       table: {
         rows: [
-          ...(Number(claimableCrv) > 0
-            ? [{ amount: claimableCrv, symbol: 'CRV', notional: Number(claimableCrv) }]
-            : []),
+          ...notFalsy(
+            Number(claimableCrv) > 0 && { amount: claimableCrv, symbol: 'CRV', notional: Number(claimableCrv) },
+          ),
           ...claimableRewards.map(({ amount, symbol }) => ({ amount, symbol, notional: Number(amount) })),
         ],
         totalNotional:


### PR DESCRIPTION
Encourages the use of `notFalsy` over singleton stuff array ternaries like `x != null ? [x] : []` and `.filter(Boolean)`.