### PR TITLE
fix: artifact download parent folder

### DIFF
--- a/tests/scripts/download-artifacts.ts
+++ b/tests/scripts/download-artifacts.ts
@@ -183,7 +183,9 @@ async function downloadLatestArtifacts({ cleanup }: { cleanup: boolean }): Promi
   const runId = RUN_ID || (await findLatestRunId(branch, workflow))
   if (!runId) throw new Error(`No ${workflow} runs for branch '${branch}'`)
 
-  const path = join(DEST_DIR, artifactBranch.replace(/\//g, '-') || 'current', runId)
+  const parent = join(DEST_DIR, artifactBranch.replace(/\//g, '-') || 'current')
+  await mkdir(parent, { recursive: true }) // make sure the parent directory exists
+  const path = join(parent, runId)
   const destination = join(repoRoot, path)
   await mkdir(destination) // hard fail on purpose when the folder exists
 


### PR DESCRIPTION
- Create the parent folder before checking if the same run ID is already there.
- This fixes script crashes when downloading to an existing parent folder.