### PR TITLE
feat: disable default pools TVL filter

### DIFF
--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -80,6 +80,7 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
       globalFilter,
       ...(!isLite && { pagination, columnFilters }),
     },
+    getRowId: row => row.address,
     onExpandedChange: setExpanded,
     ...(!isLite && { onPaginationChange }),
     onSortingChange,

--- a/apps/main/src/dex/features/pool-list/filters/utils.ts
+++ b/apps/main/src/dex/features/pool-list/filters/utils.ts
@@ -19,8 +19,13 @@ export enum PoolFilterId {
   Apy = 'apy',
 }
 
-// Hide small pools by default, without treating the default min as an active UI filter on its own.
-export const POOL_DEFAULT_TVL_MIN = 10_000
+/**
+ * Hide small pools by default, without treating the default min as an active UI filter on its own.
+ * Used to be $10k but has been set to 0 as it's not immediately obvious to users why some pools are missing.
+ * Tutti is working on an alternative approach, in the menatime the TVL filter should not block the release of the new pools list.
+ * Besides, we have pagination now anyway so do we really need this filter to begin with?
+ */
+export const POOL_DEFAULT_TVL_MIN = 0
 
 export type PoolsNumberRange = Range<number | null>
 export type PoolsQueryUpdater = (update: Record<string, string | string[] | null>) => void

--- a/apps/main/src/llamalend/features/market-list/MarketsTable.tsx
+++ b/apps/main/src/llamalend/features/market-list/MarketsTable.tsx
@@ -62,6 +62,7 @@ export const MarketsTable = ({
     query: mapQuery(tableQuery, d => d.markets),
     state: { expanded, sorting, columnVisibility, columnFilters, globalFilter },
     initialState: { pagination },
+    getRowId: row => row.controllerAddress,
     onSortingChange,
     onExpandedChange: setExpanded,
     globalFilterFn,

--- a/packages/evm-ui/src/shared/ui/DataTable/data-table.utils.ts
+++ b/packages/evm-ui/src/shared/ui/DataTable/data-table.utils.ts
@@ -88,6 +88,7 @@ const options = tableOptions({
   features,
   getRowCanExpand: () => true, // expanded panels are generic sibling rows with their own 'can expand' check; subRows are tied to the column layout (which means you can't show just *any* generic panel component)
   autoResetPageIndex: false, // autoreset causes stack-too-deep errors when receiving new data
+  autoResetExpanded: false, // very annoying to have rows collapsed when searching or Merkl data comes in
   maxMultiSortColCount: 3, // allow three columns to be sorted while holding shift
 })
 

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -6,7 +6,7 @@ import { API_LOAD_TIMEOUT, type Breakpoint, LOAD_TIMEOUT, oneViewport } from '@c
 import { getRangeFilterLabel } from '@evm-ui/shared/ui/DataTable/filters'
 import { assert } from '@primitives/objects.utils'
 
-const DEFAULT_POOL_LIST_MIN_TVL_INPUT = '10k'
+const DEFAULT_POOL_LIST_MIN_TVL_INPUT = '0'
 const POOL_LIST_FILTER_POOL_TYPE = 'crypto'
 const POOL_LIST_FILTER_TVL_MIN = 480_000_000
 const POOL_LIST_FILTER_TVL_MAX = 500_000_000

--- a/tests/cypress/e2e/dex/dex-markets.cy.ts
+++ b/tests/cypress/e2e/dex/dex-markets.cy.ts
@@ -6,7 +6,6 @@ import { API_LOAD_TIMEOUT, type Breakpoint, LOAD_TIMEOUT, oneViewport } from '@c
 import { getRangeFilterLabel } from '@evm-ui/shared/ui/DataTable/filters'
 import { assert } from '@primitives/objects.utils'
 
-const DEFAULT_POOL_LIST_MIN_TVL_INPUT = '0'
 const POOL_LIST_FILTER_POOL_TYPE = 'crypto'
 const POOL_LIST_FILTER_TVL_MIN = 480_000_000
 const POOL_LIST_FILTER_TVL_MAX = 500_000_000
@@ -160,18 +159,6 @@ describe('DEX Pools', () => {
       return waitForPoolListResponse()
     }
 
-    it('applies the default TVL min without URL or active filter state', () => {
-      visitAndWait(width, height)
-      cy.location('search').should('not.include', 'tvl=')
-      expectLastPoolRequestParams(params => {
-        expect(params.get('min_tvl')).to.equal(`${POOL_DEFAULT_TVL_MIN}`)
-      })
-      cy.get('[data-testid="dex-pool-active-filter-tvl"]').should('not.exist')
-      openPoolFilters()
-      cy.get('[data-testid="range-filter-tvl-min"] input').should('have.value', DEFAULT_POOL_LIST_MIN_TVL_INPUT)
-      closePoolFilters()
-    })
-
     it('sorts by TVL (desc/asc)', () => {
       visitAndWait(width, height)
       cy.url().should('not.include', 'tvl') // initial sort not in URL
@@ -245,25 +232,6 @@ describe('DEX Pools', () => {
       cy.get('[data-testid="dex-pool-active-filter-tvl"]').should('be.visible')
     })
 
-    it('filters by TVL max input with an explicit zero min in the URL and API request', () => {
-      visitAndWait(width, height)
-      const maxTvl = POOL_LIST_FILTER_TVL_MAX
-
-      setRangeFilter('tvl', 'min', 0)
-      expectUrlQueryParam('tvl', '0~')
-
-      setRangeFilter('tvl', 'max', maxTvl)
-      expectLastPoolRequestParams(params => {
-        expect(params.get('min_tvl')).to.equal('0')
-        expect(params.get('max_tvl')).to.equal(`${maxTvl}`)
-      })
-      // Direct range-input edits preserve the component's explicit zero lower bound.
-      expectUrlQueryParam('tvl', `0~${maxTvl}`)
-      cy.get('[data-testid="dex-pool-active-filter-tvl"]')
-        .should('be.visible')
-        .and('contain.text', getPoolListTvlRangeChip(0, maxTvl))
-    })
-
     it('filters by Volume range input', () => {
       visitAndWait(width, height)
       const maxVolume = POOL_LIST_FILTER_VOLUME_MAX
@@ -295,15 +263,6 @@ describe('DEX Pools', () => {
       cy.get('[data-testid="dex-pool-active-filter-tvl"]')
         .should('be.visible')
         .and('contain.text', getPoolListTvlRangeChip(POOL_DEFAULT_TVL_MIN, maxTvl))
-    })
-
-    it('keeps explicit zero TVL min as an active filter', () => {
-      visitAndWait(width, height, { query: { tvl: '0~' } })
-      expectLastPoolRequestParams(params => {
-        expect(params.get('min_tvl')).to.equal('0')
-      })
-      expectUrlQueryParam('tvl', '0~')
-      cy.get('[data-testid="dex-pool-active-filter-tvl"]').should('be.visible').and('contain.text', '>$0')
     })
 
     it('keeps zero Base vAPY min as an active filter', () => {

--- a/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
+++ b/tests/cypress/support/helpers/dex-pools-list-v2.helpers.ts
@@ -63,7 +63,8 @@ export const showV2PoolColumns = (columnIds: readonly PoolColumnId[]) => {
   cy.get('body').click(0, 0)
 }
 
-export const getV2PoolExpandedPanel = (address: string) => getV2PoolRow(address).next('tr').should('be.visible')
+export const getV2PoolExpandedPanel = (address: string) =>
+  getV2PoolRow(address).next('tr').should('have.attr', 'data-testid', 'data-table-expansion-row').and('be.visible')
 
 export const expandV2PoolRow = (address: string) => {
   getV2PoolRow(address).find('[data-testid="expand-icon"]').click()


### PR DESCRIPTION
We've decided to disable the default $10k TVL filter for now as we wait for an alternative solution, so we can release the new pools list. But perhaps one is not needed, given we have pagination now anyway.

Also fixes some tests (I hope)