### PR TITLE
feat: support multiple max receive providers

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -18,7 +18,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@curvefi/llamalend-api": "2.5.1",
+    "@curvefi/llamalend-api": "2.5.2",
     "@supercharge/promise-pool": "3.3.0",
     "@tanstack/react-router": "1.170.18",
     "@tanstack/react-router-devtools": "1.167.0",

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -12,13 +12,14 @@ import { t } from '@evm-ui/lib/i18n'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { q, type Range } from '@evm-ui/types/util'
+import { mapQuery, q, type Range } from '@evm-ui/types/util'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts, HighPriceImpactAlert } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { shouldBlockTransaction } from '@evm-ui/widgets/DetailPageLayout/price-impact.util'
 import Collapse from '@mui/material/Collapse'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
+import { assert } from '@primitives/objects.utils'
 import { useMarketContext } from '../../market-context'
 import { useCreateLoanForm } from '../hooks/useCreateLoanForm'
 import { AdvancedCreateLoanOptions } from './AdvancedCreateLoanOptions'
@@ -77,6 +78,12 @@ export const CreateLoanForm = <ChainId extends IChainId>({
     (event: ChangeEvent<HTMLInputElement>) => updateForm({ leverageEnabled: event.target.checked, routeId: undefined }),
     [updateForm],
   )
+  const maxDebtBalance = mapQuery(maxDebt, ({ maxDebt }) => maxDebt)
+  const onMax = useCallback((): undefined => {
+    const { maxDebt: maxDebtAmount, router } = assert(maxDebt.data, 'expected max debt data')
+    if (router) routes?.onChange(router)
+    updateForm({ debt: getMaxBorrowAmount(maxDebtAmount, values.leverageEnabled) })
+  }, [maxDebt.data, routes, updateForm, values.leverageEnabled])
 
   return (
     <Form
@@ -113,11 +120,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           blockchainId={network.id}
           name="debt"
           form={form}
-          max={{
-            ...q(maxDebt),
-            fieldName: 'maxDebt',
-            onMax: maxDebt => getMaxBorrowAmount(maxDebt, values.leverageEnabled),
-          }}
+          max={{ ...maxDebtBalance, fieldName: 'maxDebt', onMax }}
           hideBalance
           testId="borrow-debt-input"
           network={network}
@@ -127,11 +130,8 @@ export const CreateLoanForm = <ChainId extends IChainId>({
               prefix={t`Max borrow:`}
               tooltip={t`Max borrow`}
               symbol={borrowToken?.symbol}
-              balance={q(maxDebt)}
-              onClick={useCallback(
-                () => updateForm({ debt: getMaxBorrowAmount(values.maxDebt, values.leverageEnabled) }),
-                [updateForm, values.leverageEnabled, values.maxDebt],
-              )}
+              balance={maxDebtBalance}
+              onClick={onMax}
               buttonTestId="borrow-set-debt-to-max"
             />
           }

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -139,12 +139,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
       </Stack>
       {isLeverageSupported && (
         <Stack>
-          <LeverageInput
-            checked={values.leverageEnabled}
-            leverage={leverage}
-            onToggle={toggleLeverage}
-            maxLeverage={maxLeverage.data}
-          />
+          <LeverageInput checked={values.leverageEnabled} leverage={leverage} onToggle={toggleLeverage} />
           <LoanActionSettings
             show={values.leverageEnabled}
             slippage={values.slippage}

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -79,7 +79,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
     [updateForm],
   )
   const maxDebtBalance = mapQuery(maxDebt, ({ maxDebt }) => maxDebt)
-  const onMax = useCallback((): undefined => {
+  const onMax = useCallback(() => {
     const { maxDebt: maxDebtAmount, router } = assert(maxDebt.data, 'expected max debt data')
     if (router) routes?.onChange(router)
     updateForm({ debt: getMaxBorrowAmount(maxDebtAmount, values.leverageEnabled) })

--- a/apps/main/src/llamalend/features/borrow/components/LeverageInput.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/LeverageInput.tsx
@@ -1,7 +1,6 @@
 import { type ChangeEvent } from 'react'
 import { t } from '@evm-ui/lib/i18n'
 import { ActionInfo } from '@evm-ui/shared/ui/ActionInfo'
-import { WithSkeleton } from '@evm-ui/shared/ui/WithSkeleton'
 import { mapQuery, type QueryProp } from '@evm-ui/types/util'
 import { formatNumber } from '@evm-ui/utils'
 import { CheckboxField } from '@evm-ui/widgets/DetailPageLayout/CheckboxField'
@@ -14,28 +13,23 @@ export const LeverageInput = ({
   checked,
   leverage,
   onToggle,
-  maxLeverage,
 }: {
   checked: boolean | undefined
   leverage: QueryProp<Decimal | null>
   onToggle: (event: ChangeEvent<HTMLInputElement>) => void
-  maxLeverage: Decimal | undefined
 }) => (
-  <WithSkeleton loading={leverage.isLoading} width="100%">
-    <CheckboxField
-      checked={!!checked}
-      disabled={!maxLeverage}
-      label={t`Enable leverage`}
-      testIdPrefix={TEST_ID_PREFIX}
-      onChange={onToggle}
-      endContent={
-        <ActionInfo
-          label={t`Leverage`}
-          value={mapQuery(leverage, v => formatNumber(maybe(v, Number) && v, 'multiplier'))}
-          size="medium"
-          data-testid={`${TEST_ID_PREFIX}-value`}
-        />
-      }
-    />
-  </WithSkeleton>
+  <CheckboxField
+    checked={!!checked}
+    label={t`Enable leverage`}
+    testIdPrefix={TEST_ID_PREFIX}
+    onChange={onToggle}
+    endContent={
+      <ActionInfo
+        label={t`Leverage`}
+        value={mapQuery(leverage, v => formatNumber(maybe(v, Number) && v, 'multiplier'))}
+        size="medium"
+        data-testid={`${TEST_ID_PREFIX}-value`}
+      />
+    }
+  />
 )

--- a/apps/main/src/llamalend/features/borrow/hooks/useMaxTokenValues.tsx
+++ b/apps/main/src/llamalend/features/borrow/hooks/useMaxTokenValues.tsx
@@ -12,7 +12,7 @@ import { mapQuery } from '@evm-ui/types/util'
 import { decimal, decimalMin } from '@evm-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
-import { useCreateLoanMaxReceive } from '../../../queries/create-loan/create-loan-max-receive.query'
+import { useCreateLoanMaxReceiveQueries } from '../../../queries/create-loan/create-loan-max-receive.query'
 import type { CreateLoanForm } from '../types'
 
 /**
@@ -33,7 +33,7 @@ export function useMaxTokenValues({
 }) {
   const { update: updateForm, getValues } = form
   const tokenBalance = useTokenBalance({ ...params, tokenAddress: collateralTokenAddress })
-  const maxBorrow = useCreateLoanMaxReceive(params)
+  const maxBorrow = useCreateLoanMaxReceiveQueries(params)
   const maxLeverage = useMarketMaxLeverage(params)
 
   const { maxDebt } = maxBorrow.data ?? {}
@@ -72,7 +72,7 @@ export function useMaxTokenValues({
   return {
     setRange,
     collateral: maxCollateral,
-    debt: mapQuery(maxBorrow, ({ maxDebt }) => maxDebt),
+    debt: mapQuery(maxBorrow, ({ maxDebt, router }) => ({ maxDebt, router })),
     maxLeverage: combineQueries(
       [maxLeverage, maxBorrow],
       (maxTotalLeverage, { maxLeverage: maxBorrowLeverage }) => maxBorrowLeverage ?? maxTotalLeverage,

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -72,10 +72,10 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
     [updateForm],
   )
   const maxDebt = mapQuery(max.debt, ({ maxDebt }) => maxDebt)
-  const onMax = useCallback((): undefined => {
-    const { maxDebt: maxDebt, router } = assert(max.debt.data, 'expected max debt data')
+  const onMax = useCallback(() => {
+    const { maxDebt: debt, router } = assert(max.debt.data, 'expected max debt data')
     if (router) routes?.onChange(router)
-    updateForm({ maxDebt: getMaxBorrowAmount(maxDebt, values.leverageEnabled) })
+    updateForm({ debt: getMaxBorrowAmount(debt, values.leverageEnabled) })
   }, [max.debt.data, routes, updateForm, values.leverageEnabled])
 
   return (
@@ -143,12 +143,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
       </Stack>
       {isLeverageSupported && (
         <Stack>
-          <LeverageInput
-            checked={values.leverageEnabled}
-            leverage={leverage}
-            onToggle={onLeverageToggle}
-            maxLeverage={max.maxLeverage.data}
-          />
+          <LeverageInput checked={values.leverageEnabled} leverage={leverage} onToggle={onLeverageToggle} />
           <LoanActionSettings
             show={values.leverageEnabled === true}
             slippage={values.slippage}

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -14,13 +14,13 @@ import { t } from '@evm-ui/lib/i18n'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { q, type QueryProp, type Range } from '@evm-ui/types/util'
+import { mapQuery, q, type QueryProp, type Range } from '@evm-ui/types/util'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts, HighPriceImpactAlert } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { shouldBlockTransaction } from '@evm-ui/widgets/DetailPageLayout/price-impact.util'
 import Stack from '@mui/material/Stack'
 import type { Decimal } from '@primitives/decimal.utils'
-import { notFalsy } from '@primitives/objects.utils'
+import { assert, notFalsy } from '@primitives/objects.utils'
 import { useMarketContext } from '../../market-context'
 import { useBorrowMoreForm } from '../hooks/useBorrowMoreForm'
 
@@ -71,7 +71,12 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
     (event: ChangeEvent<HTMLInputElement>) => updateForm({ leverageEnabled: event.target.checked, routeId: undefined }),
     [updateForm],
   )
-  const getMaxDebt = (maxDebt?: Decimal) => getMaxBorrowAmount(maxDebt, values.leverageEnabled)
+  const maxDebt = mapQuery(max.debt, ({ maxDebt }) => maxDebt)
+  const onMax = useCallback((): undefined => {
+    const { maxDebt: maxDebt, router } = assert(max.debt.data, 'expected max debt data')
+    if (router) routes?.onChange(router)
+    updateForm({ maxDebt: getMaxBorrowAmount(maxDebt, values.leverageEnabled) })
+  }, [max.debt.data, routes, updateForm, values.leverageEnabled])
 
   return (
     <Form
@@ -120,7 +125,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           blockchainId={network.id}
           name="debt"
           form={form}
-          max={{ ...max.debt, fieldName: max.debt.field, onMax: getMaxDebt }}
+          max={{ ...maxDebt, fieldName: max.debt.field, onMax }}
           testId="borrow-more-input-debt"
           network={network}
           hideBalance
@@ -130,8 +135,8 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
               prefix={t`Max borrow amount:`}
               tooltip={t`Max available to borrow`}
               symbol={borrowToken?.symbol}
-              balance={max.debt}
-              onClick={() => updateForm({ debt: getMaxDebt(max.debt.data) })}
+              balance={maxDebt}
+              onClick={onMax}
             />
           }
         />

--- a/apps/main/src/llamalend/features/manage-loan/hooks/useMaxBorrowMoreValues.ts
+++ b/apps/main/src/llamalend/features/manage-loan/hooks/useMaxBorrowMoreValues.ts
@@ -5,16 +5,15 @@ import type { MarketTemplate } from '@/llamalend/llamalend.types'
 import { resetBorrowMoreExpectedCollateral } from '@/llamalend/queries/borrow-more/borrow-more-expected-collateral.query'
 import {
   type BorrowMoreMaxReceiveParams,
-  useBorrowMoreMaxReceive,
+  useBorrowMoreMaxReceiveQueries,
 } from '@/llamalend/queries/borrow-more/borrow-more-max-receive.query'
 import { useMarketMaxLeverage } from '@/llamalend/queries/market'
 import { BorrowMoreForm } from '@/llamalend/queries/validation/borrow-more.validation'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { useFormSync, useOnChangeCallback } from '@evm-ui/features/forms'
 import type { UseFormReturn } from '@evm-ui/features/forms'
+import { useFormSync, useOnChangeCallback } from '@evm-ui/features/forms'
 import { useTokenBalance } from '@evm-ui/hooks/useTokenBalance'
 import { mapQuery, type QueryProp } from '@evm-ui/types/util'
-import { decimal } from '@evm-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import { maybe } from '@primitives/objects.utils'
 
@@ -46,7 +45,7 @@ export function useMaxBorrowMoreValues<ChainId extends LlamaChainId>({
     tokenAddress: borrowTokenAddress,
   })
 
-  const maxReceive = useBorrowMoreMaxReceive(params)
+  const maxReceive = useBorrowMoreMaxReceiveQueries(params)
   const maxLeverage = useMarketMaxLeverage({ chainId, marketId, range: PRESET_RANGES.MaxLtv })
 
   useFormSync(form, { maxCollateral: maxUserCollateral.data })
@@ -66,7 +65,7 @@ export function useMaxBorrowMoreValues<ChainId extends LlamaChainId>({
   return {
     userCollateral: { ...maxUserCollateral, field: 'maxCollateral' as const },
     userBorrowed: { ...maxUserBorrowed, field: 'maxBorrowed' as const },
-    debt: { ...mapQuery(maxReceive, d => decimal(d.maxDebt)), field: 'maxDebt' as const },
+    debt: { ...mapQuery(maxReceive, ({ maxDebt, router }) => ({ maxDebt, router })), field: 'maxDebt' as const },
     maxLeverage,
   }
 }

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-future-leverage.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-future-leverage.query.ts
@@ -64,5 +64,5 @@ export const { useQuery: useBorrowMoreFutureLeverage, invalidate: invalidateBorr
 export function useBorrowMoreLeverage(params: BorrowMoreParams) {
   const current = useUserCurrentLeverage(params)
   const future = useBorrowMoreFutureLeverage(params)
-  return q(future.enabled ? future : current)
+  return q(future.isEnabled ? future : current)
 }

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
@@ -3,7 +3,7 @@ import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getBorrowMoreImplementation } from '@/llamalend/queries/borrow-more/borrow-more-query.helpers'
 import type { BorrowMoreQuery } from '@/llamalend/queries/validation/borrow-more.validation'
 import { borrowMoreValidationGroup } from '@/llamalend/queries/validation/borrow-more.validation'
-import { getExpectedFn, NoQuoteError } from '@evm-ui/entities/router-api'
+import { getExpectedFn } from '@evm-ui/entities/router-api'
 import { createValidationSuite, type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
@@ -32,34 +32,28 @@ export type BorrowMoreMaxReceiveParams<ChainId = number> = Omit<BorrowMoreMaxRec
   leverageProviders?: readonly RouteProvider[] | undefined
 }
 
-function castFieldsToDecimal(foo: {
+const castFieldsToDecimal = ({
+  maxDebt,
+  maxTotalCollateral,
+  userCollateral: userCollateralReceive,
+  collateralFromUserBorrowed,
+  collateralFromMaxDebt,
+  avgPrice,
+}: {
   maxDebt: string
-  router?: RouteProvider
   maxTotalCollateral: string
   userCollateral: string
   collateralFromUserBorrowed: string
   collateralFromMaxDebt: string
   avgPrice: string
-}) {
-  const {
-    maxDebt,
-    router,
-    maxTotalCollateral,
-    userCollateral: userCollateralReceive,
-    collateralFromUserBorrowed,
-    collateralFromMaxDebt,
-    avgPrice,
-  } = foo
-  return {
-    maxDebt: maxDebt as Decimal,
-    router,
-    maxTotalCollateral: decimal(maxTotalCollateral),
-    userCollateral: decimal(userCollateralReceive),
-    collateralFromUserBorrowed: decimal(collateralFromUserBorrowed),
-    collateralFromMaxDebt: decimal(collateralFromMaxDebt),
-    avgPrice: decimal(avgPrice),
-  }
-}
+}) => ({
+  maxDebt: maxDebt as Decimal,
+  maxTotalCollateral: decimal(maxTotalCollateral),
+  userCollateral: decimal(userCollateralReceive),
+  collateralFromUserBorrowed: decimal(collateralFromUserBorrowed),
+  collateralFromMaxDebt: decimal(collateralFromMaxDebt),
+  avgPrice: decimal(avgPrice),
+})
 
 const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateBorrowMoreProviderMaxReceive } =
   queryFactory({
@@ -89,29 +83,24 @@ const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateB
       chainId,
       userAddress,
       slippage,
-      router,
+      router: routerProvider,
     }: BorrowMoreMaxReceiveQuery): Promise<BorrowMoreMaxReceiveResult> => {
       const market = getMarket(marketId)
       const [type, impl] = getBorrowMoreImplementation(market, leverageEnabled)
       switch (type) {
         case 'zapV2': {
-          const selectedRouter = assert(router, 'No router enabled')
+          const router = assert(routerProvider, 'No router enabled')
           const zapAddress = getZapAddress(market)
-          const getExpected = getExpectedFn({ chainId, userAddress, zapAddress, slippage, router: selectedRouter })
-          try {
-            const result = await impl.borrowMoreMaxRecv({ userCollateral, address: userAddress, getExpected })
-            return castFieldsToDecimal({ router: selectedRouter, ...result })
-          } catch (e) {
-            if (e instanceof NoQuoteError) return { maxDebt: '0' } // todo: remove this after https://github.com/curvefi/curve-llamalend.js/pull/141
-            throw e
-          }
+          const getExpected = getExpectedFn({ chainId, userAddress, zapAddress, slippage, router })
+          const result = await impl.borrowMoreMaxRecv({ userCollateral, address: userAddress, getExpected })
+          return { router, ...castFieldsToDecimal(result) }
         }
         case 'unleveraged':
           return { maxDebt: (await impl.borrowMoreMaxRecv(userCollateral)) as Decimal }
       }
     },
     category: 'llamalend.borrowMore',
-    validationSuite: createValidationSuite((params: BorrowMoreMaxReceiveParams) =>
+    validationSuite: createValidationSuite((params: BorrowMoreMaxReceiveQueryParams) =>
       borrowMoreValidationGroup(params, {
         leverageRequired: false,
         debtRequired: false,

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
@@ -7,7 +7,6 @@ import { getExpectedFn, NoQuoteError } from '@evm-ui/entities/router-api'
 import { createValidationSuite, type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
-import type { Query } from '@evm-ui/types/util'
 import { decimal, decimalCompare } from '@evm-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
@@ -71,7 +70,6 @@ const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateB
       userCollateral = '0',
       userBorrowed = '0',
       leverageEnabled,
-      routeId,
       slippage,
       router,
     }: BorrowMoreMaxReceiveQueryParams) =>
@@ -81,7 +79,6 @@ const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateB
         { userCollateral },
         { userBorrowed },
         { leverageEnabled },
-        { routeId },
         { slippage },
         { router },
       ] as const,
@@ -136,12 +133,9 @@ export const useBorrowMoreMaxReceiveQueries = (params: BorrowMoreMaxReceiveParam
       () => getMaxReceiveProviders(params).map(router => getBorrowMoreMaxReceiveOptions({ ...params, router })),
       [params],
     ),
-    combine: (results: Query<BorrowMoreMaxReceiveResult>[]) =>
-      combineQueries(results, (...data) =>
-        data.reduce<BorrowMoreMaxReceiveResult | undefined>(
-          (max, data) => (decimalCompare(data.maxDebt, max?.maxDebt ?? '0') > 0 ? data : max),
-          undefined,
-        ),
+    combine: results =>
+      combineQueries(results, (first, ...rest) =>
+        rest.reduce((max, item) => (decimalCompare(item.maxDebt, max?.maxDebt ?? '0') > 0 ? item : max), first),
       ),
   })
 

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
@@ -3,7 +3,7 @@ import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getBorrowMoreImplementation } from '@/llamalend/queries/borrow-more/borrow-more-query.helpers'
 import type { BorrowMoreQuery } from '@/llamalend/queries/validation/borrow-more.validation'
 import { borrowMoreValidationGroup } from '@/llamalend/queries/validation/borrow-more.validation'
-import { getExpectedFn } from '@evm-ui/entities/router-api'
+import { getExpectedFn, NoQuoteError } from '@evm-ui/entities/router-api'
 import { createValidationSuite, type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
@@ -99,20 +99,15 @@ const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateB
       switch (type) {
         case 'zapV2': {
           const selectedRouter = assert(router, 'No router enabled')
-          return castFieldsToDecimal({
-            router: selectedRouter,
-            ...(await impl.borrowMoreMaxRecv({
-              userCollateral,
-              address: userAddress,
-              getExpected: getExpectedFn({
-                chainId,
-                userAddress,
-                zapAddress: getZapAddress(market),
-                slippage,
-                router: selectedRouter,
-              }),
-            })),
-          })
+          const zapAddress = getZapAddress(market)
+          const getExpected = getExpectedFn({ chainId, userAddress, zapAddress, slippage, router: selectedRouter })
+          try {
+            const result = await impl.borrowMoreMaxRecv({ userCollateral, address: userAddress, getExpected })
+            return castFieldsToDecimal({ router: selectedRouter, ...result })
+          } catch (e) {
+            if (e instanceof NoQuoteError) return { maxDebt: '0' } // todo: remove this after https://github.com/curvefi/curve-llamalend.js/pull/141
+            throw e
+          }
         }
         case 'unleveraged':
           return { maxDebt: (await impl.borrowMoreMaxRecv(userCollateral)) as Decimal }

--- a/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/borrow-more/borrow-more-max-receive.query.ts
@@ -1,16 +1,22 @@
+import { useMemo } from 'react'
 import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getBorrowMoreImplementation } from '@/llamalend/queries/borrow-more/borrow-more-query.helpers'
 import type { BorrowMoreQuery } from '@/llamalend/queries/validation/borrow-more.validation'
 import { borrowMoreValidationGroup } from '@/llamalend/queries/validation/borrow-more.validation'
-import { getExpectedFn, getRouteById } from '@evm-ui/entities/router-api'
+import { getExpectedFn } from '@evm-ui/entities/router-api'
 import { createValidationSuite, type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
-import { decimal } from '@evm-ui/utils'
+import { combineQueries } from '@evm-ui/lib/queries/combine'
+import type { Query } from '@evm-ui/types/util'
+import { decimal, decimalCompare } from '@evm-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
+import { assert } from '@primitives/objects.utils'
 import type { RouteProvider } from '@primitives/router.utils'
+import { useQueries } from '@tanstack/react-query'
 
-type BorrowMoreMaxReceiveResult = {
+export type BorrowMoreMaxReceiveResult = {
   maxDebt: Decimal
+  router?: RouteProvider
   maxTotalCollateral?: Decimal
   userCollateral?: Decimal
   collateralFromUserBorrowed?: Decimal
@@ -19,12 +25,17 @@ type BorrowMoreMaxReceiveResult = {
 }
 
 type BorrowMoreMaxReceiveQuery<ChainId = number> = BorrowMoreQuery<ChainId> & {
-  leverageProviders: readonly RouteProvider[] | undefined
+  router: RouteProvider | null
 }
-export type BorrowMoreMaxReceiveParams<ChainId = number> = FieldsOf<BorrowMoreMaxReceiveQuery<ChainId>>
+export type BorrowMoreMaxReceiveQueryParams<ChainId = number> = FieldsOf<BorrowMoreMaxReceiveQuery<ChainId>>
+
+export type BorrowMoreMaxReceiveParams<ChainId = number> = Omit<BorrowMoreMaxReceiveQueryParams<ChainId>, 'router'> & {
+  leverageProviders?: readonly RouteProvider[] | undefined
+}
 
 function castFieldsToDecimal(foo: {
   maxDebt: string
+  router?: RouteProvider
   maxTotalCollateral: string
   userCollateral: string
   collateralFromUserBorrowed: string
@@ -33,6 +44,7 @@ function castFieldsToDecimal(foo: {
 }) {
   const {
     maxDebt,
+    router,
     maxTotalCollateral,
     userCollateral: userCollateralReceive,
     collateralFromUserBorrowed,
@@ -41,6 +53,7 @@ function castFieldsToDecimal(foo: {
   } = foo
   return {
     maxDebt: maxDebt as Decimal,
+    router,
     maxTotalCollateral: decimal(maxTotalCollateral),
     userCollateral: decimal(userCollateralReceive),
     collateralFromUserBorrowed: decimal(collateralFromUserBorrowed),
@@ -49,71 +62,95 @@ function castFieldsToDecimal(foo: {
   }
 }
 
-export const { useQuery: useBorrowMoreMaxReceive, invalidate: invalidateBorrowMoreMaxReceive } = queryFactory({
-  queryKey: ({
-    chainId,
-    marketId,
-    userAddress,
-    userCollateral = '0',
-    userBorrowed = '0',
-    leverageEnabled,
-    routeId,
-    slippage,
-    leverageProviders,
-  }: BorrowMoreMaxReceiveParams) =>
-    [
-      ...rootKeys.userMarket({ chainId, marketId, userAddress }),
-      'borrowMoreMaxRecv',
-      { userCollateral },
-      { userBorrowed },
-      { leverageEnabled },
-      { routeId },
-      { slippage },
-      { leverageProviders },
-    ] as const,
-  queryFn: async ({
-    marketId,
-    userCollateral = '0',
-    leverageEnabled,
-    chainId,
-    routeId,
-    userAddress,
-    slippage,
-    leverageProviders,
-  }: BorrowMoreMaxReceiveQuery): Promise<BorrowMoreMaxReceiveResult> => {
-    const market = getMarket(marketId)
-    const [type, impl] = getBorrowMoreImplementation(market, leverageEnabled)
-    switch (type) {
-      case 'zapV2': {
-        const selectedProvider = routeId && getRouteById(routeId).router
-        return castFieldsToDecimal(
-          await impl.borrowMoreMaxRecv({
-            userCollateral,
-            address: userAddress,
-            getExpected: getExpectedFn({
-              chainId,
-              userAddress,
-              zapAddress: getZapAddress(market),
-              slippage,
-              router:
-                selectedProvider && leverageProviders?.includes(selectedProvider)
-                  ? selectedProvider
-                  : leverageProviders,
-            }),
-          }),
-        )
+const { getQueryOptions: getBorrowMoreMaxReceiveOptions, invalidate: invalidateBorrowMoreProviderMaxReceive } =
+  queryFactory({
+    queryKey: ({
+      chainId,
+      marketId,
+      userAddress,
+      userCollateral = '0',
+      userBorrowed = '0',
+      leverageEnabled,
+      routeId,
+      slippage,
+      router,
+    }: BorrowMoreMaxReceiveQueryParams) =>
+      [
+        ...rootKeys.userMarket({ chainId, marketId, userAddress }),
+        'borrowMoreMaxRecv',
+        { userCollateral },
+        { userBorrowed },
+        { leverageEnabled },
+        { routeId },
+        { slippage },
+        { router },
+      ] as const,
+    queryFn: async ({
+      marketId,
+      userCollateral = '0',
+      leverageEnabled,
+      chainId,
+      userAddress,
+      slippage,
+      router,
+    }: BorrowMoreMaxReceiveQuery): Promise<BorrowMoreMaxReceiveResult> => {
+      const market = getMarket(marketId)
+      const [type, impl] = getBorrowMoreImplementation(market, leverageEnabled)
+      switch (type) {
+        case 'zapV2': {
+          const selectedRouter = assert(router, 'No router enabled')
+          return castFieldsToDecimal({
+            router: selectedRouter,
+            ...(await impl.borrowMoreMaxRecv({
+              userCollateral,
+              address: userAddress,
+              getExpected: getExpectedFn({
+                chainId,
+                userAddress,
+                zapAddress: getZapAddress(market),
+                slippage,
+                router: selectedRouter,
+              }),
+            })),
+          })
+        }
+        case 'unleveraged':
+          return { maxDebt: (await impl.borrowMoreMaxRecv(userCollateral)) as Decimal }
       }
-      case 'unleveraged':
-        return { maxDebt: (await impl.borrowMoreMaxRecv(userCollateral)) as Decimal }
-    }
-  },
-  category: 'llamalend.borrowMore',
-  validationSuite: createValidationSuite((params: BorrowMoreMaxReceiveParams) =>
-    borrowMoreValidationGroup(params, {
-      leverageRequired: false,
-      debtRequired: false,
-      maxDebtRequired: false,
-      ignoreMaxDebt: true,
-    }),
-  ),
-})
+    },
+    category: 'llamalend.borrowMore',
+    validationSuite: createValidationSuite((params: BorrowMoreMaxReceiveParams) =>
+      borrowMoreValidationGroup(params, {
+        leverageRequired: false,
+        debtRequired: false,
+        maxDebtRequired: false,
+        ignoreMaxDebt: true,
+      }),
+    ),
+  })
+
+const getMaxReceiveProviders = ({ marketId, leverageEnabled, leverageProviders }: BorrowMoreMaxReceiveParams) => {
+  if (!marketId) return []
+  const [type] = getBorrowMoreImplementation(marketId, leverageEnabled)
+  return type === 'zapV2' ? (leverageProviders ?? []) : [null]
+}
+
+export const useBorrowMoreMaxReceiveQueries = (params: BorrowMoreMaxReceiveParams) =>
+  useQueries({
+    queries: useMemo(
+      () => getMaxReceiveProviders(params).map(router => getBorrowMoreMaxReceiveOptions({ ...params, router })),
+      [params],
+    ),
+    combine: (results: Query<BorrowMoreMaxReceiveResult>[]) =>
+      combineQueries(results, (...data) =>
+        data.reduce<BorrowMoreMaxReceiveResult | undefined>(
+          (max, data) => (decimalCompare(data.maxDebt, max?.maxDebt ?? '0') > 0 ? data : max),
+          undefined,
+        ),
+      ),
+  })
+
+export const invalidateBorrowMoreMaxReceive = async (params: BorrowMoreMaxReceiveParams) =>
+  await Promise.all(
+    getMaxReceiveProviders(params).map(router => invalidateBorrowMoreProviderMaxReceive({ ...params, router })),
+  )

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-bands.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-bands.query.ts
@@ -6,7 +6,7 @@ import { notFalsy } from '@primitives/objects.utils'
 import type { CreateLoanDebtParams, CreateLoanDebtQuery } from '../../features/borrow/types'
 import { createLoanQueryValidationSuite } from '../validation/borrow.validation'
 import { createLoanExpectedCollateralQueryKey } from './create-loan-expected-collateral.query'
-import { createLoanMaxReceiveKey } from './create-loan-max-receive.query'
+import { createLoanRouteMaxReceiveKey } from './create-loan-max-receive.query'
 
 type CreateLoanBandsResult = Range<number>
 
@@ -53,7 +53,7 @@ export const { invalidate: invalidateCreateLoanBands } = queryFactory({
   category: 'llamalend.createLoan',
   validationSuite: createLoanQueryValidationSuite({ debtRequired: true }),
   dependencies: params => [
-    createLoanMaxReceiveKey(params),
+    createLoanRouteMaxReceiveKey(params),
     ...notFalsy(params.leverageEnabled && createLoanExpectedCollateralQueryKey(params)),
   ],
 })

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-estimate-gas.query.ts
@@ -10,7 +10,7 @@ import { notFalsy } from '@primitives/objects.utils'
 import type { CreateLoanFormQuery } from '../../features/borrow/types'
 import { createLoanQueryValidationSuite } from '../validation/borrow.validation'
 import { useCreateLoanIsApproved } from './create-loan-approved.query'
-import { createLoanMaxReceiveKey } from './create-loan-max-receive.query'
+import { createLoanRouteMaxReceiveKey } from './create-loan-max-receive.query'
 
 type CreateLoanEstimateGasQuery<T = IChainId> = CreateLoanFormQuery<T>
 type GasEstimateParams<T = IChainId> = FieldsOf<CreateLoanEstimateGasQuery<T>>
@@ -37,7 +37,7 @@ const { useQuery: useCreateLoanApproveEstimateGas, invalidate: invalidateCreateL
     },
     category: 'llamalend.createLoan',
     validationSuite: createLoanQueryValidationSuite({ debtRequired: false, collateralRequired: true }),
-    dependencies: params => [createLoanMaxReceiveKey(params)],
+    dependencies: params => [createLoanRouteMaxReceiveKey(params)],
   })
 
 const {
@@ -95,7 +95,7 @@ const {
   category: 'llamalend.createLoan',
   validationSuite: createLoanQueryValidationSuite({ debtRequired: true, collateralRequired: true }),
   dependencies: params => [
-    createLoanMaxReceiveKey(params),
+    createLoanRouteMaxReceiveKey(params),
     ...notFalsy(params.leverageEnabled && createLoanExpectedCollateralQueryKey(params)),
   ],
 })

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-health.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-health.query.ts
@@ -7,7 +7,7 @@ import { notFalsy } from '@primitives/objects.utils'
 import type { CreateLoanDebtParams, CreateLoanDebtQuery } from '../../features/borrow/types'
 import { createLoanQueryValidationSuite } from '../validation/borrow.validation'
 import { createLoanExpectedCollateralQueryKey } from './create-loan-expected-collateral.query'
-import { createLoanMaxReceiveKey } from './create-loan-max-receive.query'
+import { createLoanRouteMaxReceiveKey } from './create-loan-max-receive.query'
 
 export const { useQuery: useCreateLoanHealth, invalidate: invalidateCreateLoanHealth } = queryFactory({
   queryKey: ({
@@ -54,7 +54,7 @@ export const { useQuery: useCreateLoanHealth, invalidate: invalidateCreateLoanHe
   category: 'llamalend.createLoan',
   validationSuite: createLoanQueryValidationSuite({ debtRequired: true, ignoreMaxCollateral: true }),
   dependencies: params => [
-    createLoanMaxReceiveKey(params),
+    createLoanRouteMaxReceiveKey(params),
     ...notFalsy(params.leverageEnabled && createLoanExpectedCollateralQueryKey(params)),
   ],
 })

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/create-loan-query.helpers'
-import { getExpectedFn, getRouteById } from '@evm-ui/entities/router-api'
+import { getExpectedFn, getRouteById, NoQuoteError } from '@evm-ui/entities/router-api'
 import { type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
@@ -101,20 +101,16 @@ const {
     switch (type) {
       case 'zapV2': {
         const selectedRouter = assert(router, 'No router enabled')
-        return convertNumbers({
-          router: selectedRouter,
-          ...(await impl.createLoanMaxRecv({
-            userCollateral,
-            range,
-            getExpected: getExpectedFn({
-              chainId,
-              router: selectedRouter,
-              userAddress,
-              zapAddress: getZapAddress(market),
-              slippage,
-            }),
-          })),
-        })
+        const zapAddress = getZapAddress(market)
+        const getExpected = getExpectedFn({ chainId, router: selectedRouter, userAddress, zapAddress, slippage })
+        try {
+          const result = await impl.createLoanMaxRecv({ userCollateral, range, getExpected })
+          return convertNumbers({ router: selectedRouter, ...result })
+        } catch (e) {
+          // todo: remove this after https://github.com/curvefi/curve-llamalend.js/pull/141
+          if (e instanceof NoQuoteError) return { maxDebt: '0' }
+          throw e
+        }
       }
       case 'V0': {
         assert(!+userBorrowed, `userBorrowed must be 0 for non-leverage mint markets`)

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
@@ -5,7 +5,6 @@ import { getExpectedFn, getRouteById } from '@evm-ui/entities/router-api'
 import { type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
-import type { Query } from '@evm-ui/types/util'
 import { decimal, decimalCompare } from '@evm-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
@@ -152,12 +151,9 @@ export const useCreateLoanMaxReceiveQueries = (params: CreateLoanMaxReceiveParam
       () => getMaxReceiveProviders(params).map(router => getCreateLoanMaxReceiveOptions({ ...params, router })),
       [params],
     ),
-    combine: (results: Query<CreateLoanMaxReceiveResult>[]) =>
-      combineQueries(results, (...data) =>
-        data.reduce<CreateLoanMaxReceiveResult | undefined>(
-          (max, data) => (!max || decimalCompare(data.maxDebt, max.maxDebt) > 0 ? data : max),
-          undefined,
-        ),
+    combine: results =>
+      combineQueries(results, (first, ...rest) =>
+        rest.reduce((max, item) => (decimalCompare(item.maxDebt, max.maxDebt) > 0 ? item : max), first),
       ),
   })
 

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
@@ -1,25 +1,35 @@
+import { useMemo } from 'react'
 import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/create-loan-query.helpers'
-import { getExpectedFn } from '@evm-ui/entities/router-api'
+import { getExpectedFn, getRouteById } from '@evm-ui/entities/router-api'
 import { type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
-import { decimal } from '@evm-ui/utils'
+import { combineQueries } from '@evm-ui/lib/queries/combine'
+import type { Query } from '@evm-ui/types/util'
+import { decimal, decimalCompare } from '@evm-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { assert } from '@primitives/objects.utils'
 import type { RouteProvider } from '@primitives/router.utils'
+import { useQueries } from '@tanstack/react-query'
 import type { CreateLoanFormQuery } from '../../features/borrow/types'
 import { createLoanQueryValidationSuite } from '../validation/borrow.validation'
 
 type CreateLoanMaxReceiveQuery = Omit<CreateLoanFormQuery, 'userCollateral' | 'debt' | 'routeId'> & {
   userCollateral: Decimal
   userAddress: Address
-  leverageProviders: readonly RouteProvider[] | undefined
+  router: RouteProvider | null
 }
-export type CreateLoanMaxReceiveParams = FieldsOf<CreateLoanMaxReceiveQuery>
+export type CreateLoanMaxReceiveQueryParams = FieldsOf<CreateLoanMaxReceiveQuery>
 
-type CreateLoanMaxReceiveResult = {
+export type CreateLoanMaxReceiveParams = Omit<CreateLoanMaxReceiveQueryParams, 'router'> & {
+  leverageProviders?: readonly RouteProvider[] | undefined
+}
+type CreateLoanMaxReceiveRouteParams = CreateLoanMaxReceiveParams & { routeId?: string | null }
+
+export type CreateLoanMaxReceiveResult = {
   maxDebt: Decimal
+  router?: RouteProvider
   maxTotalCollateral?: Decimal
   maxLeverage?: Decimal
   userCollateral?: Decimal
@@ -29,6 +39,7 @@ type CreateLoanMaxReceiveResult = {
 }
 
 const convertNumbers = ({
+  router,
   maxDebt,
   maxLeverage,
   maxTotalCollateral,
@@ -36,8 +47,11 @@ const convertNumbers = ({
   userCollateral,
   collateralFromUserBorrowed,
   collateralFromMaxDebt,
-}: { [K in keyof CreateLoanMaxReceiveResult]: string }): CreateLoanMaxReceiveResult => ({
+}: Omit<{ [K in keyof CreateLoanMaxReceiveResult]: string }, 'router'> & {
+  router?: RouteProvider
+}): CreateLoanMaxReceiveResult => ({
   maxDebt: maxDebt as Decimal,
+  router,
   maxLeverage: decimal(maxLeverage),
   maxTotalCollateral: decimal(maxTotalCollateral),
   avgPrice: decimal(avgPrice),
@@ -46,10 +60,10 @@ const convertNumbers = ({
   collateralFromMaxDebt: decimal(collateralFromMaxDebt),
 })
 
-export const {
-  useQuery: useCreateLoanMaxReceive,
-  queryKey: createLoanMaxReceiveKey,
-  invalidate: invalidateCreateLoanMaxReceive,
+const {
+  queryKey: createLoanProviderMaxReceiveKey,
+  getQueryOptions: getCreateLoanMaxReceiveOptions,
+  invalidate: invalidateCreateLoanProviderMaxReceive,
 } = queryFactory({
   queryKey: ({
     chainId,
@@ -60,8 +74,8 @@ export const {
     range,
     leverageEnabled,
     slippage,
-    leverageProviders,
-  }: CreateLoanMaxReceiveParams) =>
+    router,
+  }: CreateLoanMaxReceiveQueryParams) =>
     [
       ...rootKeys.userMarket({ chainId, marketId, userAddress }),
       'createLoanMaxRecv',
@@ -70,7 +84,7 @@ export const {
       { range },
       { leverageEnabled },
       { slippage },
-      { leverageProviders },
+      { router },
     ] as const,
   queryFn: async ({
     chainId,
@@ -81,25 +95,28 @@ export const {
     range,
     leverageEnabled,
     slippage,
-    leverageProviders,
+    router,
   }: CreateLoanMaxReceiveQuery): Promise<CreateLoanMaxReceiveResult> => {
     const market = getMarket(marketId)
     const [type, impl] = getCreateLoanImplementation(market, leverageEnabled)
     switch (type) {
-      case 'zapV2':
-        return convertNumbers(
-          await impl.createLoanMaxRecv({
+      case 'zapV2': {
+        const selectedRouter = assert(router, 'No router enabled')
+        return convertNumbers({
+          router: selectedRouter,
+          ...(await impl.createLoanMaxRecv({
             userCollateral,
             range,
             getExpected: getExpectedFn({
               chainId,
-              router: leverageProviders,
+              router: selectedRouter,
               userAddress,
               zapAddress: getZapAddress(market),
               slippage,
             }),
-          }),
-        )
+          })),
+        })
+      }
       case 'V0': {
         assert(!+userBorrowed, `userBorrowed must be 0 for non-leverage mint markets`)
         const result = await impl.createLoanMaxRecv(userCollateral, range)
@@ -119,3 +136,32 @@ export const {
     ignoreMaxCollateral: true, // allow users to calculate max receive before they have collateral
   }),
 })
+
+export const createLoanRouteMaxReceiveKey = (params: CreateLoanMaxReceiveRouteParams) =>
+  createLoanProviderMaxReceiveKey({ ...params, router: params.routeId ? getRouteById(params.routeId).router : null })
+
+const getMaxReceiveProviders = ({ marketId, leverageEnabled, leverageProviders }: CreateLoanMaxReceiveParams) => {
+  if (!marketId || leverageEnabled == null) return []
+  const [type] = getCreateLoanImplementation(marketId, leverageEnabled)
+  return type === 'zapV2' ? (leverageProviders ?? []) : [null]
+}
+
+export const useCreateLoanMaxReceiveQueries = (params: CreateLoanMaxReceiveParams) =>
+  useQueries({
+    queries: useMemo(
+      () => getMaxReceiveProviders(params).map(router => getCreateLoanMaxReceiveOptions({ ...params, router })),
+      [params],
+    ),
+    combine: (results: Query<CreateLoanMaxReceiveResult>[]) =>
+      combineQueries(results, (...data) =>
+        data.reduce<CreateLoanMaxReceiveResult | undefined>(
+          (max, data) => (!max || decimalCompare(data.maxDebt, max.maxDebt) > 0 ? data : max),
+          undefined,
+        ),
+      ),
+  })
+
+export const invalidateCreateLoanMaxReceive = async (params: CreateLoanMaxReceiveParams) =>
+  await Promise.all(
+    getMaxReceiveProviders(params).map(router => invalidateCreateLoanProviderMaxReceive({ ...params, router })),
+  )

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-max-receive.query.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { getMarket, getZapAddress } from '@/llamalend/llama.utils'
 import { getCreateLoanImplementation } from '@/llamalend/queries/create-loan/create-loan-query.helpers'
-import { getExpectedFn, getRouteById, NoQuoteError } from '@evm-ui/entities/router-api'
+import { getExpectedFn, getRouteById } from '@evm-ui/entities/router-api'
 import { type FieldsOf } from '@evm-ui/lib'
 import { queryFactory, rootKeys } from '@evm-ui/lib/model'
 import { combineQueries } from '@evm-ui/lib/queries/combine'
@@ -24,7 +24,6 @@ export type CreateLoanMaxReceiveQueryParams = FieldsOf<CreateLoanMaxReceiveQuery
 export type CreateLoanMaxReceiveParams = Omit<CreateLoanMaxReceiveQueryParams, 'router'> & {
   leverageProviders?: readonly RouteProvider[] | undefined
 }
-type CreateLoanMaxReceiveRouteParams = CreateLoanMaxReceiveParams & { routeId?: string | null }
 
 export type CreateLoanMaxReceiveResult = {
   maxDebt: Decimal
@@ -38,7 +37,6 @@ export type CreateLoanMaxReceiveResult = {
 }
 
 const convertNumbers = ({
-  router,
   maxDebt,
   maxLeverage,
   maxTotalCollateral,
@@ -46,11 +44,8 @@ const convertNumbers = ({
   userCollateral,
   collateralFromUserBorrowed,
   collateralFromMaxDebt,
-}: Omit<{ [K in keyof CreateLoanMaxReceiveResult]: string }, 'router'> & {
-  router?: RouteProvider
-}): CreateLoanMaxReceiveResult => ({
+}: { [K in keyof CreateLoanMaxReceiveResult]: string }) => ({
   maxDebt: maxDebt as Decimal,
-  router,
   maxLeverage: decimal(maxLeverage),
   maxTotalCollateral: decimal(maxTotalCollateral),
   avgPrice: decimal(avgPrice),
@@ -94,23 +89,17 @@ const {
     range,
     leverageEnabled,
     slippage,
-    router,
+    router: routerProvider,
   }: CreateLoanMaxReceiveQuery): Promise<CreateLoanMaxReceiveResult> => {
     const market = getMarket(marketId)
     const [type, impl] = getCreateLoanImplementation(market, leverageEnabled)
     switch (type) {
       case 'zapV2': {
-        const selectedRouter = assert(router, 'No router enabled')
+        const router = assert(routerProvider, 'No router enabled')
         const zapAddress = getZapAddress(market)
-        const getExpected = getExpectedFn({ chainId, router: selectedRouter, userAddress, zapAddress, slippage })
-        try {
-          const result = await impl.createLoanMaxRecv({ userCollateral, range, getExpected })
-          return convertNumbers({ router: selectedRouter, ...result })
-        } catch (e) {
-          // todo: remove this after https://github.com/curvefi/curve-llamalend.js/pull/141
-          if (e instanceof NoQuoteError) return { maxDebt: '0' }
-          throw e
-        }
+        const getExpected = getExpectedFn({ chainId, router, userAddress, zapAddress, slippage })
+        const result = await impl.createLoanMaxRecv({ userCollateral, range, getExpected })
+        return { router, ...convertNumbers(result) }
       }
       case 'V0': {
         assert(!+userBorrowed, `userBorrowed must be 0 for non-leverage mint markets`)
@@ -132,7 +121,7 @@ const {
   }),
 })
 
-export const createLoanRouteMaxReceiveKey = (params: CreateLoanMaxReceiveRouteParams) =>
+export const createLoanRouteMaxReceiveKey = (params: CreateLoanMaxReceiveParams & { routeId?: string | null }) =>
   createLoanProviderMaxReceiveKey({ ...params, router: params.routeId ? getRouteById(params.routeId).router : null })
 
 const getMaxReceiveProviders = ({ marketId, leverageEnabled, leverageProviders }: CreateLoanMaxReceiveParams) => {

--- a/apps/main/src/llamalend/queries/create-loan/create-loan-prices.query.ts
+++ b/apps/main/src/llamalend/queries/create-loan/create-loan-prices.query.ts
@@ -7,7 +7,7 @@ import { notFalsy } from '@primitives/objects.utils'
 import type { CreateLoanDebtQuery, CreateLoanForm, CreateLoanFormQuery } from '../../features/borrow/types'
 import { createLoanQueryValidationSuite } from '../validation/borrow.validation'
 import { createLoanExpectedCollateralQueryKey } from './create-loan-expected-collateral.query'
-import { createLoanMaxReceiveKey } from './create-loan-max-receive.query'
+import { createLoanRouteMaxReceiveKey } from './create-loan-max-receive.query'
 
 type CreateLoanPricesReceiveQuery = CreateLoanFormQuery & Pick<CreateLoanForm, 'maxDebt'>
 type CreateLoanPricesReceiveParams = FieldsOf<CreateLoanPricesReceiveQuery>
@@ -59,7 +59,7 @@ export const { useQuery: useCreateLoanPrices, invalidate: invalidateCreateLoanPr
   category: 'llamalend.createLoan',
   validationSuite: createLoanQueryValidationSuite({ debtRequired: true, ignoreMaxCollateral: true }),
   dependencies: params => [
-    createLoanMaxReceiveKey(params),
+    createLoanRouteMaxReceiveKey(params),
     ...notFalsy(params.leverageEnabled && createLoanExpectedCollateralQueryKey(params)),
   ],
 })

--- a/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
+++ b/apps/main/src/llamalend/widgets/action-card/LoanFormTokenInput.tsx
@@ -29,10 +29,7 @@ export type LoanFormTokenInputProps<
    * Optional max-value query for this field, including loading and error state.
    * When present, it also carries an optional related max-field name whose errors should be reflected here.
    */
-  max?: QueryProp<Decimal> & {
-    fieldName: TMaxFieldName
-    onMax?: NonNullable<LargeTokenInputProps['maxBalance']>['onMax']
-  }
+  max?: QueryProp<Decimal> & { fieldName: TMaxFieldName; onMax?: () => void }
   name: TFieldName
   form: UseFormReturn<TFieldValues> // the form, used to set the value and get errors
   testId: string
@@ -131,7 +128,6 @@ export const LoanFormTokenInput = <
     },
     [name, onValueChange, updateForm],
   )
-  const onMaxBalance = useCallback((v?: Decimal) => onBalance(onMax ? onMax(v) : v), [onBalance, onMax])
   return (
     <LargeTokenInput
       name={name}
@@ -150,13 +146,13 @@ export const LoanFormTokenInput = <
       balance={q({ data: value, isLoading: value == null, error: error ?? null })}
       onBalance={onBalance}
       {...(!hideBalance && { walletBalance })}
-      maxBalance={max && { chips: 'range', balance: max, onMax: max.onMax }}
+      maxBalance={max && { chips: 'range', balance: max, onMax }}
       inputBalanceUsd={decimal(usdRate && usdRate * +(value ?? 0))}
       message={errorMessage ? undefined : message}
       disabled={disabled}
     >
       {maxMessage && !errorMessage && <HelperMessage onNumberClick={onBalance} message={maxMessage} />}
-      {errorMessage && <HelperMessage message={errorMessage} onNumberClick={onMaxBalance} isError />}
+      {errorMessage && <HelperMessage message={errorMessage} onNumberClick={onMax ?? onBalance} isError />}
     </LargeTokenInput>
   )
 }

--- a/packages/evm-ui/src/entities/router-api/router-api.query.ts
+++ b/packages/evm-ui/src/entities/router-api/router-api.query.ts
@@ -145,11 +145,11 @@ const { useQuery: useRouterApi, fetchQuery: fetchApiRoutes } = queryFactory({
 })
 
 function useRouterQuery(params: Omit<RoutesParams, 'router'>, router: RouteProvider, enabled = true): RouteQuery {
-  const { data, isLoading, error, isFetching } = useRouterApi({ ...params, router }, enabled)
+  const { data, isLoading, error, isFetching, isEnabled } = useRouterApi({ ...params, router }, enabled)
   const route = maybe(data, ([route]) => route) ?? null
   return useMemo(
-    () => ({ ...q({ isLoading, data: route, error }), isFetching, enabled }),
-    [isLoading, route, error, isFetching, enabled],
+    () => ({ ...q({ isLoading, data: route, error }), isFetching, enabled: isEnabled }),
+    [isLoading, route, error, isFetching, isEnabled],
   )
 }
 

--- a/packages/evm-ui/src/entities/router-api/router-api.utils.ts
+++ b/packages/evm-ui/src/entities/router-api/router-api.utils.ts
@@ -89,14 +89,8 @@ export const getExpectedFn =
       userAddress,
       zapAddress,
     })
-    // Prefer Curve Solver, then Curve Router, then the rest
-    const route = assert(
-      routes.find(({ router }) => router === 'curve-solver') ??
-        routes.find(({ router }) => router === 'curve') ??
-        routes[0],
-      'No route available',
-    )
-    return parseRoute(route.id).quote
+    if (!routes.length) return { outAmount: '0', priceImpact: null }
+    return parseRoute(routes[0].id).quote // router api is expected to return a single entry, add sorting if needed
   }
 
 export const createHash = async (

--- a/packages/evm-ui/src/entities/router-api/router-api.utils.ts
+++ b/packages/evm-ui/src/entities/router-api/router-api.utils.ts
@@ -61,8 +61,6 @@ export const parseMutationRoute = (
   return { ...route, minRecv: zapV2.calcMinRecv(expected, Number(slippage)) }
 }
 
-export class NoQuoteError extends Error {}
-
 /**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
  */
@@ -91,7 +89,7 @@ export const getExpectedFn =
       userAddress,
       zapAddress,
     })
-    if (!routes.length) throw new NoQuoteError()
+    if (!routes.length) return null
     return parseRoute(routes[0].id).quote // router api is expected to return a single entry, add sorting if needed
   }
 

--- a/packages/evm-ui/src/entities/router-api/router-api.utils.ts
+++ b/packages/evm-ui/src/entities/router-api/router-api.utils.ts
@@ -61,6 +61,8 @@ export const parseMutationRoute = (
   return { ...route, minRecv: zapV2.calcMinRecv(expected, Number(slippage)) }
 }
 
+export class NoQuoteError extends Error {}
+
 /**
  * This function can be used as a callback for curve-js calldata methods or llamalend.js leverageZapV2 methods.
  */
@@ -89,7 +91,7 @@ export const getExpectedFn =
       userAddress,
       zapAddress,
     })
-    if (!routes.length) return { outAmount: '0', priceImpact: null }
+    if (!routes.length) throw new NoQuoteError()
     return parseRoute(routes[0].id).quote // router api is expected to return a single entry, add sorting if needed
   }
 

--- a/packages/evm-ui/src/lib/model/query/factory.ts
+++ b/packages/evm-ui/src/lib/model/query/factory.ts
@@ -171,13 +171,7 @@ export function queryFactory<
         ...options,
         staleTime: 0,
       }),
-    useQuery: (params: TParams, condition?: boolean) => {
-      const { enabled, ...options } = getQueryOptions(params, condition)
-      const query = useQuery({ enabled, ...options })
-      const validation = enabled ? {} : validate(validationSuite, params)
-      // eslint-disable-next-line @eslint-react/purity -- Preserve the query result object's getters and generic inference.
-      return Object.assign(query, { enabled, validation })
-    },
+    useQuery: (params: TParams, condition?: boolean) => useQuery(getQueryOptions(params, condition)),
     /** Invalidates the cache for the query, marking it as stale and triggering a refetch if needed **/
     invalidate: (params: TParams) => queryClient.invalidateQueries({ queryKey: queryKey(params) }),
     /** Removes all the cached data for the query **/

--- a/packages/evm-ui/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
+++ b/packages/evm-ui/src/shared/ui/LargeTokenInput/LargeTokenInput.tsx
@@ -98,7 +98,7 @@ export type LargeTokenInputProps = {
     /** Custom or preset chips to show. */
     chips?: ChipsPreset | InputChip[]
     /** Optional override for the amount selected by a Max-style chip. */
-    onMax?: (maxBalance?: Decimal) => Decimal | undefined
+    onMax?: (maxBalance?: Decimal) => void
   }
 
   /** Optional usd value of the balance given as input. */
@@ -337,8 +337,8 @@ export const LargeTokenInput = ({
                       data-testid={!chipDisabled && `input-chip-${chip.label}`}
                       disabled={chipDisabled}
                       toggle={() => {
-                        const newBalance =
-                          chip.isMax && onMax ? onMax(maxBalanceValue) : chip.newBalance(maxBalanceValue)
+                        if (chip.isMax && onMax) return onMax(maxBalanceValue)
+                        const newBalance = chip.newBalance(maxBalanceValue)
                         if (newBalance !== undefined) {
                           handleBalanceChange(newBalance)
                         }

--- a/packages/evm-ui/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
+++ b/packages/evm-ui/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
@@ -3,7 +3,6 @@ import type { RouteQueries, RouteResponse } from '@evm-ui/entities/router-api'
 import { t } from '@evm-ui/lib/i18n'
 import { ReloadIcon } from '@evm-ui/shared/icons/ReloadIcon'
 import { Accordion } from '@evm-ui/shared/ui/Accordion'
-import { EmptyStateCard } from '@evm-ui/shared/ui/EmptyStateCard'
 import { ErrorIconButton } from '@evm-ui/shared/ui/ErrorIconButton'
 import { WithSkeleton } from '@evm-ui/shared/ui/WithSkeleton'
 import { LoadingAnimation } from '@evm-ui/themes/design/0_primitives'
@@ -58,9 +57,7 @@ export const RouteProvidersAccordion = ({
   const Icon = selectedRoute ? RouteProviderIcons[selectedRoute.router] : null
   const allError = queryList.every(r => r.error)
   const allLoading = queryList.every(r => r.isLoading)
-  const allDisabled = queryList.every(r => !r.enabled)
   const anyFetching = queryList.some(r => r.isFetching)
-  const anyData = queryList.some(route => route.data)
   return (
     enabled && (
       <Accordion
@@ -113,29 +110,22 @@ export const RouteProvidersAccordion = ({
               {t`Best route is selected based on net output after gas fees (only when possible to calculate).`}
             </Typography>
           </Stack>
-          {anyData ? (
-            <Stack sx={{ gap: Spacing.xs }}>
-              {providers.map(provider => (
-                <RouteProviderCard
-                  key={provider}
-                  tokenOut={tokenOut}
-                  isSelected={provider === selectedRouter}
-                  router={provider}
-                  query={queries[provider]}
-                  bestOutputAmount={maxAmountOut}
-                  onSelect={onChange}
-                  networks={networks}
-                  chainId={chainId}
-                />
-              ))}
-            </Stack>
-          ) : (
-            <EmptyStateCard
-              title={anyFetching ? t`Finding the best route...` : t`No routes available`}
-              description={!allDisabled && !anyFetching && t`We could not find any routes with your parameters.`}
-              size="sm"
-            />
-          )}
+          <Stack sx={{ gap: Spacing.xs }}>
+            {/* we don't need to handle providers.length === 0, this component shouldn't be displayed in that case */}
+            {providers.map(provider => (
+              <RouteProviderCard
+                key={provider}
+                tokenOut={tokenOut}
+                isSelected={provider === selectedRouter}
+                router={provider}
+                query={queries[provider]}
+                bestOutputAmount={maxAmountOut}
+                onSelect={onChange}
+                networks={networks}
+                chainId={chainId}
+              />
+            ))}
+          </Stack>
         </Stack>
       </Accordion>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,15 +502,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@curvefi/llamalend-api@npm:2.5.1":
-  version: 2.5.1
-  resolution: "@curvefi/llamalend-api@npm:2.5.1"
+"@curvefi/llamalend-api@npm:2.5.2":
+  version: 2.5.2
+  resolution: "@curvefi/llamalend-api@npm:2.5.2"
   dependencies:
     "@curvefi/ethcall": "npm:6.0.20"
     bignumber.js: "npm:9.3.1"
     ethers: "npm:6.17.0"
     memoizee: "npm:0.4.17"
-  checksum: 10c0/c534f019e2a822cc3280072a6d7bbb569bcf6dc9b3a7961731791e483f7df804ed40fad72e07b97ff588226036eb1fc8a82903aa2c3e1399d3690ee7b9c0bf68
+  checksum: 10c0/18dd656d929670db6ed04ff42a4e731d9ffeeef3312ba9aeaf03eb92dca5a20c9664e26c210e4c4cc795af634eaad3552492846e45c3e96438dc959e012562df
   languageName: node
   linkType: hard
 
@@ -10536,7 +10536,7 @@ __metadata:
   resolution: "main@workspace:apps/main"
   dependencies:
     "@curvefi/api": "npm:*"
-    "@curvefi/llamalend-api": "npm:2.5.1"
+    "@curvefi/llamalend-api": "npm:2.5.2"
     "@sentry/vite-plugin": "npm:5.4.0"
     "@supercharge/promise-pool": "npm:3.3.0"
     "@tanstack/react-router": "npm:1.170.18"


### PR DESCRIPTION
- Refactor max-receive queries to evaluate one router at a time.
- Add multi-router max selection for create-loan and borrow-more flows.
- Return the winning router with the max borrow result so the form can use the same route choice.
- Update max-button behavior to select the matching router when applying max borrow.
- Updates llamalend.js https://github.com/curvefi/curve-llamalend.js/pull/141