### PR TITLE
feat: table visibility migration

### DIFF
--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from 'react'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
 import type { MigrationOptions } from '@evm-ui/hooks/useStoredState'
-import { useVisibilitySettings } from '@evm-ui/shared/ui/DataTable/hooks/useVisibilitySettings'
+import {
+  preserveVisibilityChoices,
+  useVisibilitySettings,
+} from '@evm-ui/shared/ui/DataTable/hooks/useVisibilitySettings'
 import type { VisibilityGroup } from '@evm-ui/shared/ui/DataTable/visibility.types'
-import { fromEntries, recordValues } from '@primitives/objects.utils'
+import { fromEntries, mapRecord, recordValues } from '@primitives/objects.utils'
 import { POOL_COLUMNS, POOLS_COLUMN_OPTIONS, PoolColumnId } from '../columns'
 import type { PoolsSorting } from './usePoolsSorting'
 
@@ -11,6 +14,8 @@ export type PoolColumnVariant = keyof typeof POOLS_COLUMN_OPTIONS
 
 const migration: MigrationOptions<Record<PoolColumnVariant, VisibilityGroup<PoolColumnId>[]>> = {
   version: 3,
+  migrate: (oldValue, initialValue) =>
+    mapRecord(initialValue, (variant, currentGroups) => preserveVisibilityChoices(oldValue[variant], currentGroups)),
 }
 
 /**

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
@@ -13,7 +13,7 @@ import type { PoolsSorting } from './usePoolsSorting'
 export type PoolColumnVariant = keyof typeof POOLS_COLUMN_OPTIONS
 
 const migration: MigrationOptions<Record<PoolColumnVariant, VisibilityGroup<PoolColumnId>[]>> = {
-  version: 3,
+  version: 4,
   migrate: (oldValue, initialValue) =>
     mapRecord(initialValue, (variant, currentGroups) => preserveVisibilityChoices(oldValue[variant], currentGroups)),
 }

--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketsVisibility.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketsVisibility.tsx
@@ -3,7 +3,10 @@ import { useMemo } from 'react'
 import type { LlamaMarketsResult } from '@/llamalend/queries/market-list/llama-markets'
 import { useIsMobile } from '@evm-ui/hooks/useBreakpoints'
 import type { MigrationOptions } from '@evm-ui/hooks/useStoredState'
-import { useVisibilitySettings } from '@evm-ui/shared/ui/DataTable/hooks/useVisibilitySettings'
+import {
+  preserveVisibilityChoices,
+  useVisibilitySettings,
+} from '@evm-ui/shared/ui/DataTable/hooks/useVisibilitySettings'
 import type { VisibilityGroup } from '@evm-ui/shared/ui/DataTable/visibility.types'
 import { mapRecord } from '@primitives/objects.utils'
 import { SortingState } from '@tanstack/react-table'
@@ -17,28 +20,23 @@ import {
 
 type MarketColumnVariant = keyof typeof MARKETS_COLUMN_OPTIONS
 
-/** Preserve users' saved visibility choices while adding newly introduced column options from defaults. */
-const mergeVisibilityGroups = (
-  oldGroups: VisibilityGroup<MarketColumnId>[] | undefined,
-  initialGroups: VisibilityGroup<MarketColumnId>[],
-): VisibilityGroup<MarketColumnId>[] =>
-  initialGroups.map((initialGroup, index) => {
-    const oldGroup = oldGroups?.find(group => group.label === initialGroup.label) ?? oldGroups?.[index]
-    return oldGroup
-      ? {
-          ...initialGroup,
-          options: initialGroup.options.map(initialOption => {
-            const oldOption =
-              oldGroup.options.find(oldOption => isEqual(oldOption.columns, initialOption.columns)) ?? initialOption
-            return isEqual(initialOption.columns, [MarketColumnId.NetBorrowRate])
-              ? { ...oldOption, active: initialOption.active }
-              : isEqual(initialOption.columns, [MarketColumnId.BorrowRate])
-                ? { ...oldOption, active: false }
-                : oldOption
-          }),
-        }
-      : initialGroup
-  })
+const resolveMarketActive = (
+  preservedActive: boolean,
+  currentOption: VisibilityGroup<MarketColumnId>['options'][number],
+) =>
+  isEqual(currentOption.columns, [MarketColumnId.NetBorrowRate])
+    ? currentOption.active
+    : isEqual(currentOption.columns, [MarketColumnId.BorrowRate])
+      ? false
+      : preservedActive
+
+const migration: MigrationOptions<Record<MarketColumnVariant, VisibilityGroup<MarketColumnId>[]>> = {
+  version: 6,
+  migrate: (oldValue, initialValue) =>
+    mapRecord(initialValue, (variant, currentGroups) =>
+      preserveVisibilityChoices(oldValue[variant], currentGroups, resolveMarketActive),
+    ),
+}
 
 export const getMarketsColumnVariant = (
   userHasPositions: LlamaMarketsResult['userHasPositions'] | undefined,
@@ -46,12 +44,6 @@ export const getMarketsColumnVariant = (
   userHasPositions == null // we treat undefined (loading),  and null (no positions at all) as the same variant
     ? 'noPositions'
     : 'hasPositions' // show the general market table, for users with positions
-
-const migration: MigrationOptions<Record<MarketColumnVariant, VisibilityGroup<MarketColumnId>[]>> = {
-  version: 6,
-  migrate: (oldValue, initialValue) =>
-    mapRecord(initialValue, (variant, initialGroups) => mergeVisibilityGroups(oldValue[variant], initialGroups)),
-}
 
 /**
  * Hook to manage the visibility of columns in the markets table.

--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketsVisibility.tsx
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketsVisibility.tsx
@@ -26,9 +26,7 @@ const resolveMarketActive = (
 ) =>
   isEqual(currentOption.columns, [MarketColumnId.NetBorrowRate])
     ? currentOption.active
-    : isEqual(currentOption.columns, [MarketColumnId.BorrowRate])
-      ? false
-      : preservedActive
+    : !isEqual(currentOption.columns, [MarketColumnId.BorrowRate]) && preservedActive
 
 const migration: MigrationOptions<Record<MarketColumnVariant, VisibilityGroup<MarketColumnId>[]>> = {
   version: 6,

--- a/packages/evm-ui/src/shared/ui/DataTable/hooks/useVisibilitySettings.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/hooks/useVisibilitySettings.tsx
@@ -22,6 +22,29 @@ const flatten = <ColumnIds extends string>(visibilitySettings: VisibilityGroup<C
     {},
   )
 
+/** Preserve stored visibility choices for migrations. An optional resolver allows for migration-specific behavior. */
+export const preserveVisibilityChoices = <ColumnIds extends string>(
+  storedGroups: VisibilityGroup<ColumnIds>[] | undefined,
+  currentGroups: VisibilityGroup<ColumnIds>[],
+  resolveActive: (
+    preservedActive: boolean,
+    currentOption: VisibilityGroup<ColumnIds>['options'][number],
+  ) => boolean = preservedActive => preservedActive,
+): VisibilityGroup<ColumnIds>[] => {
+  const storedOptions = storedGroups?.flatMap(group => group.options) ?? []
+
+  return currentGroups.map(group => ({
+    ...group,
+    options: group.options.map(option => ({
+      ...option,
+      active: resolveActive(
+        storedOptions.find(storedOption => isEqual(storedOption.columns, option.columns))?.active ?? option.active,
+        option,
+      ),
+    })),
+  }))
+}
+
 /**
  * Hook to manage column and feature visibility settings. Currently saved in the state.
  *


### PR DESCRIPTION
Adds a table visibility migration helper function that keeps columns on/off based on what they were, with an optional override for new defaults. This prevents new versions from erasing all previously configured column visibilities.

Pool version has been bumped to fix missing columns from the visibility settings if they tested beta before it got deployed to stable.