### PR TITLE
fix: use HTTP 510 to avoid retry logic

### DIFF
--- a/tests/cypress/e2e/dex/pool-list-v2/network-support.cy.ts
+++ b/tests/cypress/e2e/dex/pool-list-v2/network-support.cy.ts
@@ -1,6 +1,6 @@
 import { setupDexPoolListV2Mocks } from '@cy/support/helpers/dex-pool-list-v2-mocks'
 import { DESKTOP_VIEWPORT } from '@cy/support/helpers/dex-pools-list-v2.helpers'
-import { API_LOAD_TIMEOUT } from '@cy/support/ui'
+import { API_LOAD_TIMEOUT, UnexpectedApiRequest } from '@cy/support/ui'
 import { Chain } from '@evm-ui/utils/network'
 
 const visitPoolList = (network: string, supportAlias: `@${string}`) => {
@@ -34,7 +34,7 @@ describe('V2 pool-list network support', () => {
   it('shows the table error state without fetching pools for an unsupported Lite network', () => {
     cy.intercept(
       { method: 'GET', hostname: 'api2.curve.finance', pathname: `/get_pools/${Chain.Celo}` },
-      { statusCode: 503 },
+      UnexpectedApiRequest,
     ).as('dex-v2-unexpected-lite-pools')
 
     visitPoolList('celo', '@dex-v2-lite-pool-chains')

--- a/tests/cypress/support/helpers/dex-pool-list-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-mocks.ts
@@ -3,6 +3,7 @@ import { POOL_TYPE_FILTERS } from '@/dex/features/pool-list/filters/utils'
 import type { SortDirection, V2PoolSortField, PoolType } from '@curvefi/prices-api/pools'
 import { oneAddress, oneFloat } from '@cy/support/generators'
 import { oneToken } from '@cy/support/helpers/tokens'
+import { UnexpectedApiRequest } from '@cy/support/ui'
 import { Chain, requireBlockchainId } from '@evm-ui/utils/network'
 import type { Address } from '@primitives/address.utils'
 import { notFalsy, range } from '@primitives/objects.utils'
@@ -238,9 +239,10 @@ const mockDexPoolList = () =>
 
 // Keep DEX pool-list tests deterministic by failing on any prices API endpoint this helper does not own.
 const blockUnmockedDexPoolListApis = () =>
-  cy.intercept({ method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ }, req => {
-    req.reply({ statusCode: 503, body: { error: `Unexpected DEX pool list API request: ${req.url}` } })
-  })
+  cy.intercept(
+    { method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ },
+    UnexpectedApiRequest,
+  )
 
 export const setupDexPoolListMocks = () => {
   blockUnmockedDexPoolListApis()

--- a/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
+++ b/tests/cypress/support/helpers/dex-pool-list-v2-mocks.ts
@@ -1,5 +1,6 @@
 import { orderBy } from 'lodash'
 import type { PoolType } from '@curvefi/prices-api/pools'
+import { UnexpectedApiRequest } from '@cy/support/ui'
 import { Chain } from '@evm-ui/utils/network'
 import type { Address } from '@primitives/address.utils'
 
@@ -564,16 +565,15 @@ const mockMerklOpportunities = () =>
       return
     }
 
-    req.reply({ statusCode: 503, body: { error: `Unexpected Merkl request: ${req.url}` } })
+    req.reply(UnexpectedApiRequest)
   })
 
 export const setupDexPoolListV2Mocks = () => {
-  cy.intercept({ method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ }, req => {
-    req.reply({ statusCode: 503, body: { error: `Unexpected V2 pool-list request: ${req.url}` } })
-  })
-  cy.intercept({ method: 'GET', hostname: 'api2.curve.finance', pathname: /^\/get_pools\/\d+$/ }, req => {
-    req.reply({ statusCode: 503, body: { error: `Unexpected API2 pool-list request: ${req.url}` } })
-  })
+  cy.intercept(
+    { method: 'GET', hostname: 'prices.curve.finance', pathname: /^\/v2\/pools(?:\/.*)?$/ },
+    UnexpectedApiRequest,
+  )
+  cy.intercept({ method: 'GET', hostname: 'api2.curve.finance', pathname: /^\/get_pools\/\d+$/ }, UnexpectedApiRequest)
   mockPoolChains().as('dex-v2-pool-chains')
   mockLitePoolChains().as('dex-v2-lite-pool-chains')
   mockPoolList().as('dex-v2-pools')

--- a/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
+++ b/tests/cypress/support/helpers/llamalend/market-list-mocks.ts
@@ -6,6 +6,7 @@ import {
   mockMerklCampaigns,
 } from '@cy/support/helpers/lending-mocks'
 import { mockLlamalendChartApis } from '@cy/support/helpers/llamalend/mocks/llamalend-chart.mocks'
+import { UnexpectedApiRequest } from '@cy/support/ui'
 import { mockMintMarkets, mockMintSnapshots } from '../minting-mocks'
 import { mockTokenPrices } from '../tokens'
 
@@ -19,15 +20,8 @@ export const blockUnmockedApis = () => {
     'api.merkl.xyz',
     'api-core.curve.finance',
     'api.coingecko.com',
-  ].forEach(
-    hostname =>
-      void cy.intercept({ hostname }, req =>
-        req.reply({ statusCode: 503, body: { error: `Unexpected API request in Cypress test: ${req.url}` } }),
-      ),
-  )
-  cy.intercept('/api/merkl/*', req =>
-    req.reply({ statusCode: 503, body: { error: `Unexpected API request in Cypress test: ${req.url}` } }),
-  )
+  ].forEach(hostname => void cy.intercept({ hostname }, UnexpectedApiRequest))
+  cy.intercept('/api/merkl/*', UnexpectedApiRequest)
 }
 
 /** The cypress-wagmi-test-connector generates a fresh address at runtime, so we have to mock by pattern. */

--- a/tests/cypress/support/ui.ts
+++ b/tests/cypress/support/ui.ts
@@ -1,3 +1,4 @@
+import type { HttpRequestInterceptor } from 'cypress/types/net-stubbing'
 import { oneInt, oneOf } from '@cy/support/generators'
 
 export const e2eBaseUrl = () => Cypress.config('baseUrl')
@@ -48,6 +49,10 @@ export type AppPath = ReturnType<typeof oneAppPath>
 export const LOAD_TIMEOUT = { timeout: 30000 }
 export const TRANSACTION_LOAD_TIMEOUT = { timeout: 60000 } // higher timeout in case confirmations are slow
 export const API_LOAD_TIMEOUT = { timeout: 120000 } // unfortunately the prices API can be REAL SLOW 😭
+
+/** Intercept callback for blocking the backend for testing. We use 510 to avoid the HTTP retries for some 5xx errors */
+export const UnexpectedApiRequest: HttpRequestInterceptor = req =>
+  req.reply({ statusCode: 510, body: { error: `Unexpected API request in Cypress test to url ${req.url}` } })
 
 // scrollbar in px for the test browser. Firefox behaves when headless.
 export const SCROLL_WIDTH = Cypress.browser.name === 'firefox' ? (Cypress.browser.isHeadless ? 12 : 0) : 15


### PR DESCRIPTION
- In #3078 I have added retries for the HTTP requests with status 503.
- However, this was also used in tests for blocking API requests.
- This means the tests take a lot longer to accept an error when the API is blocked.
- Instead, this PR changes the logic to use HTTP 510.