### PR TITLE
fix: various expanded pool panel improvements

### DIFF
--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
@@ -57,6 +57,8 @@ const isColumnEnabled = (variant: PoolColumnVariant, columnId: PoolColumnId) =>
 
 type PoolExpandedPanelProps = Parameters<ExpandedPanelComponent<PoolRow>>[0] & { variant: PoolColumnVariant }
 
+const PRIMARY_METRIC_SIZE = 6 as const
+
 export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
   const pool = row.original
   const currentDate = useCurrentDate()
@@ -66,39 +68,32 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
   const rewardsApy = getRewardsApy(pool)
   const crvApyRange = pool.gauge?.isKilled ? null : getCrvApyRange(pool)
   const pointsCampaigns = getPointsCampaigns(pool)
-  const supportsNetApy = isColumnEnabled(variant, PoolColumnId.NetApy)
-  const supportsVolume = isColumnEnabled(variant, PoolColumnId.Volume)
-  const supportsTvl = isColumnEnabled(variant, PoolColumnId.Tvl)
-  const primaryMetricCount = [supportsNetApy, supportsVolume, supportsTvl].filter(Boolean).length
-  const primaryMetricSize = primaryMetricCount ? 12 / primaryMetricCount : 12
   const volatileBaseApy = isVolatileApy(baseApy)
 
   return (
     <Grid container spacing={Spacing.md}>
-      {supportsNetApy && (
-        <Grid size={primaryMetricSize}>
-          <Metric
-            category={PRIMARY_METRIC_CATEGORY}
-            label={POOL_TITLES[PoolColumnId.NetApy]}
-            value={netApy || null}
-            valueOptions={getRateValueOptions(netApy, { volatile: volatileBaseApy })}
-            valueTooltip={
-              netApy
-                ? {
-                    body: <NetApyTooltipContent pool={pool} volatile={volatileBaseApy} />,
-                    clickable: true,
-                    placement: 'top',
-                    title: t`Net APY`,
-                  }
-                : undefined
-            }
-            icon={<RewardIcons pool={pool} includeCrv includePoints tooltipPlacement="top" />}
-            testId="pool-net-apy"
-          />
-        </Grid>
-      )}
-      {supportsVolume && (
-        <Grid size={primaryMetricSize}>
+      <Grid size={PRIMARY_METRIC_SIZE}>
+        <Metric
+          category={PRIMARY_METRIC_CATEGORY}
+          label={POOL_TITLES[PoolColumnId.NetApy]}
+          value={netApy || null}
+          valueOptions={getRateValueOptions(netApy, { volatile: volatileBaseApy })}
+          valueTooltip={
+            netApy
+              ? {
+                  body: <NetApyTooltipContent pool={pool} volatile={volatileBaseApy} />,
+                  clickable: true,
+                  placement: 'top',
+                  title: t`Net APY`,
+                }
+              : undefined
+          }
+          icon={<RewardIcons pool={pool} includeCrv includePoints tooltipPlacement="top" />}
+          testId="pool-net-apy"
+        />
+      </Grid>
+      {variant === 'full' && (
+        <Grid size={PRIMARY_METRIC_SIZE}>
           <Metric
             category={PRIMARY_METRIC_CATEGORY}
             label={t`24h Volume`}
@@ -108,8 +103,8 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
           />
         </Grid>
       )}
-      {supportsTvl && (
-        <Grid size={primaryMetricSize}>
+      {variant === 'lite' && (
+        <Grid size={PRIMARY_METRIC_SIZE}>
           <Metric
             category={PRIMARY_METRIC_CATEGORY}
             label={t`TVL`}

--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
@@ -31,7 +31,6 @@ import type { PoolRow } from '../types'
 const { Spacing } = SizesAndSpaces
 const PRIMARY_METRIC_CATEGORY = 'dex.poolListMobileExpanded'
 const DETAIL_METRIC_CATEGORY = 'dex.poolListMobileExpandedDetails'
-const highlight = { color: 'success' as const }
 
 type RateValueOptions = {
   hasTooltip?: boolean
@@ -58,7 +57,7 @@ const isColumnEnabled = (variant: PoolColumnVariant, columnId: PoolColumnId) =>
 
 type PoolExpandedPanelProps = Parameters<ExpandedPanelComponent<PoolRow>>[0] & { variant: PoolColumnVariant }
 
-export const PoolExpandedPanel = ({ row, table, variant }: PoolExpandedPanelProps) => {
+export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
   const pool = row.original
   const currentDate = useCurrentDate()
   const baseApy = getBaseApy(pool, 'daily')
@@ -104,10 +103,7 @@ export const PoolExpandedPanel = ({ row, table, variant }: PoolExpandedPanelProp
             category={PRIMARY_METRIC_CATEGORY}
             label={t`24h Volume`}
             value={decimal(pool.tradingVolume24h) ?? null}
-            valueOptions={{
-              unit: 'dollar',
-              ...(table.getColumn(PoolColumnId.Volume)?.getIsSorted() && highlight),
-            }}
+            valueOptions={{ unit: 'dollar' }}
             testId="pool-volume"
           />
         </Grid>
@@ -118,10 +114,7 @@ export const PoolExpandedPanel = ({ row, table, variant }: PoolExpandedPanelProp
             category={PRIMARY_METRIC_CATEGORY}
             label={t`TVL`}
             value={decimal(pool.tvlUsd) ?? null}
-            valueOptions={{
-              unit: 'dollar',
-              ...(table.getColumn(PoolColumnId.Tvl)?.getIsSorted() && highlight),
-            }}
+            valueOptions={{ unit: 'dollar' }}
             testId="pool-tvl"
           />
         </Grid>

--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
@@ -93,6 +93,15 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
       )}
 
       <Grid size={12}>
+        {variant === 'full' && (
+          <Metric
+            category={DETAIL_METRIC_CATEGORY}
+            label={POOL_TITLES[PoolColumnId.Tvl]}
+            value={pool.tvlUsd}
+            valueOptions={{ unit: 'dollar' }}
+            testId="pool-tvl"
+          />
+        )}
         {maybe(pool.creationDate, creationDate => (
           <Metric
             category={DETAIL_METRIC_CATEGORY}

--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
@@ -1,30 +1,16 @@
-import { BaseApyTooltipContent } from '@/dex/components/BaseApyTooltipContent'
-import { CrvApyTooltipContent } from '@/dex/components/CrvApyTooltipContent'
 import { useCurrentDate } from '@evm-ui/hooks/useCurrentDate'
 import { t } from '@evm-ui/lib/i18n'
 import type { ExpandedPanelComponent } from '@evm-ui/shared/ui/DataTable/ExpansionRow'
 import { Metric, type MetricProps } from '@evm-ui/shared/ui/Metric'
-import { RewardIcon } from '@evm-ui/shared/ui/RewardIcon'
-import { TokenIcon } from '@evm-ui/shared/ui/TokenIcon'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { decimal, formatCappedRateValue, formatNumber, MAINNET_CRV, relativeTime } from '@evm-ui/utils'
+import { decimal, formatCappedRateValue, relativeTime } from '@evm-ui/utils'
 import { formatDate } from '@legacy-ui/utils'
 import Grid from '@mui/material/Grid'
-import Link from '@mui/material/Link'
 import { maybe } from '@primitives/objects.utils'
 import { NetApyTooltipContent } from '../cells/NetApyTooltipContent'
 import { RewardIcons } from '../cells/RewardIcons'
-import { RewardsApyTooltipContent } from '../cells/RewardsApyTooltipContent'
-import {
-  formatCrvApyRange,
-  getBaseApy,
-  getCrvApyRange,
-  getNetApy,
-  getPointsCampaigns,
-  getRewardsApy,
-  isVolatileApy,
-} from '../cells/utils'
-import { POOLS_COLUMN_OPTIONS, POOL_TITLES, PoolColumnId } from '../columns'
+import { getBaseApy, getNetApy, isVolatileApy } from '../cells/utils'
+import { POOL_TITLES, PoolColumnId } from '../columns'
 import type { PoolColumnVariant } from '../hooks/usePoolsVisibility'
 import type { PoolRow } from '../types'
 
@@ -50,11 +36,6 @@ const getRateValueOptions = (
   ...(volatile && { color: 'error', formatter: formatCappedRateValue }),
 })
 
-const isColumnEnabled = (variant: PoolColumnVariant, columnId: PoolColumnId) =>
-  POOLS_COLUMN_OPTIONS[variant].some(({ options }) =>
-    options.some(({ columns, enabled }) => enabled && columns.includes(columnId)),
-  )
-
 type PoolExpandedPanelProps = Parameters<ExpandedPanelComponent<PoolRow>>[0] & { variant: PoolColumnVariant }
 
 const PRIMARY_METRIC_SIZE = 6 as const
@@ -63,11 +44,7 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
   const pool = row.original
   const currentDate = useCurrentDate()
   const baseApy = getBaseApy(pool, 'daily')
-  const weeklyBaseApy = getBaseApy(pool, 'weekly')
   const netApy = getNetApy(pool)
-  const rewardsApy = getRewardsApy(pool)
-  const crvApyRange = pool.gauge?.isKilled ? null : getCrvApyRange(pool)
-  const pointsCampaigns = getPointsCampaigns(pool)
   const volatileBaseApy = isVolatileApy(baseApy)
 
   return (
@@ -116,137 +93,19 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
       )}
 
       <Grid size={12}>
-        {isColumnEnabled(variant, PoolColumnId.BaseApy) && (
-          <Metric
-            category={DETAIL_METRIC_CATEGORY}
-            label={POOL_TITLES[PoolColumnId.BaseApy]}
-            value={baseApy || null}
-            valueOptions={getRateValueOptions(baseApy, {
-              hasTooltip: pool.baseDailyApr != null,
-              volatile: volatileBaseApy,
-            })}
-            valueTooltip={maybe(pool.baseDailyApr, () => ({
-              body: <BaseApyTooltipContent dailyApy={baseApy} weeklyApy={weeklyBaseApy} weekly={false} />,
-              placement: 'top',
-              title: t`Base APY`,
-            }))}
-            testId="pool-base-apy"
-          />
-        )}
-        {isColumnEnabled(variant, PoolColumnId.WeeklyBaseApy) && (
-          <Metric
-            category={DETAIL_METRIC_CATEGORY}
-            label={POOL_TITLES[PoolColumnId.WeeklyBaseApy]}
-            value={weeklyBaseApy || null}
-            valueOptions={getRateValueOptions(weeklyBaseApy, {
-              hasTooltip: pool.baseWeeklyApr != null,
-              volatile: isVolatileApy(weeklyBaseApy),
-            })}
-            valueTooltip={maybe(pool.baseWeeklyApr, () => ({
-              body: <BaseApyTooltipContent dailyApy={baseApy} weeklyApy={weeklyBaseApy} weekly />,
-              placement: 'top',
-              title: t`Weekly Base APY`,
-            }))}
-            testId="pool-weekly-base-apy"
-          />
-        )}
-        {isColumnEnabled(variant, PoolColumnId.RewardsApy) && (
-          <Metric
-            category={DETAIL_METRIC_CATEGORY}
-            label={POOL_TITLES[PoolColumnId.RewardsApy]}
-            value={rewardsApy || null}
-            valueOptions={getRateValueOptions(rewardsApy)}
-            valueTooltip={
-              rewardsApy
-                ? {
-                    body: <RewardsApyTooltipContent pool={pool} />,
-                    clickable: true,
-                    placement: 'top',
-                    title: t`Rewards APY`,
-                  }
-                : undefined
-            }
-            icon={<RewardIcons pool={pool} tooltipPlacement="top" />}
-            testId="pool-rewards-apy"
-          />
-        )}
-        {isColumnEnabled(variant, PoolColumnId.CrvApy) && (
-          <Metric
-            category={DETAIL_METRIC_CATEGORY}
-            label={POOL_TITLES[PoolColumnId.CrvApy]}
-            value={crvApyRange?.unboostedApy ?? null}
-            valueOptions={{
-              abbreviate: false,
-              fallback: '-',
-              disableTooltip: !crvApyRange,
-              formatter: crvApyRange ? () => formatCrvApyRange(crvApyRange) : undefined,
-            }}
-            valueTooltip={
-              crvApyRange
-                ? {
-                    body: (
-                      <CrvApyTooltipContent
-                        unboostedApy={crvApyRange.unboostedApy}
-                        maximumApy={crvApyRange.boostedApy}
-                      />
-                    ),
-                    placement: 'top',
-                    title: t`CRV APY`,
-                  }
-                : undefined
-            }
-            icon={<TokenIcon blockchainId={MAINNET_CRV.chain} address={MAINNET_CRV.address} size="mui-sm" />}
-            testId="pool-crv-apy"
-          />
-        )}
-        {isColumnEnabled(variant, PoolColumnId.Points) &&
-          pointsCampaigns.map((campaign, index) => {
-            const campaignValue =
-              campaign.reward?.type === 'points'
-                ? formatNumber(campaign.reward.value, 'multiplier')
-                : campaign.symbol || '-'
-
-            return (
-              <Link
-                // eslint-disable-next-line @eslint-react/no-array-index-key -- Campaigns can have duplicate platform metadata and no stable identifier.
-                key={`${campaign.platform}-${campaign.description}-${index}`}
-                aria-label={t`Open ${campaign.platform} points dashboard`}
-                color="inherit"
-                href={campaign.dashboardLink}
-                rel="noopener noreferrer"
-                sx={{ display: 'block' }}
-                target="_blank"
-                underline="none"
-              >
-                <Metric
-                  category={DETAIL_METRIC_CATEGORY}
-                  label={t`Points`}
-                  value={null}
-                  valueOptions={{ disableTooltip: true, fallback: campaignValue }}
-                  icon={<RewardIcon src={campaign.platformImageId} alt={campaign.platform} size="sm" />}
-                  testId={`pool-points-campaign-${index}`}
-                />
-              </Link>
-            )
-          })}
-        {isColumnEnabled(variant, PoolColumnId.Age) && (
+        {maybe(pool.creationDate, creationDate => (
           <Metric
             category={DETAIL_METRIC_CATEGORY}
             label={POOL_TITLES[PoolColumnId.Age]}
-            value={pool.creationDate}
+            value={creationDate}
             valueOptions={{
               abbreviate: false,
-              fallback: '-',
-              disableTooltip: pool.creationDate == null,
               formatter: () => relativeTime(currentDate.getTime(), pool.creationDate!),
             }}
-            valueTooltip={maybe(pool.creationDate, creationDate => ({
-              placement: 'top',
-              title: formatDate(creationDate, 'long'),
-            }))}
+            valueTooltip={{ title: formatDate(creationDate, 'long') }}
             testId="pool-age"
           />
-        )}
+        ))}
       </Grid>
     </Grid>
   )

--- a/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
@@ -33,20 +33,12 @@ describe('V2 pool-list mobile panels', () => {
   it('shows the full-network metrics in the required mobile order', () => {
     const { address } = V2_POOL_FIXTURES.showcase
     visitAndExpand(address)
-
     expectMetricOrder(address, FULL_NETWORK_METRIC_IDS)
-
-    getV2PoolExpandedPanel(address).find('[data-testid="pool-volume"]').should('contain.text', '24h Volume')
-    getV2PoolExpandedPanel(address)
-      .find('[data-testid="pool-crv-apy-value"]')
-      .invoke('text')
-      .should('match', /^\s*-?[\d,.]+(?:\+)?%\s*→\s*-?[\d,.]+(?:\+)?%\s*$/)
   })
 
   it('shows the supported Lite metrics in the required mobile order', () => {
     const { address } = V2_POOL_FIXTURES.lite
     visitAndExpand(address, 'taiko')
-
     expectMetricOrder(address, LITE_METRIC_IDS)
   })
 })

--- a/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
@@ -7,7 +7,6 @@ import {
 } from '@cy/support/helpers/dex-pools-list-v2.helpers'
 
 const FULL_NETWORK_METRIC_IDS = ['pool-net-apy', 'pool-volume', 'pool-tvl', 'pool-age'] as const
-
 const LITE_METRIC_IDS = ['pool-net-apy', 'pool-tvl'] as const
 
 const expectMetricOrder = (address: string, expectedIds: readonly string[]) => {
@@ -49,12 +48,5 @@ describe('V2 pool-list mobile panels', () => {
     visitAndExpand(address, 'taiko')
 
     expectMetricOrder(address, LITE_METRIC_IDS)
-  })
-
-  it('does not create a campaign metric when campaign data is unavailable', () => {
-    const { address } = V2_POOL_FIXTURES.empty
-    visitAndExpand(address)
-
-    getV2PoolExpandedPanel(address).find('[data-testid^="pool-points-campaign-"]').should('not.exist')
   })
 })

--- a/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/mobile.cy.ts
@@ -6,37 +6,9 @@ import {
   visitV2PoolList,
 } from '@cy/support/helpers/dex-pools-list-v2.helpers'
 
-const FULL_NETWORK_METRIC_IDS = [
-  'pool-net-apy',
-  'pool-volume',
-  'pool-tvl',
-  'pool-base-apy',
-  'pool-weekly-base-apy',
-  'pool-rewards-apy',
-  'pool-crv-apy',
-  'pool-points-campaign-0',
-  'pool-points-campaign-1',
-  'pool-points-campaign-2',
-  'pool-points-campaign-3',
-  'pool-points-campaign-4',
-  'pool-age',
-] as const
+const FULL_NETWORK_METRIC_IDS = ['pool-net-apy', 'pool-volume', 'pool-tvl', 'pool-age'] as const
 
-const FULL_NETWORK_CAMPAIGN_IDS = [
-  'pool-points-campaign-0',
-  'pool-points-campaign-1',
-  'pool-points-campaign-2',
-  'pool-points-campaign-3',
-  'pool-points-campaign-4',
-] as const
-
-const LITE_METRIC_IDS = [
-  'pool-net-apy',
-  'pool-tvl',
-  'pool-rewards-apy',
-  'pool-crv-apy',
-  'pool-points-campaign-0',
-] as const
+const LITE_METRIC_IDS = ['pool-net-apy', 'pool-tvl'] as const
 
 const expectMetricOrder = (address: string, expectedIds: readonly string[]) => {
   getV2PoolExpandedPanel(address)
@@ -49,16 +21,6 @@ const expectMetricOrder = (address: string, expectedIds: readonly string[]) => {
 
       expect(metricIds).to.deep.equal([...expectedIds])
     })
-}
-
-const expectCampaignRowsToBeLinks = (address: string, campaignIds: readonly string[]) => {
-  for (const campaignId of campaignIds) {
-    getV2PoolExpandedPanel(address)
-      .find(`[data-testid="${campaignId}"]`)
-      .closest('a')
-      .should('have.length', 1)
-      .and('be.visible')
-  }
 }
 
 const visitAndExpand = (address: string, network: 'ethereum' | 'taiko' = 'ethereum') => {
@@ -80,8 +42,6 @@ describe('V2 pool-list mobile panels', () => {
       .find('[data-testid="pool-crv-apy-value"]')
       .invoke('text')
       .should('match', /^\s*-?[\d,.]+(?:\+)?%\s*→\s*-?[\d,.]+(?:\+)?%\s*$/)
-
-    expectCampaignRowsToBeLinks(address, FULL_NETWORK_CAMPAIGN_IDS)
   })
 
   it('shows the supported Lite metrics in the required mobile order', () => {


### PR DESCRIPTION
* Removes highlight color from metric.
* Shows volume as primary metric for full network with TVL demoted as row metric, shows TVL as primary metric for lite network.
* Removes APY breakdown row metrics as it's all covered by the primary Net APY metric. For a breakdown people can click on it.

**Before**
<img width="450" height="296" alt="image" src="https://github.com/user-attachments/assets/4134e198-018a-4f9b-9f8c-5c0e9cd56220" />

**After**
<img width="452" height="197" alt="image" src="https://github.com/user-attachments/assets/2d85cd6d-a497-4ed6-8eeb-50bfc8811e00" />
