### PR TITLE
fix: rpc urls for mocked wagmi config

### DIFF
--- a/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
+++ b/tests/cypress/support/helpers/llamalend/test-wagmi.helpers.ts
@@ -1,8 +1,9 @@
 import { custom, fallback, http, type RpcTransactionReceipt, zeroAddress } from 'viem'
-import { mainnet } from 'viem/chains'
-import { WAGMI_HTTP_OPTIONS } from '@evm-ui/features/connect-wallet/lib/wagmi/transports'
+import { createChain } from '@evm-ui/features/connect-wallet/lib/wagmi/chains'
+import { defaultGetRpcUrls, WAGMI_HTTP_OPTIONS } from '@evm-ui/features/connect-wallet/lib/wagmi/transports'
 import { createWagmiConfig } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-config'
 import { createTestConnector } from '@evm-ui/features/connect-wallet/lib/wagmi/wagmi-test'
+import { Chain } from '@primitives/network.utils'
 import { TEST_PRIVATE_KEY, TEST_TX_HASH } from './mock-loan-test-data'
 
 const testTransactionReceipt: RpcTransactionReceipt = {
@@ -30,8 +31,15 @@ const mockedReceiptTransport = custom({
   },
 })
 
+const mainnet = createChain(Chain.Ethereum, defaultGetRpcUrls)
+
 export const mockedWagmiConfig = createWagmiConfig({
   chains: [mainnet],
   connectors: [createTestConnector({ privateKey: TEST_PRIVATE_KEY, chain: mainnet })],
-  transports: { [mainnet.id]: fallback([mockedReceiptTransport, http(undefined, WAGMI_HTTP_OPTIONS)]) },
+  transports: {
+    [mainnet.id]: fallback([
+      mockedReceiptTransport,
+      ...mainnet.rpcUrls.default.http.map(url => http(url, WAGMI_HTTP_OPTIONS)),
+    ]),
+  },
 })


### PR DESCRIPTION
- The default wagmi rpc is currently extremely slow.
- Because of that, our component tests are timing out.
- Instead, we should use our already existing RPC setup.
<img width="486" height="136" alt="Screenshot From 2026-09-07 12-04-21" src="https://github.com/user-attachments/assets/6fd2c44f-1a0c-428d-b2f5-03f8fabb84ce" />
