### PR TITLE
refactor: evm-independent forms

### DIFF
--- a/apps/main/src/bridge/features/bridge/components/BridgeButton.tsx
+++ b/apps/main/src/bridge/features/bridge/components/BridgeButton.tsx
@@ -1,4 +1,4 @@
-import { ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
+import { ConnectEvmWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectEvmWalletButton'
 import Button from '@mui/material/Button'
 import { t } from '@ui/lib/i18n'
 
@@ -46,5 +46,5 @@ export const BridgeButton = ({
       </Button>
     )
   ) : (
-    <ConnectWalletButton />
+    <ConnectEvmWalletButton />
   )

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCreate.tsx
@@ -4,7 +4,7 @@ import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActi
 import { useCreateLockForm } from '@/dao/components/PageVeCrv/hooks/useCreateLockForm'
 import { useCreateLockGasEstimate } from '@/dao/components/PageVeCrv/queries/create-lock-estimate-gas.query'
 import type { ChainId } from '@/dao/types/dao.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { fromEntries } from '@primitives/objects.utils'
@@ -77,7 +77,7 @@ export const FormLockCreate = ({ chainId }: { chainId: ChainId }) => {
         handledErrors={['lockedAmount', 'maxLockedAmount', 'utcDate', 'days']}
         userAddress={userAddress}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isPending}
         disabled={isDisabled}

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockCrv.tsx
@@ -3,7 +3,7 @@ import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActi
 import { useIncreaseLockForm } from '@/dao/components/PageVeCrv/hooks/useIncreaseLockForm'
 import { useIncreaseLockGasEstimate } from '@/dao/components/PageVeCrv/queries/increase-lock-estimate-gas.query'
 import type { ChainId } from '@/dao/types/dao.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { fromEntries } from '@primitives/objects.utils'
@@ -56,7 +56,7 @@ export const FormLockCrv = ({ chainId }: { chainId: ChainId }) => {
         handledErrors={['lockedAmount', 'maxLockedAmount']}
         userAddress={userAddress}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isPending}
         disabled={isDisabled}

--- a/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormLockDate.tsx
@@ -3,7 +3,7 @@ import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActi
 import { useExtendLockForm } from '@/dao/components/PageVeCrv/hooks/useExtendLockForm'
 import { useExtendLockGasEstimate } from '@/dao/components/PageVeCrv/queries/extend-lock-estimate-gas.query'
 import type { ChainId } from '@/dao/types/dao.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { AlertBox } from '@legacy-ui/AlertBox'
@@ -67,7 +67,7 @@ export const FormLockDate = ({ chainId }: { chainId: ChainId }) => {
         handledErrors={['utcDate', 'days']}
         userAddress={userAddress}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isPending}
         disabled={isDisabled}

--- a/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
+++ b/apps/main/src/dao/components/PageVeCrv/components/FormWithdraw.tsx
@@ -4,7 +4,7 @@ import { VeCrvActionInfo } from '@/dao/components/PageVeCrv/components/VeCrvActi
 import { useWithdrawLockForm } from '@/dao/components/PageVeCrv/hooks/useWithdrawLockForm'
 import { useWithdrawLockGasEstimate } from '@/dao/components/PageVeCrv/queries/withdraw-lock-estimate-gas.query'
 import type { ChainId } from '@/dao/types/dao.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { amount, formatNumber } from '@evm-ui/utils'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -53,7 +53,7 @@ export const FormWithdraw = ({ chainId }: { chainId: ChainId }) => {
         handledErrors={[]}
         userAddress={userAddress}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isPending}
         disabled={isDisabled}

--- a/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
+++ b/apps/main/src/dex/features/add-gauge-reward-token/ui/AddRewardToken.tsx
@@ -7,7 +7,8 @@ import type { AddRewardParams } from '@/dex/entities/gauge/types'
 import type { AddRewardFormValues } from '@/dex/features/add-gauge-reward-token/types'
 import { DistributorInput, TokenSelector } from '@/dex/features/add-gauge-reward-token/ui'
 import { ChainId } from '@/dex/types/main.types'
-import { FormButton, useForm, useFormSync } from '@evm-ui/features/forms'
+import { useForm, useFormSync } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { createValidationSuite } from '@evm-ui/lib'
 import { ActionInfoGasEstimate } from '@evm-ui/shared/ui/ActionInfo'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
@@ -57,7 +58,7 @@ export const AddRewardToken = ({ chainId, poolId }: { chainId: ChainId; poolId: 
           <TokenSelector chainId={chainId} poolId={poolId} userAddress={userAddress} disabled={isDisabled} />
           <DistributorInput disabled={isDisabled} />
         </Stack>
-        <FormButton
+        <EvmFormButton
           disabled={isDisabled || !isValid}
           loading={isLoading}
           label={t`Add Reward`}

--- a/apps/main/src/dex/features/deposit-gauge-reward/ui/DepositReward.tsx
+++ b/apps/main/src/dex/features/deposit-gauge-reward/ui/DepositReward.tsx
@@ -7,7 +7,8 @@ import { useNetworks } from '@/dex/entities/networks'
 import { DepositRewardFormValues } from '@/dex/features/deposit-gauge-reward/types'
 import { AmountTokenInput, EpochInput } from '@/dex/features/deposit-gauge-reward/ui'
 import { ChainId } from '@/dex/types/main.types'
-import { FormButton, useForm, useFormSync } from '@evm-ui/features/forms'
+import { useForm, useFormSync } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { useTokenBalance } from '@evm-ui/hooks/useTokenBalance'
 import { useTokenUsdRate } from '@evm-ui/lib/model/entities/token-usd-rate'
 import { createValidationSuite } from '@evm-ui/lib/validation'
@@ -81,7 +82,7 @@ export const DepositReward = ({ chainId, poolId }: { chainId: ChainId; poolId: s
       <Stack sx={{ gap: Spacing.sm }}>
         <AmountTokenInput chainId={chainId} poolId={poolId} blockchainId={network.blockchainId} disabled={isPending} />
         <EpochInput disabled={isPending} />
-        <FormButton
+        <EvmFormButton
           pending={isPending}
           loading={isLoading}
           disabled={!isValid || isLoading}

--- a/apps/main/src/dex/features/manage-pool/components/RefuelForm.tsx
+++ b/apps/main/src/dex/features/manage-pool/components/RefuelForm.tsx
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import type { Chain } from '@curvefi/prices-api'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { HelperMessage, LargeTokenInput } from '@evm-ui/shared/ui/LargeTokenInput'
 import { decimal } from '@evm-ui/utils'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
@@ -99,7 +99,7 @@ export const RefuelForm = ({ chainId, blockchainId, poolAddress }: RefuelFormPar
         </LargeTokenInput>
       </Stack>
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         disabled={isDisabled}
         connectWalletTestId="refuel-connect-wallet-button"

--- a/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
+++ b/apps/main/src/llamalend/features/borrow/components/CreateLoanForm.tsx
@@ -6,7 +6,7 @@ import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSe
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { useCreateLoanPreset } from '@evm-ui/hooks/useLocalStorage'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
@@ -165,7 +165,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
       </LoanPresetSelector>
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(maxLeverage)} slippageType={LEVERAGE} />
       <HighLiquidationRiskAlert isHighLiquidationRisk={isHighLiquidationRisk} />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={isDisabled || shouldBlockTransaction(priceImpact, params)}
@@ -174,7 +174,7 @@ export const CreateLoanForm = <ChainId extends IChainId>({
         connectWalletTestId="form-market-page"
       >
         {disabledAlert && <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>}
-      </FormButton>
+      </EvmFormButton>
       <LowSolvencyActionModal
         action="borrow"
         open={isOpen}

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ClosePositionForm.tsx
@@ -4,7 +4,7 @@ import { useMarketContext } from '@/llamalend/features/market-context'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { DataTable } from '@evm-ui/shared/ui/DataTable/DataTable'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -75,7 +75,7 @@ export const ClosePositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
       ) : (
         <AlertClosePosition hasBadDebt={hasBadDebt} />
       )}
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         disabled={isDisabled}
         label={[

--- a/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ResetPositionForm.tsx
+++ b/apps/main/src/llamalend/features/manage-liquidation/ui/tabs/ResetPositionForm.tsx
@@ -4,7 +4,7 @@ import { useMarketContext } from '@/llamalend/features/market-context'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId as LlamaChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import Stack from '@mui/material/Stack'
@@ -73,7 +73,7 @@ export const ResetPositionForm = ({ networks }: { networks: NetworkDict<LlamaCha
         />
       </Stack>
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={isDisabled}

--- a/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/AddCollateralForm.tsx
@@ -1,7 +1,7 @@
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import Stack from '@mui/material/Stack'
@@ -74,7 +74,7 @@ export const AddCollateralForm = <ChainId extends IChainId>({
         userAddress={userAddress}
       />
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={!marketId}
         disabled={isDisabled}

--- a/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/BorrowMoreForm.tsx
@@ -9,7 +9,7 @@ import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSe
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
@@ -163,7 +163,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
         max={q(max.maxLeverage)}
         slippageType={LEVERAGE}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={isDisabled || shouldBlockTransaction(priceImpact, params)}
@@ -171,7 +171,7 @@ export const BorrowMoreForm = <ChainId extends IChainId>({
         testId="borrow-more-submit-button"
       >
         {disabledAlert && <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>}
-      </FormButton>
+      </EvmFormButton>
       <LowSolvencyActionModal
         action="borrow"
         open={isOpen}

--- a/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RemoveCollateralForm.tsx
@@ -1,7 +1,7 @@
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -86,7 +86,7 @@ export const RemoveCollateralForm = <ChainId extends IChainId>({
         userAddress={userAddress}
       />
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={!marketId}
         disabled={isDisabled}

--- a/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
+++ b/apps/main/src/llamalend/features/manage-loan/components/RepayForm.tsx
@@ -13,7 +13,7 @@ import { useUserPrices } from '@/llamalend/queries/user'
 import { LoanActionSettings } from '@/llamalend/widgets/action-card/LoanActionSettings'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { TokenSelector } from '@evm-ui/features/select-token'
 import { Balance } from '@evm-ui/shared/ui/LargeTokenInput/Balance'
 import { CRVUSD } from '@evm-ui/utils'
@@ -198,7 +198,7 @@ export const RepayForm = <ChainId extends IChainId>({
       />
       <HighPriceImpactAlert priceImpact={priceImpact} values={values} max={q(max.expected)} slippageType={LEVERAGE} />
       {isInSoftLiquidation && <AlertRepayDebtToIncreaseHealth />}
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={

--- a/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
+++ b/apps/main/src/llamalend/features/supply/components/ClaimTab.tsx
@@ -1,7 +1,7 @@
 import { useConnection } from 'wagmi'
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
+import { ConnectEvmWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectEvmWalletButton'
 import { BUTTON_FORM_SIZE } from '@evm-ui/features/forms/constants'
 import { DataTable } from '@evm-ui/shared/ui/DataTable/DataTable'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -88,7 +88,7 @@ export const ClaimTab = <ChainId extends IChainId>({ networks }: ClaimTabProps<C
             </Button>
           </Stack>
         ) : (
-          <ConnectWalletButton />
+          <ConnectEvmWalletButton />
         )}
 
         <FormAlerts error={errors.find(Boolean) ?? null} formErrors={[]} handledErrors={[]} userAddress={userAddress} />

--- a/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/DepositForm.tsx
@@ -2,7 +2,7 @@ import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -61,7 +61,7 @@ export const DepositForm = <ChainId extends IChainId>({ networks }: DepositFormP
         network={network}
       />
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={isDisabled}
@@ -70,7 +70,7 @@ export const DepositForm = <ChainId extends IChainId>({ networks }: DepositFormP
         connectWalletTestId="form-market-page"
       >
         {disabledAlert && <AlertDisableForm>{disabledAlert.message}</AlertDisableForm>}
-      </FormButton>
+      </EvmFormButton>
       <LowSolvencyActionModal
         action="deposit"
         open={isOpen}

--- a/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/StakeForm.tsx
@@ -2,7 +2,7 @@ import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import { LowSolvencyActionModal } from '@/llamalend/widgets/action-card/LowSolvencyActionModal'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { AlertDisableForm } from '@evm-ui/shared/ui/AlertDisableForm'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
@@ -68,7 +68,7 @@ export const StakeForm = <ChainId extends IChainId>({ networks }: StakeFormProps
         onValueChange={value => updateForm({ isFull: value === max.data })}
       />
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={isLoading}
         disabled={isDisabled}
@@ -76,7 +76,7 @@ export const StakeForm = <ChainId extends IChainId>({ networks }: StakeFormProps
         testId={`${TEST_ID_PREFIX}-submit-button`}
       >
         {hasGauge ? disabledAlert && <AlertDisableForm>{disabledAlert.message}</AlertDisableForm> : <AlertNoGauge />}
-      </FormButton>
+      </EvmFormButton>
 
       <LowSolvencyActionModal
         action="stake"

--- a/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/UnstakeForm.tsx
@@ -1,7 +1,7 @@
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { t } from '@ui/lib/i18n'
@@ -62,7 +62,7 @@ export const UnstakeForm = <ChainId extends IChainId>({ networks }: UnstakeFormP
       />
       {Number(max.data) > 0 && <AlertUnstakeOnly />}
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={!marketId}
         disabled={isDisabled}

--- a/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
+++ b/apps/main/src/llamalend/features/supply/components/WithdrawForm.tsx
@@ -1,7 +1,7 @@
 import type { NetworkDict } from '@/llamalend/llamalend.types'
 import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormTokenInput'
 import type { IChainId } from '@curvefi/llamalend-api/lib/interfaces'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { t } from '@ui/lib/i18n'
@@ -67,7 +67,7 @@ export const WithdrawForm = <ChainId extends IChainId>({ networks }: WithdrawFor
         <AlertUnstakeFirst />
       )}
 
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         loading={!marketId}
         disabled={isDisabled}

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositForm.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdDepositForm.tsx
@@ -3,7 +3,7 @@ import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormToke
 import { CRVUSD_ADDRESS } from '@/loan/constants'
 import { networks, networksIdMapper } from '@/loan/networks'
 import type { NetworkUrlParams } from '@/loan/types/loan.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { q } from '@ui/features/queries/util'
@@ -56,7 +56,7 @@ export const ScrvUsdDepositForm = ({ network }: NetworkUrlParams) => {
         hideBalance={!isConnected}
         disabled={!isConnected}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         disabled={isDisabled}
         connectWalletTestId="scrvusd-deposit-connect-wallet-button"

--- a/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
+++ b/apps/main/src/loan/components/PageCrvUsdStaking/ScrvUsdWithdrawForm.tsx
@@ -3,7 +3,7 @@ import { LoanFormTokenInput } from '@/llamalend/widgets/action-card/LoanFormToke
 import { SCRVUSD_VAULT_ADDRESS } from '@/loan/constants'
 import { networks, networksIdMapper } from '@/loan/networks'
 import type { NetworkUrlParams } from '@/loan/types/loan.types'
-import { FormButton } from '@evm-ui/features/forms'
+import { EvmFormButton } from '@evm-ui/features/forms/EvmFormButton'
 import { Form } from '@evm-ui/widgets/DetailPageLayout/Form'
 import { FormAlerts } from '@evm-ui/widgets/DetailPageLayout/FormAlerts'
 import { q } from '@ui/features/queries/util'
@@ -33,7 +33,7 @@ export const ScrvUsdWithdrawForm = ({ network }: NetworkUrlParams) => {
         hideBalance={!isConnected}
         disabled={!isConnected}
       />
-      <FormButton
+      <EvmFormButton
         pending={isPending}
         disabled={isDisabled}
         connectWalletTestId="scrvusd-withdraw-connect-wallet-button"

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperRebalanceButton.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperRebalanceButton.tsx
@@ -1,5 +1,5 @@
 import { useConnection } from 'wagmi'
-import { ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
+import { ConnectEvmWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectEvmWalletButton'
 import Button from '@mui/material/Button'
 import { t } from '@ui/lib/i18n'
 
@@ -24,6 +24,6 @@ export const PegKeeperRebalanceButton = ({ canRebalance, isRebalancing, onRebala
       {isRebalancing ? t`Rebalancing...` : t`Rebalance`}
     </Button>
   ) : (
-    <ConnectWalletButton testId="pegkeeper-connect-wallet" fullWidth />
+    <ConnectEvmWalletButton testId="pegkeeper-connect-wallet" fullWidth />
   )
 }

--- a/packages/evm-ui/src/features/connect-wallet/ui/ConnectEvmWalletButton.tsx
+++ b/packages/evm-ui/src/features/connect-wallet/ui/ConnectEvmWalletButton.tsx
@@ -1,0 +1,9 @@
+import { useConnection } from 'wagmi'
+import { useWallet } from '../lib'
+import { type ConnectionProps, ConnectWalletButton, type ConnectWalletButtonProps } from './ConnectWalletButton'
+
+export const ConnectEvmWalletButton = (props: Omit<ConnectWalletButtonProps, keyof ConnectionProps>) => {
+  const { isConnecting, isConnected } = useConnection()
+  const { connect } = useWallet()
+  return <ConnectWalletButton isConnecting={isConnecting} isConnected={isConnected} connect={connect} {...props} />
+}

--- a/packages/evm-ui/src/features/connect-wallet/ui/ConnectWalletButton.tsx
+++ b/packages/evm-ui/src/features/connect-wallet/ui/ConnectWalletButton.tsx
@@ -1,32 +1,41 @@
-import { type ReactNode } from 'react'
-import { useConnection } from 'wagmi'
+import type { ReactNode } from 'react'
 import Button, { type ButtonProps } from '@mui/material/Button'
 import { t } from '@ui/lib/i18n'
-import { useWallet } from '../lib'
+
+export type ConnectionProps = {
+  isConnecting: boolean
+  isConnected: boolean
+  connect: () => Promise<void>
+}
+
+export type ConnectWalletButtonProps = Pick<ButtonProps, 'size' | 'fullWidth' | 'sx'> & {
+  label?: ReactNode
+  testId?: string
+  onConnect?: () => void
+} & ConnectionProps
 
 export const ConnectWalletButton = ({
   label = t`Connect Wallet`,
   testId,
   onConnect,
+  isConnecting,
+  isConnected,
+  connect,
   ...props
-}: Pick<ButtonProps, 'size' | 'fullWidth' | 'sx'> & { label?: ReactNode; testId?: string; onConnect?: () => void }) => {
-  const { isConnecting, isConnected } = useConnection()
-  const { connect } = useWallet()
-  return (
-    <Button
-      size="small"
-      color="primary"
-      type="button"
-      data-testid={testId}
-      loading={isConnecting}
-      disabled={isConnected || isConnecting}
-      onClick={() => {
-        onConnect?.()
-        void connect()
-      }}
-      {...props}
-    >
-      {label}
-    </Button>
-  )
-}
+}: ConnectWalletButtonProps) => (
+  <Button
+    size="small"
+    color="primary"
+    type="button"
+    data-testid={testId}
+    loading={isConnecting}
+    disabled={isConnected || isConnecting}
+    onClick={() => {
+      onConnect?.()
+      void connect()
+    }}
+    {...props}
+  >
+    {label}
+  </Button>
+)

--- a/packages/evm-ui/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
+++ b/packages/evm-ui/src/features/connect-wallet/ui/ConnectWalletIndicator.tsx
@@ -2,7 +2,7 @@ import { useConnection } from 'wagmi'
 import type { SxProps } from '@ui/utils/mui'
 import { useWallet } from '../lib'
 import { ConnectedWalletLabel } from './ConnectedWalletLabel'
-import { ConnectWalletButton } from './ConnectWalletButton'
+import { ConnectEvmWalletButton } from './ConnectEvmWalletButton'
 
 export const ConnectWalletIndicator = ({ sx, onConnect }: { sx?: SxProps; onConnect?: () => void }) => {
   const { address, isConnecting } = useConnection()
@@ -10,6 +10,6 @@ export const ConnectWalletIndicator = ({ sx, onConnect }: { sx?: SxProps; onConn
   return address ? (
     <ConnectedWalletLabel address={address} onClick={() => disconnect()} loading={isConnecting} sx={sx} />
   ) : (
-    <ConnectWalletButton onConnect={onConnect} sx={sx} testId="navigation-connect-wallet" />
+    <ConnectEvmWalletButton onConnect={onConnect} sx={sx} testId="navigation-connect-wallet" />
   )
 }

--- a/packages/evm-ui/src/features/forms/EvmFormButton.tsx
+++ b/packages/evm-ui/src/features/forms/EvmFormButton.tsx
@@ -1,0 +1,9 @@
+import { useConnection } from 'wagmi'
+import { useWallet } from '@evm-ui/features/connect-wallet'
+import { pick } from '@primitives/objects.utils'
+import type { ConnectionProps } from '../connect-wallet/ui/ConnectWalletButton'
+import { FormButton, type FormButtonProps } from './FormButton'
+
+export const EvmFormButton = (props: Omit<FormButtonProps, keyof ConnectionProps>) => (
+  <FormButton {...props} {...pick(useConnection(), 'isConnecting', 'isConnected')} connect={useWallet().connect} />
+)

--- a/packages/evm-ui/src/features/forms/FormButton.tsx
+++ b/packages/evm-ui/src/features/forms/FormButton.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
-import { useConnection } from 'wagmi'
-import { ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
+import { type ConnectionProps, ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
 import { useIsMobileFormDrawer } from '@evm-ui/widgets/DetailPageLayout/form-context/FormPlacementContext'
 import Button, { type ButtonProps } from '@mui/material/Button'
 import type { Falsy } from '@primitives/objects.utils'
@@ -17,7 +16,7 @@ export type FormButtonProps = Pick<ButtonProps, 'disabled' | 'fullWidth' | 'load
   label?: string | FormButtonLabelPart[]
   pending?: boolean
   testId?: string
-}
+} & ConnectionProps
 
 const fixedBottomSx = { position: 'fixed', bottom: 0, left: 0, right: 0 } as const
 
@@ -31,10 +30,12 @@ export const FormButton = ({
   pending = false,
   sx,
   testId,
+  isConnecting,
+  isConnected,
+  connect,
 }: FormButtonProps) => {
   const isMobileDrawer = useIsMobileFormDrawer()
-
-  return useConnection().isConnected ? (
+  return isConnected ? (
     children || (
       <Button
         type="submit"
@@ -50,6 +51,9 @@ export const FormButton = ({
     )
   ) : (
     <ConnectWalletButton
+      isConnecting={isConnecting}
+      isConnected={isConnected}
+      connect={connect}
       size={BUTTON_FORM_SIZE}
       fullWidth={isMobileDrawer || fullWidth}
       sx={applySxProps(sx, isMobileDrawer && fixedBottomSx)}

--- a/packages/evm-ui/src/shared/ui/EmptyStateCard.tsx
+++ b/packages/evm-ui/src/shared/ui/EmptyStateCard.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { ConnectWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectWalletButton'
+import { ConnectEvmWalletButton } from '@evm-ui/features/connect-wallet/ui/ConnectEvmWalletButton'
 import { Box, Button, ButtonProps, Skeleton } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
@@ -58,7 +58,7 @@ const EmptyStateButton = ({
     ...(testId && { 'data-testid': testId }),
   } as const
   return type === 'connect-wallet' ? (
-    <ConnectWalletButton {...sharedProps} label={label} />
+    <ConnectEvmWalletButton {...sharedProps} label={label} />
   ) : href?.startsWith('https') ? (
     <ExternalLink {...sharedProps} href={href} label={label} wide />
   ) : (

--- a/packages/evm-ui/src/shared/ui/ErrorMessage.tsx
+++ b/packages/evm-ui/src/shared/ui/ErrorMessage.tsx
@@ -23,7 +23,7 @@ export const ErrorMessage = ({
   refreshData?: () => Promise<unknown> | void
   sx?: SxProps
   size?: EmptyStateCardProps['size']
-  userAddress?: Address
+  userAddress: Address | undefined
 }) => {
   const [isReportOpen, openReportModal, closeReportModal] = useSwitch(false)
 


### PR DESCRIPTION
- Refactor forms so that they don't depend on evm-specific hooks.
- Includes the connect wallet button.
- Depends on #3156
- Does not move the forms to ui yet, that's done in https://github.com/curvefi/curve-frontend/pull/3162