### PR TITLE
fix: always fetch gauge data

### DIFF
--- a/apps/main/src/dex/hooks/useAutoRefresh.tsx
+++ b/apps/main/src/dex/hooks/useAutoRefresh.tsx
@@ -17,6 +17,6 @@ export const useAutoRefresh = (chainId: number | undefined) => {
 
   usePageVisibleInterval(async () => {
     if (!curveApi || !poolIds || !chainId) return
-    await fetchPools(curveApi, poolIds, true)
+    await fetchPools(curveApi, poolIds, { includeGaugeData: true })
   }, REFRESH_INTERVAL['15m'])
 }

--- a/apps/main/src/dex/hooks/useAutoRefresh.tsx
+++ b/apps/main/src/dex/hooks/useAutoRefresh.tsx
@@ -1,13 +1,11 @@
 import { useMemo } from 'react'
 import { useStore } from '@/dex/store/useStore'
 import { useCurve } from '@evm-ui/features/connect-wallet'
-import { useDexPoolListV2 } from '@evm-ui/hooks/useFeatureFlags'
 import { useGasInfoAndUpdateLib } from '@evm-ui/lib/model/entities/gas-info'
 import { usePageVisibleInterval } from '@ui/hooks/usePageVisibleInterval'
 import { REFRESH_INTERVAL } from '@ui/lib/time'
 
 export const useAutoRefresh = (chainId: number | undefined) => {
-  const usePoolListV2 = useDexPoolListV2()
   const { curveApi, isHydrated } = useCurve()
   const fetchPools = useStore(state => state.pools.fetchPools)
   const poolIds = useMemo(
@@ -19,6 +17,6 @@ export const useAutoRefresh = (chainId: number | undefined) => {
 
   usePageVisibleInterval(async () => {
     if (!curveApi || !poolIds || !chainId) return
-    await fetchPools(curveApi, poolIds, !usePoolListV2)
+    await fetchPools(curveApi, poolIds, true)
   }, REFRESH_INTERVAL['15m'])
 }

--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -95,7 +95,7 @@ export const createGlobalSlice = (set: StoreApi<State>['setState'], get: StoreAp
       // Legacy TVL/gauge enrichment is skipped there because the v2 pool list uses backend data.
       ...notFalsy(isLegacy && refetchPoolTvls({ chainId })),
     ])
-    await state.pools.fetchPools(curveApi, poolIds, isLegacy)
+    await state.pools.fetchPools(curveApi, poolIds, true)
 
     log(`Hydrated DEX - Complete in ${formatTimeDiff(start)}`)
   },

--- a/apps/main/src/dex/store/createGlobalSlice.ts
+++ b/apps/main/src/dex/store/createGlobalSlice.ts
@@ -95,7 +95,7 @@ export const createGlobalSlice = (set: StoreApi<State>['setState'], get: StoreAp
       // Legacy TVL/gauge enrichment is skipped there because the v2 pool list uses backend data.
       ...notFalsy(isLegacy && refetchPoolTvls({ chainId })),
     ])
-    await state.pools.fetchPools(curveApi, poolIds, true)
+    await state.pools.fetchPools(curveApi, poolIds, { includeGaugeData: true })
 
     log(`Hydrated DEX - Complete in ${formatTimeDiff(start)}`)
   },

--- a/apps/main/src/dex/store/createPoolsSlice.ts
+++ b/apps/main/src/dex/store/createPoolsSlice.ts
@@ -48,7 +48,7 @@ export type PoolsSlice = {
     fetchPools: (
       curve: CurveApi,
       poolIds: string[],
-      includeGaugeData: boolean,
+      options: { includeGaugeData: boolean },
     ) => Promise<{ poolsMapper: PoolDataMapper; poolDatas: PoolData[] } | undefined>
     fetchNewPool: (curve: CurveApi, poolId: string) => Promise<PoolData | undefined>
     fetchPoolsRewardsApy: (chainId: ChainId, poolDatas: PoolData[], useApi?: boolean) => Promise<void>
@@ -79,7 +79,7 @@ export const createPoolsSlice = (set: StoreApi<State>['setState'], get: StoreApi
   [SLICE_KEY]: {
     ...DEFAULT_STATE,
 
-    fetchPools: async (curve, poolIds, includeGaugeData) => {
+    fetchPools: async (curve, poolIds, { includeGaugeData }) => {
       const { pools, tokens } = get()
       const { chainId } = curve
 
@@ -161,7 +161,7 @@ export const createPoolsSlice = (set: StoreApi<State>['setState'], get: StoreApi
         curve.tricryptoFactory.fetchNewPools(),
         curve.stableNgFactory.fetchNewPools(),
       ])
-      const resp = await get()[SLICE_KEY].fetchPools(curve, [poolId], true)
+      const resp = await get()[SLICE_KEY].fetchPools(curve, [poolId], { includeGaugeData: true })
       return resp?.poolsMapper?.[poolId]
     },
     fetchPoolCurrenciesReserves: async (curve, poolData) => {


### PR DESCRIPTION
I think JJ thought this could be omitted in the new pool list, but we also use the (legacy) gauge data on the pool page itself as that still uses curve-js. Until we use prices API there as well we should always include gauge data when fetching pools.

You can test this by going into production and clicking a page with an inactive gauge. It won't show as inactive in the advanced details as it lacks this data.