### PR TITLE
feat: new pool title tooltip

### DIFF
--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
@@ -42,7 +42,7 @@ export const LegacyPoolTitleCell = ({
         <Stack direction="column">
           <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
             <PoolAlertIcons poolAlert={poolAlert} tokenAlert={tokenAlert} />
-            <TableRowTitle id={pool.address} url={url} title={pool.name}></TableRowTitle>
+            <TableRowTitle url={url} title={pool.name} testId={pool.address} />
             <CopyIconButton
               className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
               label={t`Copy pool address`}

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
@@ -3,10 +3,10 @@ import { useMemo } from 'react'
 import { usePoolAlert } from '@/dex/hooks/usePoolAlert'
 import { useTokenAlert } from '@/dex/hooks/useTokenAlert'
 import { t } from '@evm-ui/lib/i18n'
+import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { MarketTitle } from '@evm-ui/widgets/MarketTitle'
 import Stack from '@mui/material/Stack'
 import type { Address } from '@primitives/address.utils'
 import type { CellContext } from '@tanstack/react-table'
@@ -41,7 +41,7 @@ export const LegacyPoolTitleCell = ({
         <Stack direction="column">
           <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
             <PoolAlertIcons poolAlert={poolAlert} tokenAlert={tokenAlert} />
-            <MarketTitle url={url} address={pool.address as Address} title={pool.name} />
+            <TableRowTitle url={url} address={pool.address as Address} title={pool.name} />
           </Stack>
           <PoolTokens tokenList={tokenList} filterValue={getFilterValue() as string} />
         </Stack>

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
@@ -3,12 +3,13 @@ import { useMemo } from 'react'
 import { usePoolAlert } from '@/dex/hooks/usePoolAlert'
 import { useTokenAlert } from '@/dex/hooks/useTokenAlert'
 import { t } from '@evm-ui/lib/i18n'
+import { CopyIconButton } from '@evm-ui/shared/ui/CopyIconButton'
+import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from '@evm-ui/shared/ui/DataTable/data-table.utils'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import Stack from '@mui/material/Stack'
-import type { Address } from '@primitives/address.utils'
 import type { CellContext } from '@tanstack/react-table'
 import type { LegacyPoolRow } from '../../types'
 import { PoolAlertBadge } from './PoolAlertBadge'
@@ -41,7 +42,13 @@ export const LegacyPoolTitleCell = ({
         <Stack direction="column">
           <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
             <PoolAlertIcons poolAlert={poolAlert} tokenAlert={tokenAlert} />
-            <TableRowTitle url={url} address={pool.address as Address} title={pool.name} />
+            <TableRowTitle id={pool.address} url={url} title={pool.name}></TableRowTitle>
+            <CopyIconButton
+              className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
+              label={t`Copy pool address`}
+              copyText={pool.address}
+              confirmationText={t`Pool address copied`}
+            />
           </Stack>
           <PoolTokens tokenList={tokenList} filterValue={getFilterValue() as string} />
         </Stack>

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolBadges.tsx
@@ -9,25 +9,14 @@ import { Tooltip } from '@evm-ui/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import Stack from '@mui/material/Stack'
 import type { PoolRow } from '../../types'
+import { poolTypeClassifications, type PoolClassification } from './classifications'
 
 const { Spacing } = SizesAndSpaces
-type PoolType = NonNullable<PoolRow['poolType']>
-
-const poolTypeClassifications: Record<PoolType, 'stable' | 'volatile'> = {
-  main: 'stable',
-  factory: 'stable',
-  crvusd: 'stable',
-  stableswapng: 'stable',
-  crypto: 'volatile',
-  factory_crypto: 'volatile',
-  factory_tricrypto: 'volatile',
-  twocryptong: 'volatile',
-}
 
 const poolTypeLabels = {
   stable: t`Stable`,
   volatile: t`Volatile`,
-} as const
+} satisfies Record<PoolClassification, string>
 
 const alertTypeToBadgeColor: Record<AlertType, BadgeProps['color']> = {
   '': 'accent',

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolTooltipContent.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/PoolTooltipContent.tsx
@@ -1,0 +1,65 @@
+import { useNetworkFromUrl } from '@/dex/hooks/useChainId'
+import { t } from '@evm-ui/lib/i18n'
+import { AddressActionInfo } from '@evm-ui/shared/ui/AddressActionInfo'
+import { TokenLabel } from '@evm-ui/shared/ui/TokenLabel'
+import { TooltipDescription, TooltipItem, TooltipItems, TooltipWrapper } from '@evm-ui/shared/ui/TooltipComponents'
+import Stack from '@mui/material/Stack'
+import { maybe, notFalsy } from '@primitives/objects.utils'
+import type { PoolRow } from '../../types'
+import { poolTypeClassifications, type PoolClassification } from './classifications'
+
+const CLASSIFICATIONS = {
+  stable: t`A stable pool is a liquidity pool designed for assets that trade at similar values, enabling low-slippage swaps with minimal fees.`,
+  volatile: t`A volatile pool is a liquidity pool designed for assets whose values can fluctuate independently, enabling efficient swaps across a wide range of prices.`,
+} satisfies Record<PoolClassification, string>
+
+const METAPOOL_DESCRIPTION = t`A metapool pairs an asset with a base pool's LP token, enabling swaps with the base pool's underlying assets.`
+
+export const PoolTooltipContent = ({ pool }: { pool: PoolRow }) => {
+  const network = useNetworkFromUrl()
+
+  const classification = pool.poolType && poolTypeClassifications[pool.poolType]
+  const descriptions = notFalsy(
+    classification && CLASSIFICATIONS[classification],
+    pool.isMetapool && METAPOOL_DESCRIPTION,
+  )
+
+  return (
+    <TooltipWrapper>
+      {descriptions.map(description => (
+        <TooltipDescription key={description} text={description} />
+      ))}
+
+      <Stack>
+        <TooltipItems secondary>
+          <TooltipItem title={t`Pool tokens`} />
+          {pool.tradeableCoins.map(({ address, symbol }) => (
+            <AddressActionInfo
+              key={address}
+              network={network}
+              title={
+                <TokenLabel
+                  blockchainId={pool.network}
+                  address={address}
+                  label={symbol}
+                  size="mui-sm"
+                  typographyVariant="bodyXsRegular"
+                />
+              }
+              address={address}
+              size="small"
+            />
+          ))}
+        </TooltipItems>
+
+        <TooltipItems secondary extraMargin>
+          <TooltipItem title={t`Contracts`} />
+          <AddressActionInfo network={network} title={t`Pool`} address={pool.address} size="small" />
+          {maybe(pool.gauge, gauge => (
+            <AddressActionInfo network={network} title={t`Gauge`} address={gauge.address} size="small" />
+          ))}
+        </TooltipItems>
+      </Stack>
+    </TooltipWrapper>
+  )
+}

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/classifications.ts
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/classifications.ts
@@ -1,0 +1,15 @@
+import type { PoolRow } from '../../types'
+
+type PoolType = NonNullable<PoolRow['poolType']>
+export type PoolClassification = 'stable' | 'volatile'
+
+export const poolTypeClassifications: Record<PoolType, PoolClassification> = {
+  main: 'stable',
+  factory: 'stable',
+  crvusd: 'stable',
+  stableswapng: 'stable',
+  crypto: 'volatile',
+  factory_crypto: 'volatile',
+  factory_tricrypto: 'volatile',
+  twocryptong: 'volatile',
+}

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react'
 import { t } from '@evm-ui/lib/i18n'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
@@ -12,22 +11,14 @@ import { PoolBadges } from './PoolBadges'
 const { Spacing, Height } = SizesAndSpaces
 
 export const PoolTitleCell = ({ row: { original: pool } }: CellContext<PoolRow, string>) => (
-  <PoolListTitle pool={pool} />
-)
-
-// Memoization avoids repeating token icon and badge rendering for unchanged rows.
-// eslint-disable-next-line local/no-single-line-named-functions
-const PoolListTitle = memo(function PoolListTitle({ pool }: { pool: PoolRow }) {
-  return (
-    <Stack direction="row" sx={{ height: Height.row }}>
-      {pool.hasPosition && <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />}
-      <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
-        <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
-        <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
-          <PoolBadges pool={pool} />
-        </Stack>
+  <Stack direction="row" sx={{ height: Height.row }}>
+    {pool.hasPosition && <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />}
+    <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
+      <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
+      <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
+        <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
+        <PoolBadges pool={pool} />
       </Stack>
     </Stack>
-  )
-})
+  </Stack>
+)

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -2,23 +2,27 @@ import { t } from '@evm-ui/lib/i18n'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
+import { Tooltip } from '@evm-ui/shared/ui/Tooltip'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import Stack from '@mui/material/Stack'
 import type { CellContext } from '@tanstack/react-table'
 import type { PoolRow } from '../../types'
 import { PoolBadges } from './PoolBadges'
+import { PoolTooltipContent } from './PoolTooltipContent'
 
 const { Spacing, Height } = SizesAndSpaces
 
 export const PoolTitleCell = ({ row: { original: pool } }: CellContext<PoolRow, string>) => (
   <Stack direction="row" sx={{ height: Height.row }}>
     {pool.hasPosition && <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />}
-    <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
-      <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
-      <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-        <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
-        <PoolBadges pool={pool} />
+    <Tooltip clickable title={pool.name} body={<PoolTooltipContent pool={pool} />} placement="top">
+      <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
+        <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} showTooltips={false} />
+        <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
+          <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
+          <PoolBadges pool={pool} />
+        </Stack>
       </Stack>
-    </Stack>
+    </Tooltip>
   </Stack>
 )

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -19,7 +19,7 @@ export const PoolTitleCell = ({ row: { original: pool } }: CellContext<PoolRow, 
       <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
         <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} showTooltips={false} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
+          <TableRowTitle url={pool.url} title={pool.name} testId={pool.address} />
           <PoolBadges pool={pool} />
         </Stack>
       </Stack>

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react'
 import { t } from '@evm-ui/lib/i18n'
+import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { MarketTitle } from '@evm-ui/widgets/MarketTitle'
 import Stack from '@mui/material/Stack'
 import type { CellContext } from '@tanstack/react-table'
 import type { PoolRow } from '../../types'
@@ -24,7 +24,7 @@ const PoolListTitle = memo(function PoolListTitle({ pool }: { pool: PoolRow }) {
       <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
         <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <MarketTitle url={pool.url} address={pool.address} title={pool.name} addressLabel={t`pool`} />
+          <TableRowTitle url={pool.url} address={pool.address} title={pool.name} addressLabel={t`pool`} />
           <PoolBadges pool={pool} />
         </Stack>
       </Stack>

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -24,7 +24,7 @@ const PoolListTitle = memo(function PoolListTitle({ pool }: { pool: PoolRow }) {
       <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
         <TokenIcons blockchainId={pool.network} tokens={pool.tradeableCoins} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <TableRowTitle url={pool.url} address={pool.address} title={pool.name} addressLabel={t`pool`} />
+          <TableRowTitle id={pool.address} url={pool.url} title={pool.name} />
           <PoolBadges pool={pool} />
         </Stack>
       </Stack>

--- a/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
@@ -1,8 +1,8 @@
 import type { LlamaMarketRow } from '@/llamalend/queries/market-list/llama-market-stats'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
+import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
-import { MarketTitle } from '@evm-ui/widgets/MarketTitle'
 import Stack from '@mui/material/Stack'
 import { CellContext } from '@tanstack/react-table'
 import { MarketBadges } from './MarketBadges'
@@ -19,7 +19,7 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
       <Stack direction="row" sx={{ gap: Spacing.sm, alignItems: 'center' }}>
         <TokenIcons blockchainId={market.chain} tokens={[collateral, borrowed]} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <MarketTitle
+          <TableRowTitle
             title={[collateral.symbol, borrowed.symbol].join(' • ')}
             address={market.controllerAddress}
             url={market.url}

--- a/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
@@ -24,9 +24,9 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
           <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
             <TableRowTitle
-              id={market.controllerAddress}
               title={[collateral.symbol, borrowed.symbol].join(' • ')}
               url={market.url}
+              testId={market.controllerAddress}
             />
             <CopyIconButton
               className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}

--- a/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
@@ -1,5 +1,8 @@
 import type { LlamaMarketRow } from '@/llamalend/queries/market-list/llama-market-stats'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
+import { t } from '@evm-ui/lib/i18n'
+import { CopyIconButton } from '@evm-ui/shared/ui/CopyIconButton'
+import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from '@evm-ui/shared/ui/DataTable/data-table.utils'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { TokenIcons } from '@evm-ui/shared/ui/TokenIcons'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
@@ -19,11 +22,20 @@ export const MarketTitleCell = ({ row: { original: market } }: CellContext<Llama
       <Stack direction="row" sx={{ gap: Spacing.sm, alignItems: 'center' }}>
         <TokenIcons blockchainId={market.chain} tokens={[collateral, borrowed]} />
         <Stack direction="column" sx={{ justifyContent: 'center', gap: Spacing.xxs }}>
-          <TableRowTitle
-            title={[collateral.symbol, borrowed.symbol].join(' • ')}
-            address={market.controllerAddress}
-            url={market.url}
-          />
+          <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.xs }}>
+            <TableRowTitle
+              id={market.controllerAddress}
+              title={[collateral.symbol, borrowed.symbol].join(' • ')}
+              url={market.url}
+            />
+            <CopyIconButton
+              className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
+              label={t`Copy market address`}
+              copyText={market.controllerAddress}
+              confirmationText={t`Market address copied`}
+              data-testid={`copy-market-address-${market.controllerAddress}`}
+            />
+          </Stack>
           <MarketBadges market={market} isMobile={isMobile} />
         </Stack>
       </Stack>

--- a/packages/evm-ui/src/shared/ui/AddressActionInfo.tsx
+++ b/packages/evm-ui/src/shared/ui/AddressActionInfo.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import { t } from '@evm-ui/lib/i18n'
+import type { TypographyVariantKey } from '@evm-ui/themes/typography'
 import { BaseConfig, scanAddressPath } from '@legacy-ui/utils'
 import { Typography } from '@mui/material'
 import { maybe } from '@primitives/objects.utils'
@@ -11,15 +12,22 @@ type AddressActionInfoProps = {
   network: BaseConfig | undefined
   title: ReactNode
   labelTooltip?: ActionInfoProps['labelTooltip']
+  size?: ActionInfoProps['size']
   address: string | undefined
   isBorderBottom?: boolean
   testId?: string
 }
 
+const VALUE_SIZE = {
+  small: 'bodyXsBold',
+  medium: 'bodyMBold',
+} satisfies Record<NonNullable<AddressActionInfoProps['size']>, TypographyVariantKey>
+
 export const AddressActionInfo = ({
   network,
   title,
   labelTooltip,
+  size = 'medium',
   address,
   isBorderBottom,
   testId,
@@ -28,10 +36,11 @@ export const AddressActionInfo = ({
     testId={testId}
     label={title}
     labelTooltip={labelTooltip}
+    size={size}
     value={
       /** TODO: Clarify: The design has this typography component as as semi-bold,
        * should Bold typography variants have an updated font-weight? 🤔 */
-      <Typography variant="bodyMBold">{shortenAddress(address)}</Typography>
+      <Typography variant={VALUE_SIZE[size]}>{shortenAddress(address)}</Typography>
     }
     copyValue={address}
     valueTooltip={maybe(address && scanAddressPath(network, address), link => (

--- a/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
@@ -7,7 +7,7 @@ import { responsiveTitleEllipsisSx } from '../titleTruncate'
 import { CLICKABLE_IN_ROW_CLASS } from './data-table.utils'
 
 /** Title as in, the name of the pool or market, used in the corresponding title cell */
-export function TableRowTitle({ id, title, url }: { id: string; title: ReactNode; url: string }) {
+export function TableRowTitle({ title, url, testId }: { title: ReactNode; url: string; testId: string }) {
   const isMobile = useIsMobile()
   return (
     <Typography
@@ -21,7 +21,7 @@ export function TableRowTitle({ id, title, url }: { id: string; title: ReactNode
         underline="none"
         href={url}
         className={CLICKABLE_IN_ROW_CLASS}
-        data-testid={`table-row-link-${id}`}
+        {...(testId && { 'data-testid': `table-row-link-${testId}` })}
         {...(isMobile && {
           // cancel click on mobile so the panel can open, there is a separate button for navigating
           onClick: (e: MouseEvent<HTMLAnchorElement>) => e.preventDefault(),

--- a/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
@@ -5,12 +5,13 @@ import { t } from '@evm-ui/lib/i18n'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import type { Address } from '@primitives/address.utils'
-import { CopyIconButton } from '../shared/ui/CopyIconButton'
-import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from '../shared/ui/DataTable/data-table.utils'
-import { RouterLink } from '../shared/ui/RouterLink'
-import { responsiveTitleEllipsisSx } from '../shared/ui/titleTruncate'
+import { CopyIconButton } from '../CopyIconButton'
+import { RouterLink } from '../RouterLink'
+import { responsiveTitleEllipsisSx } from '../titleTruncate'
+import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from './data-table.utils'
 
-export function MarketTitle({
+/** Title as in, the name of the pool or market, used in the corresponding title cell */
+export function TableRowTitle({
   address,
   title,
   url,

--- a/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableRowTitle.tsx
@@ -1,27 +1,13 @@
-import { capitalize } from 'lodash'
 import { MouseEvent, type ReactNode } from 'react'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
-import { t } from '@evm-ui/lib/i18n'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import type { Address } from '@primitives/address.utils'
-import { CopyIconButton } from '../CopyIconButton'
 import { RouterLink } from '../RouterLink'
 import { responsiveTitleEllipsisSx } from '../titleTruncate'
-import { CLICKABLE_IN_ROW_CLASS, DESKTOP_ONLY_HOVER_CLASS } from './data-table.utils'
+import { CLICKABLE_IN_ROW_CLASS } from './data-table.utils'
 
 /** Title as in, the name of the pool or market, used in the corresponding title cell */
-export function TableRowTitle({
-  address,
-  title,
-  url,
-  addressLabel = t`market`,
-}: {
-  address: Address
-  title: ReactNode
-  url: string
-  addressLabel?: string
-}) {
+export function TableRowTitle({ id, title, url }: { id: string; title: ReactNode; url: string }) {
   const isMobile = useIsMobile()
   return (
     <Typography
@@ -35,7 +21,7 @@ export function TableRowTitle({
         underline="none"
         href={url}
         className={CLICKABLE_IN_ROW_CLASS}
-        data-testid={`market-link-${address}`}
+        data-testid={`table-row-link-${id}`}
         {...(isMobile && {
           // cancel click on mobile so the panel can open, there is a separate button for navigating
           onClick: (e: MouseEvent<HTMLAnchorElement>) => e.preventDefault(),
@@ -48,14 +34,6 @@ export function TableRowTitle({
       >
         {title}
       </RouterLink>
-      <CopyIconButton
-        className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
-        label={t`Copy ${addressLabel.toLowerCase()} address`}
-        copyText={address}
-        confirmationText={t`${capitalize(addressLabel)} address copied`}
-        data-testid={`copy-market-address-${address}`}
-        sx={{ display: { mobile: 'none', tablet: 'flex' } }}
-      />
     </Typography>
   )
 }

--- a/packages/evm-ui/src/shared/ui/TokenIcons.tsx
+++ b/packages/evm-ui/src/shared/ui/TokenIcons.tsx
@@ -43,6 +43,7 @@ export type TokenIconsProps = {
   /** Size of the complete token group, not the individual token icons. */
   size?: TokenIconsSize
   showChainIcon?: boolean
+  showTooltips?: boolean
   /** How to render token collections containing more than four tokens. */
   overflowMode?: TokenIconsOverflowMode
 }
@@ -65,6 +66,7 @@ export function TokenIcons({
   tokens,
   size = 'xl',
   showChainIcon = false,
+  showTooltips = true,
   overflowMode = 'counter',
 }: TokenIconsProps) {
   // Trivial base case of zero tokens.
@@ -79,7 +81,7 @@ export function TokenIcons({
       <TokenIcon
         blockchainId={blockchainId}
         address={address}
-        tooltip={symbol}
+        {...(showTooltips && { tooltip: symbol })}
         showChainIcon={showChainIcon}
         sx={{ width: IconSize[size], height: IconSize[size] }}
       />
@@ -97,7 +99,7 @@ export function TokenIcons({
             key={address}
             blockchainId={blockchainId}
             address={address}
-            tooltip={symbol}
+            {...(showTooltips && { tooltip: symbol })}
             showChainIcon={showChainIcon && index === 0}
             sx={{
               width: IconSize[STACK_ICON_SIZE[size]],
@@ -132,7 +134,7 @@ export function TokenIcons({
           <TokenIcon
             blockchainId={blockchainId}
             address={address}
-            tooltip={symbol}
+            {...(showTooltips && { tooltip: symbol })}
             showChainIcon={showChainIcon && index === 0}
             sx={{ width: '100%', height: '100%' }}
           />

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -20,7 +20,7 @@ const getPoolListResponseFirstPoolName = (body: unknown) =>
 const waitForPoolListResponse = () =>
   cy.wait('@dex-pools', API_LOAD_TIMEOUT).then(({ response }) => {
     cy.contains(
-      '[data-testid^="market-link-"]',
+      '[data-testid^="table-row-link-"]',
       getPoolListResponseFirstPoolName(response?.body),
       API_LOAD_TIMEOUT,
     ).should('be.visible')
@@ -348,7 +348,7 @@ describe('DEX Pools', () => {
         .should('be.visible')
         .click({ waitForAnimations: false })
     } else {
-      cy.contains('[data-testid^="market-link-"]', filter).click()
+      cy.contains('[data-testid^="table-row-link-"]', filter).click()
     }
     cy.get('[data-testid="pool-form-tab-deposit"]', API_LOAD_TIMEOUT).should('be.visible')
     cy.window().then(win => win.history.go(-1))

--- a/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/columns.cy.ts
@@ -58,7 +58,7 @@ const expectFirstPool = (address: string) =>
   cy
     .get('[data-testid^="data-table-row-"]', API_LOAD_TIMEOUT)
     .first()
-    .find(`[data-testid="market-link-${address}"]`)
+    .find(`[data-testid="table-row-link-${address}"]`)
     .should('exist')
 
 const DEFAULT_FULL_COLUMNS = [PoolColumnId.PoolName, PoolColumnId.NetApy, PoolColumnId.Volume, PoolColumnId.Tvl]

--- a/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
+++ b/tests/cypress/e2e/llamalend/llamalend-markets.cy.ts
@@ -56,7 +56,7 @@ testCases.forEach(([width, height, breakpoint]) => {
         [MarketType.Lend, /\/lend\/\w+\/markets\/.+\/?$/],
       )
       filterByMarketType([width, height], type)
-      cy.get(`[data-testid^="market-link-"]`).first().click()
+      cy.get(`[data-testid^="table-row-link-"]`).first().click()
       if (breakpoint === 'mobile') {
         cy.get(`[data-testid^="llama-market-go-to-borrow"]`).click()
       }
@@ -128,7 +128,7 @@ testCases.forEach(([width, height, breakpoint]) => {
       const utilizationColumnId = MarketColumnId.UtilizationPercent
       cy.get(`[data-testid^="data-table-row"]`)
         .first()
-        .find(`[data-testid="market-link-${HIGH_TVL_ADDRESS}"]`)
+        .find(`[data-testid="table-row-link-${HIGH_TVL_ADDRESS}"]`)
         .should('exist')
       if (breakpoint == 'mobile') {
         withFilters(breakpoint, () => {
@@ -142,7 +142,7 @@ testCases.forEach(([width, height, breakpoint]) => {
         cy.get('[data-testid="drawer-sort-menu-lamalend-markets"]').should('not.be.visible')
         cy.get(`[data-testid^="data-table-row"]`)
           .first()
-          .find(`[data-testid="market-link-${HIGH_UTILIZATION_ADDRESS}"]`)
+          .find(`[data-testid="table-row-link-${HIGH_UTILIZATION_ADDRESS}"]`)
           .should('exist')
         expandFirstRowOnMobile(breakpoint)
         // note: not possible currently to sort ascending
@@ -194,14 +194,14 @@ testCases.forEach(([width, height, breakpoint]) => {
       cy.get("[data-testid='table-text-search-Llamalend Markets'] input").type('wstETH crvUSD')
       cy.url().should('include', 'search=wstETH+crvUSD')
       cy.scrollTo(0, 0)
-      cy.get(`[data-testid='market-link-${SFRX_ETH_MARKET}']`).should('not.exist')
-      cy.get(`[data-testid="market-link-${WST_ETH_MARKET}"]`).should('exist')
+      cy.get(`[data-testid='table-row-link-${SFRX_ETH_MARKET}']`).should('not.exist')
+      cy.get(`[data-testid="table-row-link-${WST_ETH_MARKET}"]`).should('exist')
     })
 
     it('should persists search filter across reload', () => {
       visitAndWait([width, height], `/llamalend/ethereum/markets/?search=wstETH+crvUSD`)
       cy.get("[data-testid='table-text-search-Llamalend Markets'] input").should('have.value', 'wstETH crvUSD')
-      cy.get(`[data-testid="market-link-${WST_ETH_MARKET}"]`).should('exist')
+      cy.get(`[data-testid="table-row-link-${WST_ETH_MARKET}"]`).should('exist')
       getTableCellAssets().first().contains('wstETH')
     })
 

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -41,7 +41,7 @@ export const visitV2PoolList = ({
 
 export const getV2PoolRow = (address: string) =>
   cy
-    .get(`[data-testid="market-link-${address}"]`, API_LOAD_TIMEOUT)
+    .get(`[data-testid="table-row-link-${address}"]`, API_LOAD_TIMEOUT)
     .should('exist')
     .closest('[data-testid^="data-table-row-"]')
 


### PR DESCRIPTION
Adds a new tooltip to pool titles that give a better quick overview of the pool's tokens, contracts and badges.

This means that we no longer need the copy button in the pool title itself.

<img width="470" height="475" alt="image" src="https://github.com/user-attachments/assets/3cf1b772-50f5-4426-826d-6ea49695ead5" />
