### PR TITLE
fix(ui): restore alert token layering

### DIFF
--- a/packages/ui/src/features/themes/design/0_primitives.ts
+++ b/packages/ui/src/features/themes/design/0_primitives.ts
@@ -50,12 +50,6 @@ export const Reds = {
   '950': '#311615',
 } as const
 
-// Figma's older Primitives collection reuses these numeric names with different values.
-export const LegacyReds = {
-  '500': '#ff6644',
-  '600': '#ff0606',
-} as const
-
 export const Blues = {
   '50': '#f6f9ff',
   '100': '#e0e8f7',

--- a/packages/ui/src/features/themes/design/0_primitives.ts
+++ b/packages/ui/src/features/themes/design/0_primitives.ts
@@ -50,6 +50,12 @@ export const Reds = {
   '950': '#311615',
 } as const
 
+// Figma's older Primitives collection reuses these numeric names with different values.
+export const LegacyReds = {
+  '500': '#ff6644',
+  '600': '#ff0606',
+} as const
+
 export const Blues = {
   '50': '#f6f9ff',
   '100': '#e0e8f7',

--- a/packages/ui/src/features/themes/design/1_surfaces_text.ts
+++ b/packages/ui/src/features/themes/design/1_surfaces_text.ts
@@ -1,4 +1,4 @@
-import { Blues, Grays, Greens, LegacyReds, Reds, Violets, Yellows, Oranges } from './0_primitives'
+import { Blues, Grays, Greens, Reds, Violets, Yellows, Oranges } from './0_primitives'
 
 function createLightSurfaces() {
   const Text = {
@@ -58,7 +58,7 @@ function createLightSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: LegacyReds[600],
+      Alert: Reds[400],
     },
     Highlight: Blues[100],
     TypeAction: {
@@ -172,7 +172,7 @@ function createDarkSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: LegacyReds[500],
+      Alert: Reds[200],
     },
     Highlight: Grays[850],
     TypeAction: {
@@ -285,7 +285,7 @@ function createChadSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: LegacyReds[600],
+      Alert: Reds[400],
     },
     TypeAction: {
       Selected: Violets[50],
@@ -398,7 +398,7 @@ function createLightInvertedSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: LegacyReds[600],
+      Alert: Reds[400],
     },
     Highlight: Blues[100],
     TypeAction: {
@@ -510,7 +510,7 @@ function createDarkInvertedSurfaces() {
       Caution: Yellows[500],
       Warning: Oranges[500],
       Danger: Oranges[500],
-      Alert: LegacyReds[500],
+      Alert: Reds[200],
       Error: Reds[500],
     },
     Highlight: Grays[850],
@@ -624,7 +624,7 @@ function createChadInvertedSurfaces() {
       Warning: Oranges[500],
       Error: Reds[500],
       Danger: Oranges[500],
-      Alert: LegacyReds[600],
+      Alert: Reds[400],
     },
     TypeAction: {
       Selected: Violets[900],

--- a/packages/ui/src/features/themes/design/1_surfaces_text.ts
+++ b/packages/ui/src/features/themes/design/1_surfaces_text.ts
@@ -1,6 +1,4 @@
-import { Blues, Grays, Greens, Reds, Violets, Yellows, Oranges } from './0_primitives'
-
-const FeedbackAlert = { Light: '#ff0606', Dark: '#ff6644', Chad: '#ff0606' } as const
+import { Blues, Grays, Greens, LegacyReds, Reds, Violets, Yellows, Oranges } from './0_primitives'
 
 function createLightSurfaces() {
   const Text = {
@@ -60,7 +58,7 @@ function createLightSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: FeedbackAlert.Light,
+      Alert: LegacyReds[600],
     },
     Highlight: Blues[100],
     TypeAction: {
@@ -174,7 +172,7 @@ function createDarkSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: FeedbackAlert.Dark,
+      Alert: LegacyReds[500],
     },
     Highlight: Grays[850],
     TypeAction: {
@@ -287,7 +285,7 @@ function createChadSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: FeedbackAlert.Chad,
+      Alert: LegacyReds[600],
     },
     TypeAction: {
       Selected: Violets[50],
@@ -400,7 +398,7 @@ function createLightInvertedSurfaces() {
       Warning: Oranges[500],
       Danger: Oranges[500],
       Error: Reds[500],
-      Alert: FeedbackAlert.Light,
+      Alert: LegacyReds[600],
     },
     Highlight: Blues[100],
     TypeAction: {
@@ -512,7 +510,7 @@ function createDarkInvertedSurfaces() {
       Caution: Yellows[500],
       Warning: Oranges[500],
       Danger: Oranges[500],
-      Alert: FeedbackAlert.Dark,
+      Alert: LegacyReds[500],
       Error: Reds[500],
     },
     Highlight: Grays[850],
@@ -626,7 +624,7 @@ function createChadInvertedSurfaces() {
       Warning: Oranges[500],
       Error: Reds[500],
       Danger: Oranges[500],
-      Alert: FeedbackAlert.Chad,
+      Alert: LegacyReds[600],
     },
     TypeAction: {
       Selected: Violets[900],


### PR DESCRIPTION
Follow-up to #3168 addressing [0xLokiB's review comment](https://github.com/curvefi/curve-frontend/pull/3168#discussion_r3948591224).

Uses existing primitives for the Alert Banner border and migrates the Figma alias chain—no new primitives.

- Light / Chad: `#ff0606` → `Reds[400]` / `#f03d47`
- Dark: `#ff6644` → `Reds[200]` / `#f67178`
- Alert fill remains `#ed242f`; this is visual separation, not a WCAG 3:1 claim.

Validated: Figma alias migration and zero legacy bindings across 46 pages; Prettier; UI lint; UI typecheck; Storybook Alert Banner in Light, Dark, and Chad. Final diff: `packages/ui/src/features/themes/design/1_surfaces_text.ts` only.