### PR TITLE
fix: pool visibility settings can unmount when table starts to overflow

### DIFF
--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -11,6 +11,7 @@ import { TableFiltersChip } from '@evm-ui/shared/ui/DataTable/TableFiltersChip'
 import { TableFiltersOverlay } from '@evm-ui/shared/ui/DataTable/TableFiltersOverlay'
 import { TableHeader } from '@evm-ui/shared/ui/DataTable/TableHeader'
 import { TableSortDrawer } from '@evm-ui/shared/ui/DataTable/TableSortDrawer'
+import { TableVisibilitySettingsPopover } from '@evm-ui/shared/ui/DataTable/TableVisibilitySettingsPopover'
 import { CURVE_SOCIALS } from '@legacy-ui/utils'
 import Stack from '@mui/material/Stack'
 import type { ExpandedState } from '@tanstack/react-table'
@@ -38,7 +39,9 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   const isLite = network.isLite
   const isMobile = useIsMobile()
   const [filtersOpen, , , , setFiltersOpen] = useSwitch(false)
+  const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch(false)
   const filterChipRef = useRef<HTMLDivElement>(null)
+  const visibilitySettingsRef = useRef<HTMLButtonElement>(null)
   const { onPaginationChange, pagination, updateQueryAndResetPage } = usePoolsPagination()
   const { globalFilter, columnFilters, apiParams, filterProps, onSearch, resetFilters, searchText } = usePoolsFilters()
   const { onSortingChange, sortBy, sortDirection, sortField, sorting, sortOptions } = usePoolsSorting(
@@ -108,10 +111,13 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
         expandedPanel={{ Body: POOL_EXPANDED_PANEL_BODIES[variant], Actions: PoolExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
-        <TableFilters<PoolColumnId>
+        <TableFilters
           testIdPrefix={LOCAL_STORAGE_KEY}
-          visibilityGroups={columnSettings}
-          toggleVisibility={toggleVisibility}
+          visibilitySettings={{
+            anchorRef: visibilitySettingsRef,
+            open: visibilitySettingsOpen,
+            onOpen: openVisibilitySettings,
+          }}
           searchText={searchText}
           onSearch={onSearch}
           collapsibleFilters={
@@ -151,7 +157,13 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
           }
         />
       </DataTable>
-      {/* Keep the overlay outside DataTable children because DataTable remounts them when switching sticky header layout. */}
+      <TableVisibilitySettingsPopover<PoolColumnId>
+        anchorRef={visibilitySettingsRef}
+        visibilityGroups={columnSettings}
+        toggleVisibility={toggleVisibility}
+        open={visibilitySettingsOpen}
+        onClose={closeVisibilitySettings}
+      />
       {!isLite && (
         <TableFiltersOverlay
           anchorRef={filterChipRef}

--- a/apps/main/src/llamalend/features/market-list/MarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/MarketsTable.tsx
@@ -10,6 +10,7 @@ import { useFilters } from '@evm-ui/shared/ui/DataTable/hooks/useFilters'
 import { TableFilters } from '@evm-ui/shared/ui/DataTable/TableFilters'
 import { TableFiltersChip } from '@evm-ui/shared/ui/DataTable/TableFiltersChip'
 import { TableHeader } from '@evm-ui/shared/ui/DataTable/TableHeader'
+import { TableVisibilitySettingsPopover } from '@evm-ui/shared/ui/DataTable/TableVisibilitySettingsPopover'
 import { mapQuery, type QueryProp } from '@evm-ui/types/util'
 import Stack from '@mui/material/Stack'
 import { ExpandedState } from '@tanstack/react-table'
@@ -38,7 +39,9 @@ export const MarketsTable = ({
 }) => {
   const { markets: data = [], userHasPositions, hasFavorites } = queryData ?? {}
   const [filtersOpen, , , , setFiltersOpen] = useSwitch(false)
+  const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch(false)
   const filterChipRef = useRef<HTMLDivElement>(null)
+  const visibilitySettingsRef = useRef<HTMLButtonElement>(null)
   const isMobile = useIsMobile()
 
   const { globalFilter, setGlobalFilter, columnFilters, columnFiltersById, setColumnFilter, resetFilters } = useFilters(
@@ -82,10 +85,13 @@ export const MarketsTable = ({
         expandedPanel={{ Body: MarketExpandedPanel, Actions: MarketExpandedPanelActions }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
-        <TableFilters<MarketColumnId>
+        <TableFilters
           testIdPrefix={LOCAL_STORAGE_KEY}
-          visibilityGroups={columnSettings}
-          toggleVisibility={toggleVisibility}
+          visibilitySettings={{
+            anchorRef: visibilitySettingsRef,
+            open: visibilitySettingsOpen,
+            onOpen: openVisibilitySettings,
+          }}
           disableSearchAutoFocus
           searchText={globalFilter}
           onSearch={setGlobalFilter}
@@ -113,7 +119,13 @@ export const MarketsTable = ({
           chips={<MarketsChips hasFavorites={hasFavorites} {...filterProps} />}
         />
       </DataTable>
-      {/* Keep the overlay outside DataTable children because DataTable remounts them when switching sticky header layout. */}
+      <TableVisibilitySettingsPopover<MarketColumnId>
+        anchorRef={visibilitySettingsRef}
+        visibilityGroups={columnSettings}
+        toggleVisibility={toggleVisibility}
+        open={visibilitySettingsOpen}
+        onClose={closeVisibilitySettings}
+      />
       <MarketsFiltersOverlay
         table={table}
         hasActiveFilters={hasActiveFilters}

--- a/packages/evm-ui/src/shared/ui/DataTable/TableFilters.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableFilters.tsx
@@ -1,6 +1,5 @@
-import { ReactNode, useRef } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
-import { useSwitch } from '@evm-ui/hooks/useSwitch'
 import { GearIcon } from '@evm-ui/shared/icons/GearIcon'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import Box from '@mui/material/Box'
@@ -9,18 +8,15 @@ import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
 import { TableButton } from './TableButton'
 import { TableSearchField } from './TableSearchField'
-import { TableVisibilitySettingsPopover } from './TableVisibilitySettingsPopover'
-import type { VisibilityGroup } from './visibility.types'
 
 const { Spacing } = SizesAndSpaces
 
 /**
  * A component that wraps a table and provides a title, subtitle, and filter controls.
  */
-export const TableFilters = <ColumnIds extends string>({
+export const TableFilters = ({
   testIdPrefix,
-  visibilityGroups,
-  toggleVisibility,
+  visibilitySettings,
   collapsibleFilters,
   chips,
   filterChip,
@@ -30,8 +26,11 @@ export const TableFilters = <ColumnIds extends string>({
   onSearch,
 }: {
   testIdPrefix: string
-  visibilityGroups: VisibilityGroup<ColumnIds>[]
-  toggleVisibility?: (columns: string[]) => void
+  visibilitySettings?: {
+    anchorRef: RefObject<HTMLButtonElement | null>
+    open: boolean
+    onOpen: () => void
+  }
   // collapsible bar that displays the active filters
   collapsibleFilters?: { collapsible: ReactNode; hasActiveFilters?: boolean | undefined }
   chips?: ReactNode // buttons that are part of the collapsible (on mobile) or always visible (on larger screens)
@@ -41,8 +40,6 @@ export const TableFilters = <ColumnIds extends string>({
   disableSearchAutoFocus?: boolean
   onSearch: (value: string) => void
 }) => {
-  const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch()
-  const settingsRef = useRef<HTMLButtonElement>(null)
   // search is here because we remove the table title when searching on mobile
   const isMobile = useIsMobile()
   const { collapsible, hasActiveFilters } = collapsibleFilters ?? {}
@@ -77,26 +74,19 @@ export const TableFilters = <ColumnIds extends string>({
         {!isMobile && (
           <Grid container size="grow" spacing="none" sx={{ justifyContent: 'flex-end' }}>
             {chips}
-            <TableButton
-              ref={settingsRef}
-              onClick={openVisibilitySettings}
-              icon={GearIcon}
-              testId="btn-visibility-settings"
-              active={visibilitySettingsOpen}
-            />
+            {visibilitySettings && (
+              <TableButton
+                ref={visibilitySettings.anchorRef}
+                onClick={visibilitySettings.onOpen}
+                icon={GearIcon}
+                testId="btn-visibility-settings"
+                active={visibilitySettings.open}
+              />
+            )}
           </Grid>
         )}
       </Grid>
       {collapsible && <Collapse in={!!hasActiveFilters || isMobile}>{collapsible}</Collapse>}
-      {visibilitySettingsOpen != null && toggleVisibility && (
-        <TableVisibilitySettingsPopover<ColumnIds>
-          anchorRef={settingsRef}
-          visibilityGroups={visibilityGroups}
-          toggleVisibility={toggleVisibility}
-          open={visibilitySettingsOpen}
-          onClose={closeVisibilitySettings}
-        />
-      )}
     </Stack>
   )
 }

--- a/packages/evm-ui/src/shared/ui/DataTable/TableVisibilitySettingsPopover.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/TableVisibilitySettingsPopover.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from 'react'
+import { useSwitch } from '@evm-ui/hooks/useSwitch'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import { borderStyle } from '@evm-ui/utils'
 import { FormControlLabel } from '@mui/material'
@@ -18,27 +19,30 @@ export const TableVisibilitySettingsPopover = <ColumnIds extends string>({
   toggleVisibility,
   open,
   onClose,
-  anchorRef: { current: anchorEl },
+  anchorRef,
 }: {
   open: boolean
   onClose: () => void
   visibilityGroups: VisibilityGroup<ColumnIds>[]
   toggleVisibility: (columns: string[]) => void
   anchorRef: RefObject<HTMLButtonElement | null>
-}) =>
-  anchorEl && (
+}) => {
+  const [isReady, setReady, resetReady] = useSwitch()
+
+  return (
     <Popover
       open={open}
       onClose={onClose}
-      anchorEl={anchorEl}
+      anchorEl={() => anchorRef.current}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       slotProps={{
         paper: {
           sx: { padding: Spacing.md },
         },
+        transition: { onEntered: setReady, onExited: resetReady },
       }}
     >
-      <Stack sx={{ gap: Spacing.md }}>
+      <Stack data-testid={isReady ? 'visibility-settings-popover' : undefined} sx={{ gap: Spacing.md }}>
         {visibilityGroups
           .filter(({ options }) => options.some(o => o.enabled))
           .map(({ options, label }) => (
@@ -70,3 +74,4 @@ export const TableVisibilitySettingsPopover = <ColumnIds extends string>({
       </Stack>
     </Popover>
   )
+}

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -50,16 +50,15 @@ export const getV2PoolCell = (address: string, columnId: PoolColumnId) =>
   getV2PoolRow(address).find(`[data-testid="data-table-cell-${columnId}"]`)
 
 export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
+  cy.get('[data-testid="btn-visibility-settings"]').click()
   for (const columnId of columnIds) {
-    cy.get('[data-testid="btn-visibility-settings"]').click()
     cy.get(`[data-testid="visibility-toggle-${columnId}"]`)
       .should('be.visible')
-      .find('input')
-      .then($input => {
-        if (!$input.is(':checked')) cy.wrap($input).check({ force: true })
+      .then($toggle => {
+        if (!$toggle.find('input').is(':checked')) cy.wrap($toggle).click()
       })
-    cy.get('body').click(0, 0)
   }
+  cy.get('body').click(0, 0)
 }
 
 export const getV2PoolExpandedPanel = (address: string) => getV2PoolRow(address).next('tr').should('be.visible')

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -28,6 +28,7 @@ export const visitV2PoolList = ({
     cy.wait('@dex-v2-pools', API_LOAD_TIMEOUT)
   }
   cy.wait('@dex-v2-merkl-curve', API_LOAD_TIMEOUT)
+  cy.get('[data-testid="data-table"]', API_LOAD_TIMEOUT).should('be.visible')
 
   if (!isMobile && network === 'ethereum') {
     cy.get(`[data-testid="data-table-header-${PoolColumnId.NetApy}"]`, API_LOAD_TIMEOUT).should('be.visible')

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -50,15 +50,16 @@ export const getV2PoolCell = (address: string, columnId: PoolColumnId) =>
   getV2PoolRow(address).find(`[data-testid="data-table-cell-${columnId}"]`)
 
 export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
-  cy.get('[data-testid="btn-visibility-settings"]').click()
   for (const columnId of columnIds) {
+    // Adding columns can remount the filters when the table starts overflowing.
+    cy.get('[data-testid="btn-visibility-settings"]').click()
     cy.get(`[data-testid="visibility-toggle-${columnId}"]`)
       .should('be.visible')
       .then($toggle => {
         if (!$toggle.find('input').is(':checked')) cy.wrap($toggle).click()
       })
+    cy.get('body').click(0, 0)
   }
-  cy.get('body').click(0, 0)
 }
 
 export const getV2PoolExpandedPanel = (address: string) => getV2PoolRow(address).next('tr').should('be.visible')

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -24,6 +24,7 @@ export const visitV2PoolList = ({
     cy.wait('@dex-v2-lite-pool-chains', API_LOAD_TIMEOUT)
     cy.wait('@dex-v2-lite-pools', API_LOAD_TIMEOUT)
   } else {
+    cy.wait(['@dex-v2-pool-filters', '@dex-v2-hidden-pools'], API_LOAD_TIMEOUT)
     cy.wait('@dex-v2-pool-chains', API_LOAD_TIMEOUT)
     cy.wait('@dex-v2-pools', API_LOAD_TIMEOUT)
   }
@@ -50,16 +51,16 @@ export const getV2PoolCell = (address: string, columnId: PoolColumnId) =>
   getV2PoolRow(address).find(`[data-testid="data-table-cell-${columnId}"]`)
 
 export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
+  cy.get('[data-testid="btn-visibility-settings"]').click()
+  cy.get('[data-testid="visibility-settings-popover"]').should('be.visible')
   for (const columnId of columnIds) {
-    // Adding columns can remount the filters when the table starts overflowing.
-    cy.get('[data-testid="btn-visibility-settings"]').click()
     cy.get(`[data-testid="visibility-toggle-${columnId}"]`)
       .should('be.visible')
       .then($toggle => {
         if (!$toggle.find('input').is(':checked')) cy.wrap($toggle).click()
       })
-    cy.get('body').click(0, 0)
   }
+  cy.get('body').click(0, 0)
 }
 
 export const getV2PoolExpandedPanel = (address: string) => getV2PoolRow(address).next('tr').should('be.visible')


### PR DESCRIPTION
PR was initially created to fix the flakyness surrounding the visibility settings in the new pool list tests, but turns out there was also a real bug regarding table overflowing when too many columns are being toggled on.

The solution for now is to pull the visibility settings popover out of the filters component and make the table itself own it, so that it won't get remounted when an overflow occurs.

You can reproduce the issue on stable by having a small browser window (still desktop or tablet viewport) and toggle on all columns in the new v2 pool list.