### PR TITLE
chore: flaky tests

### DIFF
--- a/packages/evm-ui/src/shared/route-redirects.ts
+++ b/packages/evm-ui/src/shared/route-redirects.ts
@@ -47,10 +47,10 @@ const OldRoutes: Record<AppName, string[]> = {
  * This handles the old hash-based routing from react-router. We remove the hash and redirect to the new routes.
  * We also handle old redirects that were hardcoded in react-router.
  */
-export function getHashRedirectUrl({ pathname: path, search: query, hash }: ParsedLocation, networkId: string) {
-  const { host } = window.location // host is not available in the tanstack router location
+export function getHashRedirectUrl({ pathname: path, search: query }: ParsedLocation, networkId: string) {
+  const { host, hash } = window.location // host is not available in the tanstack router location
   const search = new URLSearchParams(query)
-  const hashPath = hash.replace(/^\/?/, '') // note tanstack hash doesn't start with #, but window.location.hash does
+  const hashPath = hash.replace(/^#?\/?/, '') // note tanstack hash doesn't start with #, but window.location.hash does
   const pathname = path.endsWith('/') ? path : `${path}/` // the ending slash is only there in root routes
   const oldApp = oldOrigins.find(app => host.startsWith(app)) || (pathname === '/' && hashPath && 'dex')
   const [, app, network, ...rest] = `${oldApp ? `/${oldApp}` : ''}${pathname}${hashPath}`.split('/')

--- a/packages/evm-ui/src/shared/ui/DataTable/TableFiltersOverlay.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableFiltersOverlay.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, type RefObject } from 'react'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
+import { useSwitch } from '@evm-ui/hooks/useSwitch'
 import { t } from '@evm-ui/lib/i18n'
 import { Cross2Icon } from '@evm-ui/shared/icons/Cross2Icon'
 import { DrawerHeader } from '@evm-ui/shared/ui/SwipeableDrawer/DrawerHeader'
@@ -40,6 +41,7 @@ export const TableFiltersOverlay = ({
   title,
 }: TableFiltersOverlayProps) => {
   const isMobile = useIsMobile()
+  const [isReady, setReady, resetReady] = useSwitch()
   const resetButton = (
     <Button
       color="ghost"
@@ -70,9 +72,11 @@ export const TableFiltersOverlay = ({
           ...{ 'data-testid': 'table-filters-popover-root' },
           sx: { backgroundColor: t => t.design.Layer[3].Fill, width: Width.modal.md },
         },
+        // Keep test IDs until exit completes so tests cannot reopen the popover during its closing transition.
+        transition: { onEntered: setReady, onExited: resetReady },
       }}
     >
-      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} {...testId('table-filters-popover', open)}>
+      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })} {...testId('table-filters-popover', isReady)}>
         <Stack
           direction="row"
           sx={{
@@ -86,7 +90,7 @@ export const TableFiltersOverlay = ({
           <Typography variant="headingXsBold" color="textSecondary" sx={{ paddingBlockEnd: Spacing.xs }}>
             {title}
           </Typography>
-          <IconButton size="extraSmall" onClick={() => setOpen(false)} {...testId('btn-close-filters', open)}>
+          <IconButton size="extraSmall" onClick={() => setOpen(false)} {...testId('btn-close-filters', isReady)}>
             <Cross2Icon />
           </IconButton>
         </Stack>

--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -10,7 +10,7 @@ import { MockLoanTestWrapper } from '@cy/support/helpers/llamalend/MockLoanTestW
 import { createBorrowMoreScenario } from '@cy/support/helpers/llamalend/mocks/borrow-more.mocks'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -63,7 +63,7 @@ const testCases = [
 
 describe('BorrowMoreForm (mocked)', () => {
   beforeEach(() => {
-    resetLlamaTestContext()
+    setupMockedLlamalendComponentTest()
     mockMintSnapshots({ limit: 1 })
   })
 

--- a/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
@@ -10,8 +10,9 @@ import {
   touchCollateralForm,
 } from '@cy/support/helpers/llamalend/collateral.helpers'
 import { oneLoanTestMarket } from '@cy/support/helpers/llamalend/create-loan.helpers'
-import { LlammalendTestCase, setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { LlammalendTestCase } from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import { setupTenderlyLoan } from '@cy/support/helpers/llamalend/loan-setup.helpers'
+import { setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/mock-market.helpers'
 import { createVirtualTestnet } from '@cy/support/helpers/tenderly'
 import { getRpcUrls } from '@cy/support/helpers/tenderly/vnet'
 import { skipTestsAfterFailure } from '@cy/support/ui'

--- a/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/collateral.rpc.cy.tsx
@@ -10,9 +10,8 @@ import {
   touchCollateralForm,
 } from '@cy/support/helpers/llamalend/collateral.helpers'
 import { oneLoanTestMarket } from '@cy/support/helpers/llamalend/create-loan.helpers'
-import { LlammalendTestCase } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { LlammalendTestCase, setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import { setupTenderlyLoan } from '@cy/support/helpers/llamalend/loan-setup.helpers'
-import { blockUnmockedApis } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { createVirtualTestnet } from '@cy/support/helpers/tenderly'
 import { getRpcUrls } from '@cy/support/helpers/tenderly/vnet'
 import { skipTestsAfterFailure } from '@cy/support/ui'
@@ -97,7 +96,7 @@ describe('Collateral forms', () => {
 
         beforeEach(() => {
           onPricesUpdated = cy.stub().as('onPricesUpdated')
-          if (!hasApi) blockUnmockedApis()
+          setupLlammalendTestCaseMocks({ hasApi })
         })
 
         it('adds collateral', () => {

--- a/tests/cypress/component/llamalend/create-loan.cy.tsx
+++ b/tests/cypress/component/llamalend/create-loan.cy.tsx
@@ -10,7 +10,7 @@ import { MockLoanTestWrapper } from '@cy/support/helpers/llamalend/MockLoanTestW
 import { createCreateLoanScenario } from '@cy/support/helpers/llamalend/mocks/create-loan.mocks'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -34,7 +34,7 @@ const testCases = [
 ])
 
 describe('CreateLoanForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(({ approved, hasLeverage, leverageEnabled, title }) => {
     it(title, () => {

--- a/tests/cypress/component/llamalend/liquidation.cy.tsx
+++ b/tests/cypress/component/llamalend/liquidation.cy.tsx
@@ -28,7 +28,7 @@ import {
 } from '@cy/support/helpers/llamalend/soft-liquidation.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -55,7 +55,7 @@ const mountResetPositionForm = ({
 }
 
 describe('Soft Liquidation Forms (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   describe('ImproveHealthForm', () => {
     testCases.forEach(({ approved, title }: { approved: boolean; title: string }) => {

--- a/tests/cypress/component/llamalend/liquidation.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/liquidation.rpc.cy.tsx
@@ -1,11 +1,8 @@
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { DECIMAL_REGEX, DECIMAL_RANGE_REGEX, getActionValue } from '@cy/support/helpers/llamalend/action-info.helpers'
 import { setupLlv2BorrowingLiquidity } from '@cy/support/helpers/llamalend/borrow-cap.helpers'
-import {
-  LlammalendTestCase,
-  setupLlammalendTestCaseMocks,
-  type LlammalendTestCaseProps,
-} from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/mock-market.helpers'
 import { submitRepayForm, writeRepayLoanForm } from '@cy/support/helpers/llamalend/repay-loan.helpers'
 import { setupTenderlySoftLiquidation } from '@cy/support/helpers/llamalend/soft-liq-setup.helpers'
 import {

--- a/tests/cypress/component/llamalend/liquidation.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/liquidation.rpc.cy.tsx
@@ -1,7 +1,11 @@
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { DECIMAL_REGEX, DECIMAL_RANGE_REGEX, getActionValue } from '@cy/support/helpers/llamalend/action-info.helpers'
 import { setupLlv2BorrowingLiquidity } from '@cy/support/helpers/llamalend/borrow-cap.helpers'
-import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import {
+  LlammalendTestCase,
+  setupLlammalendTestCaseMocks,
+  type LlammalendTestCaseProps,
+} from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import { submitRepayForm, writeRepayLoanForm } from '@cy/support/helpers/llamalend/repay-loan.helpers'
 import { setupTenderlySoftLiquidation } from '@cy/support/helpers/llamalend/soft-liq-setup.helpers'
 import {
@@ -90,6 +94,7 @@ describe('Manage liquidation', () => {
   beforeEach(() => {
     resetLlamaTestContext()
     snapshot.revert()
+    setupLlammalendTestCaseMocks()
   })
 
   it('resets the position', () => {

--- a/tests/cypress/component/llamalend/loan.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/loan.rpc.cy.tsx
@@ -17,11 +17,8 @@ import {
   submitCreateLoanForm,
   writeCreateLoanForm,
 } from '@cy/support/helpers/llamalend/create-loan.helpers'
-import {
-  LlammalendTestCase,
-  setupLlammalendTestCaseMocks,
-  type LlammalendTestCaseProps,
-} from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/mock-market.helpers'
 import {
   checkRepayDetailsLoaded,
   selectRepayToken,

--- a/tests/cypress/component/llamalend/loan.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/loan.rpc.cy.tsx
@@ -17,8 +17,11 @@ import {
   submitCreateLoanForm,
   writeCreateLoanForm,
 } from '@cy/support/helpers/llamalend/create-loan.helpers'
-import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
-import { blockUnmockedApis } from '@cy/support/helpers/llamalend/market-list-mocks'
+import {
+  LlammalendTestCase,
+  setupLlammalendTestCaseMocks,
+  type LlammalendTestCaseProps,
+} from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import {
   checkRepayDetailsLoaded,
   selectRepayToken,
@@ -124,7 +127,7 @@ testCases.forEach(
         fundErc20({ adminRpcUrl, amountWei: CREATE_LOAN_FUND_AMOUNT, tokenAddress, recipientAddresses: [address] })
         cy.log(`Funded some eth and collateral to ${address} in vnet ${vnet.slug}`)
 
-        if (!HAS_API) blockUnmockedApis()
+        setupLlammalendTestCaseMocks({ hasApi: HAS_API })
       })
 
       const LoanTestWrapper = ({ tab }: Pick<LlammalendTestCaseProps, 'tab'>) => (

--- a/tests/cypress/component/llamalend/repay.cy.tsx
+++ b/tests/cypress/component/llamalend/repay.cy.tsx
@@ -12,7 +12,7 @@ import {
 } from '@cy/support/helpers/llamalend/repay-loan.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -38,7 +38,7 @@ const testCases = [
 ])
 
 describe('RepayForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(({ approved, leverage, repayToken, title }) => {
     it(title, () => {

--- a/tests/cypress/component/llamalend/supply-claim.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-claim.cy.tsx
@@ -11,7 +11,7 @@ import {
 import { createClaimScenario } from '@cy/support/helpers/llamalend/supply/supply-test-scenarios.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -35,7 +35,7 @@ const testCases: {
 ]
 
 describe('ClaimTab (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(({ title, claimableCrv, claimableRewards }) => {
     it(`shows ${title} state`, () => {

--- a/tests/cypress/component/llamalend/supply-deposit.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-deposit.cy.tsx
@@ -13,7 +13,7 @@ import { createDepositScenario } from '@cy/support/helpers/llamalend/supply/supp
 import { checkSupplyActionInfoValues } from '@cy/support/helpers/llamalend/supply/supply.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -43,7 +43,7 @@ const testCases: {
 ]
 
 describe('DepositForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(
     ({

--- a/tests/cypress/component/llamalend/supply-stake.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-stake.cy.tsx
@@ -11,7 +11,7 @@ import { createStakeScenario } from '@cy/support/helpers/llamalend/supply/supply
 import { checkSupplyActionInfoValues } from '@cy/support/helpers/llamalend/supply/supply.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -25,7 +25,7 @@ const testCases: { approved: boolean; title: string; buttonText: string; hasGaug
 ]
 
 describe('StakeForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(({ approved, title, buttonText, hasGauge }) => {
     it(title, () => {

--- a/tests/cypress/component/llamalend/supply-unstake.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-unstake.cy.tsx
@@ -13,7 +13,7 @@ import {
 } from '@cy/support/helpers/llamalend/supply/unstake.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -22,7 +22,7 @@ import { Chain } from '@evm-ui/utils'
 const chainId = Chain.Ethereum
 
 describe('UnstakeForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   it('fills and submits', () => {
     const { input, market, llamaApi, expected, stubs } = createUnstakeScenario({ chainId })

--- a/tests/cypress/component/llamalend/supply-withdraw.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-withdraw.cy.tsx
@@ -9,7 +9,7 @@ import {
 import { submitWithdrawForm, writeWithdrawForm } from '@cy/support/helpers/llamalend/supply/withdraw.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -22,7 +22,7 @@ const testCases = [
 ]
 
 describe('WithdrawForm (mocked)', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   testCases.forEach(({ isFull, title, buttonText }) => {
     it(title, () => {

--- a/tests/cypress/component/llamalend/supply.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/supply.rpc.cy.tsx
@@ -1,11 +1,8 @@
 import { BigNumber } from 'bignumber.js'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { oneBool, oneOf } from '@cy/support/generators'
-import {
-  LlammalendTestCase,
-  setupLlammalendTestCaseMocks,
-  type LlammalendTestCaseProps,
-} from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
+import { setupLlammalendTestCaseMocks } from '@cy/support/helpers/llamalend/mock-market.helpers'
 import {
   checkClaimDetailsLoaded,
   prepareClaimRewards,

--- a/tests/cypress/component/llamalend/supply.rpc.cy.tsx
+++ b/tests/cypress/component/llamalend/supply.rpc.cy.tsx
@@ -1,8 +1,11 @@
 import { BigNumber } from 'bignumber.js'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { oneBool, oneOf } from '@cy/support/generators'
-import { LlammalendTestCase, type LlammalendTestCaseProps } from '@cy/support/helpers/llamalend/LlammalendTestCase'
-import { blockUnmockedApis } from '@cy/support/helpers/llamalend/market-list-mocks'
+import {
+  LlammalendTestCase,
+  setupLlammalendTestCaseMocks,
+  type LlammalendTestCaseProps,
+} from '@cy/support/helpers/llamalend/LlammalendTestCase'
 import {
   checkClaimDetailsLoaded,
   prepareClaimRewards,
@@ -96,7 +99,7 @@ testCases.forEach(
       })
 
       beforeEach(() => {
-        if (!hasApi) blockUnmockedApis()
+        setupLlammalendTestCaseMocks({ hasApi })
       })
 
       it('deposits into the vault', () => {

--- a/tests/cypress/component/llamalend/zap-v2-calldata-size.cy.tsx
+++ b/tests/cypress/component/llamalend/zap-v2-calldata-size.cy.tsx
@@ -13,7 +13,7 @@ import { createRepayScenario } from '@cy/support/helpers/llamalend/mocks/repay.m
 import { selectRepayToken, writeRepayLoanForm } from '@cy/support/helpers/llamalend/repay-loan.helpers'
 import {
   llamaNetworks,
-  resetLlamaTestContext,
+  setupMockedLlamalendComponentTest,
   setGasInfo,
   setLlamaApi,
 } from '@cy/support/helpers/llamalend/test-context.helpers'
@@ -32,7 +32,7 @@ const checkOversizedCalldataBlocked = (submitButtonTestId: string) => {
 }
 
 describe('ZapV2 router calldata size', () => {
-  beforeEach(resetLlamaTestContext)
+  beforeEach(setupMockedLlamalendComponentTest)
 
   it('accepts calldata at the size limit', () => {
     const { llamaApi, market, borrow, collateral } = createCreateLoanScenario({

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -332,7 +332,7 @@ describe('DEX Pools', () => {
     visitAndWait(width, height, { network: 'ethereum' })
     const filter = DEX_POOL_LIST_SEARCH
     cy.get('[data-testid="table-text-search-dex-pool-list"] input').type(filter)
-    cy.url().should('include', `?search=${filter}`)
+    cy.url(API_LOAD_TIMEOUT).should('include', `?search=${filter}`)
     cy.wait('@dex-pools', API_LOAD_TIMEOUT)
     const getMatchedPoolRow = () =>
       cy.contains('[data-testid^="data-table-row-"]', filter, API_LOAD_TIMEOUT).should('be.visible')
@@ -352,7 +352,7 @@ describe('DEX Pools', () => {
     }
     cy.get('[data-testid="pool-form-tab-deposit"]', API_LOAD_TIMEOUT).should('be.visible')
     cy.window().then(win => win.history.go(-1))
-    cy.url().should('include', `?search=${filter}`)
+    cy.url(API_LOAD_TIMEOUT).should('include', `?search=${filter}`)
   })
 
   it('keeps search-only state out of active filter chips and empty reset clears search', () => {

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -114,7 +114,6 @@ describe('DEX Pools', () => {
       cy.get('body').click(0, 0)
     } else {
       cy.get('[data-testid="btn-close-filters"]').click()
-      cy.get('[data-testid="table-filters-popover-root"]').should('not.exist')
     }
   }
 

--- a/tests/cypress/e2e/lend/basic.cy.ts
+++ b/tests/cypress/e2e/lend/basic.cy.ts
@@ -4,6 +4,7 @@ import {
   shouldLoadLendVaultDetails,
 } from '@cy/support/helpers/llamalend/market-details.helpers'
 import { blockUnmockedApis } from '@cy/support/helpers/llamalend/market-list-mocks'
+import { mockLlamalendChartApis } from '@cy/support/helpers/llamalend/mocks/llamalend-chart.mocks'
 import { LOAD_TIMEOUT, oneViewport } from '@cy/support/ui'
 
 const LEND_MARKET = '0x23F5a668A9590130940eF55964ead9787976f2CC'
@@ -14,6 +15,7 @@ describe('Lend app', () => {
   beforeEach(() => {
     mockLendingSnapshots('ethereum')
     mockMerklCampaigns()
+    mockLlamalendChartApis()
     cy.viewport(WIDTH, HEIGHT)
   })
 

--- a/tests/cypress/e2e/loan/basic.cy.ts
+++ b/tests/cypress/e2e/loan/basic.cy.ts
@@ -1,6 +1,7 @@
 import { mockMerklCampaigns } from '@cy/support/helpers/lending-mocks'
 import { shouldLoadMintBorrowDetails } from '@cy/support/helpers/llamalend/market-details.helpers'
 import { blockUnmockedApis } from '@cy/support/helpers/llamalend/market-list-mocks'
+import { mockLlamalendChartApis } from '@cy/support/helpers/llamalend/mocks/llamalend-chart.mocks'
 import { LOAD_TIMEOUT, oneViewport } from '@cy/support/ui'
 
 const MINT_MARKET = 'WBTC'
@@ -10,6 +11,7 @@ const [WIDTH, HEIGHT, BREAKPOINT] = oneViewport()
 describe('Mint app', () => {
   beforeEach(() => {
     mockMerklCampaigns()
+    mockLlamalendChartApis()
     cy.viewport(WIDTH, HEIGHT)
   })
 

--- a/tests/cypress/support/helpers/data-table.helpers.ts
+++ b/tests/cypress/support/helpers/data-table.helpers.ts
@@ -1,4 +1,4 @@
-import { Breakpoint } from '@cy/support/ui'
+import { Breakpoint, LOAD_TIMEOUT } from '@cy/support/ui'
 
 /**
  * Makes sure that the filter chips are visible during the given callback.
@@ -60,13 +60,14 @@ export function closeDrawer(breakpoint: Breakpoint) {
 export function withFilters<T>(breakpoint: Breakpoint, callback: () => Cypress.Chainable<T>) {
   cy.get(`[data-testid="btn-open-filters"]`).click({ waitForAnimations: true })
   if (breakpoint !== 'mobile') {
-    cy.get('[data-testid="table-filters-popover"]').should('be.visible')
+    cy.get('[data-testid="table-filters-popover"]', LOAD_TIMEOUT).should('be.visible')
   }
   return callback().then(result => {
     if (breakpoint === 'mobile') {
       closeDrawer(breakpoint)
     } else {
       cy.get('[data-testid="btn-close-filters"]').click({ waitForAnimations: true })
+      cy.get('[data-testid="table-filters-popover"]', LOAD_TIMEOUT).should('not.exist')
       cy.get('[data-testid="table-filters-popover-root"]').should('not.exist')
     }
     return cy.wrap(result)

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -20,7 +20,6 @@ import { ChainId as MintChain } from '@/loan/types/loan.types'
 import { Loading } from '@/routes/Loading'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
-import { blockUnmockedApis, mockNewHashCollateralEvents } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { fakeCollateralEvents } from '@cy/support/helpers/llamalend/mock-loan-test-data'
 import { llamaNetworks } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createTenderlyWagmiConfigFromVNet } from '@cy/support/helpers/tenderly'
@@ -106,9 +105,6 @@ function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: Ll
 }
 
 export type LlammalendTestCaseProps = LlammalendTestProps & TenderlyWagmiConfigFromVNet
-
-export const setupLlammalendTestCaseMocks = ({ hasApi = true }: { hasApi?: boolean } = {}) =>
-  hasApi ? mockNewHashCollateralEvents() : blockUnmockedApis()
 
 export const LlammalendTestCase = ({ vnet, privateKey, chainId, marketType, ...props }: LlammalendTestCaseProps) => (
   <ComponentTestWrapper config={createTenderlyWagmiConfigFromVNet({ vnet, privateKey })} autoConnect>

--- a/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
+++ b/tests/cypress/support/helpers/llamalend/LlammalendTestCase.tsx
@@ -20,6 +20,7 @@ import { ChainId as MintChain } from '@/loan/types/loan.types'
 import { Loading } from '@/routes/Loading'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import { ComponentTestWrapper } from '@cy/support/helpers/ComponentTestWrapper'
+import { blockUnmockedApis, mockNewHashCollateralEvents } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { fakeCollateralEvents } from '@cy/support/helpers/llamalend/mock-loan-test-data'
 import { llamaNetworks } from '@cy/support/helpers/llamalend/test-context.helpers'
 import { createTenderlyWagmiConfigFromVNet } from '@cy/support/helpers/tenderly'
@@ -105,6 +106,9 @@ function LlammalendTest({ tab, onPricesUpdated, type, marketType, ...props }: Ll
 }
 
 export type LlammalendTestCaseProps = LlammalendTestProps & TenderlyWagmiConfigFromVNet
+
+export const setupLlammalendTestCaseMocks = ({ hasApi = true }: { hasApi?: boolean } = {}) =>
+  hasApi ? mockNewHashCollateralEvents() : blockUnmockedApis()
 
 export const LlammalendTestCase = ({ vnet, privateKey, chainId, marketType, ...props }: LlammalendTestCaseProps) => (
   <ComponentTestWrapper config={createTenderlyWagmiConfigFromVNet({ vnet, privateKey })} autoConnect>

--- a/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/create-loan.helpers.ts
@@ -225,6 +225,7 @@ export const checkLoanRangeSlider = () => {
 }
 
 export function submitLoanForm({ form, message }: { form: string; message: string }) {
+  cy.get('[data-testid="toast-success"]', LOAD_TIMEOUT).should('not.exist') // wait previous confirmations are gone
   cy.get(`[data-testid="${form}-submit-button"]`).click(LOAD_TIMEOUT)
   cy.get('[data-testid="toast-success"]', TRANSACTION_LOAD_TIMEOUT).contains(message, TRANSACTION_LOAD_TIMEOUT)
   return cy.get('[data-testid="loan-form-errors"]').should('not.exist')

--- a/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
@@ -5,6 +5,7 @@ import {
   mockLendingVaults,
   mockMerklCampaigns,
 } from '@cy/support/helpers/lending-mocks'
+import { mockLlamalendChartApis } from '@cy/support/helpers/llamalend/mocks/llamalend-chart.mocks'
 import { mockMintMarkets, mockMintSnapshots } from '../minting-mocks'
 import { mockTokenPrices } from '../tokens'
 
@@ -63,11 +64,44 @@ const mockEmptyCrvUsdAmms = () =>
     { body: { success: true, data: { amms: [], totalVolume: 0 }, generatedTimeMs: Date.now() } },
   )
 
+/**
+ * During component tests, the backend can take a long time to reply when we send a new_hash.
+ * The transactions do not exist in the backend anyway, since we are in a fork, so we mock an empty response.
+ */
+export const mockNewHashCollateralEvents = () => {
+  cy.intercept(
+    { method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/collateral_events\/.+/, query: { new_hash: /.+/ } },
+    req => {
+      const [, , endpoint, , chain, controller, user] = new URL(req.url).pathname.split('/')
+      const body = {
+        chain,
+        controller,
+        user,
+        total_deposit: 0,
+        total_deposit_from_user: 0,
+        total_borrowed: 0,
+        total_deposit_precise: '0',
+        total_borrowed_precise: '0',
+        total_deposit_from_user_precise: '0',
+        total_deposit_from_user_usd_value: 0,
+        total_deposit_usd_value: 0,
+        ...(endpoint === 'lending' && { total_borrowed_usd_value: 0 }),
+        count: 0,
+        pagination: null,
+        page: null,
+        data: [],
+      }
+      req.reply({ body })
+    },
+  )
+}
+
 export function setupLlamalendListMocks(vaultData = createLendingVaultChainsResponse()) {
   blockUnmockedApis()
   mockEmptyMarketUserData()
   mockEmptyMarketBadDebt()
   mockEmptyCrvUsdAmms()
+  mockLlamalendChartApis()
   mockTokenPrices()
   const lendingVaults = mockLendingVaults(vaultData)
   mockLendingSnapshots().as('lend-snapshots')

--- a/tests/cypress/support/helpers/llamalend/mock-loan-test-data.ts
+++ b/tests/cypress/support/helpers/llamalend/mock-loan-test-data.ts
@@ -4,7 +4,7 @@ import type { UserCollateralEvents } from '@/llamalend/features/user-position-hi
 export const TEST_PRIVATE_KEY = generatePrivateKey()
 export const TEST_ACCOUNT = privateKeyToAccount(TEST_PRIVATE_KEY)
 export const TEST_ADDRESS = TEST_ACCOUNT.address
-// Real mined Ethereum mainnet transaction hash used to avoid any RPC mocking in component tests.
+// Deterministic transaction hash with a mocked receipt in mocked LlamaLend component tests.
 export const TEST_TX_HASH: `0x${string}` = '0xb664cb54f72491d8f459bb2a0db0bf074b30fa0fb1179a989ff4e1932291a69d'
 
 export const createMockLlamaApi = (chainId: number, mockMarket: unknown) => ({

--- a/tests/cypress/support/helpers/llamalend/mock-market.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/mock-market.helpers.ts
@@ -3,6 +3,7 @@ import { DEPRECATED_LLAMAS, MARKETS_ALERTS, MARKETS_LEVERAGE_CONFIG } from '@/ll
 import { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
 import { oneAddress, oneDecimal, oneOf } from '@cy/support/generators'
+import { blockUnmockedApis, mockNewHashCollateralEvents } from '@cy/support/helpers/llamalend/market-list-mocks'
 import { Chain, CRVUSD_ADDRESS, MAINNET_CRV_ADDRESS } from '@evm-ui/utils'
 import { recordEntries } from '@primitives/objects.utils'
 
@@ -171,3 +172,6 @@ export const createMockLendMarket = (overrides?: object) =>
     vault: createMockLendVault(),
     ...overrides,
   }) as LendMarketTemplate
+
+export const setupLlammalendTestCaseMocks = ({ hasApi = true }: { hasApi?: boolean } = {}) =>
+  hasApi ? mockNewHashCollateralEvents() : blockUnmockedApis()

--- a/tests/cypress/support/helpers/llamalend/mocks/borrow-more.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/borrow-more.mocks.ts
@@ -4,7 +4,7 @@ import { oneDecimal, oneInt } from '@cy/support/generators'
 import { decimalSum } from '@evm-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { createMockLlamaApi, TEST_TX_HASH } from '../mock-loan-test-data'
-import { createIsApprovedStub, createStub, createSyncStub } from '../test-stub.utils'
+import { createIsApprovedStub, createStub, createSyncStub, createTransactionStub } from '../test-stub.utils'
 import {
   createBorrowMoreMintMarket,
   createMockLendLoanMarket,
@@ -38,8 +38,8 @@ export const createBorrowMoreScenario = ({
   const expectedCurrentDebt = oneDecimal(10, 200, 2)
   const expectedFutureDebt = decimalSum(expectedCurrentDebt, borrow)
 
-  const borrowMoreApprove = createStub(TEST_TX_HASH)
-  const borrowMoreLeverageApprove = createStub(TEST_TX_HASH)
+  const borrowMoreApprove = createTransactionStub(TEST_TX_HASH)
+  const borrowMoreLeverageApprove = createTransactionStub(TEST_TX_HASH)
   const normalStubs = {
     parameters: createStub(oneRatePair()),
     estimateGasBorrowMore: createStub(oneInt(120_000, 240_000)),
@@ -47,7 +47,7 @@ export const createBorrowMoreScenario = ({
     borrowMoreHealth: createStub(oneDecimal(10, 65, 2)),
     borrowMoreMaxRecv: createStub(oneDecimal(100, 900, 2)),
     borrowMoreIsApproved: approved ? createStub(true) : createIsApprovedStub(borrowMoreApprove),
-    borrowMore: createStub(TEST_TX_HASH),
+    borrowMore: createTransactionStub(TEST_TX_HASH),
     borrowMoreApprove,
     borrowMorePrices: createStub([oneDecimal(2500, 4200, 2), oneDecimal(2200, 3900, 2)]),
     borrowMoreExpectedCollateral: createStub(leverageMetrics()),
@@ -75,7 +75,7 @@ export const createBorrowMoreScenario = ({
       avgPrice: oneDecimal(900, 2300, 2),
     }),
     borrowMoreIsApproved: approved ? createStub(true) : createIsApprovedStub(borrowMoreLeverageApprove),
-    borrowMore: createStub(TEST_TX_HASH),
+    borrowMore: createTransactionStub(TEST_TX_HASH),
     borrowMoreApprove: borrowMoreLeverageApprove,
     borrowMoreExpectedCollateral: createStub(leverageMetrics()),
     borrowMoreFutureLeverage: createStub(oneDecimal(1.1, 6, 2)),

--- a/tests/cypress/support/helpers/llamalend/mocks/create-loan.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/create-loan.mocks.ts
@@ -5,7 +5,7 @@ import { oneAddress, oneDecimal, oneFloat, oneInt } from '@cy/support/generators
 import { decimal } from '@evm-ui/utils'
 import { createMockLlamaApi, TEST_TX_HASH } from '../mock-loan-test-data'
 import { createMockMintMarket } from '../mock-market.helpers'
-import { createIsApprovedStub, createStub, createSyncStub } from '../test-stub.utils'
+import { createIsApprovedStub, createStub, createSyncStub, createTransactionStub } from '../test-stub.utils'
 import {
   DEFAULT_COLLATERAL_ADDRESS,
   DEFAULT_USER_BORROWED,
@@ -49,7 +49,7 @@ export const createCreateLoanScenario = ({
     createLoanMaxRecv: createStub(decimal(new BigNumber(borrow).plus(oneFloat(10, 400)).decimalPlaces(2))!),
     createLoanIsApproved: approved ? createStub(true) : createIsApprovedStub(createLoanApprove),
     estimateGasCreateLoan: createStub(`${oneInt(80_000, 220_000)}`),
-    createLoan: createStub(TEST_TX_HASH),
+    createLoan: createTransactionStub(TEST_TX_HASH),
     createLoanApprove,
     estimateGasCreateLoanApprove: createStub(`${oneInt(70_000, 200_000)}`),
     createLoanExpectedCollateral: createStub(leverageMetrics()),
@@ -75,7 +75,7 @@ export const createCreateLoanScenario = ({
     }),
     createLoanIsApproved: approved ? createStub(true) : createIsApprovedStub(createLoanLeverageApprove),
     estimateGasCreateLoan: createStub(`${oneInt(80_000, 220_000)}`),
-    createLoan: createStub(TEST_TX_HASH),
+    createLoan: createTransactionStub(TEST_TX_HASH),
     createLoanApprove: createLoanLeverageApprove,
     estimateGasCreateLoanApprove: createStub(`${oneInt(70_000, 200_000)}`),
     createLoanExpectedCollateral: createStub(leverageMetrics()),

--- a/tests/cypress/support/helpers/llamalend/mocks/create-loan.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/create-loan.mocks.ts
@@ -36,8 +36,8 @@ export const createCreateLoanScenario = ({
   const borrow = oneDecimal(5, 140, 2)
   const collateralAddress = DEFAULT_COLLATERAL_ADDRESS
   const lowPrice = oneDecimal(900, 2300, 2)
-  const createLoanApprove = createStub(TEST_TX_HASH)
-  const createLoanLeverageApprove = createStub(TEST_TX_HASH)
+  const createLoanApprove = createTransactionStub(TEST_TX_HASH)
+  const createLoanLeverageApprove = createTransactionStub(TEST_TX_HASH)
   const maxLeverage = oneDecimal(1.5, 10, 2)
 
   const normalStubs = {

--- a/tests/cypress/support/helpers/llamalend/mocks/llamalend-chart.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/llamalend-chart.mocks.ts
@@ -1,0 +1,64 @@
+import { oneAddress, oneDate, oneFloat, oneInt, onePrice } from '@cy/support/generators'
+import { oneToken } from '@cy/support/helpers/tokens'
+import { range } from '@primitives/objects.utils'
+
+const DAY = 24 * 60 * 60 * 1000
+const MIN_OHLC_POINTS = 36
+const MAX_OHLC_POINTS = 72
+
+const createOhlcData = () => {
+  const pointCount = oneInt(MIN_OHLC_POINTS, MAX_OHLC_POINTS)
+  const start = oneDate({
+    minDate: new Date(Date.now() - 30 * DAY),
+    maxDate: new Date(Date.now() - 2 * DAY),
+  }).getTime()
+  const interval = oneInt(30 * 60 * 1000, 2 * 60 * 60 * 1000)
+
+  return range(pointCount).map(index => {
+    const basePrice = Math.max(onePrice(5_000), 0.01)
+    const open = basePrice + oneFloat(0, basePrice * 0.02)
+    const close = basePrice + oneFloat(0, basePrice * 0.02)
+    const spread = oneFloat(0, basePrice * 0.01)
+
+    return {
+      time: new Date(start + index * interval).toISOString(),
+      open,
+      close,
+      high: Math.max(open, close) + spread,
+      low: Math.max(Math.min(open, close) - spread, 0),
+      base_price: basePrice,
+      oracle_price: basePrice + oneFloat(0, basePrice * 0.02),
+      volume: oneFloat(0, 1_000_000),
+    }
+  })
+}
+
+const createOraclePriceSourcePool = (chain: string) => {
+  const { address: borrowed_address, symbol: borrowed_symbol } = oneToken(chain)
+  const { address: collateral_address, symbol: collateral_symbol } = oneToken(chain)
+  return {
+    address: oneAddress(),
+    borrowed_ix: oneInt(0, 4),
+    borrowed_symbol,
+    borrowed_address,
+    collateral_ix: oneInt(0, 4),
+    collateral_symbol,
+    collateral_address,
+  }
+}
+
+/**
+ * The chart APIs can take a long time to load when running e2e tests, mock them so we test the frontend and avoid flakyness.
+ */
+export const mockLlamalendChartApis = () => {
+  cy.intercept(
+    { method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/llamma_ohlc\/.+/ },
+    { body: { data: createOhlcData() } },
+  )
+  cy.intercept({ method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/oracle_ohlc\/.+/ }, req => {
+    const [, , , , chain, controller] = new URL(req.url).pathname.split('/')
+    const price_source_pools = [createOraclePriceSourcePool(chain)]
+    const body = { chain, controller, oracle: oneAddress(), price_source_pools, data: createOhlcData() }
+    req.reply({ body })
+  })
+}

--- a/tests/cypress/support/helpers/llamalend/mocks/llamalend-chart.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/llamalend-chart.mocks.ts
@@ -1,18 +1,29 @@
-import { oneAddress, oneDate, oneFloat, oneInt, onePrice } from '@cy/support/generators'
+import { oneAddress, oneFloat, oneInt, onePrice } from '@cy/support/generators'
 import { oneToken } from '@cy/support/helpers/tokens'
 import { range } from '@primitives/objects.utils'
 
-const DAY = 24 * 60 * 60 * 1000
-const MIN_OHLC_POINTS = 36
-const MAX_OHLC_POINTS = 72
+const MAX_OHLC_POINTS = 240
+const AGG_UNIT_SECONDS = {
+  minute: 60,
+  hour: 60 * 60,
+  day: 24 * 60 * 60,
+  week: 7 * 24 * 60 * 60,
+  month: 30 * 24 * 60 * 60,
+} as const
 
-const createOhlcData = () => {
-  const pointCount = oneInt(MIN_OHLC_POINTS, MAX_OHLC_POINTS)
-  const start = oneDate({
-    minDate: new Date(Date.now() - 30 * DAY),
-    maxDate: new Date(Date.now() - 2 * DAY),
-  }).getTime()
-  const interval = oneInt(30 * 60 * 1000, 2 * 60 * 60 * 1000)
+const getOhlcTimeRange = (params: URLSearchParams) => {
+  const end = Number(params.get('end'))
+  const start = Number(params.get('start'))
+  const aggNumber = Number(params.get('agg_number'))
+  const aggUnitSeconds = AGG_UNIT_SECONDS[params.get('agg_units') as keyof typeof AGG_UNIT_SECONDS]
+  const interval = Math.max(1, aggNumber * aggUnitSeconds)
+  const pointCount = Math.min(MAX_OHLC_POINTS, Math.max(2, Math.floor((end - start) / interval)))
+
+  return { pointCount, start, interval }
+}
+
+const createOhlcData = (params: URLSearchParams) => {
+  const { pointCount, start, interval } = getOhlcTimeRange(params)
 
   return range(pointCount).map(index => {
     const basePrice = Math.max(onePrice(5_000), 0.01)
@@ -21,7 +32,7 @@ const createOhlcData = () => {
     const spread = oneFloat(0, basePrice * 0.01)
 
     return {
-      time: new Date(start + index * interval).toISOString(),
+      time: start + index * interval,
       open,
       close,
       high: Math.max(open, close) + spread,
@@ -51,14 +62,15 @@ const createOraclePriceSourcePool = (chain: string) => {
  * The chart APIs can take a long time to load when running e2e tests, mock them so we test the frontend and avoid flakyness.
  */
 export const mockLlamalendChartApis = () => {
-  cy.intercept(
-    { method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/llamma_ohlc\/.+/ },
-    { body: { data: createOhlcData() } },
-  )
+  cy.intercept({ method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/llamma_ohlc\/.+/ }, req => {
+    const { searchParams } = new URL(req.url)
+    req.reply({ body: { data: createOhlcData(searchParams) } })
+  })
   cy.intercept({ method: 'GET', pathname: /^\/v1\/(crvusd|lending)\/oracle_ohlc\/.+/ }, req => {
-    const [, , , , chain, controller] = new URL(req.url).pathname.split('/')
+    const { pathname, searchParams } = new URL(req.url)
+    const [, , , , chain, controller] = pathname.split('/')
     const price_source_pools = [createOraclePriceSourcePool(chain)]
-    const body = { chain, controller, oracle: oneAddress(), price_source_pools, data: createOhlcData() }
+    const body = { chain, controller, oracle: oneAddress(), price_source_pools, data: createOhlcData(searchParams) }
     req.reply({ body })
   })
 }

--- a/tests/cypress/support/helpers/llamalend/mocks/repay.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/repay.mocks.ts
@@ -37,8 +37,8 @@ export const createRepayScenario = ({
     ...expectedBorrowedMetrics(),
     totalBorrowed: oneDecimal(0.1, Math.max(0.2, Number(currentDebt) - 0.1), 2),
   }
-  const repayApproveStub = createStub(TEST_TX_HASH)
-  const repayLeverageApproveStub = createStub(TEST_TX_HASH)
+  const repayApproveStub = createTransactionStub(TEST_TX_HASH)
+  const repayLeverageApproveStub = createTransactionStub(TEST_TX_HASH)
   const estimateGasRepayApproveStub = createStub(oneInt(90_000, 180_000))
 
   const normalStubs = {

--- a/tests/cypress/support/helpers/llamalend/mocks/repay.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/repay.mocks.ts
@@ -4,7 +4,7 @@ import { oneDecimal, oneInt } from '@cy/support/generators'
 import { decimalMinus, decimalSum } from '@evm-ui/utils'
 import { createMockLlamaApi, TEST_ADDRESS, TEST_TX_HASH } from '../mock-loan-test-data'
 import { createMockMintMarket } from '../mock-market.helpers'
-import { createIsApprovedStub, createStub, createSyncStub } from '../test-stub.utils'
+import { createIsApprovedStub, createStub, createSyncStub, createTransactionStub } from '../test-stub.utils'
 import {
   createMockLendLoanMarket,
   DEFAULT_COLLATERAL_ADDRESS,
@@ -49,7 +49,7 @@ export const createRepayScenario = ({
     repayPrices: createStub([oneDecimal(2500, 4200, 2), oneDecimal(2200, 3900, 2)]),
     repayIsApproved: approved ? createStub(true) : createIsApprovedStub(repayApproveStub),
     repayApprove: repayApproveStub,
-    repay: createStub(TEST_TX_HASH),
+    repay: createTransactionStub(TEST_TX_HASH),
     repayExpectedBorrowed: createStub(expectedBorrowed),
     repayFutureLeverage: createStub(oneDecimal(1.1, 6, 2)),
     repayPriceImpact: createStub(oneDecimal(0.01, 1, 3)),
@@ -67,7 +67,7 @@ export const createRepayScenario = ({
     repayIsAvailable: createStub(true),
     repayIsFull: createStub(false),
     repayApprove: repayLeverageApproveStub,
-    repay: createStub(TEST_TX_HASH),
+    repay: createTransactionStub(TEST_TX_HASH),
     repayExpectedBorrowed: createStub(expectedBorrowed),
     repayFutureLeverage: createStub(oneDecimal(1.1, 6, 2)),
     calcMinRecv: createSyncStub(ROUTE_MIN_RECV),

--- a/tests/cypress/support/helpers/llamalend/mocks/soft-liquidation.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/soft-liquidation.mocks.ts
@@ -20,8 +20,8 @@ export const createSoftLiquidationScenario = ({ chainId, approved }: { chainId: 
   const stateBorrowed = oneDecimal(0.2, 8, 2)
   const debt = decimalSum(borrow, oneDecimal(0.5, 40, 2))
   const slippage = DEFAULT_LEVERAGE_SLIPPAGE
-  const repayApproveStub = createStub(TEST_TX_HASH)
-  const selfLiquidateApproveStub = createStub(TEST_TX_HASH)
+  const repayApproveStub = createTransactionStub(TEST_TX_HASH)
+  const selfLiquidateApproveStub = createTransactionStub(TEST_TX_HASH)
   const estimateGasRepayApproveStub = createStub(oneInt(90_000, 180_000))
 
   const stubs = {
@@ -120,7 +120,7 @@ export const createResetPositionScenario = ({
   const collateral = '10' as const
   const debt = '10000' as const
   const fullRepayUserBorrowed = decimalMinus(debt, convertedBorrowed)
-  const repayApproveStub = createStub(TEST_TX_HASH)
+  const repayApproveStub = createTransactionStub(TEST_TX_HASH)
   const getDebtReduction = (walletBorrowed: Decimal) => decimalSum(convertedBorrowed, walletBorrowed)
   const getFutureDebt = (walletBorrowed: Decimal) => decimalMinus(debt, decimalSum(convertedBorrowed, walletBorrowed))
   const getExpected = (walletBorrowed: Decimal) => {

--- a/tests/cypress/support/helpers/llamalend/mocks/soft-liquidation.mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/mocks/soft-liquidation.mocks.ts
@@ -4,7 +4,7 @@ import { decimal, decimalMinus, decimalSum, formatToken } from '@evm-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { createMockLlamaApi, TEST_ADDRESS, TEST_TX_HASH } from '../mock-loan-test-data'
 import { createMockLendMarket, createMockMintMarket } from '../mock-market.helpers'
-import { createIsApprovedStub, createStub } from '../test-stub.utils'
+import { createIsApprovedStub, createStub, createTransactionStub } from '../test-stub.utils'
 import {
   DEFAULT_COLLATERAL_ADDRESS,
   DEFAULT_LEVERAGE_SLIPPAGE,
@@ -34,10 +34,10 @@ export const createSoftLiquidationScenario = ({ chainId, approved }: { chainId: 
     repayPrices: createStub([oneDecimal(2500, 4200, 2), oneDecimal(2200, 3900, 2)]),
     repayIsApproved: approved ? createStub(true) : createIsApprovedStub(repayApproveStub),
     repayApprove: repayApproveStub,
-    repay: createStub(TEST_TX_HASH),
+    repay: createTransactionStub(TEST_TX_HASH),
     selfLiquidateIsApproved: approved ? createStub(true) : createIsApprovedStub(selfLiquidateApproveStub),
     selfLiquidateApprove: selfLiquidateApproveStub,
-    selfLiquidate: createStub(TEST_TX_HASH),
+    selfLiquidate: createTransactionStub(TEST_TX_HASH),
     walletBalances: createStub({
       // Ensure wallet stablecoin balance is always enough to close the position
       // canClose requires: borrowed >= (debt - stablecoin) * 1.0001
@@ -153,7 +153,7 @@ export const createResetPositionScenario = ({
     repayPrices: createStub([oneDecimal(2500, 4200, 2), oneDecimal(2200, 3900, 2)]),
     repayIsApproved: approved ? createStub(true) : createIsApprovedStub(repayApproveStub),
     repayApprove: repayApproveStub,
-    repay: createStub(TEST_TX_HASH),
+    repay: createTransactionStub(TEST_TX_HASH),
     loanExists: createStub(true),
     userState: createStub({ collateral, borrowed: convertedBorrowed, debt, N: 10 }),
     userHealth: createStub(oneDecimal(20, 70, 2)),

--- a/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/supply/supply-test-scenarios.helpers.ts
@@ -12,7 +12,7 @@ import {
   type MockLendVault,
 } from '../mock-market.helpers'
 import { seedErc20BalanceForAddresses, seedLendMarketSolvencyQueries } from '../query-cache.helpers'
-import { createIsApprovedStub, createStub, type TestStub } from '../test-stub.utils'
+import { createIsApprovedStub, createStub, createTransactionStub, type TestStub } from '../test-stub.utils'
 
 const seedSupplyMarketBalances = ({
   chainId,
@@ -170,13 +170,13 @@ export const createDepositScenario = ({
   } as const
   const currentApy = '0.0456'
   const futureApy = '0.0412'
-  const depositApprove = createStub([TEST_TX_HASH])
+  const depositApprove = createTransactionStub([TEST_TX_HASH])
   const depositIsApproved = approved ? createStub(true) : createIsApprovedStub(depositApprove)
   const maxDepositStub = createStub(input.maxDeposit)
   const previewDeposit = createStub(input.amount)
   const estimateGasDeposit = createStub(`${150_000}`)
   const estimateGasDepositApprove = createStub(`${95_000}`)
-  const deposit = createStub(TEST_TX_HASH)
+  const deposit = createTransactionStub(TEST_TX_HASH)
   const vaultShares = decimalSum(balances.vaultShares, balances.gauge)
 
   const { market, sharedStubs } = createBaseSupplyMarket({
@@ -258,11 +258,11 @@ export const createStakeScenario = ({
   } as const
   const currentApy = '0.0375'
   const futureApy = currentApy
-  const stakeApprove = createStub([TEST_TX_HASH])
+  const stakeApprove = createTransactionStub([TEST_TX_HASH])
   const stakeIsApproved = approved ? createStub(true) : createIsApprovedStub(stakeApprove)
   const estimateGasStake = createStub(`${132_000}`)
   const estimateGasStakeApprove = createStub(`${91_000}`)
-  const stake = createStub(TEST_TX_HASH)
+  const stake = createTransactionStub(TEST_TX_HASH)
   const convertToAssets = cy
     .stub()
     .callsFake((shares: Decimal) => Promise.resolve(decimalDiv(shares, '2'))) as TestStub<readonly [string], string>
@@ -355,8 +355,8 @@ export const createWithdrawScenario = ({
   const previewWithdraw = createStub(input.amount)
   const estimateGasWithdraw = createStub(`${142_000}`)
   const estimateGasRedeem = createStub(`${149_000}`)
-  const withdraw = createStub(TEST_TX_HASH)
-  const redeem = createStub(TEST_TX_HASH)
+  const withdraw = createTransactionStub(TEST_TX_HASH)
+  const redeem = createTransactionStub(TEST_TX_HASH)
   const vaultShares = decimalSum(depositedShares, stakedShares)
 
   const { market, sharedStubs } = createBaseSupplyMarket({
@@ -426,7 +426,7 @@ export const createUnstakeScenario = ({ chainId }: { chainId: number }) => {
   const currentApy = '0.0440'
   const futureApy = currentApy
   const estimateGasUnstake = createStub(`${121_000}`)
-  const unstake = createStub(TEST_TX_HASH)
+  const unstake = createTransactionStub(TEST_TX_HASH)
   const convertToAssets = cy
     .stub()
     .callsFake((shares: Decimal) => Promise.resolve(decimalDiv(shares, '2'))) as TestStub<readonly [string], string>
@@ -489,8 +489,8 @@ export const createClaimScenario = ({
   claimableCrv?: Decimal
   claimableRewards?: { amount: Decimal; symbol: string; token: Address }[]
 }) => {
-  const claimCrv = createStub(TEST_TX_HASH)
-  const claimRewards = createStub(TEST_TX_HASH)
+  const claimCrv = createTransactionStub(TEST_TX_HASH)
+  const claimRewards = createTransactionStub(TEST_TX_HASH)
   const claimableCrvStub = createStub(claimableCrv)
   const claimableRewardsStub = createStub(claimableRewards)
   const estimateGasClaimCrv = createStub(`${77_000}`)

--- a/tests/cypress/support/helpers/llamalend/test-context.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/test-context.helpers.ts
@@ -6,6 +6,7 @@ import { globalLibs } from '@evm-ui/features/connect-wallet/lib/utils'
 import { queryClient } from '@evm-ui/lib/api'
 import { type GasInfo, type GasInfoQueryOptions, setGasInfoAndUpdateLib } from '@evm-ui/lib/model/entities/gas-info'
 import { getTokenUsdRateKey } from '@evm-ui/lib/model/entities/token-usd-rate'
+import { blockUnmockedApis, mockNewHashCollateralEvents } from './market-list-mocks'
 
 export const llamaNetworks = loanNetworks as unknown as NetworkDict<LlamaChainId>
 
@@ -15,6 +16,12 @@ export const resetLlamaTestContext = () => {
   queryClient.clear()
   globalLibs.current = {}
   globalLibs.hydrated = {}
+}
+
+export const setupMockedLlamalendComponentTest = () => {
+  resetLlamaTestContext()
+  blockUnmockedApis()
+  mockNewHashCollateralEvents()
 }
 
 export const setGasInfo = (

--- a/tests/cypress/support/helpers/llamalend/test-stub.utils.ts
+++ b/tests/cypress/support/helpers/llamalend/test-stub.utils.ts
@@ -10,6 +10,15 @@ export type TestStub<TArgs extends readonly TestStubArg[], TResult> = ((...args:
 export const createStub = <TResult, TArgs extends readonly TestStubArg[] = readonly TestStubArg[]>(result: TResult) =>
   cy.stub().resolves(result) as TestStub<TArgs, Promise<TResult>>
 
+/** Resolves on the next macrotask so mocked transactions do not bypass UI query updates. */
+export const createTransactionStub = <TResult, TArgs extends readonly TestStubArg[] = readonly TestStubArg[]>(
+  result: TResult,
+) =>
+  cy.stub().callsFake(() => new Promise<TResult>(resolve => setTimeout(() => resolve(result), 0))) as TestStub<
+    TArgs,
+    Promise<TResult>
+  >
+
 export const createSyncStub = <TResult, TArgs extends readonly TestStubArg[] = readonly TestStubArg[]>(
   result: TResult,
 ) => cy.stub().returns(result) as TestStub<TArgs, TResult>

--- a/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
@@ -1,4 +1,37 @@
-import { createTestWagmiConfig } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-test-config'
-import { TEST_PRIVATE_KEY } from './mock-loan-test-data'
+import { custom, fallback, http, type RpcTransactionReceipt, zeroAddress } from 'viem'
+import { ethereum } from '@evm-ui/features/connect-wallet/lib/wagmi/custom-chains'
+import { WAGMI_HTTP_OPTIONS } from '@evm-ui/features/connect-wallet/lib/wagmi/transports'
+import { createWagmiConfig } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-config'
+import { createTestConnector } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-test'
+import { TEST_PRIVATE_KEY, TEST_TX_HASH } from './mock-loan-test-data'
 
-export const mockedWagmiConfig = createTestWagmiConfig({ privateKey: TEST_PRIVATE_KEY })
+const testTransactionReceipt: RpcTransactionReceipt = {
+  blockHash: `0x${'0'.repeat(64)}` as const,
+  blockNumber: '0x1',
+  contractAddress: null,
+  cumulativeGasUsed: '0x5208',
+  effectiveGasPrice: '0x1',
+  from: zeroAddress,
+  gasUsed: '0x5208',
+  logs: [],
+  logsBloom: `0x${'0'.repeat(512)}` as const,
+  status: '0x1',
+  to: zeroAddress,
+  transactionHash: TEST_TX_HASH,
+  transactionIndex: '0x0',
+  type: '0x2',
+}
+
+const mockedReceiptTransport = custom({
+  request: ({ method, params }: { method: string; params?: unknown[] }): Promise<unknown> => {
+    const [hash] = params ?? []
+    if (method === 'eth_getTransactionReceipt' && hash === TEST_TX_HASH) return Promise.resolve(testTransactionReceipt)
+    return Promise.reject(new Error(`Unsupported method: ${method}, http fallback is used`))
+  },
+})
+
+export const mockedWagmiConfig = createWagmiConfig({
+  chains: [ethereum],
+  connectors: [createTestConnector({ privateKey: TEST_PRIVATE_KEY, chain: ethereum })],
+  transports: { [ethereum.id]: fallback([mockedReceiptTransport, http(undefined, WAGMI_HTTP_OPTIONS)]) },
+})

--- a/tests/scripts/download-artifacts.ts
+++ b/tests/scripts/download-artifacts.ts
@@ -6,6 +6,7 @@ import { stripVTControlCharacters } from 'util'
 const { ARTIFACT_BRANCH, BRANCH, WORKFLOW, RUN_ID, REPOSITORY = 'curvefi/curve-frontend' } = process.env
 const DEST_DIR = 'artifacts'
 const MAX_LOG_SIZE = 100 * 1024 * 1024
+const COMMAND_TIMEOUT = 10 * 60 * 1000
 
 type WorkflowJob = {
   databaseId: number
@@ -17,8 +18,14 @@ type WorkflowJob = {
  */
 const run = (command: string, args: string[], options?: ExecFileOptionsWithStringEncoding): Promise<string> =>
   new Promise((resolve, reject) => {
-    execFile(command, args, { encoding: 'utf8', ...options }, (error, stdout) =>
-      error ? reject(new Error(`${error.code}`, { cause: error })) : resolve(stdout.trim()),
+    execFile(command, args, { encoding: 'utf8', timeout: COMMAND_TIMEOUT, ...options }, (error, stdout, stderr) =>
+      error
+        ? reject(
+            new Error(`Command failed with exit code ${error.code}: ${stderr.trim() || stdout.trim()}`, {
+              cause: error,
+            }),
+          )
+        : resolve(stdout.trim()),
     )
   })
 

--- a/tests/scripts/download-artifacts.ts
+++ b/tests/scripts/download-artifacts.ts
@@ -98,21 +98,19 @@ async function downloadFailedJobLogs(runId: string, dest: string) {
   const logsDir = join(dest, 'failed-job-logs')
   await mkdir(logsDir, { recursive: true })
 
-  await Promise.all(
-    failedJobs.map(async job => {
-      const log = await run(
-        'gh',
-        ['run', 'view', '--repo', REPOSITORY, '--job', String(job.databaseId), '--log-failed'],
-        {
-          encoding: 'utf8',
-          maxBuffer: MAX_LOG_SIZE,
-        },
-      )
-      const path = join(logsDir, `${job.databaseId}-${safeFilename(job.name)}.log`)
-      await writeFile(path, `${stripVTControlCharacters(log)}\n`)
-      console.info(`Downloaded failed job log: ${path}`)
-    }),
-  )
+  for (const job of failedJobs) {
+    const log = await run(
+      'gh',
+      ['run', 'view', '--repo', REPOSITORY, '--job', String(job.databaseId), '--log-failed'],
+      {
+        encoding: 'utf8',
+        maxBuffer: MAX_LOG_SIZE,
+      },
+    )
+    const path = join(logsDir, `${job.databaseId}-${safeFilename(job.name)}.log`)
+    await writeFile(path, `${stripVTControlCharacters(log)}\n`)
+    console.info(`Downloaded failed job log: ${path}`)
+  }
 }
 
 const getArtifactCount = (runId: string) =>


### PR DESCRIPTION
- Restore transition detection.
- Use the window hash for getHashRedirectUrl, as router version can be out-of-date on Firefox.
- Increase timeouts for DEX URL changes.
- Add mocks for Llamalend chart APIs and collateral events.
- Create a transaction stub with a delay for async processing.
- Create mock Transaction Receipt.
- Download artifacts in sequence, to avoid `gh` errors.