### PR TITLE
fix: show price query states in rate breakdown cells

### DIFF
--- a/apps/main/src/llamalend/features/rate-breakdown/MarketRateBreakdowns.tsx
+++ b/apps/main/src/llamalend/features/rate-breakdown/MarketRateBreakdowns.tsx
@@ -7,7 +7,7 @@ import { MAINNET_CRV_ADDRESS } from '@evm-ui/utils'
 import Stack from '@mui/material/Stack'
 import { Chain } from '@primitives/network.utils'
 import { notFalsy, notFalsyArray } from '@primitives/objects.utils'
-import { mapQuery } from '@ui/features/queries/util'
+import { mapQuery, q } from '@ui/features/queries/util'
 import { stackedMarketCardHeadersSx } from '@ui/utils/mui'
 import { buildBorrowRateBreakdown, buildSupplyRateBreakdown } from './market-rate-breakdown.utils'
 import { PointsCampaignsCard, RateBreakdownTable } from './MarketRateBreakdownCards'
@@ -19,19 +19,11 @@ export const MarketBorrowRateBreakdown = () => {
     tokens: { collateralToken },
   } = useMarketContext()
   const { borrowRate } = usePageHeaderRates()
-  const addresses = useMemo(
-    () =>
-      notFalsy(
-        ...notFalsyArray(
-          [collateralToken?.address],
-          borrowRate.data?.extraRewards.map(({ reward }) => reward?.type === 'apr' && reward.address),
-        ),
-      ),
-    [borrowRate.data?.extraRewards, collateralToken?.address],
+  const collateralPrice = q(
+    useTokenUsdRate({ chainId, tokenAddress: collateralToken?.address }, borrowRate.data?.rebasingYield != null),
   )
-  const { data: prices } = useTokenUsdRates({ chainId, tokenAddresses: addresses })
   const borrowQuery = mapQuery(borrowRate, rate =>
-    buildBorrowRateBreakdown({ rate, chainId, blockchainId, collateralToken, prices }),
+    buildBorrowRateBreakdown({ rate, chainId, blockchainId, collateralToken, collateralPrice }),
   )
 
   return (
@@ -54,19 +46,22 @@ export const MarketSupplyRateBreakdown = () => {
   const addresses = useMemo(
     () =>
       notFalsy(
+        supplyRate?.data?.rebasingYield != null && borrowToken?.address,
         ...notFalsyArray(
-          [borrowToken?.address],
           supplyRate?.data?.extraIncentives.map(
             ({ address }) => address.toLowerCase() !== MAINNET_CRV_ADDRESS && address,
           ),
-          supplyRate?.data?.extraRewards.map(({ reward }) => reward?.type === 'apr' && reward.address),
         ),
       ),
     [borrowToken?.address, supplyRate?.data],
   )
-  const { data: prices } = useTokenUsdRates({ chainId, tokenAddresses: addresses })
-  const { data: crvPrice } = useTokenUsdRate({ chainId: Chain.Ethereum, tokenAddress: MAINNET_CRV_ADDRESS })
-
+  const prices = useTokenUsdRates({ chainId, tokenAddresses: addresses })
+  const crvPrice = q(
+    useTokenUsdRate(
+      { chainId: Chain.Ethereum, tokenAddress: MAINNET_CRV_ADDRESS },
+      !!(supplyRate?.data?.supplyApyCrvMinBoost || supplyRate?.data?.supplyApyCrvMaxBoost),
+    ),
+  )
   if (!supplyRate) return null
 
   const supplyQuery = mapQuery(supplyRate, rate =>

--- a/apps/main/src/llamalend/features/rate-breakdown/market-rate-breakdown.columns.tsx
+++ b/apps/main/src/llamalend/features/rate-breakdown/market-rate-breakdown.columns.tsx
@@ -1,9 +1,8 @@
 import { Badge } from '@evm-ui/shared/ui/Badge'
 import { createAppColumnHelper } from '@evm-ui/shared/ui/DataTable/data-table.utils'
-import { TokenCell } from '@evm-ui/shared/ui/DataTable/inline-cells'
+import { TokenCell, TokenPriceCell } from '@evm-ui/shared/ui/DataTable/inline-cells'
 import { InlineTableCell } from '@evm-ui/shared/ui/DataTable/inline-cells/InlineTableCell'
 import { formatNumber } from '@evm-ui/utils'
-import Typography from '@mui/material/Typography'
 import { maybe } from '@primitives/objects.utils'
 import type { ColumnVisibilityState } from '@tanstack/react-table'
 import { TokenInfo } from '@ui/components/TokenInfo'
@@ -40,11 +39,7 @@ const rateColumns = (rateHeader: string) =>
     rateColumnHelper.accessor('price', {
       id: RateColumnId.Price,
       header: t`Price`,
-      cell: ({ getValue }) => (
-        <InlineTableCell>
-          <Typography>{formatNumber(getValue(), 'usd.precise')}</Typography>
-        </InlineTableCell>
-      ),
+      cell: ({ getValue }) => <TokenPriceCell query={getValue()} />,
       enableSorting: false,
       meta: { type: 'numeric' },
     }),

--- a/apps/main/src/llamalend/features/rate-breakdown/market-rate-breakdown.utils.tsx
+++ b/apps/main/src/llamalend/features/rate-breakdown/market-rate-breakdown.utils.tsx
@@ -9,6 +9,7 @@ import type { Address } from '@primitives/address.utils'
 import { Chain } from '@primitives/network.utils'
 import { maybes, notFalsy } from '@primitives/objects.utils'
 import type { TokenInfoProps } from '@ui/components/TokenInfo'
+import { constQ, mapQuery, type QueryProp } from '@ui/features/queries/util'
 import { t } from '@ui/lib/i18n'
 
 export type BreakdownSource = {
@@ -20,7 +21,7 @@ export type BreakdownSource = {
 
 export type RateBreakdownRow = {
   source: BreakdownSource
-  price?: number
+  price: QueryProp<number | undefined>
   rate: number | null | undefined
   maxBoostRate?: number | null
 }
@@ -33,22 +34,18 @@ export type RateBreakdownData = {
   hasAdjustments: boolean
 }
 
-type TokenPrices = Record<string, number> | undefined
-
-const tokenPrice = (prices: TokenPrices, address: string, fallback?: number) => prices?.[address] ?? fallback
-
 export const buildBorrowRateBreakdown = ({
   rate,
   chainId,
   blockchainId,
   collateralToken,
-  prices,
+  collateralPrice,
 }: {
   rate: BorrowRate
   chainId: number
   blockchainId: string
   collateralToken: MarketToken | undefined
-  prices: TokenPrices
+  collateralPrice: QueryProp<number>
 }): RateBreakdownData => {
   const incentives = notFalsy(
     ...rate.extraRewards.map(campaign => campaign.reward?.type === 'apr' && { ...campaign, reward: campaign.reward }),
@@ -66,7 +63,7 @@ export const buildBorrowRateBreakdown = ({
         explorerUrl: scanTokenPath(chainId, collateralToken.address),
         yieldBearing: true,
       },
-      price: tokenPrice(prices, collateralToken.address),
+      price: collateralPrice,
       rate: -rebasingYield,
     })),
   )
@@ -83,12 +80,13 @@ export const buildBorrowRateBreakdown = ({
           address: reward.address,
           explorerUrl: scanTokenPath(chainId, reward.address),
         },
-        price: tokenPrice(prices, reward.address, reward.price),
+        price: constQ(reward.price),
         rate: -reward.value,
       })),
       ...rebasingRow,
       {
         source: { tokenInfo: { icon: null, iconPosition: 'left', primary: t`Borrow APR` } },
+        price: constQ(undefined), // Base APR/APY rows have no token price.
         rate: rate.rate,
       },
     ],
@@ -110,8 +108,8 @@ export const buildSupplyRateBreakdown = ({
   chainId: number
   blockchainId: string
   borrowToken: MarketToken | undefined
-  prices: TokenPrices
-  crvPrice?: number
+  prices: QueryProp<Record<string, number>>
+  crvPrice: QueryProp<number>
 }): RateBreakdownData => {
   const crvRates = [rate.supplyApyCrvMinBoost, rate.supplyApyCrvMaxBoost]
   const crvRow: RateBreakdownRow[] = notFalsy(
@@ -148,7 +146,7 @@ export const buildSupplyRateBreakdown = ({
         explorerUrl: scanTokenPath(chainId, borrowToken.address),
         yieldBearing: true,
       },
-      price: tokenPrice(prices, borrowToken.address),
+      price: mapQuery(prices, prices => prices[borrowToken.address]),
       rate: rebasingYield,
     })),
   )
@@ -162,7 +160,7 @@ export const buildSupplyRateBreakdown = ({
           address: address as Address,
           explorerUrl: scanTokenPath(chainId, address),
         },
-        price: tokenPrice(prices, address),
+        price: mapQuery(prices, prices => prices[address]),
         rate: percentage,
       })),
       ...campaigns.map(({ platform, platformImageId, reward, symbol }) => ({
@@ -175,12 +173,13 @@ export const buildSupplyRateBreakdown = ({
           address: reward.address,
           explorerUrl: scanTokenPath(chainId, reward.address),
         },
-        price: tokenPrice(prices, reward.address, reward.price),
+        price: constQ(reward.price),
         rate: aprToApy(reward.value),
       })),
       ...rebasingRow,
       {
         source: { tokenInfo: { icon: null, iconPosition: 'left', primary: t`Supply APY` } },
+        price: constQ(undefined),
         rate: rate.supplyApy,
       },
     ],

--- a/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenPriceCell.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenPriceCell.tsx
@@ -8,7 +8,7 @@ import { InlineTableCell } from './InlineTableCell'
 /** Displays a price query without letting its loading or error state affect the rest of the table. */
 export const TokenPriceCell = ({ query: { data, error, isLoading } }: { query: QueryProp<number | undefined> }) => (
   <InlineTableCell sx={{ alignItems: 'end' }}>
-    <WithSkeleton loading={isLoading} sx={{ width: '3rem', height: '1lh' }}>
+    <WithSkeleton loading={isLoading} variant="rectangular" width="3rem" height="1lh">
       {data == null && error ? (
         <ErrorIconButton error={error} size="extraExtraSmall" />
       ) : (

--- a/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenPriceCell.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenPriceCell.tsx
@@ -1,0 +1,19 @@
+import { ErrorIconButton } from '@evm-ui/shared/ui/ErrorIconButton'
+import { formatNumber } from '@evm-ui/utils'
+import Typography from '@mui/material/Typography'
+import { WithSkeleton } from '@ui/components/WithSkeleton'
+import type { QueryProp } from '@ui/features/queries/util'
+import { InlineTableCell } from './InlineTableCell'
+
+/** Displays a price query without letting its loading or error state affect the rest of the table. */
+export const TokenPriceCell = ({ query: { data, error, isLoading } }: { query: QueryProp<number | undefined> }) => (
+  <InlineTableCell sx={{ alignItems: 'end' }}>
+    <WithSkeleton loading={isLoading} sx={{ width: '3rem', height: '1lh' }}>
+      {data == null && error ? (
+        <ErrorIconButton error={error} size="extraExtraSmall" />
+      ) : (
+        <Typography>{formatNumber(data, 'usd.precise')}</Typography>
+      )}
+    </WithSkeleton>
+  </InlineTableCell>
+)

--- a/packages/evm-ui/src/shared/ui/DataTable/inline-cells/index.ts
+++ b/packages/evm-ui/src/shared/ui/DataTable/inline-cells/index.ts
@@ -4,3 +4,4 @@ export { AddressCell } from './AddressCell'
 
 export { TimestampCell } from './TimestampCell'
 export { TokenCell } from './TokenCell'
+export { TokenPriceCell } from './TokenPriceCell'


### PR DESCRIPTION
- depends on #3151
- add `TokenPriceCell` to show price loading and errors without blocking the table 

<img width="1016" height="232" alt="Screenshot 2026-09-08 at 13 11 07" src="https://github.com/user-attachments/assets/409fb5cb-a80f-4446-a46c-0e93a652fe9b" />

<img width="1005" height="237" alt="Screenshot 2026-09-08 at 13 11 14" src="https://github.com/user-attachments/assets/870418f0-18ca-4c1d-9708-528311b4b623" />
