### PR TITLE
Updates colors for alert boxes and in the theme to sync with Figma and fixes bad readability on alert boxes.

### DIFF
--- a/packages/evm-ui/src/themes/components/mui-alert.tsx
+++ b/packages/evm-ui/src/themes/components/mui-alert.tsx
@@ -10,6 +10,9 @@ import { DesignSystem } from '../design'
 const { Spacing, IconSize, OutlineWidth: OUTLINE_WIDTH } = SizesAndSpaces
 
 const TITLE_AND_ICON_SELECTOR = '.MuiAlertTitle-root, .MuiAlert-icon'
+const ICON_SELECTOR = '& .MuiAlert-icon'
+const FILLED_ACTION_SELECTOR =
+  '& .MuiAlert-action, & .MuiAlert-action .MuiButton-root, & .MuiAlert-action .MuiIconButton-root'
 
 export const defineMuiAlert = (
   { Layer: { 1: Layer1, Feedback, Highlight }, Text: { TextColors } }: DesignSystem,
@@ -45,6 +48,7 @@ export const defineMuiAlert = (
     outlined: {
       backgroundColor: Layer1.Fill,
       color: TextColors.Secondary,
+      [ICON_SELECTOR]: { opacity: 1 },
       '&.MuiAlert-colorInfo': {
         [TITLE_AND_ICON_SELECTOR]: { color: TextColors.Highlight },
         borderColor: Highlight.Outline,
@@ -63,25 +67,30 @@ export const defineMuiAlert = (
       },
     },
     filled: {
+      [ICON_SELECTOR]: { opacity: 1 },
       '&.MuiAlert-colorInfo': {
         backgroundColor: Feedback.Info,
         color: TextColors.FilledFeedback.Highlight.Secondary,
-        '& .MuiAlertTitle-root': { color: TextColors.FilledFeedback.Highlight.Primary },
+        [TITLE_AND_ICON_SELECTOR]: { color: TextColors.FilledFeedback.Highlight.Primary },
+        [FILLED_ACTION_SELECTOR]: { color: TextColors.Feedback.Inverted },
       },
       '&.MuiAlert-colorSuccess': {
         backgroundColor: Feedback.Success,
         color: TextColors.FilledFeedback.Success.Secondary,
-        '& .MuiAlertTitle-root': { color: TextColors.FilledFeedback.Success.Primary },
+        [TITLE_AND_ICON_SELECTOR]: { color: TextColors.FilledFeedback.Success.Primary },
+        [FILLED_ACTION_SELECTOR]: { color: TextColors.Feedback.Inverted },
       },
       '&.MuiAlert-colorWarning': {
         backgroundColor: Feedback.Warning,
         color: TextColors.FilledFeedback.Warning.Secondary,
-        '& .MuiAlertTitle-root': { color: TextColors.FilledFeedback.Warning.Primary },
+        [TITLE_AND_ICON_SELECTOR]: { color: TextColors.FilledFeedback.Warning.Primary },
+        [FILLED_ACTION_SELECTOR]: { color: TextColors.FilledFeedback.Warning.Primary },
       },
       '&.MuiAlert-colorError': {
         backgroundColor: Feedback.Error,
         color: TextColors.FilledFeedback.Alert.Secondary,
-        '& .MuiAlertTitle-root': { color: TextColors.FilledFeedback.Alert.Primary },
+        [TITLE_AND_ICON_SELECTOR]: { color: TextColors.FilledFeedback.Alert.Primary },
+        [FILLED_ACTION_SELECTOR]: { color: TextColors.Feedback.Inverted },
       },
     },
     icon: {

--- a/packages/evm-ui/src/themes/design/1_surfaces_text.ts
+++ b/packages/evm-ui/src/themes/design/1_surfaces_text.ts
@@ -26,7 +26,7 @@ function createLightSurfaces() {
       },
       Warning: {
         Primary: Grays[950],
-        Secondary: Grays[700],
+        Secondary: Grays[900],
       },
       Alert: {
         Primary: Grays[50],
@@ -131,7 +131,7 @@ function createDarkSurfaces() {
       },
       Warning: {
         Primary: Grays[975],
-        Secondary: Grays[700],
+        Secondary: Grays[900],
       },
       Alert: {
         Primary: Grays[50],
@@ -229,7 +229,7 @@ function createChadSurfaces() {
   const Text = {
     Feedback: {
       Caution: Yellows[700],
-      Warning: Oranges[500],
+      Warning: Oranges[600],
       Success: Greens[600],
       Danger: Oranges[500],
       Error: Reds[500],
@@ -246,7 +246,7 @@ function createChadSurfaces() {
       },
       Warning: {
         Primary: Grays[950],
-        Secondary: Grays[700],
+        Secondary: Grays[900],
       },
       Alert: {
         Primary: Grays[50],
@@ -582,7 +582,7 @@ function createChadInvertedSurfaces() {
       },
       Warning: {
         Primary: Grays[950],
-        Secondary: Grays[700],
+        Secondary: Grays[900],
       },
       Alert: {
         Primary: Grays[950],

--- a/packages/evm-ui/src/themes/stories/Alert.stories.tsx
+++ b/packages/evm-ui/src/themes/stories/Alert.stories.tsx
@@ -1,20 +1,27 @@
 import Alert, { AlertProps } from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
+import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+const alertAction = (
+  <Button color="ghost" size="extraSmall">
+    More
+  </Button>
+)
+
 const AlertStory = (props: AlertProps) => (
   <Stack spacing={5}>
-    <Alert severity="success" {...props}>
+    <Alert severity="success" action={alertAction} {...props}>
       <AlertTitle>Success</AlertTitle>A success text message is displayed. A little llama is happy 😊
     </Alert>
-    <Alert severity="info" {...props}>
+    <Alert severity="info" action={alertAction} {...props}>
       <AlertTitle>Info</AlertTitle>A info text message is displayed. A little llama is curious 🤔
     </Alert>
-    <Alert severity="warning" {...props}>
+    <Alert severity="warning" action={alertAction} {...props}>
       <AlertTitle>Warning</AlertTitle>A warning text message is displayed. A little llama is cautious 🦙.
     </Alert>
-    <Alert severity="error" {...props}>
+    <Alert severity="error" action={alertAction} {...props}>
       <AlertTitle>Error</AlertTitle>
       An error text message is displayed. A little llama is very sad 😔
     </Alert>

--- a/packages/evm-ui/src/widgets/DetailPageLayout/FormAlerts.tsx
+++ b/packages/evm-ui/src/widgets/DetailPageLayout/FormAlerts.tsx
@@ -134,7 +134,7 @@ export const HighPriceImpactAlert = ({
     (severity || (prevSeverity && isLoading)) && (
       <WithSkeleton loading={isLoading}>
         <Alert severity={severity ?? 'warning'} data-testid="high-price-impact-alert" variant="outlined">
-          <AlertTitle sx={{ color: { warning: 'warning.main', error: 'error.main' }[severity!] }}>
+          <AlertTitle>
             {t`High price impact:`} -{formatNumber(getPriceImpactPercent(data), 'percent.rate')}
           </AlertTitle>
           {t`Consider reducing the amount or waiting for better market conditions.`}


### PR DESCRIPTION
## Summary

- Restore alert icon opacity and align title, icon, and action colors across variants.
- Update warning and Chad theme text tokens for color parity.
- Add alert actions to Storybook coverage.
- Simplify high price impact alert title styling to use theme defaults.

## Testing

- Not run (not requested)