### PR TITLE
refactor: evm-independent copy utilities

### DIFF
--- a/apps/main/src/dao/components/CopyIconButton.tsx
+++ b/apps/main/src/dao/components/CopyIconButton.tsx
@@ -2,12 +2,12 @@ import { copyToClipboard } from '@evm-ui/utils'
 import { Icon } from '@legacy-ui/Icon'
 import { TooltipButton } from '@legacy-ui/Tooltip/TooltipButton'
 
-type CopyIconButtonProps = { copyContent: string; tooltip: string }
+type CopyIconButtonProps = { copyContent: string; tooltip: string; format?: (text: string) => string }
 
-export const CopyIconButton = ({ copyContent, tooltip }: CopyIconButtonProps) => (
+export const CopyIconButton = ({ copyContent, tooltip, format }: CopyIconButtonProps) => (
   <TooltipButton
     clickable
-    onClick={() => void copyToClipboard(copyContent)}
+    onClick={() => void copyToClipboard(format ? format(copyContent) : copyContent)}
     noWrap
     tooltip={tooltip}
     customIcon={<Icon name="Copy" size={16} />}

--- a/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
+++ b/apps/main/src/dao/components/PageGauge/GaugeMetrics/index.tsx
@@ -6,7 +6,7 @@ import { getGaugeDepositUrl, useGaugesLegacy } from '@/dao/queries/gauges-legacy
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
 import { parseTimestamp } from '@curvefi/prices-api/timestamp'
-import { shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import { Box } from '@legacy-ui/Box'
 import { scanAddressPath } from '@legacy-ui/utils/'
 import { formatDate } from '@primitives/date.utils'
@@ -41,7 +41,7 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
                     href={scanAddressPath(Chain.Ethereum, gaugeAddress)}
                     tooltip={t`View on explorer`}
                   />
-                  <CopyIconButton copyContent={gaugeAddress} tooltip={t`Copy address`} />
+                  <CopyIconButton copyContent={gaugeAddress} format={tryChecksumAddress} tooltip={t`Copy address`} />
                 </BigScreenButtonsWrapper>
               </Box>
             }
@@ -51,7 +51,7 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
               href={scanAddressPath(Chain.Ethereum, gaugeAddress)}
               tooltip={t`View on explorer`}
             />
-            <CopyIconButton copyContent={gaugeAddress} tooltip={t`Copy address`} />
+            <CopyIconButton copyContent={gaugeAddress} format={tryChecksumAddress} tooltip={t`Copy address`} />
           </SmallScreenButtonsWrapper>
         </Box>
         <MetricsComp
@@ -140,7 +140,11 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
                       href={gaugeExternalLink}
                       tooltip={gaugeCurveApiData?.isPool ? t`Visit pool` : t`Visit market`}
                     />
-                    <CopyIconButton copyContent={gaugeData?.pool?.address} tooltip={t`Copy address`} />
+                    <CopyIconButton
+                      copyContent={gaugeData?.pool?.address}
+                      format={tryChecksumAddress}
+                      tooltip={t`Copy address`}
+                    />
                   </BigScreenButtonsWrapper>
                 </Box>
               }
@@ -150,7 +154,11 @@ export const GaugeMetrics = ({ gaugeData, dataLoading }: GaugeMetricsProps) => {
                 href={scanAddressPath(chainId, gaugeData?.pool?.address)}
                 tooltip={t`View on explorer`}
               />
-              <CopyIconButton copyContent={gaugeData?.pool?.address} tooltip={t`Copy address`} />
+              <CopyIconButton
+                copyContent={gaugeData?.pool?.address}
+                format={tryChecksumAddress}
+                tooltip={t`Copy address`}
+              />
             </SmallScreenButtonsWrapper>
           </Box>
         )}

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/GaugeDetails.tsx
@@ -4,7 +4,7 @@ import { ExternalLinkIconButton } from '@/dao/components/ExternalLinkIconButton'
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
 import { parseTimestamp } from '@curvefi/prices-api/timestamp'
-import { shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import { Box } from '@legacy-ui/Box'
 import { Icon } from '@legacy-ui/Icon'
 import type { IconProps } from '@legacy-ui/Icon/Icon'
@@ -49,7 +49,11 @@ export const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormatt
                     href={scanAddressPath(chainId, gaugeData.pool.address)}
                     tooltip={t`View on explorer`}
                   />
-                  <CopyIconButton tooltip={t`Copy Pool Address`} copyContent={gaugeData.pool.address} />
+                  <CopyIconButton
+                    tooltip={t`Copy Pool Address`}
+                    copyContent={gaugeData.pool.address}
+                    format={tryChecksumAddress}
+                  />
                 </Box>
               )}
               <h5>
@@ -86,7 +90,11 @@ export const GaugeDetails = ({ gaugeData, className }: { gaugeData: GaugeFormatt
               {shortenAddress(gaugeData.address)}
             </StyledExternalLink>
             <ExternalLinkIconButton href={scanAddressPath(chainId, gaugeData.address)} tooltip={t`View on explorer`} />
-            <CopyIconButton tooltip={t`Copy Gauge Address`} copyContent={gaugeData.address} />
+            <CopyIconButton
+              tooltip={t`Copy Gauge Address`}
+              copyContent={gaugeData.address}
+              format={tryChecksumAddress}
+            />
           </Box>
           <Chip
             size="md"

--- a/apps/main/src/dao/components/PageGauges/GaugeListItem/TitleComp.tsx
+++ b/apps/main/src/dao/components/PageGauges/GaugeListItem/TitleComp.tsx
@@ -4,7 +4,7 @@ import { ExternalLinkIconButton } from '@/dao/components/ExternalLinkIconButton'
 import { SmallLabel } from '@/dao/components/SmallLabel'
 import { GaugeFormattedData } from '@/dao/types/dao.types'
 import { getChainIdFromGaugeData } from '@/dao/utils'
-import { shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import { Box } from '@legacy-ui/Box'
 import { scanAddressPath } from '@legacy-ui/utils'
 import { TokenIcons } from '@ui/components/TokenIcons'
@@ -41,7 +41,11 @@ export const TitleComp = ({ gaugeData, gaugeAddress }: TitleCompProps) => (
               href={scanAddressPath(getChainIdFromGaugeData(gaugeData), gaugeAddress ?? '')}
               tooltip={t`View gauge on explorer`}
             />
-            <CopyIconButton copyContent={gaugeAddress ?? ''} tooltip={t`Copy gauge address`} />
+            <CopyIconButton
+              copyContent={gaugeAddress ?? ''}
+              format={tryChecksumAddress}
+              tooltip={t`Copy gauge address`}
+            />
           </ButtonsWrapper>
         </Box>
       )}

--- a/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
+++ b/apps/main/src/dao/components/PageUser/UserHeader/index.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components'
 import { getAddress } from 'viem'
 import { TOP_HOLDERS } from '@/dao/constants'
-import { copyToClipboard } from '@evm-ui/utils'
+import { tryChecksumAddress, copyToClipboard } from '@evm-ui/utils'
 import { Box } from '@legacy-ui/Box'
 import { Icon } from '@legacy-ui/Icon'
 import { IconButton } from '@legacy-ui/IconButton'
@@ -18,7 +18,7 @@ export const UserHeader = ({ userAddress, userEnsName }: { userAddress: string; 
           <Box flex flexAlignItems="center">
             <UserAddress>{getAddress(userAddress)}</UserAddress>{' '}
             <Box margin="0 0 0 var(--spacing-1)" flex>
-              <StyledCopyButton size="small" onClick={() => void copyToClipboard(userAddress)}>
+              <StyledCopyButton size="small" onClick={() => void copyToClipboard(tryChecksumAddress(userAddress))}>
                 <Icon name="Copy" size={16} />
               </StyledCopyButton>
               <StyledExternalLink size="small" href={scanAddressPath(Chain.Ethereum, userAddress)}>
@@ -30,7 +30,7 @@ export const UserHeader = ({ userAddress, userEnsName }: { userAddress: string; 
       </Box>
       {!userEnsName && !TOP_HOLDERS[userAddress]?.title && (
         <Box flex margin="0 0 0 var(--spacing-1)">
-          <StyledCopyButton size="small" onClick={() => void copyToClipboard(userAddress)}>
+          <StyledCopyButton size="small" onClick={() => void copyToClipboard(tryChecksumAddress(userAddress))}>
             <Icon name="Copy" size={16} />
           </StyledCopyButton>
           <StyledExternalLink size="small" href={scanAddressPath(Chain.Ethereum, userAddress)}>

--- a/apps/main/src/dex/components/ChipPool.tsx
+++ b/apps/main/src/dex/components/ChipPool.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components'
 import { getAddress } from 'viem'
 import { ROUTE } from '@/dex/constants'
 import { getPath } from '@/dex/utils/utilsRouter'
-import { copyToClipboard, shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, copyToClipboard, shortenAddress } from '@evm-ui/utils'
 import { Icon } from '@legacy-ui/Icon'
 import { TextEllipsis } from '@legacy-ui/TextEllipsis'
 import { breakpoints } from '@legacy-ui/utils/responsive'
@@ -57,7 +57,7 @@ export const ChipPool = ({ blockchainId, poolId, poolName, poolAddress }: ChipPo
         </RouterLink>{' '}
       </ChipPoolName>
       <ChipPoolAdditionalInfo>
-        <Button onPress={() => void copyToClipboard(poolAddress)}>
+        <Button onPress={() => void copyToClipboard(tryChecksumAddress(poolAddress))}>
           <ChipPoolAddress>{parsedPoolAddress}</ChipPoolAddress>
           <ChipPoolCopyButtonIcon name="Copy" size={16} />
         </Button>

--- a/apps/main/src/dex/components/ChipToken.tsx
+++ b/apps/main/src/dex/components/ChipToken.tsx
@@ -4,7 +4,7 @@ import { useButton } from 'react-aria'
 import { styled } from 'styled-components'
 import { useChainId } from 'wagmi'
 import { fetchTokenUsdRate } from '@evm-ui/lib/model/entities/token-usd-rate'
-import { copyToClipboard, shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, copyToClipboard, shortenAddress } from '@evm-ui/utils'
 import { Icon } from '@legacy-ui/Icon'
 import { Spinner } from '@legacy-ui/Spinner'
 import { formatNumber } from '@primitives/number.utils'
@@ -64,7 +64,7 @@ export const ChipToken = ({ className, tokenName, tokenAddress, ...props }: Chip
     <ChipTokenWrapper className={className} onMouseEnter={handleMouseEnter}>
       <span>{parsedTokenName}</span>
       <ChipTokenAdditionalInfo>
-        <Button {...props} onPress={() => void copyToClipboard(tokenAddress)}>
+        <Button {...props} onPress={() => void copyToClipboard(tryChecksumAddress(tokenAddress))}>
           <AlignmentWrapper>
             <ChipTokenUsdRate>
               {usdRate == null ? <ChipTokenUsdRateSpinner size={10} /> : parsedUsdRate}

--- a/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
+++ b/apps/main/src/dex/components/PageCompensation/components/Compensation.tsx
@@ -4,7 +4,7 @@ import { AlertFormError } from '@/dex/components/AlertFormError'
 import type { EtherContract } from '@/dex/components/PageCompensation/types'
 import { curvejsApi } from '@/dex/lib/curvejs'
 import { ChainId, CurveApi, Provider } from '@/dex/types/main.types'
-import { copyToClipboard, shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, copyToClipboard, shortenAddress } from '@evm-ui/utils'
 import { Box } from '@legacy-ui/Box'
 import { Button } from '@legacy-ui/Button'
 import { Icon } from '@legacy-ui/Icon'
@@ -102,7 +102,7 @@ export const Compensation = ({
               {shortenAddress(contractAddress)}
               <Icon name="Launch" size={16} />
             </StyledExternalLink>
-            <StyledIconButton size="medium" onClick={() => void copyToClipboard(contractAddress)}>
+            <StyledIconButton size="medium" onClick={() => void copyToClipboard(tryChecksumAddress(contractAddress))}>
               <Icon name="Copy" size={16} />
             </StyledIconButton>
           </div>

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/LegacyPoolTitleCell.tsx
@@ -5,6 +5,7 @@ import { useTokenAlert } from '@/dex/hooks/useTokenAlert'
 import { CopyIconButton } from '@evm-ui/shared/ui/CopyIconButton'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
 import { UserPositionIndicator } from '@evm-ui/shared/ui/DataTable/UserPositionIndicator'
+import { tryChecksumAddress } from '@evm-ui/utils'
 import Stack from '@mui/material/Stack'
 import type { CellContext } from '@tanstack/react-table'
 import { TokenIcons } from '@ui/components/TokenIcons'
@@ -51,6 +52,7 @@ export const LegacyPoolTitleCell = ({
               className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
               label={t`Copy pool address`}
               copyText={pool.address}
+              format={tryChecksumAddress}
               confirmationText={t`Pool address copied`}
             />
           </Stack>

--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanelActions.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanelActions.tsx
@@ -2,6 +2,7 @@ import { ROUTE } from '@/dex/constants'
 import { getPath } from '@/dex/utils/utilsRouter'
 import { copyToClipboardWithToast } from '@evm-ui/hooks/useCopyToClipboard'
 import { ExpandedPanelActions } from '@evm-ui/shared/ui/DataTable/ExpandedPanelActions'
+import { tryChecksumAddress } from '@evm-ui/utils'
 import type { ExpandedPanelComponent } from '@ui/features/tables/ExpansionRow'
 import { t } from '@ui/lib/i18n'
 import type { PoolRow } from '../types'
@@ -21,6 +22,7 @@ export const PoolExpandedPanelActions: ExpandedPanelComponent<PoolRow> = ({ row 
       onClick: () =>
         void copyToClipboardWithToast({
           copyText: pool.address,
+          format: tryChecksumAddress,
           confirmationText: t`Pool address copied`,
           failureText: t`Failed to copy pool address`,
         }),

--- a/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
+++ b/apps/main/src/llamalend/features/market-list/cells/MarketTitleCell/index.tsx
@@ -1,6 +1,7 @@
 import type { LlamaMarketRow } from '@/llamalend/queries/market-list/llama-market-stats'
 import { CopyIconButton } from '@evm-ui/shared/ui/CopyIconButton'
 import { TableRowTitle } from '@evm-ui/shared/ui/DataTable/TableRowTitle'
+import { tryChecksumAddress } from '@evm-ui/utils'
 import Stack from '@mui/material/Stack'
 import type { CellContext } from '@tanstack/react-table'
 import { TokenIcons } from '@ui/components/TokenIcons'
@@ -38,6 +39,7 @@ export const MarketTitleCell = ({
               className={`${DESKTOP_ONLY_HOVER_CLASS} ${CLICKABLE_IN_ROW_CLASS}`}
               label={t`Copy market address`}
               copyText={market.controllerAddress}
+              format={tryChecksumAddress}
               confirmationText={t`Market address copied`}
               data-testid={`copy-market-address-${market.controllerAddress}`}
             />

--- a/apps/main/src/llamalend/features/market-list/hooks/useMarketExpandedPanelActions.ts
+++ b/apps/main/src/llamalend/features/market-list/hooks/useMarketExpandedPanelActions.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useFavoriteMarkets } from '@/llamalend/queries/market-list/favorite-markets'
 import type { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
 import { copyToClipboardWithToast } from '@evm-ui/hooks/useCopyToClipboard'
+import { tryChecksumAddress } from '@evm-ui/utils'
 import { t } from '@ui/lib/i18n'
 
 export const useMarketExpandedPanelActions = (market: LlamaMarket) => {
@@ -23,6 +24,7 @@ export const useMarketExpandedPanelActions = (market: LlamaMarket) => {
         onClick: () =>
           void copyToClipboardWithToast({
             copyText: controllerAddress,
+            format: tryChecksumAddress,
             confirmationText: t`Market address copied`,
             failureText: t`Failed to copy market address`,
           }),

--- a/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperAdvancedDetails.tsx
+++ b/apps/main/src/loan/components/PagePegKeepers/components/PegKeeperAdvancedDetails.tsx
@@ -1,6 +1,6 @@
 import { DEX_ROUTES, getInternalUrl } from '@evm-ui/shared/routes'
 import { ActionInfo } from '@evm-ui/shared/ui/ActionInfo'
-import { shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import Stack from '@mui/material/Stack'
 import { formatNumber } from '@primitives/number.utils'
@@ -42,6 +42,7 @@ export const PegKeeperAdvancedDetails = ({
         />
       }
       copyValue={poolAddress}
+      format={tryChecksumAddress}
       testId={`${testId}-action-info-pool`}
     />
 
@@ -50,6 +51,7 @@ export const PegKeeperAdvancedDetails = ({
       value={shortenAddress(address, { digits: 2 })}
       valueTooltip={<ExternalLink href={`https://etherscan.io/address/${address}`} label={t`View on Etherscan`} />}
       copyValue={address}
+      format={tryChecksumAddress}
       testId={`${testId}-action-info-contract`}
     />
 

--- a/packages/evm-ui/src/hooks/useCopyToClipboard.ts
+++ b/packages/evm-ui/src/hooks/useCopyToClipboard.ts
@@ -1,14 +1,15 @@
 import { useCallback } from 'react'
-import { isAddress } from 'viem'
 import { copyToClipboard } from '@evm-ui/utils'
+import { ADDRESS_HEX_PATTERN } from '@primitives/address.utils'
 import { showToast } from '@ui/features/toast/Toast/toast.util'
 import { t } from '@ui/lib/i18n'
 
 const getTitle = (copyText: string, title: string | undefined) =>
-  title ?? t`${isAddress(copyText, { strict: false }) ? `Address` : `Value`} has been copied to clipboard`
+  title ?? t`${ADDRESS_HEX_PATTERN.test(copyText) ? `Address` : `Value`} has been copied to clipboard`
 
 type CopyToClipboardWithToastOptions = {
   copyText: string | undefined
+  format?: (text: string) => string
   confirmationText?: string
   confirmationMessage?: string
   failureText?: string
@@ -17,6 +18,7 @@ type CopyToClipboardWithToastOptions = {
 
 export const copyToClipboardWithToast = async ({
   copyText,
+  format,
   confirmationText,
   confirmationMessage,
   failureText = t`Failed to copy to clipboard`,
@@ -24,13 +26,14 @@ export const copyToClipboardWithToast = async ({
 }: CopyToClipboardWithToastOptions) => {
   if (!copyText) return showToast({ title: t`Nothing to copy`, severity: 'warning', testId })
 
-  const copied = await copyToClipboard(copyText)
+  const formattedText = format ? format(copyText) : copyText
+  const copied = await copyToClipboard(formattedText)
   showToast(
     copied
       ? {
-          message: confirmationMessage ?? copyText,
+          message: confirmationMessage ?? formattedText,
           severity: 'info',
-          title: getTitle(copyText, confirmationText),
+          title: getTitle(formattedText, confirmationText),
           testId,
         }
       : { severity: 'error', title: failureText, testId },
@@ -39,15 +42,17 @@ export const copyToClipboardWithToast = async ({
 
 export const useCopyToClipboard = ({
   copyText,
+  format,
   confirmationText,
   confirmationMessage,
   testId,
 }: {
   copyText: string | undefined
+  format?: (text: string) => string
   confirmationText?: string
   confirmationMessage?: string
   testId?: string
 }) =>
   useCallback(() => {
-    void copyToClipboardWithToast({ copyText, confirmationText, confirmationMessage, testId })
-  }, [copyText, confirmationText, confirmationMessage, testId])
+    void copyToClipboardWithToast({ copyText, format, confirmationText, confirmationMessage, testId })
+  }, [copyText, format, confirmationText, confirmationMessage, testId])

--- a/packages/evm-ui/src/shared/ui/ActionInfo/ActionInfo.tsx
+++ b/packages/evm-ui/src/shared/ui/ActionInfo/ActionInfo.tsx
@@ -36,6 +36,8 @@ export type ActionInfoProps = {
   valueTooltip?: QueryOrValue<ReactNode>
   /** Value to copy from the primary displayed value when clicked. */
   copyValue?: string
+  /** Formats the copied value only when clicked. */
+  format?: (text: string) => string
   /** Size of the component */
   size?: ActionInfoSize
   /** Test ID for the component */
@@ -121,6 +123,7 @@ export const ActionInfo = (props: ActionInfoProps) => {
     valueTooltip,
     size = DEFAULT_SIZE,
     copyValue,
+    format,
     testId = 'action-info',
     sx,
     skeleton,
@@ -143,7 +146,7 @@ export const ActionInfo = (props: ActionInfoProps) => {
       : { width: '2ch', height: '1rem' }
   const displayedValue = isLoading && typeof skeleton === 'string' ? skeleton : error ? '' : (futureValue ?? '-')
 
-  const copyToClipboard = useCopyToClipboard({ copyText: copyValue })
+  const copyToClipboard = useCopyToClipboard({ copyText: copyValue, format })
 
   return (
     <Stack

--- a/packages/evm-ui/src/shared/ui/AddressActionInfo.tsx
+++ b/packages/evm-ui/src/shared/ui/AddressActionInfo.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import { scanAddressPath } from '@legacy-ui/utils'
 import { Typography } from '@mui/material'
 import { maybe } from '@primitives/objects.utils'
 import { ExternalLink } from '@ui/components/ExternalLink'
 import type { TypographyVariantKey } from '@ui/features/themes/typography'
 import { t } from '@ui/lib/i18n'
-import { shortenAddress } from '../../utils'
 import { ActionInfo, type ActionInfoProps } from './ActionInfo'
 
 type AddressActionInfoProps = {
@@ -45,6 +45,7 @@ export const AddressActionInfo = ({
       <Typography variant={VALUE_SIZE[size]}>{shortenAddress(address)}</Typography>
     }
     copyValue={address}
+    format={tryChecksumAddress}
     valueTooltip={
       !hideTooltip &&
       maybe(address && scanAddressPath(chainId, address), link => (

--- a/packages/evm-ui/src/shared/ui/CopyIconButton.tsx
+++ b/packages/evm-ui/src/shared/ui/CopyIconButton.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from '@ui/components/Tooltip'
 import { CopyIcon } from '@ui/icons/CopyIcon'
 
 type CopyIconButtonProps = {
+  format?: (text: string) => string
   copyText: string | undefined
   label: string
   confirmationText: string
@@ -14,6 +15,7 @@ type CopyIconButtonProps = {
 
 export const CopyIconButton = ({
   copyText,
+  format,
   label,
   confirmationText,
   confirmationMessage,
@@ -25,7 +27,7 @@ export const CopyIconButton = ({
     <IconButton
       size={size}
       {...iconProps}
-      onClick={useCopyToClipboard({ copyText, confirmationText, confirmationMessage })}
+      onClick={useCopyToClipboard({ copyText, format, confirmationText, confirmationMessage })}
     >
       {children}
     </IconButton>

--- a/packages/evm-ui/src/shared/ui/DataTable/inline-cells/AddressCell.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/inline-cells/AddressCell.tsx
@@ -1,5 +1,6 @@
 import { useCopyToClipboard } from '@evm-ui/hooks/useCopyToClipboard'
 import { InlineTableCell } from '@evm-ui/shared/ui/DataTable/inline-cells/InlineTableCell'
+import { tryChecksumAddress } from '@evm-ui/utils'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { shortenString } from '@primitives/string.utils'
@@ -38,7 +39,7 @@ export const AddressCell = ({ address, label, explorerUrl }: AddressCellProps) =
       <Stack direction="row" sx={{ gap: Spacing.xs }}>
         <Typography
           variant="tableCellMBold"
-          onClick={useCopyToClipboard({ copyText: address })}
+          onClick={useCopyToClipboard({ copyText: address, format: tryChecksumAddress })}
           sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
         >
           {shortenString(address)}

--- a/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenCell.tsx
+++ b/packages/evm-ui/src/shared/ui/DataTable/inline-cells/TokenCell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { useCopyToClipboard } from '@evm-ui/hooks/useCopyToClipboard'
 import { InlineTableCell } from '@evm-ui/shared/ui/DataTable/inline-cells/InlineTableCell'
-import { shortenAddress } from '@evm-ui/utils'
+import { tryChecksumAddress, shortenAddress } from '@evm-ui/utils'
 import Box from '@mui/material/Box'
 import { ExternalLink } from '@ui/components/ExternalLink'
 import { TokenInfo, type TokenInfoProps } from '@ui/components/TokenInfo'
@@ -26,7 +26,7 @@ type TokenCellProps = {
 /** Displays token information with copy-address and optional explorer interactions. */
 export const TokenCell = ({ source, address, explorerUrl, endAdornment }: TokenCellProps) => {
   address = address ?? ('address' in source ? source.address : undefined)
-  const copyAddress = useCopyToClipboard({ copyText: address })
+  const copyAddress = useCopyToClipboard({ copyText: address, format: tryChecksumAddress })
 
   return (
     <InlineTableCell>

--- a/packages/evm-ui/src/utils/index.ts
+++ b/packages/evm-ui/src/utils/index.ts
@@ -9,22 +9,24 @@ export * from './average-categories'
 export * from './rates'
 export * from './tokens'
 
+export function tryChecksumAddress(text: string) {
+  if (isAddress(text)) {
+    try {
+      return getAddress(text)
+    } catch (error) {
+      console.warn('Failed to checksum address', error)
+    }
+  }
+  return text
+}
+
 /**
- * Copies text to clipboard with Ethereum address checksumming
+ * Copies text to the clipboard
  * @param text - The text to copy to clipboard
  * @returns Promise resolving to true if copy was successful, false otherwise
  * @todo Potentially show a snackbar of the copied value
  */
 export async function copyToClipboard(text: string) {
-  // Check if the text is an Ethereum address and apply checksumming if it is
-  if (isAddress(text)) {
-    try {
-      text = getAddress(text)
-    } catch (error) {
-      console.warn('Failed to checksum address', error)
-    }
-  }
-
   try {
     await navigator.clipboard.writeText(text)
     return true


### PR DESCRIPTION
- Pass a formatting function to the copy utilities instead of depending directly on viem functions
- Stack:
  - #3182
  - #3175 
  - #3187
  - #3190
  - #3191
  - #3194
  - #3195 (this PR)
  - #3198
  - #3199
  - #3203