### PR TITLE
fix: user can't vote if they never ever voted before

### DIFF
--- a/apps/main/src/dao/components/UserBox/VoteDialog.tsx
+++ b/apps/main/src/dao/components/UserBox/VoteDialog.tsx
@@ -36,7 +36,7 @@ export const VoteDialog = ({
 }: Props) => {
   const { data: proposalsMapper } = useProposalsMapperQuery({})
   const { data: pricesProposal } = useProposalPricesApiQuery({ proposalId, proposalType })
-  const { data: userProposalVotes, isSuccess: userProposalVotesSuccess } = useUserProposalVotesQuery({
+  const { data: userProposalVotes, isLoading: isLoadingUserProposalVotes } = useUserProposalVotesQuery({
     userAddress: userAddress ?? '',
   })
   const proposalKey = createProposalKey(proposalId, proposalType)
@@ -149,7 +149,7 @@ export const VoteDialog = ({
     return <PendingTx pendingMessage={t`Casting vote...`} />
   }
 
-  if (userProposalVotesSuccess) {
+  if (!voted && !isLoadingUserProposalVotes) {
     return (
       <Wrapper className={className}>
         {/* Vote */}


### PR DESCRIPTION
If a user has never voted before, the prices API returns a 404 rather than an empty object with 200, so `userProposalVotesSuccess` fails and the voting buttons never show.

Instead of just checking if the API call was successful or not, we should rather always show the button when the user hasn't voted yet, except when vote data is currently being fetched.

In other words, always show vote buttons, except if we know for sure the user's already voted.