### PR TITLE
fix(ui): align Snackbar color parity

### DIFF
--- a/packages/evm-ui/.storybook/preview.tsx
+++ b/packages/evm-ui/.storybook/preview.tsx
@@ -20,12 +20,6 @@ const themes = {
 }
 
 const decorators: Decorator[] = [
-  withThemeFromJSXProvider<ReactRenderer>({
-    themes,
-    defaultTheme: 'light',
-    Provider: ThemeProvider,
-    GlobalStyles: CssBaseline,
-  }),
   Story => {
     const router = createRouter({
       routeTree: createRootRoute({ component: Story }),
@@ -39,6 +33,13 @@ const decorators: Decorator[] = [
       </>
     )
   },
+  // The last decorator wraps the others, so the shared Toast also receives the theme.
+  withThemeFromJSXProvider<ReactRenderer>({
+    themes,
+    defaultTheme: 'light',
+    Provider: ThemeProvider,
+    GlobalStyles: CssBaseline,
+  }),
 ]
 
 const preview: Preview = {

--- a/packages/evm-ui/src/widgets/Toast/Toast.tsx
+++ b/packages/evm-ui/src/widgets/Toast/Toast.tsx
@@ -3,19 +3,13 @@ import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
+import { capitalize } from '@mui/material/utils'
 import { useLayoutStore } from '@ui/features/layout/layout'
 import { Duration } from '@ui/features/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
 import { watchToasts, type ToastItem } from './toast.util'
 
 const { Spacing } = SizesAndSpaces
-
-const snackbarBorderBySeverity = {
-  info: 'Info',
-  success: 'Success',
-  warning: 'Warning',
-  error: 'Error',
-} as const satisfies Record<NonNullable<ToastItem['severity']>, string>
 
 /** Get toast duration based on severity */
 const getDuration = ({ severity = 'info' }: Pick<ToastItem, 'severity'>) => Duration.Toast[severity]
@@ -75,31 +69,27 @@ export const Toast = () => {
           flexDirection: 'column',
         }}
       >
-        {items.map(({ id, severity, title, message, testId, keepAlive }) => {
-          const resolvedSeverity = severity ?? 'info'
-          const snackbarBorder = snackbarBorderBySeverity[resolvedSeverity]
-          return (
-            <Alert
-              key={id}
-              variant="outlined"
-              severity={resolvedSeverity}
-              data-testid={testId ?? `toast-${resolvedSeverity}`}
-              sx={{
-                borderColor: theme => theme.design.Snackbar.Border[snackbarBorder],
-                ...(!keepAlive && {
-                  animation: `toastFadeOut ${getDuration({ severity: resolvedSeverity }) + Duration.Transition}ms forwards`,
-                  '@keyframes toastFadeOut': {
-                    [getDurationPercent({ severity: resolvedSeverity })]: { opacity: 1 },
-                    '100%': { opacity: 0 },
-                  },
-                }),
-              }}
-            >
-              {title && <AlertTitle>{title}</AlertTitle>}
-              {message}
-            </Alert>
-          )
-        })}
+        {items.map(({ id, severity = 'info', title, message, testId, keepAlive }) => (
+          <Alert
+            key={id}
+            variant="outlined"
+            severity={severity}
+            data-testid={testId ?? `toast-${severity}`}
+            sx={{
+              borderColor: theme => theme.design.Snackbar.Border[capitalize(severity) as Capitalize<typeof severity>],
+              ...(!keepAlive && {
+                animation: `toastFadeOut ${getDuration({ severity }) + Duration.Transition}ms forwards`,
+                '@keyframes toastFadeOut': {
+                  [getDurationPercent({ severity })]: { opacity: 1 },
+                  '100%': { opacity: 0 },
+                },
+              }),
+            }}
+          >
+            {title && <AlertTitle>{title}</AlertTitle>}
+            {message}
+          </Alert>
+        ))}
       </Stack>
     </Snackbar>
   )

--- a/packages/evm-ui/src/widgets/Toast/Toast.tsx
+++ b/packages/evm-ui/src/widgets/Toast/Toast.tsx
@@ -75,20 +75,21 @@ export const Toast = () => {
           flexDirection: 'column',
         }}
       >
-        {items.map(({ id, severity, title, message, testId = `toast-${severity}`, keepAlive }) => {
-          const snackbarBorder = snackbarBorderBySeverity[severity ?? 'info']
+        {items.map(({ id, severity, title, message, testId, keepAlive }) => {
+          const resolvedSeverity = severity ?? 'info'
+          const snackbarBorder = snackbarBorderBySeverity[resolvedSeverity]
           return (
             <Alert
               key={id}
               variant="outlined"
-              severity={severity}
-              data-testid={testId}
+              severity={resolvedSeverity}
+              data-testid={testId ?? `toast-${resolvedSeverity}`}
               sx={{
-                borderColor: theme => theme.design?.Snackbar.Border[snackbarBorder] ?? theme.palette[severity ?? 'info'].main,
+                borderColor: theme => theme.design.Snackbar.Border[snackbarBorder],
                 ...(!keepAlive && {
-                  animation: `toastFadeOut ${getDuration({ severity }) + Duration.Transition}ms forwards`,
+                  animation: `toastFadeOut ${getDuration({ severity: resolvedSeverity }) + Duration.Transition}ms forwards`,
                   '@keyframes toastFadeOut': {
-                    [getDurationPercent({ severity })]: { opacity: 1 },
+                    [getDurationPercent({ severity: resolvedSeverity })]: { opacity: 1 },
                     '100%': { opacity: 0 },
                   },
                 }),

--- a/packages/evm-ui/src/widgets/Toast/Toast.tsx
+++ b/packages/evm-ui/src/widgets/Toast/Toast.tsx
@@ -10,6 +10,13 @@ import { watchToasts, type ToastItem } from './toast.util'
 
 const { Spacing } = SizesAndSpaces
 
+const snackbarBorderBySeverity = {
+  info: 'Info',
+  success: 'Success',
+  warning: 'Warning',
+  error: 'Error',
+} as const satisfies Record<NonNullable<ToastItem['severity']>, string>
+
 /** Get toast duration based on severity */
 const getDuration = ({ severity = 'info' }: Pick<ToastItem, 'severity'>) => Duration.Toast[severity]
 
@@ -68,26 +75,30 @@ export const Toast = () => {
           flexDirection: 'column',
         }}
       >
-        {items.map(({ id, severity, title, message, testId = `toast-${severity}`, keepAlive }) => (
-          <Alert
-            key={id}
-            variant="filled"
-            severity={severity}
-            data-testid={testId}
-            {...(!keepAlive && {
-              sx: {
-                animation: `toastFadeOut ${getDuration({ severity }) + Duration.Transition}ms forwards`,
-                '@keyframes toastFadeOut': {
-                  [getDurationPercent({ severity })]: { opacity: 1 },
-                  '100%': { opacity: 0 },
-                },
-              },
-            })}
-          >
-            {title && <AlertTitle>{title}</AlertTitle>}
-            {message}
-          </Alert>
-        ))}
+        {items.map(({ id, severity, title, message, testId = `toast-${severity}`, keepAlive }) => {
+          const snackbarBorder = snackbarBorderBySeverity[severity ?? 'info']
+          return (
+            <Alert
+              key={id}
+              variant="outlined"
+              severity={severity}
+              data-testid={testId}
+              sx={{
+                borderColor: theme => theme.design?.Snackbar.Border[snackbarBorder] ?? theme.palette[severity ?? 'info'].main,
+                ...(!keepAlive && {
+                  animation: `toastFadeOut ${getDuration({ severity }) + Duration.Transition}ms forwards`,
+                  '@keyframes toastFadeOut': {
+                    [getDurationPercent({ severity })]: { opacity: 1 },
+                    '100%': { opacity: 0 },
+                  },
+                }),
+              }}
+            >
+              {title && <AlertTitle>{title}</AlertTitle>}
+              {message}
+            </Alert>
+          )
+        })}
       </Stack>
     </Snackbar>
   )

--- a/packages/evm-ui/src/widgets/Toast/Toast.tsx
+++ b/packages/evm-ui/src/widgets/Toast/Toast.tsx
@@ -1,9 +1,9 @@
+import { capitalize } from 'lodash'
 import { useEffect, useState } from 'react'
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
-import { capitalize } from '@mui/material/utils'
 import { useLayoutStore } from '@ui/features/layout/layout'
 import { Duration } from '@ui/features/themes/design/0_primitives'
 import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
@@ -76,7 +76,7 @@ export const Toast = () => {
             severity={severity}
             data-testid={testId ?? `toast-${severity}`}
             sx={{
-              borderColor: theme => theme.design.Snackbar.Border[capitalize(severity) as Capitalize<typeof severity>],
+              borderColor: theme => theme.design.Snackbar.Border[capitalize(severity)],
               ...(!keepAlive && {
                 animation: `toastFadeOut ${getDuration({ severity }) + Duration.Transition}ms forwards`,
                 '@keyframes toastFadeOut': {

--- a/packages/ui/src/features/themes/design/1_surfaces_text.ts
+++ b/packages/ui/src/features/themes/design/1_surfaces_text.ts
@@ -116,6 +116,14 @@ function createLightSurfaces() {
         Accent: Blues[500],
       },
     },
+    Snackbar: {
+      Border: {
+        Info: Blues[500],
+        Success: Greens[300],
+        Warning: Yellows[500],
+        Error: Reds[500],
+      },
+    },
   } as const
 }
 
@@ -232,6 +240,14 @@ function createDarkSurfaces() {
         Highlight: Grays[950],
         Warning: Yellows[500],
         Accent: Blues[400],
+      },
+    },
+    Snackbar: {
+      Border: {
+        Info: Blues[500],
+        Success: Greens[400],
+        Warning: Yellows[500],
+        Error: Reds[500],
       },
     },
   } as const
@@ -352,6 +368,14 @@ function createChadSurfaces() {
         Accent: Violets[800],
       },
     },
+    Snackbar: {
+      Border: {
+        Info: Violets[500],
+        Success: Greens[400],
+        Warning: Yellows[500],
+        Error: Reds[500],
+      },
+    },
   } as const
 }
 
@@ -468,6 +492,14 @@ function createLightInvertedSurfaces() {
         Highlight: Grays[10],
         Warning: Yellows[500],
         Accent: Blues[400],
+      },
+    },
+    Snackbar: {
+      Border: {
+        Info: Blues[500],
+        Success: Greens[300],
+        Warning: Yellows[500],
+        Error: Reds[500],
       },
     },
   } as const
@@ -588,6 +620,14 @@ function createDarkInvertedSurfaces() {
         Accent: Blues[500],
       },
     },
+    Snackbar: {
+      Border: {
+        Info: Blues[500],
+        Success: Greens[400],
+        Warning: Yellows[500],
+        Error: Reds[500],
+      },
+    },
   } as const
 }
 
@@ -704,6 +744,14 @@ function createChadInvertedSurfaces() {
         Highlight: Violets[950],
         Warning: Yellows[500],
         Accent: Violets[400],
+      },
+    },
+    Snackbar: {
+      Border: {
+        Info: Violets[500],
+        Success: Greens[400],
+        Warning: Yellows[500],
+        Error: Reds[500],
       },
     },
   } as const

--- a/packages/ui/src/features/themes/design/2_theme.ts
+++ b/packages/ui/src/features/themes/design/2_theme.ts
@@ -448,6 +448,15 @@ export const createLightDesign = (
     },
   } as const
 
+  const Snackbar = {
+    Border: {
+      Info: Light.Snackbar.Border.Info,
+      Success: Light.Snackbar.Border.Success,
+      Warning: Light.Snackbar.Border.Warning,
+      Error: Light.Snackbar.Border.Error,
+    },
+  } as const
+
   const Chart = {
     LiquidationZone: {
       Current: Oranges[50],
@@ -569,6 +578,7 @@ export const createLightDesign = (
     Tabs,
     Chips,
     Badges,
+    Snackbar,
     Chart,
     Toggles,
     Table,
@@ -1005,6 +1015,15 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
     },
   } as const
 
+  const Snackbar = {
+    Border: {
+      Info: Dark.Snackbar.Border.Info,
+      Success: Dark.Snackbar.Border.Success,
+      Warning: Dark.Snackbar.Border.Warning,
+      Error: Dark.Snackbar.Border.Error,
+    },
+  } as const
+
   const Chart = {
     LiquidationZone: {
       Current: Oranges[900],
@@ -1126,6 +1145,7 @@ export const createDarkDesign = (Dark: typeof SurfacesAndText.plain.Dark | typeo
     Tabs,
     Chips,
     Badges,
+    Snackbar,
     Chart,
     Toggles,
     Table,
@@ -1523,6 +1543,15 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
     },
   } as const
 
+  const Snackbar = {
+    Border: {
+      Info: Chad.Snackbar.Border.Info,
+      Success: Chad.Snackbar.Border.Success,
+      Warning: Chad.Snackbar.Border.Warning,
+      Error: Chad.Snackbar.Border.Error,
+    },
+  } as const
+
   const Chart = {
     LiquidationZone: {
       Current: Oranges[50],
@@ -1644,6 +1673,7 @@ export const createChadDesign = (Chad: typeof SurfacesAndText.plain.Chad | typeo
     Tabs,
     Chips,
     Badges,
+    Snackbar,
     Chart,
     Toggles,
     Table,


### PR DESCRIPTION
## Summary
- adds semantic Snackbar border tokens for Light, Dark, Chad, and inverted modes
- renders toasts as outlined Alerts with severity-specific semantic borders
- updates only the Snackbar master strokes in [Figma](https://www.figma.com/design/4UR2jKadU7nuW5VwUSSx5s?node-id=2257-27251)

Resolved matrix: Light (blue/green-300/yellow/red), Dark (blue/green-400/yellow/red), Chad (violet/green-400/yellow/red); inverted modes retain the same semantic severity roles.

## Validation
- yarn workspace ui typecheck
- yarn workspace ui lint
- yarn workspace evm-ui typecheck
- yarn workspace evm-ui lint
- Storybook Toast All Severities exercised in Light, Dark, Chad, and their inverted modes
- Figma semantic chains and the four target master stroke bindings verified

## Dependency
Depends on #3179 (and transitively #3176). This PR is intentionally based on the codex/fix-chip-color-parity branch while #3179 remains open.

No palette primitives, generic Alert styles, Chips, or Badges were changed.