### PR TITLE
chore: disable pool_filter schema validation

### DIFF
--- a/packages/prices-api/src/chains/schema.ts
+++ b/packages/prices-api/src/chains/schema.ts
@@ -94,13 +94,8 @@ export const getPoolFiltersResponse = z
   .object({
     data: z.array(
       z.object({
-        chain,
-        pools: z.array(
-          z.object({
-            name: z.string(),
-            address,
-          }),
-        ),
+        chain: z.string(), // API proxies Lite API filters for integrators, so chains are not limited to package support
+        pools: z.array(z.object({ name: z.string(), address })),
       }),
     ),
   })


### PR DESCRIPTION
- Remove chain validation from pool_filters endpoint.
- This endpoint proxies lite api filters.