### PR TITLE
refactor: extract gas config from network config

### DIFF
--- a/apps/main/src/bridge/features/bridge/BridgeFormTabs.tsx
+++ b/apps/main/src/bridge/features/bridge/BridgeFormTabs.tsx
@@ -1,12 +1,12 @@
 import { t } from '@evm-ui/lib/i18n'
 import { type FormTab, FormTabs } from '@evm-ui/widgets/DetailPageLayout/FormTabs'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import { BridgeForm } from './components/BridgeForm'
 import { useBridgeAlert } from './hooks/useBridgeAlert'
 
 export type BridgeFormParams = {
   chainId: number
-  networks: Record<number, BaseConfig>
+  networks: Record<number, NetworkDef>
 }
 
 const BridgeTab = (params: BridgeFormParams) => {

--- a/apps/main/src/bridge/features/bridge/hooks/useBridgeForm.ts
+++ b/apps/main/src/bridge/features/bridge/hooks/useBridgeForm.ts
@@ -6,7 +6,7 @@ import { useFormSync, useForm } from '@evm-ui/features/forms'
 import { useDebouncedValue } from '@evm-ui/hooks/useDebounce'
 import { useTokenBalance } from '@evm-ui/hooks/useTokenBalance'
 import { createApprovedEstimateGasHook } from '@evm-ui/lib/model/entities/gas-info'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useBridgeApproveMutation } from '../mutations/approve.mutation'
@@ -53,7 +53,7 @@ const formProps = {
   defaultValues: emptyBridgeForm(),
 }
 
-export const useBridgeForm = ({ chainId, networks }: { chainId: number; networks: Record<number, BaseConfig> }) => {
+export const useBridgeForm = ({ chainId, networks }: { chainId: number; networks: Record<number, NetworkDef> }) => {
   const form = useForm<BridgeForm>(formProps)
 
   const values = form.watchValues()
@@ -137,7 +137,7 @@ export const useBridgeForm = ({ chainId, networks }: { chainId: number; networks
       useIsApproved: useBridgeIsApproved,
       useApproveEstimate: useBridgeApproveGasEstimate,
       useActionEstimate: useBridgeGasEstimate,
-    })(networks, params),
+    })(params),
 
     // Errors
     amountError,

--- a/apps/main/src/dao/DaoLayout.tsx
+++ b/apps/main/src/dao/DaoLayout.tsx
@@ -10,7 +10,7 @@ export function DaoLayout() {
   const chainId = networksIdMapper[network]
 
   useRedirectToEth(networks[chainId], network)
-  useGasInfoAndUpdateLib({ chainId, networks })
+  useGasInfoAndUpdateLib({ chainId })
 
   return <Outlet />
 }

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
@@ -3,7 +3,6 @@ import { FieldLockedAmount } from '@/dao/components/PageVeCrv/components/FieldLo
 import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActionInfo'
 import { useCreateLockForm } from '@/dao/components/PageVeCrv/hooks/useCreateLockForm'
 import { useCreateLockGasEstimate } from '@/dao/components/PageVeCrv/queries/create-lock-estimate-gas.query'
-import { networks } from '@/dao/networks'
 import type { ChainId } from '@/dao/types/dao.types'
 import { FormButton } from '@evm-ui/features/forms'
 import { t } from '@evm-ui/lib/i18n'
@@ -43,7 +42,7 @@ export const FormLockCreate = ({ chainId }: { chainId: ChainId }) => {
       footer={
         <VeCrvActionInfo
           futureVeCrv={futureVeCrv}
-          gas={q(useCreateLockGasEstimate(networks, params, isOpen))}
+          gas={q(useCreateLockGasEstimate(params, isOpen))}
           isApproved={isApproved}
           isOpen={isOpen}
         />

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
@@ -2,7 +2,6 @@ import { FieldLockedAmount } from '@/dao/components/PageVeCrv/components/FieldLo
 import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActionInfo'
 import { useIncreaseLockForm } from '@/dao/components/PageVeCrv/hooks/useIncreaseLockForm'
 import { useIncreaseLockGasEstimate } from '@/dao/components/PageVeCrv/queries/increase-lock-estimate-gas.query'
-import { networks } from '@/dao/networks'
 import type { ChainId } from '@/dao/types/dao.types'
 import { FormButton } from '@evm-ui/features/forms'
 import { t } from '@evm-ui/lib/i18n'
@@ -37,7 +36,7 @@ export const FormLockCrv = ({ chainId }: { chainId: ChainId }) => {
         <VeCrvActionInfo
           currentVeCrv={q(currentVeCrv)}
           futureVeCrv={futureVeCrv}
-          gas={q(useIncreaseLockGasEstimate(networks, params, isOpen))}
+          gas={q(useIncreaseLockGasEstimate(params, isOpen))}
           isApproved={isApproved}
           isOpen={isOpen}
         />

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
@@ -2,7 +2,6 @@ import { FieldDatePicker } from '@/dao/components/PageVeCrv/components/FieldDate
 import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActionInfo'
 import { useExtendLockForm } from '@/dao/components/PageVeCrv/hooks/useExtendLockForm'
 import { useExtendLockGasEstimate } from '@/dao/components/PageVeCrv/queries/extend-lock-estimate-gas.query'
-import { networks } from '@/dao/networks'
 import type { ChainId } from '@/dao/types/dao.types'
 import { FormButton } from '@evm-ui/features/forms'
 import { t } from '@evm-ui/lib/i18n'
@@ -41,7 +40,7 @@ export const FormLockDate = ({ chainId }: { chainId: ChainId }) => {
         <VeCrvActionInfo
           currentVeCrv={q(currentVeCrv)}
           futureVeCrv={futureVeCrv}
-          gas={q(useExtendLockGasEstimate(networks, params, isOpen))}
+          gas={q(useExtendLockGasEstimate(params, isOpen))}
           isOpen={isOpen}
         />
       }

--- a/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
@@ -3,7 +3,6 @@ import { Countdown } from '@/dao/components/Countdown'
 import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActionInfo'
 import { useWithdrawLockForm } from '@/dao/components/PageVeCrv/hooks/useWithdrawLockForm'
 import { useWithdrawLockGasEstimate } from '@/dao/components/PageVeCrv/queries/withdraw-lock-estimate-gas.query'
-import { networks } from '@/dao/networks'
 import type { ChainId } from '@/dao/types/dao.types'
 import { FormButton } from '@evm-ui/features/forms'
 import { t } from '@evm-ui/lib/i18n'
@@ -23,7 +22,7 @@ export const FormWithdraw = ({ chainId }: { chainId: ChainId }) => {
     <Form
       {...form}
       onSubmit={onSubmit}
-      footer={<VeCrvActionInfo gas={q(useWithdrawLockGasEstimate(networks, params, isOpen))} isOpen={isOpen} />}
+      footer={<VeCrvActionInfo gas={q(useWithdrawLockGasEstimate(params, isOpen))} isOpen={isOpen} />}
     >
       <WithdrawInfo display="flex" flexDirection="column" flexGap="var(--spacing-1)">
         <Box display="flex" flexAlignItems="center" flexJustifyContent="space-between">

--- a/apps/main/src/dao/types/dao.types.ts
+++ b/apps/main/src/dao/types/dao.types.ts
@@ -1,5 +1,5 @@
 import type { INetworkName } from '@curvefi/api/lib/interfaces'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import type { Address } from '@primitives/address.utils'
 
 export type { CurveApi } from '@evm-ui/features/connect-wallet'
@@ -18,7 +18,7 @@ export type UrlParams = NetworkUrlParams & Partial<GaugeUrlParams & UserUrlParam
 export type NetworkConfig = {
   isActiveNetwork: boolean
   showInSelectNetwork: boolean
-} & BaseConfig<NetworkEnum, ChainId>
+} & NetworkDef<NetworkEnum, ChainId>
 
 export type EstimatedGas = number | number[] | null
 export type CurveJsProposalType = 'PARAMETER' | 'OWNERSHIP'

--- a/apps/main/src/dex/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dex/components/DetailInfoEstGas.tsx
@@ -10,7 +10,6 @@ import { useTokenUsdRate } from '@evm-ui/lib/model/entities/token-usd-rate'
 import { formatNumber } from '@evm-ui/utils'
 import { DetailInfo } from '@legacy-ui/DetailInfo'
 import { TooltipIcon as IconTooltip } from '@legacy-ui/Tooltip/TooltipIcon'
-import { useNetworkByChain, useNetworks } from '../entities/networks'
 
 type StepProgress = {
   active: number
@@ -31,15 +30,13 @@ export const DetailInfoEstGas = ({
   activeStep?: number
   stepProgress?: StepProgress | null
 }) => {
-  const { data: networks } = useNetworks()
-  const { data: network } = useNetworkByChain({ chainId })
   const { data: chainTokenUsdRate } = useTokenUsdRate({ chainId, tokenAddress: ethAddress })
-  const { data: gasInfo } = useGasInfoAndUpdateLib({ chainId, networks })
+  const { data: gasInfo } = useGasInfoAndUpdateLib({ chainId })
   const nativeSymbol = getChainNativeCurrency(chainId).symbol
 
   const { estGasCostUsd, tooltip } = useMemo(
-    () => calculateGas(estimatedGas, gasInfo, chainTokenUsdRate, network, nativeSymbol),
-    [estimatedGas, chainTokenUsdRate, network, gasInfo, nativeSymbol],
+    () => calculateGas(estimatedGas, gasInfo, chainTokenUsdRate, chainId, nativeSymbol),
+    [estimatedGas, chainTokenUsdRate, chainId, gasInfo, nativeSymbol],
   )
 
   const labelText = t`Estimated TX cost:`

--- a/apps/main/src/dex/components/PageRouterSwap/index.tsx
+++ b/apps/main/src/dex/components/PageRouterSwap/index.tsx
@@ -108,7 +108,7 @@ export const QuickSwap = ({
     { chainId, userAddress, searchedParams },
     !userAddress,
   )
-  const gas = useEstimateGasValue(networks, chainId, formEstGas?.estimatedGas, !!userAddress)
+  const gas = useEstimateGasValue(chainId, formEstGas?.estimatedGas, !!userAddress)
 
   const routesAndOutput = userAddress ? rpcRoutesAndOutput : apiRoutes
   const slippageType = routesAndOutput && getSlippageType(routesAndOutput)

--- a/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
+++ b/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
@@ -4,7 +4,6 @@ import { useAddRewardTokenEstimateGas } from '@/dex/entities/gauge/model/gauge-g
 import { gaugeAddRewardValidationGroup } from '@/dex/entities/gauge/model/gauge-validation'
 import { useGaugeRewardsDistributors, useIsDepositRewardAvailable } from '@/dex/entities/gauge/model/gauge.query'
 import type { AddRewardParams } from '@/dex/entities/gauge/types'
-import { useNetworks } from '@/dex/entities/networks'
 import type { AddRewardFormValues } from '@/dex/features/add-gauge-reward-token/types'
 import { DistributorInput, TokenSelector } from '@/dex/features/add-gauge-reward-token/ui'
 import { ChainId } from '@/dex/types/main.types'
@@ -23,7 +22,6 @@ const { Spacing } = SizesAndSpaces
 const validation = createValidationSuite((data: AddRewardParams) => gaugeAddRewardValidationGroup(data))
 
 export const AddRewardToken = ({ chainId, poolId }: { chainId: ChainId; poolId: string }) => {
-  const { data: networks } = useNetworks()
   const { address: userAddress } = useConnection()
   const { isLoading: isLoadingDistributors } = useGaugeRewardsDistributors({ chainId, poolId, userAddress })
   const { data: isRewardsAvailable, isLoading: isLoadingRewards } = useIsDepositRewardAvailable({ chainId, poolId })
@@ -37,7 +35,7 @@ export const AddRewardToken = ({ chainId, poolId }: { chainId: ChainId; poolId: 
 
   useFormSync(form, { distributorId: userAddress }, !!userAddress && !form.isTouched('distributorId'))
 
-  const gas = useAddRewardTokenEstimateGas(networks, { chainId, poolId, ...form.watchValues() }, isValid)
+  const gas = useAddRewardTokenEstimateGas({ chainId, poolId, ...form.watchValues() }, isValid)
 
   const {
     onSubmit,

--- a/apps/main/src/dex/features/deposit-gauge-reward/ui/DepositReward.tsx
+++ b/apps/main/src/dex/features/deposit-gauge-reward/ui/DepositReward.tsx
@@ -43,7 +43,7 @@ export const DepositReward = ({ chainId, poolId }: { chainId: ChainId; poolId: s
 
   const { data: userBalance } = useTokenBalance({ chainId, userAddress, tokenAddress: rewardTokenId })
   const { data: tokenUsdRate } = useTokenUsdRate({ chainId, tokenAddress: rewardTokenId })
-  const gas = useDepositRewardEstimateGas(networks, { chainId, poolId, rewardTokenId, amount, epoch, userBalance })
+  const gas = useDepositRewardEstimateGas({ chainId, poolId, rewardTokenId, amount, epoch, userBalance })
   const {
     onSubmit,
     error: depositRewardError,

--- a/apps/main/src/dex/hooks/useAutoRefresh.tsx
+++ b/apps/main/src/dex/hooks/useAutoRefresh.tsx
@@ -19,7 +19,7 @@ export const useAutoRefresh = (chainId: number | undefined) => {
     [chainId, curveApi, isHydrated],
   )
 
-  useGasInfoAndUpdateLib({ chainId, networks })
+  useGasInfoAndUpdateLib({ chainId })
 
   usePageVisibleInterval(async () => {
     if (!curveApi || !poolIds || !chainId) return

--- a/apps/main/src/dex/lib/curvejs.ts
+++ b/apps/main/src/dex/lib/curvejs.ts
@@ -36,8 +36,8 @@ import type { IProfit } from '@curvefi/api/lib/interfaces'
 import { waitForTransaction, waitForTransactions } from '@evm-ui/lib/ethers'
 import { t } from '@evm-ui/lib/i18n'
 import { log } from '@evm-ui/lib/logging'
+import { getGasConfig } from '@evm-ui/lib/model/entities/gas-info'
 import { getErrorMessage } from '@evm-ui/utils'
-import { fetchNetworks } from '../entities/networks'
 
 const helpers = { waitForTransaction, waitForTransactions }
 
@@ -300,7 +300,7 @@ const router = {
             )(fromAddress, toAddress, fromAmount, +slippageTolerance)
           : await curve.router.estimateGas.approve(fromAddress, fromAmount)
       }
-      void warnIncorrectEstGas(curve.chainId, resp.estimatedGas)
+      warnIncorrectEstGas(curve.chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -414,7 +414,7 @@ const poolDeposit = {
           ? await p.estimateGas.depositWrappedApprove(amounts)
           : await p.estimateGas.depositApprove(amounts)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       resp.error = getErrorMessage(error, 'error-est-gas-approval')
@@ -508,7 +508,7 @@ const poolDeposit = {
           ? await p.estimateGas.depositAndStakeWrappedApprove(amounts)
           : await p.estimateGas.depositAndStakeApprove(amounts)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -567,7 +567,7 @@ const poolDeposit = {
       resp.estimatedGas = resp.isApproved
         ? await p.estimateGas.stake(lpTokenAmount)
         : await p.estimateGas.stakeApprove(lpTokenAmount)
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       resp.error = getErrorMessage(error, 'error-est-gas-approval')
@@ -717,7 +717,7 @@ const poolSwap = {
           ? await p.estimateGas.swapWrappedApprove(fromAddress, fromAmount)
           : await p.estimateGas.swapApprove(fromAddress, fromAmount)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -809,7 +809,7 @@ const poolWithdraw = {
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawApprove(lpTokenAmount)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -891,7 +891,7 @@ const poolWithdraw = {
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawImbalanceApprove(amounts)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -983,7 +983,7 @@ const poolWithdraw = {
       } else {
         resp.estimatedGas = await p.estimateGas.withdrawOneCoinApprove(lpTokenAmount)
       }
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -1034,7 +1034,7 @@ const poolWithdraw = {
     const resp = { activeKey, estimatedGas: null as EstimatedGas, isApproved: true, error: '' }
     try {
       resp.estimatedGas = await p.estimateGas.unstake(lpTokenAmount)
-      void warnIncorrectEstGas(chainId, resp.estimatedGas)
+      warnIncorrectEstGas(chainId, resp.estimatedGas)
       return resp
     } catch (error) {
       console.error(error)
@@ -1298,10 +1298,9 @@ const lockCrv = {
   },
 }
 
-async function warnIncorrectEstGas(chainId: ChainId, estimatedGas: EstimatedGas) {
-  const network = (await fetchNetworks())[chainId]
-  const isGasL2 = network?.gasL2
-  if (isGasL2 && !Array.isArray(estimatedGas) && estimatedGas !== null) {
+function warnIncorrectEstGas(chainId: ChainId, estimatedGas: EstimatedGas) {
+  const { gasL2 } = getGasConfig(chainId)
+  if (gasL2 && !Array.isArray(estimatedGas) && estimatedGas !== null) {
     console.warn('Incorrect estimated gas returned for L2', estimatedGas)
   }
 }

--- a/apps/main/src/dex/store/createPoolDepositSlice.ts
+++ b/apps/main/src/dex/store/createPoolDepositSlice.ts
@@ -40,7 +40,6 @@ import { fetchTokenBalance } from '@evm-ui/hooks/useTokenBalance'
 import { t } from '@evm-ui/lib/i18n'
 import { fetchGasInfoAndUpdateLib } from '@evm-ui/lib/model/entities/gas-info'
 import { setMissingProvider } from '@evm-ui/utils/store.util'
-import { fetchNetworks } from '../entities/networks'
 import { fetchPoolTokenBalances } from '../hooks/usePoolTokenBalances'
 import { fetchPoolLpTokenBalance } from '../hooks/usePoolTokenDepositBalances'
 import { invalidateUserPoolInfo } from '../queries/invalidation'
@@ -147,8 +146,7 @@ export const createPoolDepositSlice = (
           parseAmountsForAPI(cFormValues.amounts),
           maxSlippage,
         )
-        const networks = await fetchNetworks()
-        const { basePlusPriority } = await fetchGasInfoAndUpdateLib({ chainId, networks })
+        const { basePlusPriority } = await fetchGasInfoAndUpdateLib({ chainId })
 
         if (!resp.error && resp.estimatedGas && basePlusPriority?.[0]) {
           cFormValues.amounts[idx].value = getMaxAmountMinusGas(resp.estimatedGas, basePlusPriority[0], userBalance)

--- a/apps/main/src/dex/store/createPoolSwapSlice.ts
+++ b/apps/main/src/dex/store/createPoolSwapSlice.ts
@@ -29,7 +29,6 @@ import { getSlippageImpact, getSwapActionModalType } from '@/dex/utils/utilsSwap
 import { useWallet } from '@evm-ui/features/connect-wallet'
 import { fetchGasInfoAndUpdateLib } from '@evm-ui/lib/model/entities/gas-info'
 import { setMissingProvider } from '@evm-ui/utils/store.util'
-import { fetchNetworks } from '../entities/networks'
 import { fetchPoolTokenBalances } from '../hooks/usePoolTokenBalances'
 import { invalidateUserPoolInfo } from '../queries/invalidation'
 import { invalidatePoolParameters } from '../queries/pool-parameters.query'
@@ -229,10 +228,8 @@ export const createPoolSwapSlice = (
       // stored values
       const userPoolBalances = await fetchPoolTokenBalances(config, curve, pool.id)
       const walletFromBalance = userPoolBalances[formValues.fromAddress]
-      const networks = await fetchNetworks()
       const { basePlusPriority } = await fetchGasInfoAndUpdateLib({
         chainId: curve.chainId,
-        networks,
       })
 
       let fromAmount: string = walletFromBalance ?? '0'

--- a/apps/main/src/dex/store/createQuickSwapSlice.ts
+++ b/apps/main/src/dex/store/createQuickSwapSlice.ts
@@ -23,7 +23,6 @@ import { setMissingProvider } from '@evm-ui/utils/store.util'
 import { SLIPPAGE } from '@evm-ui/widgets/SlippageSettings/slippage.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { sleep } from '@primitives/promise.utils'
-import { fetchNetworks } from '../entities/networks'
 
 type StateKey = keyof typeof DEFAULT_STATE
 
@@ -130,10 +129,8 @@ export const createQuickSwapSlice = (
 
         // get max amount for native token
         if (fromAddress.toLowerCase() === ethAddress) {
-          const networks = await fetchNetworks()
           const { basePlusPriority } = await fetchGasInfoAndUpdateLib({
             chainId,
-            networks,
           })
           const firstBasePlusPriority = basePlusPriority?.[0]
 

--- a/apps/main/src/dex/types/main.types.ts
+++ b/apps/main/src/dex/types/main.types.ts
@@ -3,7 +3,7 @@ import type { IChainId, INetworkName } from '@curvefi/api/lib/interfaces'
 import type { PoolTemplate } from '@curvefi/api/lib/pools'
 import { BannerProps } from '@evm-ui/shared/ui/Banner'
 import type { TooltipProps } from '@legacy-ui/Tooltip/types'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
 
@@ -48,7 +48,7 @@ export type NetworkConfig = {
   fxswapFactory: boolean
   hasFactory: boolean
   pricesApi: boolean
-} & BaseConfig<NetworkEnum>
+} & NetworkDef<NetworkEnum>
 
 export type Networks = Record<ChainId, NetworkConfig>
 export type CurrencyReservesToken = {

--- a/apps/main/src/lend/LendLayout.tsx
+++ b/apps/main/src/lend/LendLayout.tsx
@@ -11,7 +11,7 @@ export function LendLayout() {
   const chainId = networksIdMapper[blockchainId]
 
   useRedirectToEth(networks[chainId], blockchainId)
-  useGasInfoAndUpdateLib({ chainId, networks })
+  useGasInfoAndUpdateLib({ chainId })
 
   return (
     <>

--- a/apps/main/src/lend/types/lend.types.ts
+++ b/apps/main/src/lend/types/lend.types.ts
@@ -1,5 +1,5 @@
 import type { IChainId, INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 
 export type ChainId = IChainId
 export type NetworkEnum = INetworkName
@@ -15,4 +15,4 @@ export type NetworkConfig<TId extends string = string, TChainId extends number =
   marketListFilter: string[]
   marketListFilterType: string[]
   pricesData: boolean
-} & BaseConfig<TId, TChainId>
+} & NetworkDef<TId, TChainId>

--- a/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/BorrowMoreLoanInfoList.tsx
@@ -1,5 +1,4 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useBorrowMoreExpectedCollateral } from '@/llamalend/queries/borrow-more/borrow-more-expected-collateral.query'
 import { useBorrowMoreFutureLeverage } from '@/llamalend/queries/borrow-more/borrow-more-future-leverage.query'
 import { useBorrowMoreEstimateGas } from '@/llamalend/queries/borrow-more/borrow-more-gas-estimate.query'
@@ -26,7 +25,6 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   params,
   values: { userCollateral, debt },
   tokens: { collateralToken, borrowToken },
-  networks,
   leverageEnabled,
   form,
   controllerAddress,
@@ -35,7 +33,6 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
   params: BorrowMoreParams<ChainId>
   values: BorrowMoreForm
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
-  networks: NetworkDict<ChainId>
   controllerAddress: Address | undefined
   marketType: MarketType
   leverageEnabled: boolean | undefined
@@ -52,7 +49,7 @@ export function BorrowMoreLoanInfoList<ChainId extends IChainId>({
     <LoanActionInfoList
       isOpen={isOpen}
       isApproved={q(useBorrowMoreIsApproved(params, isOpen))}
-      gas={q(useBorrowMoreEstimateGas(networks, params, isOpen))}
+      gas={q(useBorrowMoreEstimateGas(params, isOpen))}
       health={q(useBorrowMoreHealth(params, isOpen))}
       prices={q(useBorrowMorePrices(params, isOpen))}
       oraclePrice={q(useMarketOraclePrice(params, isOpen))}

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -98,7 +98,6 @@ export const CreateLoanForm = <ChainId extends IChainId>({
           values={values}
           collateralToken={collateralToken}
           borrowToken={borrowToken}
-          networks={networks}
         />
       }
       data-testid="create-loan-form"

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useCreateLoanIsApproved } from '@/llamalend/queries/create-loan/create-loan-approved.query'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
@@ -23,7 +22,6 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
   values: { leverageEnabled, userCollateral, debt },
   collateralToken,
   borrowToken,
-  networks,
   form,
 }: {
   marketType: MarketType
@@ -32,7 +30,6 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
   values: CreateLoanForm
   collateralToken: Token | undefined
   borrowToken: Token | undefined
-  networks: NetworkDict<ChainId>
   form: UseFormReturn<CreateLoanForm>
 }) => {
   const isOpen = form.isTouched('userCollateral', 'debt')
@@ -48,7 +45,7 @@ export const CreateLoanInfoList = <ChainId extends IChainId>({
       loanToValue={q(useLoanToValue({ params, collateralToken, borrowToken }, isOpen))}
       prevLoanToValue={constQ('0')}
       oraclePrice={q(useMarketOraclePrice(params, isOpen))}
-      gas={q(useCreateLoanEstimateGas(networks, params, isOpen))}
+      gas={q(useCreateLoanEstimateGas(params, isOpen))}
       leverageEnabled={leverageEnabled}
       prevCollateral={constQ('0')}
       debt={constQ(debt)}

--- a/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/RepayLoanInfoList.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
 import { calculateReturnToWallet } from '@/llamalend/llama.utils'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useRepayExpectedBorrowed } from '@/llamalend/queries/repay/repay-expected-borrowed.query'
 import { useRepayFutureLeverage } from '@/llamalend/queries/repay/repay-future-leverage.query'
@@ -15,7 +14,6 @@ import type { RepayFormData, RepayParams } from '@/llamalend/queries/validation/
 import { useBorrowRates } from '@/llamalend/widgets/action-card/hooks/useBorrowRates'
 import { usePrevLoanState } from '@/llamalend/widgets/action-card/hooks/usePrevLoanState'
 import { LoanActionInfoList } from '@/llamalend/widgets/action-card/LoanActionInfoList'
-import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
 import type { UseFormReturn } from '@evm-ui/features/forms'
 import { combineQueryState } from '@evm-ui/lib/queries/combine'
 import type { MarketType } from '@evm-ui/types/market'
@@ -81,13 +79,12 @@ function useReturnToWallet(
   return enabled ? { data, ...combineQueryState(userBorrowed, userState) } : undefined
 }
 
-export function RepayLoanInfoList<ChainId extends IChainId>({
+export function RepayLoanInfoList({
   controllerAddress,
   marketType,
   params,
   values: { stateCollateral, userCollateral, userBorrowed, isFull },
   tokens: { collateralToken, borrowToken },
-  networks,
   showLeverage,
   form,
   prices,
@@ -98,7 +95,6 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
   params: RepayParams
   values: RepayFormData
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
-  networks: NetworkDict<ChainId>
   showLeverage: boolean | undefined
   form: UseFormReturn<RepayFormData>
   prices?: QueryProp<Range<Decimal> | null>
@@ -117,7 +113,7 @@ export function RepayLoanInfoList<ChainId extends IChainId>({
     <LoanActionInfoList
       isOpen={isOpen}
       isApproved={q(useRepayIsApproved(params, isOpen))}
-      gas={q(useRepayEstimateGas(networks, params, isOpen))}
+      gas={q(useRepayEstimateGas(params, isOpen))}
       health={q(useHealthQueries(isHealthFull => getRepayHealthOptions({ ...params, isHealthFull }, isOpen)))}
       prices={prices}
       oraclePrice={q(useMarketOraclePrice(params, isOpen))}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/ClosePositionInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/ClosePositionInfoList.tsx
@@ -1,6 +1,5 @@
 import { useConnection } from 'wagmi'
 import type { MarketTokensOrEmpty } from '@/llamalend/llama.utils'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import type { CloseLoanMutation } from '@/llamalend/mutations/close-position.mutation'
 import { useCloseEstimateGas } from '@/llamalend/queries/close-loan/close-loan-gas-estimate.query'
 import { useCloseLoanIsApproved } from '@/llamalend/queries/close-loan/close-loan-is-approved.query'
@@ -14,7 +13,6 @@ type ClosePositionInfoListProps = {
   marketId: string | undefined
   tokens: MarketTokensOrEmpty
   chainId: LlamaChainId
-  networks: NetworkDict<LlamaChainId>
   values: CloseLoanMutation
 }
 
@@ -22,14 +20,13 @@ export function ClosePositionInfoList({
   chainId,
   marketId,
   tokens: { borrowToken, collateralToken },
-  networks,
   values: { slippage },
 }: ClosePositionInfoListProps) {
   const params = { chainId, marketId, userAddress: useConnection().address, slippage }
   return (
     <LoanActionInfoList
       isOpen
-      gas={q(useCloseEstimateGas(networks, params))}
+      gas={q(useCloseEstimateGas(params))}
       debt={constQ('0')}
       collateral={constQ('0')}
       isApproved={q(useCloseLoanIsApproved(params))}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/ResetPositionInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/ResetPositionInfoList.tsx
@@ -1,6 +1,5 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useResetEstimateGas } from '@/llamalend/queries/reset/reset-gas-estimate.query'
 import { getResetHealthOptions } from '@/llamalend/queries/reset/reset-health.query'
@@ -24,14 +23,12 @@ export function ResetPositionInfoList<ChainId extends IChainId>({
   tokens: { collateralToken, borrowToken },
   controllerAddress,
   marketType,
-  networks,
 }: {
   params: ResetParams<ChainId>
   values: ResetForm
   tokens: { collateralToken: Token | undefined; borrowToken: Token | undefined }
   controllerAddress: Address | undefined
   marketType: MarketType
-  networks: NetworkDict<ChainId>
 }) {
   const debtReduction = getResetDebtReduction(values)
   const isOpen = +debtReduction > 0
@@ -43,7 +40,7 @@ export function ResetPositionInfoList<ChainId extends IChainId>({
     <LoanActionInfoList
       isOpen={isOpen}
       isApproved={q(useResetIsApproved(params, isOpen))}
-      gas={q(useResetEstimateGas(networks, params, isOpen))}
+      gas={q(useResetEstimateGas(params, isOpen))}
       health={q(useHealthQueries(isHealthFull => getResetHealthOptions({ ...params, isHealthFull }, isOpen)))}
       prices={q(useResetPrices(params, isOpen))}
       oraclePrice={q(useMarketOraclePrice(params, isOpen))}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
@@ -42,15 +42,7 @@ export const ClosePositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
     <Form
       {...form}
       onSubmit={onSubmit}
-      footer={
-        <ClosePositionInfoList
-          marketId={marketId}
-          tokens={tokens}
-          chainId={network.chainId}
-          networks={networks}
-          values={values}
-        />
-      }
+      footer={<ClosePositionInfoList marketId={marketId} tokens={tokens} chainId={network.chainId} values={values} />}
     >
       <DataTable
         category="form"

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ResetPositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ResetPositionForm.tsx
@@ -43,7 +43,6 @@ export const ResetPositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
           tokens={{ collateralToken, borrowToken }}
           controllerAddress={controllerAddress}
           marketType={marketType}
-          networks={networks}
         />
       }
     >

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
@@ -48,7 +48,6 @@ export const AddCollateralForm = <ChainId extends IChainId>({
           values={values}
           collateralToken={collateralToken}
           borrowToken={borrowToken}
-          networks={networks}
           controllerAddress={controllerAddress}
           marketType={marketType}
         />

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralInfoList.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useAddCollateralFutureLeverage } from '@/llamalend/queries/add-collateral/add-collateral-future-leverage.query'
 import { useAddCollateralEstimateGas } from '@/llamalend/queries/add-collateral/add-collateral-gas-estimate.query'
 import { getAddCollateralHealthOptions } from '@/llamalend/queries/add-collateral/add-collateral-health.query'
@@ -26,7 +25,6 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
   values: { userCollateral },
   collateralToken,
   borrowToken,
-  networks,
   form,
   controllerAddress,
   marketType,
@@ -35,7 +33,6 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
   values: CollateralForm
   collateralToken: Token | undefined
   borrowToken: Token | undefined
-  networks: NetworkDict<ChainId>
   form: UseFormReturn<CollateralForm>
   controllerAddress: Address | undefined
   marketType: MarketType
@@ -46,7 +43,7 @@ export function AddCollateralInfoList<ChainId extends IChainId>({
   return (
     <LoanActionInfoList
       isOpen={isOpen}
-      gas={q(useAddCollateralEstimateGas(networks, params, isOpen))}
+      gas={q(useAddCollateralEstimateGas(params, isOpen))}
       health={q(useHealthQueries(isFull => getAddCollateralHealthOptions({ ...params, isFull }, isOpen)))}
       debt={prevDebt}
       loanToValue={q(

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -89,7 +89,6 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
           params={params}
           values={values}
           tokens={{ collateralToken, borrowToken }}
-          networks={networks}
           marketType={marketType}
           leverageEnabled={values.leverageEnabled}
         />

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -49,7 +49,6 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
           values={values}
           collateralToken={collateralToken}
           borrowToken={borrowToken}
-          networks={networks}
           controllerAddress={controllerAddress}
           marketType={marketType}
         />

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralInfoList.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralInfoList.tsx
@@ -1,6 +1,5 @@
 import { useLoanToValueFromUserState } from '@/llamalend/features/manage-loan/hooks/useLoanToValueFromUserState'
 import { useHealthQueries } from '@/llamalend/hooks/useHealthQueries'
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useMarketOraclePrice } from '@/llamalend/queries/market'
 import { useRemoveCollateralFutureLeverage } from '@/llamalend/queries/remove-collateral/remove-collateral-future-leverage.query'
 import { useRemoveCollateralEstimateGas } from '@/llamalend/queries/remove-collateral/remove-collateral-gas-estimate.query'
@@ -25,7 +24,6 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
   values: { userCollateral },
   collateralToken,
   borrowToken,
-  networks,
   form,
   controllerAddress,
   marketType,
@@ -34,7 +32,6 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
   values: CollateralForm
   collateralToken: Token | undefined
   borrowToken: Token | undefined
-  networks: NetworkDict<ChainId>
   form: UseFormReturn<CollateralForm>
   controllerAddress: Address | undefined
   marketType: MarketType
@@ -45,7 +42,7 @@ export function RemoveCollateralInfoList<ChainId extends IChainId>({
   return (
     <LoanActionInfoList
       isOpen={isOpen}
-      gas={q(useRemoveCollateralEstimateGas(networks, params, isOpen))}
+      gas={q(useRemoveCollateralEstimateGas(params, isOpen))}
       health={q(useHealthQueries(isFull => getRemoveCollateralHealthOptions({ ...params, isFull }, isOpen)))}
       debt={prevDebt}
       loanToValue={q(

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -143,7 +143,6 @@ export const RepayForm = <ChainId extends IChainId>({
           params={params}
           values={values}
           tokens={{ collateralToken, borrowToken }}
-          networks={networks}
           showLeverage={showLeverage}
           prices={q(useRepayPrices(params, !isInSoftLiquidation))} // when in soft liquidation, the prices do not change
           prevPrices={q(useUserPrices(params))}

--- a/apps/main/src/llamalend/features/manage-loan/hooks/useRemoveCollateralForm.ts
+++ b/apps/main/src/llamalend/features/manage-loan/hooks/useRemoveCollateralForm.ts
@@ -16,7 +16,7 @@ import type { IChainId as LlamaChainId, INetworkName as LlamaNetworkId } from '@
 import { useCallbackSync, useFormSync, useForm, useOnChangeCallback } from '@evm-ui/features/forms'
 import { useFormDebounce } from '@evm-ui/hooks/useDebounce'
 import { mapQuery, type Range } from '@evm-ui/types/util'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import type { Decimal } from '@primitives/decimal.utils'
 import { useMarketContext } from '../../market-context'
 
@@ -34,7 +34,7 @@ export const useRemoveCollateralForm = <
   network,
   onPricesUpdated,
 }: {
-  network: BaseConfig<NetworkName, ChainId>
+  network: NetworkDef<NetworkName, ChainId>
   onPricesUpdated: (prices: Range<Decimal> | undefined) => void
 }) => {
   const { market, marketId, tokens, userAddress } = useMarketContext<ChainId>()

--- a/apps/main/src/llamalend/features/supply/components/ClaimActionInfoList.tsx
+++ b/apps/main/src/llamalend/features/supply/components/ClaimActionInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import {
   useClaimCrvEstimateGas,
   useClaimRewardsEstimateGas,
@@ -14,24 +13,22 @@ import Stack from '@mui/material/Stack'
 
 type ClaimActionInfoListProps<ChainId extends IChainId> = {
   params: UserMarketParams<ChainId>
-  networks: NetworkDict<ChainId>
   isOpen?: boolean
 }
 
 export const ClaimActionInfoList = <ChainId extends IChainId>({
   params,
-  networks,
   isOpen,
 }: ClaimActionInfoListProps<ChainId>) => (
   <ActionInfoCollapse isOpen={isOpen} testId="claim-action-info-list">
     <Stack sx={ACTION_INFO_GROUP_SX}>
       <ActionInfoGasEstimate
-        gas={q(useClaimRewardsEstimateGas(networks, params))}
+        gas={q(useClaimRewardsEstimateGas(params))}
         label={t`Claim other rewards tx cost`}
         testId="claim-other-rewards-estimated-tx-cost"
       />
       <ActionInfoGasEstimate
-        gas={q(useClaimCrvEstimateGas(networks, params))}
+        gas={q(useClaimCrvEstimateGas(params))}
         label={t`Claim CRV rewards tx cost`}
         testId="claim-crv-rewards-estimated-tx-cost"
       />

--- a/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
+++ b/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
@@ -44,9 +44,7 @@ export const ClaimTab = <ChainId extends IChainId>({ networks }: ClaimTabProps<C
   } = useClaimTab({ network })
   return (
     <>
-      <FormContent
-        footer={<ClaimActionInfoList params={params} networks={networks} isOpen={!!claimableTokens.length} />}
-      >
+      <FormContent footer={<ClaimActionInfoList params={params} isOpen={!!claimableTokens.length} />}>
         <DataTable
           category="form"
           table={table}

--- a/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
@@ -44,7 +44,6 @@ export const DepositForm = <ChainId extends IChainId>({ networks }: DepositFormP
         <DepositSupplyInfoList
           form={form}
           params={params}
-          networks={networks}
           tokens={{ borrowToken }}
           controllerAddress={controllerAddress}
         />

--- a/apps/main/src/llamalend/features/supply/components/DepositSupplyInfoList.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositSupplyInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useDepositIsApproved } from '@/llamalend/queries/supply/supply-deposit-approved.query'
 import { useDepositEstimateGas } from '@/llamalend/queries/supply/supply-deposit-estimate-gas.query'
 import { useDepositExpectedVaultShares } from '@/llamalend/queries/supply/supply-expected-vault-shares.query'
@@ -16,7 +15,6 @@ import { useVaultUserBalances } from '../hooks/useVaultUserBalances'
 
 type DepositSupplyInfoListProps<ChainId extends IChainId> = {
   params: DepositParams<ChainId>
-  networks: NetworkDict<ChainId>
   tokens: { borrowToken: Token | undefined }
   form: UseFormReturn<DepositForm>
   controllerAddress: Address | undefined
@@ -24,7 +22,6 @@ type DepositSupplyInfoListProps<ChainId extends IChainId> = {
 
 export function DepositSupplyInfoList<ChainId extends IChainId>({
   params,
-  networks,
   tokens,
   form,
   controllerAddress,
@@ -57,7 +54,7 @@ export function DepositSupplyInfoList<ChainId extends IChainId>({
       supplyApy={mapQuery(rates, d => d.lendApy)}
       prevNetSupplyApy={prevNetSupplyApy}
       netSupplyApy={netSupplyApy}
-      gas={q(useDepositEstimateGas(networks, params, isOpen))}
+      gas={q(useDepositEstimateGas(params, isOpen))}
     />
   )
 }

--- a/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
@@ -49,7 +49,6 @@ export const StakeForm = <ChainId extends IChainId>({ networks }: StakeFormProps
         <StakeSupplyInfoList
           form={form}
           params={params}
-          networks={networks}
           tokens={{ borrowToken }}
           controllerAddress={controllerAddress}
         />

--- a/apps/main/src/llamalend/features/supply/components/StakeSupplyInfoList.tsx
+++ b/apps/main/src/llamalend/features/supply/components/StakeSupplyInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useStakeIsApproved } from '@/llamalend/queries/supply/supply-stake-approved.query'
 import { useStakeEstimateGas } from '@/llamalend/queries/supply/supply-stake-estimate-gas.query'
 import type { StakeForm, StakeFormParams } from '@/llamalend/queries/validation/supply.validation'
@@ -15,7 +14,6 @@ import { useVaultUserBalances } from '../hooks/useVaultUserBalances'
 
 type StakeSupplyInfoListProps<ChainId extends IChainId> = {
   params: StakeFormParams<ChainId>
-  networks: NetworkDict<ChainId>
   tokens: { borrowToken: Token | undefined }
   form: UseFormReturn<StakeForm>
   controllerAddress: Address | undefined
@@ -23,7 +21,6 @@ type StakeSupplyInfoListProps<ChainId extends IChainId> = {
 
 export function StakeSupplyInfoList<ChainId extends IChainId>({
   params,
-  networks,
   tokens,
   form,
   controllerAddress,
@@ -50,7 +47,7 @@ export function StakeSupplyInfoList<ChainId extends IChainId>({
       suppliedAssets={mapQuery(userBalances, d => maybes([d.stakedSharesAmount, stakeAssets], decimalSum))}
       supplyApy={mapQuery(prevRates, d => d.lendApy)}
       netSupplyApy={prevNetSupplyApy}
-      gas={q(useStakeEstimateGas(networks, params, isOpen))}
+      gas={q(useStakeEstimateGas(params, isOpen))}
     />
   )
 }

--- a/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
@@ -44,7 +44,6 @@ export const UnstakeForm = <ChainId extends IChainId>({ networks }: UnstakeFormP
         <UnstakeSupplyInfoList
           form={form}
           params={params}
-          networks={networks}
           borrowToken={borrowToken}
           controllerAddress={controllerAddress}
         />

--- a/apps/main/src/llamalend/features/supply/components/UnstakeSupplyInfoList.tsx
+++ b/apps/main/src/llamalend/features/supply/components/UnstakeSupplyInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useUnstakeEstimateGas } from '@/llamalend/queries/supply/supply-unstake-estimate-gas.query'
 import type { UnstakeForm, UnstakeFormParams } from '@/llamalend/queries/validation/supply.validation'
 import { useSupplyRates } from '@/llamalend/widgets/action-card/hooks/useSupplyRates'
@@ -14,7 +13,6 @@ import { useVaultUserBalances } from '../hooks/useVaultUserBalances'
 
 type UnstakeSupplyInfoListProps<ChainId extends IChainId> = {
   params: UnstakeFormParams<ChainId>
-  networks: NetworkDict<ChainId>
   borrowToken: Token | undefined
   form: UseFormReturn<UnstakeForm>
   controllerAddress: Address | undefined
@@ -22,7 +20,6 @@ type UnstakeSupplyInfoListProps<ChainId extends IChainId> = {
 
 export function UnstakeSupplyInfoList<ChainId extends IChainId>({
   params,
-  networks,
   borrowToken,
   form,
   controllerAddress,
@@ -46,7 +43,7 @@ export function UnstakeSupplyInfoList<ChainId extends IChainId>({
       suppliedAssets={mapQuery(userBalances, d => maybes([d.stakedSharesAmount, unstakeAssets], decimalMinus))}
       supplyApy={mapQuery(prevRates, d => d.lendApy)}
       netSupplyApy={prevNetSupplyApy}
-      gas={q(useUnstakeEstimateGas(networks, params, isOpen))}
+      gas={q(useUnstakeEstimateGas(params, isOpen))}
     />
   )
 }

--- a/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
@@ -42,7 +42,6 @@ export const WithdrawForm = <ChainId extends IChainId>({ networks }: WithdrawFor
         <WithdrawSupplyInfoList
           form={form}
           params={params}
-          networks={networks}
           tokens={{ borrowToken }}
           controllerAddress={controllerAddress}
         />

--- a/apps/main/src/llamalend/features/supply/components/WithdrawSupplyInfoList.tsx
+++ b/apps/main/src/llamalend/features/supply/components/WithdrawSupplyInfoList.tsx
@@ -1,4 +1,3 @@
-import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { useWithdrawRemovableVaultShares } from '@/llamalend/queries/supply/supply-expected-vault-shares.query'
 import { useWithdrawEstimateGas } from '@/llamalend/queries/supply/supply-withdraw-estimate-gas.query'
 import type { WithdrawForm, WithdrawParams } from '@/llamalend/queries/validation/supply.validation'
@@ -15,7 +14,6 @@ import { useVaultUserBalances } from '../hooks/useVaultUserBalances'
 
 type WithdrawSupplyInfoListProps<ChainId extends IChainId> = {
   params: WithdrawParams<ChainId>
-  networks: NetworkDict<ChainId>
   tokens: { borrowToken: Token | undefined }
   form: UseFormReturn<WithdrawForm>
   controllerAddress: Address | undefined
@@ -23,7 +21,6 @@ type WithdrawSupplyInfoListProps<ChainId extends IChainId> = {
 
 export function WithdrawSupplyInfoList<ChainId extends IChainId>({
   params,
-  networks,
   tokens,
   form,
   controllerAddress,
@@ -55,7 +52,7 @@ export function WithdrawSupplyInfoList<ChainId extends IChainId>({
       supplyApy={mapQuery(rates, d => d.lendApy)}
       prevNetSupplyApy={prevNetSupplyApy}
       netSupplyApy={netSupplyApy}
-      gas={q(useWithdrawEstimateGas(networks, params, isOpen))}
+      gas={q(useWithdrawEstimateGas(params, isOpen))}
     />
   )
 }

--- a/apps/main/src/llamalend/hooks/useMarketRoutes.ts
+++ b/apps/main/src/llamalend/hooks/useMarketRoutes.ts
@@ -14,7 +14,7 @@ import { useTokenUsdRate } from '@evm-ui/lib/model/entities/token-usd-rate'
 import { q, type QueryProp } from '@evm-ui/types/util'
 import { decimalCompare, decimalMax, toWei, decimalDiv, decimalMinus, decimalMultiply, fromWei } from '@evm-ui/utils'
 import type { PriceImpact } from '@evm-ui/widgets/DetailPageLayout/price-impact.util'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import { Address } from '@primitives/address.utils'
 import { toArray } from '@primitives/array.utils'
 import { Decimal } from '@primitives/decimal.utils'
@@ -30,7 +30,7 @@ export type MarketRoutes = {
   onChange: (option: RouteProvider | undefined) => void
   onRefresh: () => Promise<unknown>
   tokenOut: Partial<{ symbol: string | undefined; address: Address; decimals: number }> & { usdRate: QueryProp<number> }
-  networks: Record<number, BaseConfig>
+  networks: Record<number, NetworkDef>
   chainId: number
   providers: readonly RouteProvider[]
 }
@@ -84,7 +84,7 @@ export function useMarketRoutes<TData extends TGas | null, GasQueryKey extends Q
   amountIn: Decimal | undefined
   slippage: Decimal | undefined
   enabled: boolean
-  networks: Record<number, BaseConfig>
+  networks: Record<number, NetworkDef>
   getRouteGasOptions: GetGasCallback<TData, GasQueryKey>
   zapAddress: Address | undefined
   providers: readonly RouteProvider[] | undefined

--- a/apps/main/src/llamalend/llamalend.types.ts
+++ b/apps/main/src/llamalend/llamalend.types.ts
@@ -1,9 +1,9 @@
 import type { IChainId, INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
 import type { LendMarketTemplate } from '@curvefi/llamalend-api/lib/lendMarkets'
 import type { MintMarketTemplate } from '@curvefi/llamalend-api/lib/mintMarkets'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 
-export type LlamaNetwork<ChainId extends IChainId = IChainId> = BaseConfig<INetworkName, ChainId>
+export type LlamaNetwork<ChainId extends IChainId = IChainId> = NetworkDef<INetworkName, ChainId>
 export type NetworkDict<ChainId extends IChainId = IChainId> = Record<ChainId, LlamaNetwork<ChainId>>
 
 export type MarketTemplate = MintMarketTemplate | LendMarketTemplate

--- a/apps/main/src/loan/CrvUsdClientLayout.tsx
+++ b/apps/main/src/loan/CrvUsdClientLayout.tsx
@@ -8,7 +8,7 @@ import type { UrlParams } from './types/loan.types'
 export function CrvUsdClientLayout() {
   const { network: blockchainId = 'ethereum' } = useParams<Partial<UrlParams>>()
   const chainId = networksIdMapper[blockchainId]
-  useGasInfoAndUpdateLib({ chainId, networks })
+  useGasInfoAndUpdateLib({ chainId })
   useRedirectToEth(networks[chainId], blockchainId)
   return <Outlet />
 }

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositInfoList.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositInfoList.tsx
@@ -3,7 +3,6 @@ import { ACTION_INFO_GROUP_SX } from '@/llamalend/widgets/action-card/info-actio
 import { useScrvUsdDepositEstimateGas } from '@/loan/entities/scrvusd-deposit-estimate-gas.query'
 import { useScrvUsdPreviewDeposit } from '@/loan/entities/scrvusd-preview.query'
 import type { ScrvUsdDepositParams } from '@/loan/entities/scrvusd.validation'
-import { networks } from '@/loan/networks'
 import type { ChainId } from '@/loan/types/loan.types'
 import { t } from '@evm-ui/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate } from '@evm-ui/shared/ui/ActionInfo'
@@ -31,7 +30,7 @@ export const ScrvUsdDepositInfoList = ({
   onApproveInfiniteToggle,
 }: ScrvUsdDepositInfoListProps) => {
   const expectedScrvUsd = useScrvUsdPreviewDeposit(params, isOpen)
-  const gas = useScrvUsdDepositEstimateGas(networks, params, isOpen)
+  const gas = useScrvUsdDepositEstimateGas(params, isOpen)
 
   return (
     <ActionInfoCollapse isOpen={isOpen} testId="scrvusd-deposit-action-info-list">

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
@@ -21,11 +21,7 @@ export const ScrvUsdWithdrawForm = ({ network }: NetworkUrlParams) => {
   const networkConfig = networks[chainId]
 
   return (
-    <Form
-      {...form}
-      onSubmit={onSubmit}
-      footer={<ScrvUsdWithdrawInfoList form={form} params={params} networks={networks} />}
-    >
+    <Form {...form} onSubmit={onSubmit} footer={<ScrvUsdWithdrawInfoList form={form} params={params} />}>
       <LoanFormTokenInput
         label={t`Amount to withdraw`}
         token={{ address: SCRVUSD_VAULT_ADDRESS, symbol: 'scrvUSD' }}

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawInfoList.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawInfoList.tsx
@@ -4,7 +4,6 @@ import { ScrvUsdExchangeRateActionInfo } from '@/loan/components/PageCrvUsdStaki
 import { useScrvUsdPreviewWithdraw } from '@/loan/entities/scrvusd-preview.query'
 import { useScrvUsdWithdrawEstimateGas } from '@/loan/entities/scrvusd-withdraw-estimate-gas.query'
 import type { ScrvUsdWithdrawForm, ScrvUsdWithdrawParams } from '@/loan/entities/scrvusd.validation'
-import type { NetworkConfig } from '@/loan/types/loan.types'
 import type { UseFormReturn } from '@evm-ui/features/forms'
 import { t } from '@evm-ui/lib/i18n'
 import { ActionInfo, ActionInfoGasEstimate } from '@evm-ui/shared/ui/ActionInfo'
@@ -14,11 +13,10 @@ import Stack from '@mui/material/Stack'
 
 type ScrvUsdWithdrawInfoListProps = {
   params: ScrvUsdWithdrawParams
-  networks: Record<number, NetworkConfig>
   form: UseFormReturn<ScrvUsdWithdrawForm>
 }
 
-export const ScrvUsdWithdrawInfoList = ({ params, networks, form }: ScrvUsdWithdrawInfoListProps) => {
+export const ScrvUsdWithdrawInfoList = ({ params, form }: ScrvUsdWithdrawInfoListProps) => {
   const isOpen = form.isTouched('withdrawAmount')
   const expectedCrvUsd = useScrvUsdPreviewWithdraw(params, isOpen)
   return (
@@ -32,7 +30,7 @@ export const ScrvUsdWithdrawInfoList = ({ params, networks, form }: ScrvUsdWithd
           testId="scrvusd-withdraw-receive"
         />
         <ScrvUsdExchangeRateActionInfo chainId={params.chainId} enabled={isOpen} />
-        <ActionInfoGasEstimate gas={q(useScrvUsdWithdrawEstimateGas(networks, params, isOpen))} />
+        <ActionInfoGasEstimate gas={q(useScrvUsdWithdrawEstimateGas(params, isOpen))} />
       </Stack>
     </ActionInfoCollapse>
   )

--- a/apps/main/src/loan/types/loan.types.ts
+++ b/apps/main/src/loan/types/loan.types.ts
@@ -1,5 +1,5 @@
 import type { INetworkName } from '@curvefi/llamalend-api/lib/interfaces'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 
 export type ChainId = 1 // note lend also has other chains, but we only use eth in this app
 
@@ -10,7 +10,7 @@ export type NetworkUrlParams = { network: NetworkEnum }
 export type CollateralUrlParams = NetworkUrlParams & { collateralId: string }
 export type UrlParams = NetworkUrlParams & Partial<CollateralUrlParams>
 
-export type NetworkConfig = { isActiveNetwork: boolean; showInSelectNetwork: boolean } & BaseConfig<
+export type NetworkConfig = { isActiveNetwork: boolean; showInSelectNetwork: boolean } & NetworkDef<
   NetworkEnum,
   ChainId
 >

--- a/packages/evm-ui/src/lib/model/entities/gas-info.ts
+++ b/packages/evm-ui/src/lib/model/entities/gas-info.ts
@@ -10,11 +10,39 @@ import { combineQueries, useCombinedQueries } from '@evm-ui/lib/queries/combine'
 import { createValidationSuite, type FieldsOf } from '@evm-ui/lib/validation'
 import { constQ, type Query as QueryResult } from '@evm-ui/types/util'
 import { Chain, formatNumber, formatToken, gweiToEther, gweiToWai, weiToGwei } from '@evm-ui/utils'
-import { type BaseConfig } from '@legacy-ui/utils'
 import type { Amount, Decimal } from '@primitives/decimal.utils'
-import { assert, maybe, maybes } from '@primitives/objects.utils'
+import { assert, maybe, maybes, type PartialRecord } from '@primitives/objects.utils'
 import { chainValidationGroup } from '../query/chain-validation'
 import { useTokenUsdRate } from './token-usd-rate'
+
+type ChainGasConfig = {
+  gasL2: boolean
+  gasPricesUnit: string
+  gasPricesUrl: string
+  gasPricesDefault: number
+}
+
+const BASE_CHAIN_GAS_CONFIG: ChainGasConfig = {
+  gasL2: false,
+  gasPricesUnit: 'GWEI',
+  gasPricesUrl: '',
+  gasPricesDefault: 0,
+}
+
+const CHAIN_GAS_CONFIGS: PartialRecord<Chain, Partial<ChainGasConfig>> = {
+  [Chain.Ethereum]: { gasPricesUrl: 'https://api.curve.finance/api/getGas', gasPricesDefault: 1 },
+  [Chain.Optimism]: { gasL2: true },
+  [Chain.Polygon]: { gasPricesUrl: 'https://gasstation.polygon.technology/v2', gasPricesDefault: 0 },
+  [Chain.Kava]: { gasPricesUnit: 'UKAVA' },
+  [Chain.Avalanche]: {
+    gasPricesUnit: 'nAVAX',
+    gasPricesUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    gasPricesDefault: 0,
+  },
+  [Chain.Base]: { gasL2: true },
+} as const
+
+export const getGasConfig = (chainId: Chain) => ({ ...BASE_CHAIN_GAS_CONFIG, ...CHAIN_GAS_CONFIGS[chainId] })
 
 type GasInfoQuery<T = number> = ChainQuery<T> & {
   /** Network dependent url for fetching the latest gas prices */
@@ -290,25 +318,21 @@ async function parseGasInfo(curve: AnyCurveApi, provider: Provider, l2GasUrl?: s
   }
 }
 
-type Network = { gasPricesUrl: string; gasL2: boolean }
-
 export type GasInfoQueryOptions<TChainId extends number = number> = {
   chainId?: TChainId | null
-  networks: Record<TChainId, Network>
 }
 
 /** Helper function to create required query options based on network configs. */
 function createGasInfoQueryOptions<TChainId extends number>({
   chainId,
-  networks,
 }: GasInfoQueryOptions<TChainId>): GasInfoParams<TChainId> {
-  const network = chainId && networks[chainId]
+  const { gasPricesUrl, gasL2 } = maybe(chainId, chainId => getGasConfig(chainId)) ?? {}
   return {
     chainId,
-    gasPricesUrl: network?.gasPricesUrl,
+    gasPricesUrl,
     // It seems that in the original code the Ethereum mainnet gas prices URL was used for L2 price fetching.
     // I do not question whether this is right or not. I just re-use what was already being used.
-    gasPricesUrlL2: network?.gasL2 ? networks?.[1 as TChainId]?.gasPricesUrl : undefined,
+    gasPricesUrlL2: gasL2 ? CHAIN_GAS_CONFIGS[Chain.Ethereum]!.gasPricesUrl : undefined,
   }
 }
 
@@ -316,28 +340,26 @@ function createGasInfoQueryOptions<TChainId extends number>({
  * Fetches gas info and updates the library. This wrapper exists as the base query requires query options
  * derived from network config objects. Having to import and use `createGasInfoQueryOptions` is cumbersome.
  */
-export const fetchGasInfoAndUpdateLib = <TChainId extends number>({
-  chainId,
-  networks,
-}: GasInfoQueryOptions<TChainId>) => fetchGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId, networks }))
+export const fetchGasInfoAndUpdateLib = <TChainId extends number>({ chainId }: GasInfoQueryOptions<TChainId>) =>
+  fetchGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId }))
 
 /**
  * Fetches gas info and updates the library. This wrapper exists as the base query requires query options
  * derived from network config objects. Having to import and use `createGasInfoQueryOptions` is cumbersome.
  */
 export const useGasInfoAndUpdateLib = <TChainId extends number>(
-  { chainId, networks }: GasInfoQueryOptions<TChainId>,
+  { chainId }: GasInfoQueryOptions<TChainId>,
   enabled?: boolean,
 ) => {
   const { provider } = useWallet() // validate provider manually because otherwise query won't get enabled when connected
-  return useGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId, networks }), !!provider && enabled)
+  return useGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId }), !!provider && enabled)
 }
 
 /** Sets gas info query data directly in the query cache. */
 export const setGasInfoAndUpdateLib = <TChainId extends number>(
-  { chainId, networks }: GasInfoQueryOptions<TChainId>,
+  { chainId }: GasInfoQueryOptions<TChainId>,
   gasInfo: GasInfo,
-) => setGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId, networks }), gasInfo)
+) => setGasInfoAndUpdateLibBase(createGasInfoQueryOptions({ chainId }), gasInfo)
 
 // calculates L1+L2 gas for optimistic rollups
 const calculateOptimisticRollupGas = (
@@ -352,17 +374,7 @@ export function calculateGas(
   estimatedGas: Amount | [Decimal, Decimal] | number[] | null | undefined,
   gasInfo: GasInfo | undefined,
   chainTokenUsdRate: number | undefined,
-  {
-    chainId,
-    gasPricesUnit,
-    gasL2: isL2Network,
-    gasPricesDefault = 0,
-  }: {
-    chainId: number
-    gasPricesUnit: string
-    gasL2: boolean
-    gasPricesDefault: number | undefined
-  },
+  chainId: number,
   networkSymbol: string,
 ): {
   estGasCost?: number
@@ -370,6 +382,7 @@ export function calculateGas(
   tooltip?: string
   gasCostInWei?: number
 } {
+  const { gasPricesUnit, gasL2, gasPricesDefault } = getGasConfig(chainId)
   const basePlusPriority = gasInfo?.basePlusPriority?.[gasPricesDefault]
   if (!estimatedGas || !basePlusPriority) {
     return {}
@@ -379,7 +392,7 @@ export function calculateGas(
   const gasCostInWei =
     L2_NETWORKS_WITH_GAS_PRICE.includes(chainId) && l2GasPriceWei && !Array.isArray(estimatedGas)
       ? l2GasPriceWei * +estimatedGas
-      : isL2Network && Array.isArray(estimatedGas) && l2GasPriceWei && l1GasPriceWei
+      : gasL2 && Array.isArray(estimatedGas) && l2GasPriceWei && l1GasPriceWei
         ? calculateOptimisticRollupGas(estimatedGas, [l2GasPriceWei, l1GasPriceWei])
         : Array.isArray(estimatedGas)
           ? 0
@@ -395,24 +408,18 @@ export function calculateGas(
 type GasEstimate = Amount | [Decimal, Decimal] | number[] | null | undefined
 
 /** Converts an existing gas estimate query into native/USD gas cost info. */
-const useEstimateGas = (
-  networks: Record<number, BaseConfig>,
-  chainId: number | null | undefined,
-  estimate: QueryResult<GasEstimate>,
-  enabled?: boolean,
-) => {
+const useEstimateGas = (chainId: number | null | undefined, estimate: QueryResult<GasEstimate>, enabled?: boolean) => {
   const ethRate = useTokenUsdRate({ chainId, tokenAddress: ethAddress }, enabled)
-  const gasInfo = useGasInfoAndUpdateLib({ chainId, networks }, enabled)
-  const network = maybe(chainId, chainId => networks[chainId])
+  const gasInfo = useGasInfoAndUpdateLib({ chainId }, enabled)
   const networkSymbol = maybe(chainId, chainId => getChainNativeCurrency(chainId).symbol)
   return useCombinedQueries(
     [estimate, gasInfo, ethRate],
     useCallback(
       (estimate, gasInfo, ethRate) =>
-        maybes([network, networkSymbol], (network, networkSymbol) =>
-          calculateGas(estimate, gasInfo, ethRate, network, networkSymbol),
+        maybes([chainId, networkSymbol], (chainId, networkSymbol) =>
+          calculateGas(estimate, gasInfo, ethRate, chainId, networkSymbol),
         ),
-      [network, networkSymbol],
+      [chainId, networkSymbol],
     ),
   )
 }
@@ -421,14 +428,8 @@ const useEstimateGas = (
  * Converts a raw gas estimate value into native/USD gas cost info.
  * @deprecated Prefer `createEstimateGasHook`.
  */
-export const useEstimateGasValue = (
-  networks: Record<number, BaseConfig>,
-  chainId: number | null | undefined,
-  estimate: GasEstimate,
-  enabled?: boolean,
-) => useEstimateGas(networks, chainId, constQ(estimate), enabled)
-
-type NetworkDict = Record<number, BaseConfig>
+export const useEstimateGasValue = (chainId: number | null | undefined, estimate: GasEstimate, enabled?: boolean) =>
+  useEstimateGas(chainId, constQ(estimate), enabled)
 
 type EstimateValue = number | number[] | null | undefined
 
@@ -441,9 +442,9 @@ export const createEstimateGasHook =
   <Query extends WithOptionalChainId, Estimate extends EstimateValue>(
     useEstimate: (query: Query, enabled?: boolean) => QueryResult<Estimate>,
   ) =>
-  (networks: NetworkDict, query: Query & { chainId?: number | null | undefined }, enabled = true) => {
+  (query: Query & { chainId?: number | null | undefined }, enabled = true) => {
     const estimate = useEstimate(query, enabled)
-    const converted = useEstimateGas(networks, query.chainId, estimate, enabled)
+    const converted = useEstimateGas(query.chainId, estimate, enabled)
     return combineQueries([converted, estimate], data => data)
   }
 
@@ -458,11 +459,11 @@ export const createApprovedEstimateGasHook =
     useApproveEstimate: (query: Query, enabled?: boolean) => QueryResult<Estimate>
     useActionEstimate: (query: Query, enabled?: boolean) => QueryResult<Estimate>
   }) =>
-  (networks: NetworkDict, query: Query & { chainId?: number | null | undefined }, enabled = true) => {
+  (query: Query & { chainId?: number | null | undefined }, enabled = true) => {
     const isApproved = useIsApproved(query, enabled)
     const approveEstimate = useApproveEstimate(query, enabled && isApproved.data === false)
     const actionEstimate = useActionEstimate(query, enabled && isApproved.data === true)
     const estimate = isApproved.data ? actionEstimate : approveEstimate
-    const gas = useEstimateGas(networks, query.chainId, estimate, enabled)
+    const gas = useEstimateGas(query.chainId, estimate, enabled)
     return combineQueries([isApproved, gas], (_, gas) => gas)
   }

--- a/packages/evm-ui/src/widgets/RouteProvider/RouteProvider.stories.tsx
+++ b/packages/evm-ui/src/widgets/RouteProvider/RouteProvider.stories.tsx
@@ -7,7 +7,6 @@ import { TestQueryProvider } from '@evm-ui/lib/queries/test-query.provider.test'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import { constQ, q } from '@evm-ui/types/util'
 import { mockRoutes } from '@evm-ui/widgets/RouteProvider/route.mock'
-import type { BaseConfig } from '@legacy-ui/utils'
 import Box from '@mui/material/Box'
 import { fromEntries, mapRecord } from '@primitives/objects.utils'
 import { RouteProviders } from '@primitives/router.utils'
@@ -76,7 +75,6 @@ const meta: Meta<typeof RouteProviderStory> = {
   component: RouteProviderStory,
   args: {
     chainId: 1,
-    networks: { 1: {} as BaseConfig },
     queries: fromEntries(
       RouteProviders.map(router => [
         router,
@@ -116,14 +114,6 @@ export const Expanded: Story = {
 export const GasEstimate: Story = {
   args: {
     isExpanded: true,
-    networks: {
-      1: {
-        gasL2: false,
-        gasPricesDefault: 0,
-        gasPricesUnit: 'GWEI',
-        gasPricesUrl: 'https://api.curve.finance/api/getGas',
-      } as BaseConfig,
-    },
     queryData: [
       [['chain', { chainId: 1 }, 'token', { tokenAddress: ethAddress }, 'usdRate'], 3_000],
       [

--- a/packages/evm-ui/src/widgets/RouteProvider/RouteProviderCard.tsx
+++ b/packages/evm-ui/src/widgets/RouteProvider/RouteProviderCard.tsx
@@ -16,7 +16,6 @@ import type { QueryProp } from '@evm-ui/types/util'
 import { formatNumber, fromWei, PLACEHOLDER, PLACEHOLDER_USD } from '@evm-ui/utils'
 import { RouteComparisonChip } from '@evm-ui/widgets/RouteProvider/RouteComparisonChip'
 import { RouteProviderIcons, RouteProviderLabels } from '@evm-ui/widgets/RouteProvider/RouteProviders'
-import type { BaseConfig } from '@legacy-ui/utils'
 import Box from '@mui/material/Box'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -34,7 +33,6 @@ export type RouteProviderCardProps = {
   bestOutputAmount: Decimal | undefined
   router: RouteProvider
   onSelect: (provider: RouteProvider) => void
-  networks: Record<number, BaseConfig>
   chainId: number
 }
 
@@ -46,10 +44,9 @@ export const RouteProviderCard = ({
   onSelect,
   router,
   chainId,
-  networks,
 }: RouteProviderCardProps) => {
   const out = maybes([route, decimals], ({ amountOut }, decimals) => fromWei(amountOut[0], decimals))
-  const { data: gasEstimate } = useEstimateGasValue(networks, chainId, route?.gas)
+  const { data: gasEstimate } = useEstimateGasValue(chainId, route?.gas)
   const Icon = RouteProviderIcons[router]
   const disabledTooltip = t`${RouteProviderLabels[router]} is unavailable on ${getChainName(chainId)}.`
   const onClick = useCallback(() => (enabled ? onSelect(router) : undefined), [onSelect, router, enabled])

--- a/packages/evm-ui/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
+++ b/packages/evm-ui/src/widgets/RouteProvider/RouteProvidersAccordion.tsx
@@ -9,7 +9,6 @@ import { LoadingAnimation } from '@evm-ui/themes/design/0_primitives'
 import { SizesAndSpaces } from '@evm-ui/themes/design/1_sizes_spaces'
 import { decimalMax } from '@evm-ui/utils'
 import { RouteComparisonChip } from '@evm-ui/widgets/RouteProvider/RouteComparisonChip'
-import type { BaseConfig } from '@legacy-ui/utils'
 import IconButton from '@mui/material/IconButton'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -30,7 +29,6 @@ export type RouteProviderProps = {
   isExpanded: boolean
   onToggle: () => void
   onRefresh: () => void
-  networks: Record<number, BaseConfig>
   chainId: number
   providers: readonly RouteProvider[]
 }
@@ -45,7 +43,6 @@ export const RouteProvidersAccordion = ({
   isExpanded,
   onToggle,
   onRefresh,
-  networks,
   chainId,
   providers,
 }: RouteProviderProps) => {
@@ -121,7 +118,6 @@ export const RouteProvidersAccordion = ({
                 query={queries[provider]}
                 bestOutputAmount={maxAmountOut}
                 onSelect={onChange}
-                networks={networks}
                 chainId={chainId}
               />
             ))}

--- a/packages/legacy-ui/src/utils/utilsNetworks.ts
+++ b/packages/legacy-ui/src/utils/utilsNetworks.ts
@@ -2,40 +2,20 @@ import { getChainBlockExplorer } from '@evm-ui/features/connect-wallet/lib/wagmi
 import { Chain } from '@evm-ui/utils/network'
 import { maybe } from '@primitives/objects.utils'
 
-const NETWORK_BASE_CONFIG_DEFAULT = {
-  gasL2: false,
-  gasPricesUnit: 'GWEI',
-  gasPricesUrl: '',
-  gasPricesDefault: 0,
-}
-
 export const NETWORK_BASE_CONFIG = {
-  [Chain.Ethereum]: {
-    blockchainId: 'ethereum',
-    gasPricesUrl: 'https://api.curve.finance/api/getGas',
-    gasPricesDefault: 1,
-  },
-  [Chain.Optimism]: { blockchainId: 'optimism', gasL2: true },
+  [Chain.Ethereum]: { blockchainId: 'ethereum' },
+  [Chain.Optimism]: { blockchainId: 'optimism' },
   [Chain.Gnosis]: { blockchainId: 'xdai' },
   [Chain.Moonbeam]: { blockchainId: 'moonbeam' },
-  [Chain.Polygon]: {
-    blockchainId: 'polygon',
-    gasPricesUrl: 'https://gasstation.polygon.technology/v2',
-    gasPricesDefault: 0,
-  },
-  [Chain.Kava]: { blockchainId: 'kava', gasPricesUnit: 'UKAVA' },
+  [Chain.Polygon]: { blockchainId: 'polygon' },
+  [Chain.Kava]: { blockchainId: 'kava' },
   [Chain.Fantom]: { blockchainId: 'fantom' },
   [Chain.Arbitrum]: { blockchainId: 'arbitrum' },
-  [Chain.Avalanche]: {
-    blockchainId: 'avalanche',
-    gasPricesUnit: 'nAVAX',
-    gasPricesUrl: 'https://api.avax.network/ext/bc/C/rpc',
-    gasPricesDefault: 0,
-  },
+  [Chain.Avalanche]: { blockchainId: 'avalanche' },
   [Chain.Celo]: { blockchainId: 'celo' },
   [Chain.Aurora]: { blockchainId: 'aurora' },
   [Chain.ZkSync]: { blockchainId: 'zksync' },
-  [Chain.Base]: { blockchainId: 'base', gasL2: true },
+  [Chain.Base]: { blockchainId: 'base' },
   [Chain.Bsc]: { blockchainId: 'bsc' },
   [Chain.Fraxtal]: { blockchainId: 'fraxtal' },
   [Chain.XLayer]: { blockchainId: 'x-layer' },
@@ -57,20 +37,10 @@ export type NetworkMapping<TId extends string = string, TChainId extends number 
   NetworkDef<TId, TChainId>
 >
 
-export type BaseConfig<TId extends string = string, TChainId extends number = number> = NetworkDef<TId, TChainId> & {
-  gasL2: boolean
-  gasPricesUnit: string
-  gasPricesUrl: string
-  gasPricesDefault: number
-}
-
-export function getBaseNetworksConfig<TId extends string, ChainId extends number>(
+export const getBaseNetworksConfig = <TId extends string, ChainId extends number>(
   chainId: ChainId,
   networkConfig: { blockchainId: TId },
-): Omit<BaseConfig<TId>, 'showInSelectNetwork' | 'showRouterSwap'> {
-  const { ...rest } = { ...NETWORK_BASE_CONFIG_DEFAULT, ...networkConfig }
-  return { ...rest, chainId }
-}
+): Omit<NetworkDef<TId>, 'showInSelectNetwork' | 'showRouterSwap'> => ({ ...networkConfig, chainId })
 
 export const scanAddressPath = (chainId: number, hash: string) =>
   maybe(getChainBlockExplorer(chainId), url => `${url}/address/${hash}`)

--- a/tests/cypress/component/dao/create-vecrv-lock.cy.tsx
+++ b/tests/cypress/component/dao/create-vecrv-lock.cy.tsx
@@ -1,5 +1,4 @@
 import { FormLockCreate } from '@/dao/components/PageVeCrv/components/FormLockCreate'
-import { networks } from '@/dao/networks'
 import { CurveComponentTestWrapper } from '@cy/support/helpers/CurveComponentTestWrapper'
 import { createCreateVeCrvLockScenario } from '@cy/support/helpers/dao/mocks/create-vecrv-lock.mocks'
 import { setupMockedDaoComponentTest } from '@cy/support/helpers/dao/test-context.helpers'
@@ -43,7 +42,7 @@ describe('FormLockCreate (mocked)', () => {
   testCases.forEach(({ isApproved, title }) => {
     it(title, () => {
       const { assertPreSubmit, assertSubmit, curve, lockedAmount } = createCreateVeCrvLockScenario({ isApproved })
-      setGasInfo({ chainId: CHAIN_ID, networks })
+      setGasInfo({ chainId: CHAIN_ID })
 
       cy.mount(<CreateVeCrvLockForm curve={curve} />)
       fillCreateLockForm(lockedAmount)
@@ -63,7 +62,7 @@ describe('FormLockCreate (mocked)', () => {
 
   it('rounds quick action dates in the picker while submitting the selected duration', () => {
     const { assertPreSubmit, curve, lockedAmount } = createCreateVeCrvLockScenario({ isApproved: true })
-    setGasInfo({ chainId: CHAIN_ID, networks })
+    setGasInfo({ chainId: CHAIN_ID })
 
     cy.mount(<CreateVeCrvLockForm curve={curve} />)
     fillCreateLockForm(lockedAmount, 0)
@@ -75,7 +74,7 @@ describe('FormLockCreate (mocked)', () => {
 
   it('shows the effective rounded unlock date for a typed non-Thursday date', () => {
     const { assertPreSubmit, curve, lockedAmount } = createCreateVeCrvLockScenario({ isApproved: true })
-    setGasInfo({ chainId: CHAIN_ID, networks })
+    setGasInfo({ chainId: CHAIN_ID })
 
     cy.mount(<CreateVeCrvLockForm curve={curve} />)
     cy.get('input[name="lockedAmount"]').clear().type(lockedAmount)

--- a/tests/cypress/component/dao/extend-lock.cy.tsx
+++ b/tests/cypress/component/dao/extend-lock.cy.tsx
@@ -1,5 +1,4 @@
 import { FormLockDate } from '@/dao/components/PageVeCrv/components/FormLockDate'
-import { networks } from '@/dao/networks'
 import { CurveComponentTestWrapper } from '@cy/support/helpers/CurveComponentTestWrapper'
 import { createExtendLockScenario } from '@cy/support/helpers/dao/mocks/extend-lock.mocks'
 import { setupMockedDaoComponentTest } from '@cy/support/helpers/dao/test-context.helpers'
@@ -31,7 +30,7 @@ describe('FormLockDate (mocked)', () => {
 
   it('estimates and extends a lock', () => {
     const { assertPreSubmit, assertSubmit, curve } = createExtendLockScenario()
-    setGasInfo({ chainId: CHAIN_ID, networks })
+    setGasInfo({ chainId: CHAIN_ID })
 
     cy.mount(<ExtendLockForm curve={curve} />)
     cy.get('[data-testid="btn-adjust-date-date-picker-inline-quick-action-3"]').click()
@@ -47,7 +46,7 @@ describe('FormLockDate (mocked)', () => {
 
   it('shows the effective rounded unlock date for a typed non-Thursday date', () => {
     const { assertPreSubmit, curve } = createExtendLockScenario()
-    setGasInfo({ chainId: CHAIN_ID, networks })
+    setGasInfo({ chainId: CHAIN_ID })
 
     cy.mount(<ExtendLockForm curve={curve} />)
     typeExtendUnlockDate({ month: '8', day: '25', year: '2028' })

--- a/tests/cypress/component/dao/lock-more.cy.tsx
+++ b/tests/cypress/component/dao/lock-more.cy.tsx
@@ -1,5 +1,4 @@
 import { FormLockCrv } from '@/dao/components/PageVeCrv/components/FormLockCrv'
-import { networks } from '@/dao/networks'
 import { CurveComponentTestWrapper } from '@cy/support/helpers/CurveComponentTestWrapper'
 import { createLockMoreScenario } from '@cy/support/helpers/dao/mocks/lock-more.mocks'
 import { setupMockedDaoComponentTest } from '@cy/support/helpers/dao/test-context.helpers'
@@ -29,7 +28,7 @@ describe('FormLockCrv (mocked)', () => {
   testCases.forEach(({ isApproved, title }) => {
     it(title, () => {
       const { assertPreSubmit, assertSubmit, curve, lockedAmount } = createLockMoreScenario({ isApproved })
-      setGasInfo({ chainId: CHAIN_ID, networks })
+      setGasInfo({ chainId: CHAIN_ID })
 
       cy.mount(<LockMoreForm curve={curve} />)
       writeLockMoreForm(lockedAmount)

--- a/tests/cypress/component/dao/withdraw-lock.cy.tsx
+++ b/tests/cypress/component/dao/withdraw-lock.cy.tsx
@@ -1,5 +1,4 @@
 import { FormWithdraw } from '@/dao/components/PageVeCrv/components/FormWithdraw'
-import { networks } from '@/dao/networks'
 import { CurveComponentTestWrapper } from '@cy/support/helpers/CurveComponentTestWrapper'
 import { createWithdrawLockScenario } from '@cy/support/helpers/dao/mocks/withdraw-lock.mocks'
 import { setupMockedDaoComponentTest } from '@cy/support/helpers/dao/test-context.helpers'
@@ -20,7 +19,7 @@ describe('FormWithdraw (mocked)', () => {
 
   it('estimates and withdraws an expired lock', () => {
     const { assertPreSubmit, assertSubmit, curve } = createWithdrawLockScenario()
-    setGasInfo({ chainId: CHAIN_ID, networks })
+    setGasInfo({ chainId: CHAIN_ID })
 
     cy.mount(<WithdrawLockForm curve={curve} />)
     cy.get('[data-testid="withdraw-lock-submit-button"]').should('be.enabled')

--- a/tests/cypress/component/form-skeleton.cy.tsx
+++ b/tests/cypress/component/form-skeleton.cy.tsx
@@ -48,7 +48,7 @@ describe('FormSkeleton', () => {
     })
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: 1, networks: llamaNetworks })
+    setGasInfo({ chainId: 1 })
 
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/borrow-more.cy.tsx
+++ b/tests/cypress/component/llamalend/borrow-more.cy.tsx
@@ -89,7 +89,7 @@ describe('BorrowMoreForm (mocked)', () => {
           })
 
         setLlamaApi(llamaApi)
-        setGasInfo({ chainId, networks: llamaNetworks })
+        setGasInfo({ chainId })
 
         cy.mount(
           <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/create-loan.cy.tsx
+++ b/tests/cypress/component/llamalend/create-loan.cy.tsx
@@ -47,7 +47,7 @@ describe('CreateLoanForm (mocked)', () => {
       const onPricesUpdated = cy.spy().as('onPricesUpdated')
 
       setLlamaApi(llamaApi)
-      setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+      setGasInfo({ chainId: CHAIN_ID })
 
       cy.mount(
         <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
@@ -72,7 +72,7 @@ describe('CreateLoanForm (mocked)', () => {
     })
     Object.assign((market as LendMarketTemplate).addresses, { controller: zeroAddress })
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+    setGasInfo({ chainId: CHAIN_ID })
     cy.intercept('GET', '**/api/router/v1/routes*').as('routerRoutes')
 
     cy.mount(

--- a/tests/cypress/component/llamalend/liquidation.cy.tsx
+++ b/tests/cypress/component/llamalend/liquidation.cy.tsx
@@ -46,7 +46,7 @@ const mountResetPositionForm = ({
   market,
 }: Pick<ReturnType<typeof createResetPositionScenario>, 'llamaApi' | 'market'>) => {
   setLlamaApi(llamaApi)
-  setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+  setGasInfo({ chainId: CHAIN_ID })
   cy.mount(
     <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
       <ResetPositionForm networks={llamaNetworks} />
@@ -66,7 +66,7 @@ describe('Soft Liquidation Forms (mocked)', () => {
         })
 
         setLlamaApi(llamaApi)
-        setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+        setGasInfo({ chainId: CHAIN_ID })
         seedCrvUsdBalance({ chainId: CHAIN_ID, addresses: [TEST_ADDRESS], min: borrow })
 
         cy.mount(
@@ -122,7 +122,7 @@ describe('Soft Liquidation Forms (mocked)', () => {
         })
 
         setLlamaApi(llamaApi)
-        setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+        setGasInfo({ chainId: CHAIN_ID })
         seedCrvUsdBalance({ chainId: CHAIN_ID, addresses: [TEST_ADDRESS], min: `${oneInt(15, 90)}` })
 
         cy.mount(

--- a/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
+++ b/tests/cypress/component/llamalend/loan-action-info-layout.cy.tsx
@@ -9,7 +9,7 @@ import { q } from '@evm-ui/types/util'
 import { mockRoutes } from '@evm-ui/widgets/RouteProvider/route.mock'
 import { SlippageToleranceActionInfo } from '@evm-ui/widgets/SlippageSettings'
 import { SLIPPAGE } from '@evm-ui/widgets/SlippageSettings/slippage.utils'
-import type { BaseConfig } from '@legacy-ui/utils'
+import type { NetworkDef } from '@legacy-ui/utils'
 import { fromEntries, notFalsy } from '@primitives/objects.utils'
 import { RouteProviders } from '@primitives/router.utils'
 
@@ -31,7 +31,7 @@ const routes: MarketRoutes = {
       },
     ]),
   ),
-  networks: { 1: {} as BaseConfig },
+  networks: { 1: {} as NetworkDef },
   chainId: 1,
   selectedRoute: mockRoutes[0],
   selectedRouter: mockRoutes[0].router,

--- a/tests/cypress/component/llamalend/repay.cy.tsx
+++ b/tests/cypress/component/llamalend/repay.cy.tsx
@@ -59,7 +59,7 @@ describe('RepayForm (mocked)', () => {
           : { symbol: 'crvUSD', tokenAddress: CRVUSD_ADDRESS, optionIndex: 0 }
 
       setLlamaApi(llamaApi)
-      setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+      setGasInfo({ chainId: CHAIN_ID })
       seedCrvUsdBalance({ chainId: CHAIN_ID, addresses: [TEST_ADDRESS], min: borrow })
 
       cy.mount(

--- a/tests/cypress/component/llamalend/supply-claim.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-claim.cy.tsx
@@ -46,7 +46,7 @@ describe('ClaimTab (mocked)', () => {
       })
 
       setLlamaApi(llamaApi)
-      setGasInfo({ chainId, networks: llamaNetworks })
+      setGasInfo({ chainId })
 
       cy.mount(
         <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/supply-deposit.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-deposit.cy.tsx
@@ -64,7 +64,7 @@ describe('DepositForm (mocked)', () => {
         })
 
         setLlamaApi(llamaApi)
-        setGasInfo({ chainId, networks: llamaNetworks })
+        setGasInfo({ chainId })
 
         cy.mount(
           <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/supply-stake.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-stake.cy.tsx
@@ -32,7 +32,7 @@ describe('StakeForm (mocked)', () => {
       const { input, market, llamaApi, expected, stubs } = createStakeScenario({ chainId, approved, hasGauge })
 
       setLlamaApi(llamaApi)
-      setGasInfo({ chainId, networks: llamaNetworks })
+      setGasInfo({ chainId })
 
       cy.mount(
         <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/supply-unstake.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-unstake.cy.tsx
@@ -28,7 +28,7 @@ describe('UnstakeForm (mocked)', () => {
     const { input, market, llamaApi, expected, stubs } = createUnstakeScenario({ chainId })
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId, networks: llamaNetworks })
+    setGasInfo({ chainId })
 
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/supply-withdraw.cy.tsx
+++ b/tests/cypress/component/llamalend/supply-withdraw.cy.tsx
@@ -29,7 +29,7 @@ describe('WithdrawForm (mocked)', () => {
       const { input, market, llamaApi, expected, stubs } = createWithdrawScenario({ chainId, isFull })
 
       setLlamaApi(llamaApi)
-      setGasInfo({ chainId, networks: llamaNetworks })
+      setGasInfo({ chainId })
 
       cy.mount(
         <MockLoanTestWrapper llamaApi={llamaApi} market={market}>

--- a/tests/cypress/component/llamalend/zap-v2-calldata-size.cy.tsx
+++ b/tests/cypress/component/llamalend/zap-v2-calldata-size.cy.tsx
@@ -44,7 +44,7 @@ describe('ZapV2 router calldata size', () => {
     })
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+    setGasInfo({ chainId: CHAIN_ID })
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
         <CreateLoanForm networks={llamaNetworks} onPricesUpdated={cy.spy()} />
@@ -64,7 +64,7 @@ describe('ZapV2 router calldata size', () => {
     })
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+    setGasInfo({ chainId: CHAIN_ID })
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
         <CreateLoanForm networks={llamaNetworks} onPricesUpdated={cy.spy()} />
@@ -86,7 +86,7 @@ describe('ZapV2 router calldata size', () => {
     })
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+    setGasInfo({ chainId: CHAIN_ID })
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
         <BorrowMoreForm
@@ -111,7 +111,7 @@ describe('ZapV2 router calldata size', () => {
     const { collateralToken } = getTokens(market)
 
     setLlamaApi(llamaApi)
-    setGasInfo({ chainId: CHAIN_ID, networks: llamaNetworks })
+    setGasInfo({ chainId: CHAIN_ID })
     cy.mount(
       <MockLoanTestWrapper llamaApi={llamaApi} market={market}>
         <RepayForm

--- a/tests/cypress/component/route-provider-card.cy.tsx
+++ b/tests/cypress/component/route-provider-card.cy.tsx
@@ -5,7 +5,6 @@ import type { RouteResponse } from '@evm-ui/entities/router-api'
 import { lightTheme } from '@evm-ui/themes'
 import { constQ, q, type QueryProp } from '@evm-ui/types/util'
 import { RouteProviderCard } from '@evm-ui/widgets/RouteProvider/RouteProviderCard'
-import type { BaseConfig } from '@legacy-ui/utils'
 import type { RouteProvider } from '@primitives/router.utils'
 
 const { design } = lightTheme()
@@ -64,7 +63,6 @@ const mountRouteProviderCard = ({
           enabled,
           ...q<RouteResponse | null>({ error: null, isLoading, data: route }),
         }}
-        networks={{ 1: {} as BaseConfig }}
         chainId={1}
         tokenOut={{ symbol: 'crvUSD', decimals: 18, usdRate }}
         isSelected={isSelected}


### PR DESCRIPTION
* Extracts `GasConfig` from `BaseConfig`
* Removes `BaseConfig` in favor of just `NetworkDef`
* Place gas config logic inside its only user (`gas-info.ts`) and basically delete a shitton of dependencies on the network object where a simple chain id suffices.

RPC Tests: [1](https://github.com/curvefi/curve-frontend/actions/runs/33646814529) | [2](https://github.com/curvefi/curve-frontend/actions/runs/33646814529/job/100309559227)