### PR TITLE
fix: abbreviate y axis for historical rate charts

### DIFF
--- a/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
+++ b/apps/main/src/dex/features/PoolHistoricalBaseRateChart.tsx
@@ -152,7 +152,7 @@ export const PoolHistoricalBaseRateChart = ({
             series={series}
             visibleSeries={visibleSeries}
             xTickFormatter={value => formatDate(value)}
-            yTickFormatter={value => formatNumber(decimal(value), 'percent.value')}
+            yTickFormatter={value => formatNumber(decimal(value), 'percent.rate')}
             yPaddingRatio={0.05}
             renderTooltip={({ datum, visibleSeries: activeSeries }) => (
               <ChartTooltipShell title={formatDate(datum.timestamp, 'long')}>
@@ -163,7 +163,7 @@ export const PoolHistoricalBaseRateChart = ({
                       label={activeSeriesItem.label}
                       lineColor={activeSeriesItem.color}
                       dash={activeSeriesItem.dash}
-                      value={formatNumber(datum[activeSeriesItem.key], 'percent.value')}
+                      value={formatNumber(datum[activeSeriesItem.key], 'percent.rate')}
                     />
                   ))}
                 </ChartTooltipSeriesGroup>

--- a/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
+++ b/apps/main/src/llamalend/widgets/MarketHistoricalRatesChart.tsx
@@ -264,7 +264,7 @@ export const MarketHistoricalRatesChart = ({ rateMode }: MarketHistoricalRatesCh
             series={series}
             visibleSeries={visibleSeries}
             xTickFormatter={(value: RateChartPoint['timestamp'] | string) => formatDate(value)}
-            yTickFormatter={value => formatNumber(decimal(value), 'percent.value')}
+            yTickFormatter={value => formatNumber(decimal(value), 'percent.rate')}
             yPaddingRatio={0.05}
             renderTooltip={HistoricalRatesTooltip}
           />

--- a/apps/main/src/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip.tsx
+++ b/apps/main/src/llamalend/widgets/tooltips/chart/HistoricalRatesTooltip.tsx
@@ -20,7 +20,7 @@ export const HistoricalRatesTooltip = ({ datum, visibleSeries }: HistoricalRates
           label={activeSeries.label}
           lineColor={activeSeries.color}
           dash={activeSeries.dash}
-          value={formatNumber(datum[activeSeries.key], 'percent.value')}
+          value={formatNumber(datum[activeSeries.key], 'percent.rate')}
         />
       ))}
     </ChartTooltipSeriesGroup>


### PR DESCRIPTION
This obviously doesn't fix the bad data itself, but at least it doesn't mess up the rendering of the page

**Before**
<img width="1065" height="380" alt="image" src="https://github.com/user-attachments/assets/d22aaabf-582a-4dca-b85b-fe859973e26d" />

**After**
<img width="1065" height="372" alt="image" src="https://github.com/user-attachments/assets/0b3db5fd-558a-45de-9cd5-358cf5888df4" />