### PR TITLE
fix: re-enable sorting for all lite network pool columns

### DIFF
--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -14,7 +14,7 @@ import { TableSortDrawer } from '@evm-ui/shared/ui/DataTable/TableSortDrawer'
 import { CURVE_SOCIALS } from '@legacy-ui/utils'
 import Stack from '@mui/material/Stack'
 import type { ExpandedState } from '@tanstack/react-table'
-import { LITE_POOL_COLUMNS, POOL_COLUMNS, PoolColumnId } from './columns'
+import { POOL_COLUMNS, PoolColumnId } from './columns'
 import { PoolExpandedPanel } from './components/PoolExpandedPanel'
 import { PoolExpandedPanelActions } from './components/PoolExpandedPanelActions'
 import { PoolsFilters } from './filters/PoolsFilters'
@@ -67,7 +67,7 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   )
 
   const table = useTable({
-    columns: isLite ? LITE_POOL_COLUMNS : POOL_COLUMNS,
+    columns: POOL_COLUMNS,
     query: tableQuery,
     state: {
       expanded,

--- a/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
+++ b/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
@@ -9,6 +9,7 @@ import { PointsCell } from '../cells/PointsCell'
 import { PoolTitleCell } from '../cells/PoolTitleCell'
 import { RewardsApyCell } from '../cells/RewardsApyCell'
 import { UsdCell } from '../cells/UsdCell'
+import { getCrvApyRange, getNetApy, getRewardsApy } from '../cells/utils'
 import { AgeHeaderTooltipContent } from '../header-tooltips/AgeHeaderTooltipContent'
 import { BaseApyHeaderTooltipContent } from '../header-tooltips/BaseApyHeaderTooltipContent'
 import { CrvApyHeaderTooltipContent } from '../header-tooltips/CrvApyHeaderTooltipContent'
@@ -27,9 +28,6 @@ type PoolColumn = ColumnDefinition<PoolRow>
 type PoolColumnOptions = Omit<PoolColumn, 'id' | 'header'>
 
 const columnHelper = createColumnHelper<PoolRow>()
-
-// TanStack requires an accessorFn for sorting controls, even when it's a computed value rather than a direct property; manualSorting leaves ordering to the v2 pools API on full networks.
-const serverSortableAccessor = () => 0
 
 const createTooltip = (id: keyof typeof POOL_TITLES, body: ReactNode): Tooltip => ({
   title: POOL_TITLES[id],
@@ -53,85 +51,79 @@ const accessor = (
     header: POOL_TITLES[id],
   })
 
-const createPoolColumns = ({ isLite }: { isLite: boolean }) =>
-  [
-    accessor(PoolColumnId.PoolName, 'name', {
-      cell: PoolTitleCell,
-      meta: { tooltip: createTooltip(PoolColumnId.PoolName, <PoolHeaderTooltipContent />) },
-    }),
-    accessor(PoolColumnId.NetApy, serverSortableAccessor, {
-      cell: ({ row }) => <NetApyCell pool={row.original} />,
-      enableSorting: !isLite,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.NetApy, <NetApyHeaderTooltipContent />),
-      },
-    }),
-    accessor(PoolColumnId.BaseApy, 'baseDailyApr', {
-      cell: BaseApyCell,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.BaseApy, <BaseApyHeaderTooltipContent />),
-      },
-      sortUndefined: 'last',
-    }),
-    accessor(PoolColumnId.WeeklyBaseApy, 'baseWeeklyApr', {
-      cell: WeeklyBaseApyCell,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.WeeklyBaseApy, <BaseApyHeaderTooltipContent weekly />),
-      },
-      sortUndefined: 'last',
-    }),
-    accessor(PoolColumnId.CrvApy, serverSortableAccessor, {
-      cell: ({ row }) => <CrvApyCell pool={row.original} />,
-      enableSorting: !isLite,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.CrvApy, <CrvApyHeaderTooltipContent />),
-      },
-    }),
-    accessor(PoolColumnId.RewardsApy, serverSortableAccessor, {
-      cell: ({ row }) => <RewardsApyCell pool={row.original} />,
-      enableSorting: !isLite,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.RewardsApy, <RewardsApyHeaderTooltipContent />),
-      },
-    }),
-    display(PoolColumnId.Points, {
-      cell: ({ row }) => <PointsCell pool={row.original} />,
-      enableSorting: false,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.Points, <PointsHeaderTooltipContent />),
-      },
-    }),
-    accessor(PoolColumnId.Volume, 'tradingVolume24h', {
-      cell: UsdCell,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.Volume, <VolumeHeaderTooltipContent />),
-      },
-      sortUndefined: 'last',
-    }),
-    accessor(PoolColumnId.Tvl, 'tvlUsd', {
-      cell: UsdCell,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.Tvl, <TvlHeaderTooltipContent />),
-      },
-      sortUndefined: 'last',
-    }),
-    accessor(PoolColumnId.Age, 'creationDate', {
-      cell: AgeCell,
-      meta: {
-        type: 'numeric',
-        tooltip: createTooltip(PoolColumnId.Age, <AgeHeaderTooltipContent />),
-      },
-      sortUndefined: 'last',
-    }),
-  ] satisfies PoolColumn[]
-
-export const POOL_COLUMNS = createPoolColumns({ isLite: false })
-export const LITE_POOL_COLUMNS = createPoolColumns({ isLite: true })
+export const POOL_COLUMNS = [
+  accessor(PoolColumnId.PoolName, 'name', {
+    cell: PoolTitleCell,
+    meta: { tooltip: createTooltip(PoolColumnId.PoolName, <PoolHeaderTooltipContent />) },
+  }),
+  accessor(PoolColumnId.NetApy, getNetApy, {
+    cell: ({ row }) => <NetApyCell pool={row.original} />,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.NetApy, <NetApyHeaderTooltipContent />),
+    },
+  }),
+  accessor(PoolColumnId.BaseApy, 'baseDailyApr', {
+    cell: BaseApyCell,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.BaseApy, <BaseApyHeaderTooltipContent />),
+    },
+    sortUndefined: 'last',
+  }),
+  accessor(PoolColumnId.WeeklyBaseApy, 'baseWeeklyApr', {
+    cell: WeeklyBaseApyCell,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.WeeklyBaseApy, <BaseApyHeaderTooltipContent weekly />),
+    },
+    sortUndefined: 'last',
+  }),
+  accessor(PoolColumnId.CrvApy, pool => (pool.gauge?.isKilled ? undefined : getCrvApyRange(pool)?.unboostedApy), {
+    cell: ({ row }) => <CrvApyCell pool={row.original} />,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.CrvApy, <CrvApyHeaderTooltipContent />),
+    },
+    sortUndefined: 'last',
+  }),
+  accessor(PoolColumnId.RewardsApy, getRewardsApy, {
+    cell: ({ row }) => <RewardsApyCell pool={row.original} />,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.RewardsApy, <RewardsApyHeaderTooltipContent />),
+    },
+  }),
+  display(PoolColumnId.Points, {
+    cell: ({ row }) => <PointsCell pool={row.original} />,
+    enableSorting: false,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.Points, <PointsHeaderTooltipContent />),
+    },
+  }),
+  accessor(PoolColumnId.Volume, 'tradingVolume24h', {
+    cell: UsdCell,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.Volume, <VolumeHeaderTooltipContent />),
+    },
+    sortUndefined: 'last',
+  }),
+  accessor(PoolColumnId.Tvl, 'tvlUsd', {
+    cell: UsdCell,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.Tvl, <TvlHeaderTooltipContent />),
+    },
+    sortUndefined: 'last',
+  }),
+  accessor(PoolColumnId.Age, 'creationDate', {
+    cell: AgeCell,
+    meta: {
+      type: 'numeric',
+      tooltip: createTooltip(PoolColumnId.Age, <AgeHeaderTooltipContent />),
+    },
+    sortUndefined: 'last',
+  }),
+] satisfies PoolColumn[]

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
@@ -21,7 +21,13 @@ const POOL_SORT_BY = {
 type PoolSortableColumn = keyof typeof POOL_SORT_BY
 
 const SORT_QUERY_FIELD = 'sort'
-const LITE_SORT_COLUMNS = new Set<PoolColumnId>([PoolColumnId.PoolName, PoolColumnId.Tvl])
+const LITE_SORT_COLUMNS = new Set<PoolColumnId>([
+  PoolColumnId.PoolName,
+  PoolColumnId.NetApy,
+  PoolColumnId.CrvApy,
+  PoolColumnId.RewardsApy,
+  PoolColumnId.Tvl,
+])
 
 type ColumnSort = { id: PoolSortableColumn; desc: boolean }
 export type PoolsSorting = [ColumnSort]

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -74,13 +74,15 @@ const OPTIONAL_FULL_COLUMNS = [
 const DEFAULT_LITE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.NetApy, PoolColumnId.Tvl]
 const OPTIONAL_LITE_COLUMNS = [PoolColumnId.CrvApy, PoolColumnId.RewardsApy, PoolColumnId.Points]
 const FULL_ONLY_COLUMNS = [PoolColumnId.BaseApy, PoolColumnId.WeeklyBaseApy, PoolColumnId.Volume, PoolColumnId.Age]
-const LITE_SORTABLE_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.Tvl]
-const LITE_NON_SORTABLE_COLUMNS = [
+const LITE_SORTABLE_COLUMNS = [
+  PoolColumnId.PoolName,
   PoolColumnId.NetApy,
   PoolColumnId.CrvApy,
   PoolColumnId.RewardsApy,
-  PoolColumnId.Points,
+  PoolColumnId.Tvl,
 ]
+const LITE_NON_SORTABLE_COLUMNS = [PoolColumnId.Points]
+const LITE_COMPUTED_SORT_COLUMNS = [PoolColumnId.NetApy, PoolColumnId.CrvApy, PoolColumnId.RewardsApy]
 
 describe('V2 pool-list columns', () => {
   beforeEach(() => {
@@ -223,10 +225,16 @@ describe('V2 pool-list columns', () => {
     cy.get('[data-testid^="data-table-row-"]').should('have.length', 2)
 
     cy.get(`[data-testid="data-table-header-${PoolColumnId.Tvl}"]`).click()
-    cy.get('[data-testid^="data-table-row-"]')
-      .first()
-      .find(`[data-testid="market-link-${V2_POOL_FIXTURES.liteLowTvl.address}"]`)
-      .should('exist')
+    expectFirstPool(V2_POOL_FIXTURES.liteLowTvl.address)
+
+    showV2PoolColumns([PoolColumnId.CrvApy, PoolColumnId.RewardsApy])
+    for (const columnId of LITE_COMPUTED_SORT_COLUMNS) {
+      getColumnHeader(columnId).click()
+      expectFirstPool(V2_POOL_FIXTURES.lite.address)
+      getColumnHeader(columnId).click()
+      expectFirstPool(V2_POOL_FIXTURES.liteLowTvl.address)
+    }
+
     cy.get('@dex-v2-lite-pools.all').should('have.length', 1)
   })
 

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -278,6 +278,8 @@ const LITE_POOL_LOW_TVL = createLitePoolFixture({
   address: '0x9999999999999999999999999999999999999999',
   name: 'V2 Low TVL',
   tvl: 1,
+  gauge_address: address('2009'),
+  gauge_crv_apr: [1, 2.5],
   coins: [
     { address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', decimals: '18', symbol: 'WETH' },
     { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', decimals: '18', symbol: 'TAIKO' },


### PR DESCRIPTION
A bit difficult to test perhaps as there's no pools with CRV APY, and the only lite networks with APYs is Monad.