### PR TITLE
fix: pool column visibility labels might still show apy

### DIFF
--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
@@ -13,7 +13,7 @@ import type { PoolsSorting } from './usePoolsSorting'
 export type PoolColumnVariant = keyof typeof POOLS_COLUMN_OPTIONS
 
 const migration: MigrationOptions<Record<PoolColumnVariant, VisibilityGroup<PoolColumnId>[]>> = {
-  version: 4,
+  version: 5,
   migrate: (oldValue, initialValue) =>
     mapRecord(initialValue, (variant, currentGroups) => preserveVisibilityChoices(oldValue[variant], currentGroups)),
 }


### PR DESCRIPTION
Turns out the labels are stored inside local storage as well, so we need to bump the version to migrate and recreate labels anew.

These labels might still show APY for some
<img width="215" height="395" alt="image" src="https://github.com/user-attachments/assets/d1b3c5e3-9a30-4d3f-be09-d5ad8db52c7c" />
