### PR TITLE
fix: handle solver 404 errors

### DIFF
--- a/apps/router-api/src/curve-solver-router/curve-solver-router.ts
+++ b/apps/router-api/src/curve-solver-router/curve-solver-router.ts
@@ -47,10 +47,12 @@ export const buildCurveSolverRouteResponse = async (
     ...(receiver && { receiver }),
     min_out: amountOut ?? '0', // todo: use slippage?
   }
-  const { calldata, debug, expected_out, gas_estimate, router_address } = await fetchJson<CurveSolverQuoteResponse>(
-    `${API_URLS[chainId]}/quote?debug=true`,
-    { body: params },
-  ).catch(error => logSolverError(error, log, API_URLS[chainId], params))
+  const quote = await fetchJson<CurveSolverQuoteResponse>(`${API_URLS[chainId]}/quote?debug=true`, {
+    body: params,
+  }).catch(error => handleSolverError(error, log, API_URLS[chainId], params))
+  if (!quote) return []
+
+  const { calldata, debug, expected_out, gas_estimate, router_address } = quote
   const { coins, pools, pool_addresses, swap_addresses, swap_params } = debug?.routes.find(r => r.selected) ?? {}
 
   return [
@@ -85,9 +87,18 @@ export const buildCurveSolverRouteResponse = async (
   ]
 }
 
-function logSolverError(error: unknown, log: FastifyBaseLogger, url: string, body: CurveSolverQuoteRequest): never {
+function handleSolverError(
+  error: unknown,
+  log: FastifyBaseLogger,
+  url: string,
+  body: CurveSolverQuoteRequest,
+): undefined {
   if (error instanceof FetchError) {
-    log.error({ message: 'curve-solver route request failed', status: error.status, url, body })
+    if (error.status === 404) {
+      log.info({ message: 'curve-solver route not found', status: error.status, url, body, response: error.body })
+      return
+    }
+    log.error({ message: 'curve-solver route request failed', status: error.status, url, body, response: error.body })
   }
   throw error
 }

--- a/apps/router-api/test/integration/routes-mocked.test.ts
+++ b/apps/router-api/test/integration/routes-mocked.test.ts
@@ -45,6 +45,28 @@ describe('GET routes mocked unit tests', () => {
     expect(json()).toEqual([])
   })
 
+  it('returns an empty response when curve-solver returns no route found', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn<typeof fetch>(() => Promise.resolve(Response.json({ error: 'no routes found' }, { status: 404 }))),
+    )
+
+    const { json, statusCode } = await server.inject({
+      url: '/api/router/v1/routes',
+      query: {
+        chainId: '1',
+        tokenIn: [zeroAddress],
+        tokenOut: [zeroAddress],
+        amountIn: ['1000000000'],
+        router: ['curve-solver'],
+        userAddress: zeroAddress,
+      },
+    })
+
+    expect(statusCode).toBe(200)
+    expect(json()).toEqual([])
+  })
+
   // TODO: test 0x slippage and fees
   it.each([
     { slippage: '0.5', expectedSlippage: '50', expectedFee: '0' },


### PR DESCRIPTION
- Handle 404 errors from the solver by returning no routes.