### PR TITLE
fix: guard for unknown chains

### DIFF
--- a/apps/main/src/bridge/features/bridge/components/BridgeActionInfos.tsx
+++ b/apps/main/src/bridge/features/bridge/components/BridgeActionInfos.tsx
@@ -7,7 +7,7 @@ import { t } from '@ui/lib/i18n'
 type BridgeActionInfosProps = EstimatedTxCostProps & {
   /** Query returning the estimated bridge cost in the chain's native token. */
   bridgeCost: QueryProp<number>
-  nativeTokenSymbol: string
+  nativeTokenSymbol: string | undefined
 }
 
 export const BridgeActionInfos = ({ bridgeCost, gas, isApproved, nativeTokenSymbol }: BridgeActionInfosProps) => (

--- a/apps/main/src/bridge/features/bridge/components/BridgeForm.tsx
+++ b/apps/main/src/bridge/features/bridge/components/BridgeForm.tsx
@@ -61,7 +61,7 @@ export const BridgeForm = ({
             bridgeCost={q(bridgeCost)}
             gas={q(gas)}
             isApproved={isApproved.data}
-            nativeTokenSymbol={getChainNativeCurrency(chainId).symbol}
+            nativeTokenSymbol={getChainNativeCurrency(chainId)?.symbol}
           />
           <BridgeInfoAlert />
         </>

--- a/apps/main/src/dex/components/DetailInfoEstGas.tsx
+++ b/apps/main/src/dex/components/DetailInfoEstGas.tsx
@@ -32,7 +32,7 @@ export const DetailInfoEstGas = ({
 }) => {
   const { data: chainTokenUsdRate } = useTokenUsdRate({ chainId, tokenAddress: ethAddress })
   const { data: gasInfo } = useGasInfoAndUpdateLib({ chainId })
-  const nativeSymbol = getChainNativeCurrency(chainId).symbol
+  const nativeSymbol = getChainNativeCurrency(chainId)?.symbol
 
   const { estGasCostUsd, tooltip } = useMemo(
     () => calculateGas(estimatedGas, gasInfo, chainTokenUsdRate, chainId, nativeSymbol),

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/chains.ts
@@ -105,9 +105,12 @@ export const isLiteChain = (chainId: number) =>
 export const getChainName = (chainId: number) =>
   CHAIN_NAMES[chainId] ?? wagmiChainsMap[chainId]?.name ?? `Chain ${chainId}`
 
-export const getChainNativeCurrency = (chainId: number) => wagmiChainsMap[chainId]?.nativeCurrency
-export const getChainBlockExplorer = (chainId: number) => wagmiChainsMap[chainId]?.blockExplorers?.default.url
-export const getChainDefaultRpcUrls = (chainId: number) => wagmiChainsMap[chainId]?.rpcUrls.default.http
+export const getChainNativeCurrency = (chainId: number): { symbol: string } | undefined =>
+  wagmiChainsMap[chainId]?.nativeCurrency
+export const getChainBlockExplorer = (chainId: number): string | undefined =>
+  wagmiChainsMap[chainId]?.blockExplorers?.default.url
+export const getChainDefaultRpcUrls = (chainId: number): readonly string[] | undefined =>
+  wagmiChainsMap[chainId]?.rpcUrls.default.http
 
 /** Creates a Wagmi / Viem chain configuration with potential custom overrides. */
 export const createChain = (chainId: number, getRpcUrls: typeof defaultGetRpcUrls): Chain =>

--- a/packages/evm-ui/src/features/connect-wallet/lib/wagmi/transports.ts
+++ b/packages/evm-ui/src/features/connect-wallet/lib/wagmi/transports.ts
@@ -1,5 +1,6 @@
 import lodash from 'lodash'
 import type { HttpTransportConfig } from 'viem'
+import { notFalsyArray } from '@primitives/objects.utils'
 import { Duration } from '@ui/features/themes/design/0_primitives'
 import { injected } from '@wagmi/connectors'
 import { fallback, http, unstable_connector } from '@wagmi/core'
@@ -20,11 +21,10 @@ export const WAGMI_HTTP_OPTIONS = {
  * 2. Default Wagmi chain RPC URLs as fallbacks
  *
  * @param chainId - The chain ID to get RPC URLs for
- * @param networkRpcUrl - The primary RPC URL from the network configuration
  * @returns Array of unique RPC URLs in priority order
  */
 export const defaultGetRpcUrls = <ChainId extends number>(chainId: ChainId) =>
-  lodash.uniq([...(RPC[chainId] ?? []), ...getChainDefaultRpcUrls(chainId)])
+  lodash.uniq(notFalsyArray(RPC[chainId], getChainDefaultRpcUrls(chainId)))
 
 /**
  * Transport configuration for Wagmi:

--- a/packages/evm-ui/src/lib/model/entities/gas-info.ts
+++ b/packages/evm-ui/src/lib/model/entities/gas-info.ts
@@ -376,7 +376,7 @@ export function calculateGas(
   gasInfo: GasInfo | undefined,
   chainTokenUsdRate: number | undefined,
   chainId: number,
-  networkSymbol: string,
+  networkSymbol: string | undefined,
 ): {
   estGasCost?: number
   estGasCostUsd?: number
@@ -412,7 +412,7 @@ type GasEstimate = Amount | [Decimal, Decimal] | number[] | null | undefined
 const useEstimateGas = (chainId: number | null | undefined, estimate: QueryResult<GasEstimate>, enabled?: boolean) => {
   const ethRate = useTokenUsdRate({ chainId, tokenAddress: ethAddress }, enabled)
   const gasInfo = useGasInfoAndUpdateLib({ chainId }, enabled)
-  const networkSymbol = maybe(chainId, chainId => getChainNativeCurrency(chainId).symbol)
+  const networkSymbol = maybe(chainId, chainId => getChainNativeCurrency(chainId)?.symbol)
   return useCombinedQueries(
     [estimate, gasInfo, ethRate],
     useCallback(


### PR DESCRIPTION
- If the API returns an unknown chain the app could crash due to `...` being used on `undefined`
- This PR updates the returned type to explicitly show that the functions can return such values