### PR TITLE
refactor: network inversion part 2

### DIFF
--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
@@ -17,6 +17,7 @@ import {
   gnosis,
   ink,
   kava,
+  mainnet,
   mantle,
   monad,
   moonbeam,
@@ -35,7 +36,7 @@ import {
   xLayer,
   zksync,
 } from '@wagmi/core/chains'
-import { ethereum as mainnet, expchain, hyperliquid, megaeth, strata } from './custom-chains'
+import { expchain, hyperliquid, megaeth, strata } from './custom-chains'
 
 const wagmiChains = [
   arbitrum,

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
@@ -15,6 +15,7 @@ import {
   fantom,
   fraxtal,
   gnosis,
+  hyperliquid,
   ink,
   kava,
   mainnet,
@@ -36,7 +37,7 @@ import {
   xLayer,
   zksync,
 } from '@wagmi/core/chains'
-import { expchain, hyperliquid, megaeth, strata } from './custom-chains'
+import { expchain, megaeth, strata } from './custom-chains'
 
 const wagmiChains = [
   arbitrum,

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/custom-chains.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/custom-chains.ts
@@ -1,26 +1,8 @@
-/**
- * WalletConnect ignores the configured HTTP transport URLs from Wagmi config
- * and instead creates a provider using only the first URL from chain.rpcUrls.default.http.
- *
- * This is why we need to define custom chains with specific RPC URLs that will work
- * properly when WalletConnect initializes its provider with:
- * `new WalletConnectProvider({ rpc: chain.rpcUrls.default.http[0] })`
- *
- * blockExplorers are not defined here, they get set in `createChain`.
- */
 import { chainConfig } from 'viem/op-stack'
 import { defineChain } from 'viem/utils'
 import { Chain as ChainId } from '@evm-ui/utils/network'
 import { mainnet } from '@wagmi/core/chains'
 import { RPC } from './rpc'
-
-export const ethereum = defineChain({
-  ...mainnet,
-  rpcUrls: {
-    default: { http: RPC[ChainId.Ethereum] },
-    public: { http: RPC[ChainId.Ethereum] },
-  },
-})
 
 export const hyperliquid = defineChain({
   ...chainConfig,

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/custom-chains.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/custom-chains.ts
@@ -4,15 +4,6 @@ import { Chain as ChainId } from '@evm-ui/utils/network'
 import { mainnet } from '@wagmi/core/chains'
 import { RPC } from './rpc'
 
-export const hyperliquid = defineChain({
-  ...chainConfig,
-  id: ChainId.Hyperliquid as const,
-  name: 'hyperliquid',
-  testnet: false,
-  nativeCurrency: { name: 'Hype', symbol: 'HYPE', decimals: 18 },
-  rpcUrls: { default: { http: RPC[ChainId.Hyperliquid] } },
-})
-
 export const megaeth = defineChain({
   ...chainConfig,
   id: ChainId.MegaEth as const,

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/wagmi-test-config.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/wagmi-test-config.ts
@@ -1,7 +1,7 @@
 import { http } from 'viem'
 import { generatePrivateKey } from 'viem/accounts'
+import { mainnet } from 'viem/chains'
 import type { Hex } from '@primitives/address.utils'
-import { ethereum } from './custom-chains'
 import { createWagmiConfig } from './wagmi-config'
 import { createTestConnector } from './wagmi-test'
 
@@ -11,7 +11,7 @@ type CreateTestWagmiConfigOptions = {
 
 export const createTestWagmiConfig = ({ privateKey = generatePrivateKey() }: CreateTestWagmiConfigOptions = {}) =>
   createWagmiConfig({
-    chains: [ethereum],
-    connectors: [createTestConnector({ privateKey, chain: ethereum })],
-    transports: { [ethereum.id]: http() },
+    chains: [mainnet],
+    connectors: [createTestConnector({ privateKey, chain: mainnet })],
+    transports: { [mainnet.id]: http() },
   })

--- a/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
@@ -1,5 +1,5 @@
 import { custom, fallback, http, type RpcTransactionReceipt, zeroAddress } from 'viem'
-import { ethereum } from '@evm-ui/features/connect-wallet/lib/wagmi/custom-chains'
+import { mainnet } from 'viem/chains'
 import { WAGMI_HTTP_OPTIONS } from '@evm-ui/features/connect-wallet/lib/wagmi/transports'
 import { createWagmiConfig } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-config'
 import { createTestConnector } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-test'
@@ -31,7 +31,7 @@ const mockedReceiptTransport = custom({
 })
 
 export const mockedWagmiConfig = createWagmiConfig({
-  chains: [ethereum],
-  connectors: [createTestConnector({ privateKey: TEST_PRIVATE_KEY, chain: ethereum })],
-  transports: { [ethereum.id]: fallback([mockedReceiptTransport, http(undefined, WAGMI_HTTP_OPTIONS)]) },
+  chains: [mainnet],
+  connectors: [createTestConnector({ privateKey: TEST_PRIVATE_KEY, chain: mainnet })],
+  transports: { [mainnet.id]: fallback([mockedReceiptTransport, http(undefined, WAGMI_HTTP_OPTIONS)]) },
 })


### PR DESCRIPTION
Removes the custom mainnet and hyperliquid chain definitons, wagmi provides those. `createChainFromNetwork` also overrides the default RPCs with `getRpcUrls` so that whole WalletConnect thing isn't needed anymore for mainnet.