### PR TITLE
feat: user pools position table

### DIFF
--- a/apps/main/src/dex/features/pool-list/PoolsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/PoolsTable.tsx
@@ -26,15 +26,19 @@ import { usePoolsGlobalFilterFn } from './hooks/usePoolsGlobalFilter'
 import { usePoolsPagination } from './hooks/usePoolsPagination'
 import { usePoolsSorting } from './hooks/usePoolsSorting'
 import { usePoolsTable } from './hooks/usePoolsTable'
-import { type PoolColumnVariant, usePoolsVisibility } from './hooks/usePoolsVisibility'
-import type { PoolRow } from './types'
+import { usePoolsVisibility } from './hooks/usePoolsVisibility'
+import type { PoolRow, PoolTableMeta } from './types'
 
 const LOCAL_STORAGE_KEY = 'dex-pool-list'
 const EMPTY_POOL_ROWS: readonly PoolRow[] = []
-const POOL_EXPANDED_PANEL_BODIES = {
-  full: props => <PoolExpandedPanel {...props} variant="full" />,
-  lite: props => <PoolExpandedPanel {...props} variant="lite" />,
-} satisfies Record<PoolColumnVariant, ExpandedPanelComponent<PoolRow>>
+
+const FullPoolExpandedPanel: ExpandedPanelComponent<PoolRow> = ({ row }) => (
+  <PoolExpandedPanel pool={row.original} variant="full" />
+)
+
+const LitePoolExpandedPanel: ExpandedPanelComponent<PoolRow> = ({ row }) => (
+  <PoolExpandedPanel pool={row.original} variant="lite" />
+)
 
 export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   const isLite = isLiteChain(network.chainId)
@@ -52,8 +56,8 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
 
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const { columnSettings, columnVisibility, toggleVisibility, variant } = usePoolsVisibility(LOCAL_STORAGE_KEY, {
-    isLite,
-    sorting,
+    variant: isLite ? 'lite' : 'full',
+    mobileColumn: sortField,
   })
 
   const { isFetching, onReload, pageCount, userHasPositions, tableQuery } = usePoolsTable({
@@ -73,7 +77,7 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
   const table = useCurveTable({
     columns: POOL_COLUMNS,
     query: tableQuery,
-    meta: { getRowHref: ({ url }) => url },
+    meta: { getRowHref: ({ url }) => url, variant } as PoolTableMeta,
     state: { expanded, sorting, columnVisibility, globalFilter, ...(!isLite && { pagination, columnFilters }) },
     getRowId: row => row.address,
     onExpandedChange: setExpanded,
@@ -100,7 +104,10 @@ export const PoolsTable = ({ network }: { network: NetworkConfig }) => {
           secondaryButton: { label: t`Telegram`, href: CURVE_SOCIALS.telegram.en },
         }}
         errorState={{ title: t`Unable to retrieve pool list`, description: tableQuery.error?.message, onReload }}
-        expandedPanel={{ Body: POOL_EXPANDED_PANEL_BODIES[variant], Actions: PoolExpandedPanelActions }}
+        expandedPanel={{
+          Body: isLite ? LitePoolExpandedPanel : FullPoolExpandedPanel,
+          Actions: PoolExpandedPanelActions,
+        }}
         shouldStickFirstColumn={Boolean(useIsTablet() && userHasPositions)}
       >
         <TableFilters

--- a/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from 'react'
+import { useConnection } from 'wagmi'
+import type { NetworkConfig } from '@/dex/types/main.types'
+import { EvmDataTable } from '@evm-ui/shared/ui/DataTable/EvmDataTable'
+import { TableFilters } from '@evm-ui/shared/ui/DataTable/TableFilters'
+import { TableHeader } from '@evm-ui/shared/ui/DataTable/TableHeader'
+import { TableVisibilitySettingsPopover } from '@evm-ui/shared/ui/DataTable/TableVisibilitySettingsPopover'
+import { EmptyStateEvmCard } from '@evm-ui/shared/ui/EmptyStateEvmCard'
+import { Metric } from '@evm-ui/shared/ui/Metric'
+import Stack from '@mui/material/Stack'
+import type { ExpandedState } from '@tanstack/react-table'
+import { constQ } from '@ui/features/queries/util'
+import { CenteredEmptyState } from '@ui/features/tables/CenteredEmptyState'
+import { useCurveTable } from '@ui/features/tables/data-table.utils'
+import type { ExpandedPanelComponent } from '@ui/features/tables/ExpansionRow'
+import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
+import { useIsTablet } from '@ui/hooks/useBreakpoints'
+import { useSwitch } from '@ui/hooks/useSwitch'
+import { t } from '@ui/lib/i18n'
+import { borderStyle, directChildrenAfterFirst } from '@ui/lib/mui'
+import { POOL_COLUMNS, PoolColumnId } from './columns'
+import { PoolExpandedPanel } from './components/PoolExpandedPanel'
+import { PoolExpandedPanelActions } from './components/PoolExpandedPanelActions'
+import { usePoolsGlobalFilterFn } from './hooks/usePoolsGlobalFilter'
+import { usePoolsVisibility } from './hooks/usePoolsVisibility'
+import { useUserPositionsTable } from './hooks/useUserPositionsTable'
+import type { PoolRow, PoolTableMeta } from './types'
+
+const { Spacing } = SizesAndSpaces
+
+const LOCAL_STORAGE_KEY = 'dex-user-pool-positions'
+const EMPTY_POOL_ROWS: readonly PoolRow[] = []
+const MAX_PAGE_SIZE = 10 as const
+
+const UserPositionsExpandedPanel: ExpandedPanelComponent<PoolRow> = ({ row }) => (
+  <PoolExpandedPanel pool={row.original} variant="userPositions" />
+)
+
+export const UserPositionsTable = ({ network }: { network: NetworkConfig }) => {
+  const { address } = useConnection()
+  const isTablet = useIsTablet()
+
+  const [expanded, setExpanded] = useState<ExpandedState>({})
+  const [searchText, setSearchText] = useState('')
+  const [visibilitySettingsOpen, openVisibilitySettings, closeVisibilitySettings] = useSwitch(false)
+  const visibilitySettingsRef = useRef<HTMLButtonElement>(null)
+  const { columnSettings, columnVisibility, toggleVisibility, variant } = usePoolsVisibility(LOCAL_STORAGE_KEY, {
+    variant: 'userPositions',
+    mobileColumn: PoolColumnId.Deposits,
+  })
+
+  const { tableQuery, totalLiquidityUsd, isFetching, onReload } = useUserPositionsTable({ network })
+
+  const globalFilterFn = usePoolsGlobalFilterFn(tableQuery.data ?? EMPTY_POOL_ROWS, searchText)
+
+  const table = useCurveTable({
+    columns: POOL_COLUMNS,
+    query: tableQuery,
+    meta: { getRowHref: ({ url }) => url, variant } as PoolTableMeta,
+    getRowId: row => row.address,
+    state: { expanded, columnVisibility, globalFilter: searchText },
+    initialState: { pagination: { pageIndex: 0, pageSize: MAX_PAGE_SIZE } },
+    onExpandedChange: setExpanded,
+    enableSorting: false,
+    globalFilterFn,
+  })
+  const rowCount = table.getFilteredRowModel().rows.length
+
+  return (
+    <Stack data-testid="user-pool-positions">
+      <TableHeader title={t`Your positions`} onReload={() => void onReload()} isLoading={isFetching} />
+      <Stack sx={directChildrenAfterFirst({ borderTop: borderStyle })}>
+        <Stack
+          sx={{ paddingBlock: Spacing.sm, paddingInline: Spacing.md, backgroundColor: t => t.design.Layer[1].Fill }}
+        >
+          <Metric
+            category="dex.userLiquidityDetails"
+            label={t`Total liquidity provided`}
+            value={address ? totalLiquidityUsd : constQ(undefined)}
+            valueOptions={{ unit: 'dollar' }}
+          />
+        </Stack>
+        {address ? (
+          <>
+            <EvmDataTable
+              category="limited"
+              table={table}
+              viewAllLabel={t`View all ${rowCount} pool positions`}
+              emptyState={{
+                title: searchText ? t`No matching positions` : t`No active positions`,
+                description: searchText
+                  ? t`Try another pool name, token symbol, or address.`
+                  : t`Provide liquidity to a pool to see your positions here.`,
+              }}
+              errorState={{ title: t`Could not load pool positions`, onReload }}
+              expandedPanel={{ Body: UserPositionsExpandedPanel, Actions: PoolExpandedPanelActions }}
+              shouldStickFirstColumn={Boolean(isTablet && rowCount)}
+            >
+              <TableFilters
+                testIdPrefix={LOCAL_STORAGE_KEY}
+                visibilitySettings={{
+                  anchorRef: visibilitySettingsRef,
+                  open: visibilitySettingsOpen,
+                  onOpen: openVisibilitySettings,
+                }}
+                searchText={searchText}
+                onSearch={value => {
+                  setSearchText(value)
+                  table.setPageIndex(0)
+                  setExpanded({})
+                }}
+                disableSearchAutoFocus
+              />
+            </EvmDataTable>
+            <TableVisibilitySettingsPopover
+              anchorRef={visibilitySettingsRef}
+              visibilityGroups={columnSettings}
+              toggleVisibility={toggleVisibility}
+              open={visibilitySettingsOpen}
+              onClose={closeVisibilitySettings}
+            />
+          </>
+        ) : (
+          <CenteredEmptyState>
+            <EmptyStateEvmCard button={{ type: 'connect-wallet', label: t`Connect to view positions` }} />
+          </CenteredEmptyState>
+        )}
+      </Stack>
+    </Stack>
+  )
+}

--- a/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
@@ -107,7 +107,6 @@ export const UserPositionsTable = ({ network }: { network: NetworkConfig }) => {
                 onSearch={value => {
                   setSearchText(value)
                   table.setPageIndex(0)
-                  setExpanded({})
                 }}
                 disableSearchAutoFocus
               />

--- a/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
+++ b/apps/main/src/dex/features/pool-list/UserPositionsTable.tsx
@@ -108,7 +108,6 @@ export const UserPositionsTable = ({ network }: { network: NetworkConfig }) => {
                   setSearchText(value)
                   table.setPageIndex(0)
                 }}
-                disableSearchAutoFocus
               />
             </EvmDataTable>
             <TableVisibilitySettingsPopover

--- a/apps/main/src/dex/features/pool-list/cells/DepositsCell.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/DepositsCell.tsx
@@ -1,0 +1,14 @@
+import { formatNumber } from '@primitives/number.utils'
+import { TokenInfo } from '@ui/components/TokenInfo'
+import type { PoolRow } from '../types'
+
+export const DepositsCell = ({ pool }: { pool: PoolRow }) => (
+  <TokenInfo
+    icon={null}
+    iconPosition="right"
+    primary={formatNumber(pool.userPosition.depositsUsd, 'usd.precise')}
+    secondary={`${formatNumber(pool.userPosition.lpBalance, 'token.balance')} LP`}
+    boldPrimary
+    sx={{ justifyContent: 'end' }}
+  />
+)

--- a/apps/main/src/dex/features/pool-list/cells/NetRateTooltipContent.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/NetRateTooltipContent.tsx
@@ -57,7 +57,7 @@ export const NetRateIncentivesTooltipItems = ({
 export const NetRateTooltipContent = ({ pool, volatile }: { pool: PoolRow; volatile: boolean }) => {
   const baseRate = getBaseApr(pool, 'daily')
   const netRate = getNetApr(pool)
-  const crvRateRange = pool.gauge && !pool.gauge.isKilled ? getCrvAprRange(pool) : null
+  const crvRateRange = pool.gauge?.isKilled ? null : getCrvAprRange(pool)
   const maxNetRate = crvRateRange ? netRate - crvRateRange.unboostedRate + crvRateRange.boostedRate : null
   const incentiveItems = getIncentivesItems(pool)
   const pointsCampaigns = getPointsCampaigns(pool)

--- a/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
+++ b/apps/main/src/dex/features/pool-list/cells/PoolTitleCell/index.tsx
@@ -7,15 +7,22 @@ import { Tooltip } from '@ui/components/Tooltip'
 import type { CurveTableFeatures } from '@ui/features/tables/data-table.utils'
 import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
 import { t } from '@ui/lib/i18n'
-import type { PoolRow } from '../../types'
+import type { PoolRow, PoolTableMeta } from '../../types'
 import { PoolBadges } from './PoolBadges'
 import { PoolTooltipContent } from './PoolTooltipContent'
 
 const { Spacing, Height } = SizesAndSpaces
 
-export const PoolTitleCell = ({ row: { original: pool } }: CellContext<CurveTableFeatures, PoolRow, string>) => (
+export const PoolTitleCell = ({
+  row: { original: pool },
+  table: {
+    options: { meta },
+  },
+}: CellContext<CurveTableFeatures, PoolRow, string>) => (
   <Stack direction="row" sx={{ height: Height.row }}>
-    {pool.hasPosition && <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />}
+    {(meta as PoolTableMeta).variant !== 'userPositions' && +pool.userPosition.lpBalance > 0 && (
+      <UserPositionIndicator tooltipTitle={t`You have a balance in this pool`} />
+    )}
     <Tooltip clickable title={pool.name} body={<PoolTooltipContent pool={pool} />} placement="top">
       <Stack direction="row" sx={{ alignItems: 'center', gap: Spacing.sm }}>
         <TokenIcons blockchainId={pool.blockchainId} tokens={pool.tradeableCoins} showTooltips={false} />

--- a/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
+++ b/apps/main/src/dex/features/pool-list/columns/column.definitions.tsx
@@ -2,6 +2,7 @@ import { createAppColumnHelper } from '@ui/features/tables/data-table.utils'
 import { AgeCell } from '../cells/AgeCell'
 import { BaseRateCell, WeeklyBaseRateCell } from '../cells/BaseRateCell'
 import { CrvRateCell } from '../cells/CrvRateCell'
+import { DepositsCell } from '../cells/DepositsCell'
 import { NetRateCell } from '../cells/NetRateCell'
 import { PointsCell } from '../cells/PointsCell'
 import { PoolTitleCell } from '../cells/PoolTitleCell'
@@ -12,6 +13,7 @@ import { getCrvAprRange, getNetApr, getRewardsApr } from '../cells/utils'
 import { AgeHeaderTooltipContent } from '../header-tooltips/AgeHeaderTooltipContent'
 import { BaseRateHeaderTooltipContent } from '../header-tooltips/BaseRateHeaderTooltipContent'
 import { CrvRateHeaderTooltipContent } from '../header-tooltips/CrvRateHeaderTooltipContent'
+import { DepositsHeaderTooltipContent } from '../header-tooltips/DepositsHeaderTooltipContent'
 import { NetRateHeaderTooltipContent } from '../header-tooltips/NetRateHeaderTooltipContent'
 import { PointsHeaderTooltipContent } from '../header-tooltips/PointsHeaderTooltipContent'
 import { PoolHeaderTooltipContent } from '../header-tooltips/PoolHeaderTooltipContent'
@@ -123,5 +125,14 @@ export const POOL_COLUMNS = columnHelper.columns([
     cell: AgeCell,
     meta: { type: 'numeric', tooltip: { title: POOL_TITLES[PoolColumnId.Age], body: <AgeHeaderTooltipContent /> } },
     sortUndefined: 'last',
+  }),
+  columnHelper.accessor(pool => pool.userPosition.depositsUsd, {
+    id: PoolColumnId.Deposits,
+    header: POOL_TITLES[PoolColumnId.Deposits],
+    cell: ({ row }) => <DepositsCell pool={row.original} />,
+    meta: {
+      type: 'numeric',
+      tooltip: { title: POOL_TITLES[PoolColumnId.Deposits], body: <DepositsHeaderTooltipContent /> },
+    },
   }),
 ])

--- a/apps/main/src/dex/features/pool-list/columns/column.options.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.options.ts
@@ -1,40 +1,71 @@
+import { recordEntries } from '@primitives/objects.utils'
 import type { VisibilityGroup } from '@ui/features/tables/visibility.types'
 import { t } from '@ui/lib/i18n'
 import { POOL_TITLES } from './column.titles'
 import { PoolColumnId } from './columns.enum'
 
-const createVisibility = ({ isLite }: { isLite: boolean }): VisibilityGroup<PoolColumnId>[] => [
+type ColumnVisibility = Record<PoolColumnId, { active: boolean; enabled: boolean }>
+
+const FULL_COLUMN_VISIBILITY = {
+  [PoolColumnId.PoolName]: { active: true, enabled: true },
+  [PoolColumnId.Tokens]: { active: false, enabled: true },
+  [PoolColumnId.NetRate]: { active: true, enabled: true },
+  [PoolColumnId.BaseRate]: { active: false, enabled: true },
+  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: true },
+  [PoolColumnId.CrvRate]: { active: false, enabled: true },
+  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
+  [PoolColumnId.Points]: { active: false, enabled: true },
+  [PoolColumnId.Volume]: { active: true, enabled: true },
+  [PoolColumnId.Tvl]: { active: true, enabled: true },
+  [PoolColumnId.Age]: { active: false, enabled: true },
+  [PoolColumnId.Deposits]: { active: false, enabled: false },
+} satisfies ColumnVisibility
+
+const LITE_COLUMN_VISIBILITY = {
+  [PoolColumnId.PoolName]: { active: true, enabled: true },
+  [PoolColumnId.Tokens]: { active: false, enabled: true },
+  [PoolColumnId.NetRate]: { active: true, enabled: true },
+  [PoolColumnId.BaseRate]: { active: false, enabled: false },
+  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: false },
+  [PoolColumnId.CrvRate]: { active: false, enabled: true },
+  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
+  [PoolColumnId.Points]: { active: false, enabled: true },
+  [PoolColumnId.Volume]: { active: false, enabled: false },
+  [PoolColumnId.Tvl]: { active: true, enabled: true },
+  [PoolColumnId.Age]: { active: false, enabled: false },
+  [PoolColumnId.Deposits]: { active: false, enabled: false },
+} satisfies ColumnVisibility
+
+const USER_POSITIONS_COLUMN_VISIBILITY = {
+  [PoolColumnId.PoolName]: { active: true, enabled: true },
+  [PoolColumnId.Tokens]: { active: false, enabled: false },
+  [PoolColumnId.NetRate]: { active: true, enabled: true },
+  [PoolColumnId.BaseRate]: { active: false, enabled: true },
+  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: true },
+  [PoolColumnId.CrvRate]: { active: false, enabled: true },
+  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
+  [PoolColumnId.Points]: { active: false, enabled: true },
+  [PoolColumnId.Volume]: { active: false, enabled: false },
+  [PoolColumnId.Tvl]: { active: false, enabled: false },
+  [PoolColumnId.Age]: { active: false, enabled: false },
+  [PoolColumnId.Deposits]: { active: true, enabled: true },
+} satisfies ColumnVisibility
+
+const createVisibility = (visibility: ColumnVisibility): VisibilityGroup<PoolColumnId>[] => [
   {
     label: t`Pools`,
-    options: [
-      { label: POOL_TITLES[PoolColumnId.Tokens], columns: [PoolColumnId.Tokens], active: false, enabled: true },
-      { label: POOL_TITLES[PoolColumnId.NetRate], columns: [PoolColumnId.NetRate], active: true, enabled: true },
-      { label: POOL_TITLES[PoolColumnId.BaseRate], columns: [PoolColumnId.BaseRate], active: false, enabled: !isLite },
-      {
-        label: POOL_TITLES[PoolColumnId.WeeklyBaseRate],
-        columns: [PoolColumnId.WeeklyBaseRate],
-        active: false,
-        enabled: !isLite,
-      },
-      { label: POOL_TITLES[PoolColumnId.CrvRate], columns: [PoolColumnId.CrvRate], active: false, enabled: true },
-      {
-        label: POOL_TITLES[PoolColumnId.RewardsRate],
-        columns: [PoolColumnId.RewardsRate],
-        active: false,
-        enabled: true,
-      },
-
-      { label: POOL_TITLES[PoolColumnId.Points], columns: [PoolColumnId.Points], active: false, enabled: true },
-      { label: POOL_TITLES[PoolColumnId.Volume], columns: [PoolColumnId.Volume], active: !isLite, enabled: !isLite },
-      { label: POOL_TITLES[PoolColumnId.Tvl], columns: [PoolColumnId.Tvl], active: true, enabled: true },
-      { label: POOL_TITLES[PoolColumnId.Age], columns: [PoolColumnId.Age], active: false, enabled: !isLite },
-    ],
+    options: recordEntries(visibility).map(([column, settings]) => ({
+      label: POOL_TITLES[column],
+      columns: [column],
+      ...settings,
+    })),
   },
 ]
 
 export const POOLS_COLUMN_OPTIONS = {
-  full: createVisibility({ isLite: false }),
-  lite: createVisibility({ isLite: true }),
+  full: createVisibility(FULL_COLUMN_VISIBILITY),
+  lite: createVisibility(LITE_COLUMN_VISIBILITY),
+  userPositions: createVisibility(USER_POSITIONS_COLUMN_VISIBILITY),
 }
 
 export const getDefaultPoolsSort = (isLite: boolean) => [

--- a/apps/main/src/dex/features/pool-list/columns/column.options.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.options.ts
@@ -26,7 +26,3 @@ export const POOLS_COLUMN_OPTIONS = {
   ),
   userPositions: createVisibility([PoolColumnId.Deposits], [PoolColumnId.Volume, PoolColumnId.Tvl, PoolColumnId.Age]),
 }
-
-export const getDefaultPoolsSort = (isLite: boolean) => [
-  { id: isLite ? PoolColumnId.Tvl : PoolColumnId.Volume, desc: true },
-]

--- a/apps/main/src/dex/features/pool-list/columns/column.options.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.options.ts
@@ -4,68 +4,27 @@ import { t } from '@ui/lib/i18n'
 import { POOL_TITLES } from './column.titles'
 import { PoolColumnId } from './columns.enum'
 
-type ColumnVisibility = Record<PoolColumnId, { active: boolean; enabled: boolean }>
+const DEFAULT_ACTIVE = [PoolColumnId.PoolName, PoolColumnId.NetRate] as const
 
-const FULL_COLUMN_VISIBILITY = {
-  [PoolColumnId.PoolName]: { active: true, enabled: true },
-  [PoolColumnId.Tokens]: { active: false, enabled: true },
-  [PoolColumnId.NetRate]: { active: true, enabled: true },
-  [PoolColumnId.BaseRate]: { active: false, enabled: true },
-  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: true },
-  [PoolColumnId.CrvRate]: { active: false, enabled: true },
-  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
-  [PoolColumnId.Points]: { active: false, enabled: true },
-  [PoolColumnId.Volume]: { active: true, enabled: true },
-  [PoolColumnId.Tvl]: { active: true, enabled: true },
-  [PoolColumnId.Age]: { active: false, enabled: true },
-  [PoolColumnId.Deposits]: { active: false, enabled: false },
-} satisfies ColumnVisibility
-
-const LITE_COLUMN_VISIBILITY = {
-  [PoolColumnId.PoolName]: { active: true, enabled: true },
-  [PoolColumnId.Tokens]: { active: false, enabled: true },
-  [PoolColumnId.NetRate]: { active: true, enabled: true },
-  [PoolColumnId.BaseRate]: { active: false, enabled: false },
-  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: false },
-  [PoolColumnId.CrvRate]: { active: false, enabled: true },
-  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
-  [PoolColumnId.Points]: { active: false, enabled: true },
-  [PoolColumnId.Volume]: { active: false, enabled: false },
-  [PoolColumnId.Tvl]: { active: true, enabled: true },
-  [PoolColumnId.Age]: { active: false, enabled: false },
-  [PoolColumnId.Deposits]: { active: false, enabled: false },
-} satisfies ColumnVisibility
-
-const USER_POSITIONS_COLUMN_VISIBILITY = {
-  [PoolColumnId.PoolName]: { active: true, enabled: true },
-  [PoolColumnId.Tokens]: { active: false, enabled: false },
-  [PoolColumnId.NetRate]: { active: true, enabled: true },
-  [PoolColumnId.BaseRate]: { active: false, enabled: true },
-  [PoolColumnId.WeeklyBaseRate]: { active: false, enabled: true },
-  [PoolColumnId.CrvRate]: { active: false, enabled: true },
-  [PoolColumnId.RewardsRate]: { active: false, enabled: true },
-  [PoolColumnId.Points]: { active: false, enabled: true },
-  [PoolColumnId.Volume]: { active: false, enabled: false },
-  [PoolColumnId.Tvl]: { active: false, enabled: false },
-  [PoolColumnId.Age]: { active: false, enabled: false },
-  [PoolColumnId.Deposits]: { active: true, enabled: true },
-} satisfies ColumnVisibility
-
-const createVisibility = (visibility: ColumnVisibility): VisibilityGroup<PoolColumnId>[] => [
+const createVisibility = (active: PoolColumnId[], disabled: PoolColumnId[]): VisibilityGroup<PoolColumnId>[] => [
   {
     label: t`Pools`,
-    options: recordEntries(visibility).map(([column, settings]) => ({
-      label: POOL_TITLES[column],
+    options: recordEntries(POOL_TITLES).map(([column, label]) => ({
+      label,
       columns: [column],
-      ...settings,
+      active: [...DEFAULT_ACTIVE, ...active].includes(column),
+      enabled: !disabled.includes(column),
     })),
   },
 ]
 
 export const POOLS_COLUMN_OPTIONS = {
-  full: createVisibility(FULL_COLUMN_VISIBILITY),
-  lite: createVisibility(LITE_COLUMN_VISIBILITY),
-  userPositions: createVisibility(USER_POSITIONS_COLUMN_VISIBILITY),
+  full: createVisibility([PoolColumnId.Volume, PoolColumnId.Tvl], [PoolColumnId.Deposits]),
+  lite: createVisibility(
+    [PoolColumnId.Tvl],
+    [PoolColumnId.BaseRate, PoolColumnId.WeeklyBaseRate, PoolColumnId.Volume, PoolColumnId.Age, PoolColumnId.Deposits],
+  ),
+  userPositions: createVisibility([PoolColumnId.Deposits], [PoolColumnId.Volume, PoolColumnId.Tvl, PoolColumnId.Age]),
 }
 
 export const getDefaultPoolsSort = (isLite: boolean) => [

--- a/apps/main/src/dex/features/pool-list/columns/column.titles.ts
+++ b/apps/main/src/dex/features/pool-list/columns/column.titles.ts
@@ -13,4 +13,5 @@ export const POOL_TITLES: Record<PoolColumnId, string> = {
   [PoolColumnId.Volume]: t`1D vol`,
   [PoolColumnId.Tvl]: t`TVL`,
   [PoolColumnId.Age]: t`Age`,
+  [PoolColumnId.Deposits]: t`Deposits`,
 }

--- a/apps/main/src/dex/features/pool-list/columns/columns.enum.ts
+++ b/apps/main/src/dex/features/pool-list/columns/columns.enum.ts
@@ -11,4 +11,5 @@ export enum PoolColumnId {
   Volume = 'volume',
   Tvl = 'tvl',
   Age = 'Age',
+  Deposits = 'Deposits',
 }

--- a/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
+++ b/apps/main/src/dex/features/pool-list/components/PoolExpandedPanel.tsx
@@ -1,5 +1,6 @@
 import { AddressActionInfo } from '@evm-ui/shared/ui/AddressActionInfo'
 import { Metric, type MetricProps } from '@evm-ui/shared/ui/Metric'
+import { formatToken } from '@evm-ui/utils'
 import { formatCappedRateValue } from '@evm-ui/utils/rates'
 import Grid from '@mui/material/Grid'
 import Stack from '@mui/material/Stack'
@@ -7,7 +8,7 @@ import Typography from '@mui/material/Typography'
 import { formatDate } from '@primitives/date.utils'
 import { maybe } from '@primitives/objects.utils'
 import { TokenLabel } from '@ui/components/TokenLabel'
-import type { ExpandedPanelComponent } from '@ui/features/tables/ExpansionRow'
+import { toQuery } from '@ui/features/queries/util'
 import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
 import { useCurrentDate } from '@ui/hooks/useCurrentDate'
 import { decimal } from '@ui/lib/decimal'
@@ -17,8 +18,7 @@ import { NetRateTooltipContent } from '../cells/NetRateTooltipContent'
 import { RewardIcons } from '../cells/RewardIcons'
 import { getBaseApr, getNetApr, isVolatileRate } from '../cells/utils'
 import { POOL_TITLES, PoolColumnId } from '../columns'
-import type { PoolColumnVariant } from '../hooks/usePoolsVisibility'
-import type { PoolRow } from '../types'
+import type { PoolRow, PoolTableVariant } from '../types'
 
 const { Spacing } = SizesAndSpaces
 const PRIMARY_METRIC_CATEGORY = 'dex.poolListMobileExpanded'
@@ -38,8 +38,6 @@ const getRateValueOptions = (
   disableTooltip: !hasTooltip,
   ...(volatile && { color: 'error', formatter: formatCappedRateValue }),
 })
-
-type PoolExpandedPanelProps = Parameters<ExpandedPanelComponent<PoolRow>>[0] & { variant: PoolColumnVariant }
 
 const PRIMARY_METRIC_SIZE = 6 as const
 
@@ -72,8 +70,7 @@ const PoolTokens = ({ pool }: { pool: PoolRow }) => (
   </Stack>
 )
 
-export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
-  const pool = row.original
+export const PoolExpandedPanel = ({ pool, variant }: { pool: PoolRow; variant: PoolTableVariant }) => {
   const currentDate = useCurrentDate()
   const baseRate = getBaseApr(pool, 'daily')
   const netRate = getNetApr(pool)
@@ -120,6 +117,18 @@ export const PoolExpandedPanel = ({ row, variant }: PoolExpandedPanelProps) => {
             value={decimal(pool.tvlUsd) ?? null}
             valueOptions={{ unit: 'dollar' }}
             testId="pool-tvl"
+          />
+        </Grid>
+      )}
+      {variant === 'userPositions' && (
+        <Grid size={PRIMARY_METRIC_SIZE}>
+          <Metric
+            category={PRIMARY_METRIC_CATEGORY}
+            label={POOL_TITLES[PoolColumnId.Deposits]}
+            value={pool.userPosition.depositsUsd}
+            valueOptions={{ unit: 'dollar' }}
+            notional={toQuery(formatToken(pool.userPosition.lpBalance, 'LP', 'balance'))}
+            testId="pool-deposits"
           />
         </Grid>
       )}

--- a/apps/main/src/dex/features/pool-list/header-tooltips/DepositsHeaderTooltipContent.tsx
+++ b/apps/main/src/dex/features/pool-list/header-tooltips/DepositsHeaderTooltipContent.tsx
@@ -1,0 +1,10 @@
+import { TooltipDescription, TooltipWrapper } from '@ui/components/TooltipComponents'
+import { t } from '@ui/lib/i18n'
+
+export const DepositsHeaderTooltipContent = () => (
+  <TooltipWrapper>
+    <TooltipDescription
+      text={t`USD value of your staked and unstaked LP tokens, calculated using the LP token price.`}
+    />
+  </TooltipWrapper>
+)

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsSorting.ts
@@ -3,7 +3,7 @@ import type { SortDirection as PoolSortDirection, V2PoolSortField as PoolSortFie
 import { useSortFromQueryString } from '@evm-ui/hooks/useSortFromQueryString'
 import { recordEntries } from '@primitives/objects.utils'
 import type { OnChangeFn, SortingState } from '@tanstack/react-table'
-import { POOL_TITLES, PoolColumnId, getDefaultPoolsSort } from '../columns'
+import { POOL_TITLES, PoolColumnId } from '../columns'
 import type { PoolsQueryUpdater } from '../filters/utils'
 
 const POOL_SORT_BY = {
@@ -36,6 +36,7 @@ type PoolsSortParams = { sortBy: PoolSortField; sortDirection: PoolSortDirection
 const SORT_OPTIONS = recordEntries(POOL_SORT_BY).map(([id]) => ({ id, label: POOL_TITLES[id] }))
 const LITE_SORT_OPTIONS = SORT_OPTIONS.filter(({ id }) => LITE_SORT_COLUMNS.has(id))
 
+const getDefaultPoolsSort = (isLite: boolean) => [{ id: isLite ? PoolColumnId.Tvl : PoolColumnId.Volume, desc: true }]
 const getPoolsSorting = (sorting: SortingState, defaultSort: SortingState, isLite: boolean): PoolsSorting => {
   const sort = [...sorting, ...defaultSort].find(
     ({ id }) => Object.hasOwn(POOL_SORT_BY, id) && (!isLite || LITE_SORT_COLUMNS.has(id as PoolColumnId)),

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsTable.ts
@@ -1,33 +1,22 @@
 import { useCallback } from 'react'
 import { isAddressEqual } from 'viem'
 import { useConnection } from 'wagmi'
-import {
-  resetLitePoolChains,
-  resetLitePoolList,
-  resetPoolChains,
-  resetPoolList,
-  useLitePoolChains,
-  useLitePoolList,
-  usePoolChains,
-  usePoolList,
-} from '@/dex/queries/pool-list.query'
-import { resetUserPoolPositions, useUserPoolPositions } from '@/dex/queries/user-pool-positions.query'
+import { resetPoolLists } from '@/dex/queries/invalidation'
+import { useLitePoolChains, useLitePoolList, usePoolChains, usePoolList } from '@/dex/queries/pool-list.query'
+import { useUserPoolPositions } from '@/dex/queries/user-pool-positions.query'
 import type { NetworkConfig } from '@/dex/types/main.types'
-import { getPath } from '@/dex/utils/utilsRouter'
 import type {
   LitePool,
   SortDirection as PoolSortDirection,
   V2Pool,
   V2PoolSortField as PoolSortField,
 } from '@curvefi/prices-api/pools'
-import { useCampaigns, type CampaignRewards } from '@evm-ui/entities/campaigns'
+import { useCampaigns } from '@evm-ui/entities/campaigns'
 import { isLiteChain } from '@evm-ui/features/connect-wallet/lib/wagmi/chains'
-import { DEX_ROUTES } from '@evm-ui/shared/routes'
-import { notFalsy } from '@primitives/objects.utils'
-import { q, useMappedQuery } from '@ui/features/queries/util'
-import { isVyperVulnerablePool } from '../alerts'
+import { useCombinedQueries } from '@evm-ui/lib'
+import { constQ, mapQuery, q, useMappedQuery } from '@ui/features/queries/util'
 import type { PoolsApiParams } from '../filters/utils'
-import type { PoolRow, PoolRowData } from '../types'
+import { enrichPoolRow, litePoolToRowData, poolToRowData } from '../utils'
 import { POOLS_PAGE_SIZE } from './usePoolsPagination'
 
 class UnsupportedPoolListError extends Error {
@@ -37,93 +26,8 @@ class UnsupportedPoolListError extends Error {
   }
 }
 
-/** Maps Prices API pool data into the source-independent pool-list model. */
-const poolToRowData = (pool: V2Pool): PoolRowData => ({
-  address: pool.address,
-  baseDailyApr: pool.baseDailyApr ?? undefined,
-  baseWeeklyApr: pool.baseWeeklyApr ?? undefined,
-  coins: pool.coins,
-  creationDate: pool.creationDate ?? undefined,
-  crvApr: pool.crvApr ?? undefined,
-  crvAprBoosted: pool.crvAprBoosted ?? undefined,
-  extraRewardsApr: pool.extraRewardsApr.map(({ address, apr, name, symbol }) => ({
-    address: address ?? undefined,
-    apr,
-    name: name ?? undefined,
-    symbol: symbol ?? undefined,
-  })),
-  gauge: pool.gauge ?? undefined,
-  gauges: pool.gauges,
-  isMetapool: pool.isMetapool ?? false,
-  name: pool.name,
-  poolType: pool.poolType ?? undefined,
-  tradeableCoins: pool.tradeableCoins.map(({ address, symbol }) => ({ address, symbol })),
-  tradingVolume24h: pool.tradingVolume24h,
-  tvlUsd: pool.tvlUsd ?? undefined,
-})
-
-/** Maps API2's Lite pool shape into the source-independent pool-list model. */
-const litePoolToRowData = (pool: LitePool): PoolRowData => {
-  const gauges = [...new Set(notFalsy(pool.gaugeAddress, pool.rootGaugeAddress))].map(address => ({
-    address,
-    isKilled: pool.gaugeIsKilled ?? false,
-  }))
-  const coins = (pool.coins ?? []).map(coin => ({ address: coin.address, symbol: coin.symbol ?? '' }))
-
-  return {
-    address: pool.address,
-    baseDailyApr: undefined,
-    baseWeeklyApr: undefined,
-    coins,
-    creationDate: undefined,
-    crvApr: pool.gaugeCrvApr?.[0],
-    crvAprBoosted: pool.gaugeCrvApr?.[1],
-    extraRewardsApr: (pool.gaugeExtraRewards ?? []).flatMap(reward =>
-      notFalsy(
-        reward.apr != null && {
-          address: reward.tokenAddress,
-          apr: reward.apr,
-          decimals: Number(reward.decimals),
-          name: reward.name,
-          price: reward.tokenPrice,
-          symbol: reward.symbol,
-        },
-      ),
-    ),
-    gauge: gauges[0],
-    gauges,
-    isMetapool: pool.isMetaPool,
-    name: pool.name ?? '',
-    poolType: undefined,
-    tradeableCoins: coins,
-    tradingVolume24h: undefined,
-    tvlUsd: pool.tvl,
-  }
-}
-
-/** Enriches a pool from the API into a fully fledged table row with all necessary data. */
-const enrichPoolRow = (
-  pool: PoolRowData,
-  {
-    chainId,
-    blockchainId,
-    hasPosition,
-    campaignsByAddress,
-  }: {
-    chainId: number
-    blockchainId: string
-    hasPosition: PoolRow['hasPosition']
-    campaignsByAddress?: Record<string, CampaignRewards[]>
-  },
-): PoolRow => ({
-  ...pool,
-  chainId,
-  blockchainId,
-  campaigns: campaignsByAddress?.[pool.address.toLocaleLowerCase()] ?? [],
-  hasPosition,
-  hasVyperVulnerability: isVyperVulnerablePool(chainId, pool.address),
-  url: getPath({ network: blockchainId }, `${DEX_ROUTES.PAGE_POOLS}/${pool.address}`),
-})
+const litePoolsToRows = ({ pools }: { pools: LitePool[] }) => pools.map(litePoolToRowData)
+const poolsToRows = ({ pools }: { pools: V2Pool[] }) => pools.map(poolToRowData)
 
 /** Fetches the selected pool-list source and maps its API rows into table rows. */
 export const usePoolsTable = ({
@@ -146,84 +50,65 @@ export const usePoolsTable = ({
   const isLite = isLiteChain(chainId)
 
   /** Network support */
-  const litePoolChainsQuery = useLitePoolChains({}, isLite)
-  const fullPoolChainsQuery = usePoolChains({}, !isLite)
-  const poolListSupportQuery = useMappedQuery(
-    isLite ? litePoolChainsQuery : fullPoolChainsQuery,
-    useCallback(poolChains => poolChains.some(poolChain => poolChain.chainId === chainId), [chainId]),
+  const litePoolChains = useLitePoolChains({}, isLite)
+  const fullPoolChains = usePoolChains({}, !isLite)
+  const poolListSupport = mapQuery(isLite ? litePoolChains : fullPoolChains, poolChains =>
+    poolChains.some(poolChain => poolChain.chainId === chainId),
   )
-  const isSupported = poolListSupportQuery.data ?? false
+  const isSupported = poolListSupport.data ?? false
 
-  const userPoolPositionsParams = { chainId, userAddress }
-  const { data: userPoolPositions, isFetching: isFetchingUserPoolPositions } = useUserPoolPositions(
-    userPoolPositionsParams,
-    isSupported,
+  const campaigns = useCampaigns({ blockchainId })
+  const positions = useUserPoolPositions({ chainId, userAddress }, isSupported)
+  const litePoolList = useLitePoolList({ chainId }, isLite && isSupported)
+  const poolList = usePoolList(
+    {
+      chainId,
+      page,
+      pageSize: POOLS_PAGE_SIZE,
+      searchString: searchText || undefined,
+      ...filters,
+      sortBy,
+      sortDirection,
+    },
+    !isLite && isSupported,
   )
-  const { data: campaignsByAddress } = useCampaigns({ blockchainId })
 
-  const toPoolRow = useCallback(
-    (poolData: PoolRowData) =>
-      enrichPoolRow(poolData, {
-        chainId,
-        blockchainId,
-        hasPosition: userPoolPositions?.positions.some(({ poolAddress }) =>
-          isAddressEqual(poolAddress, poolData.address),
+  const litePoolRows = useMappedQuery(litePoolList, litePoolsToRows)
+  const poolRows = useMappedQuery(poolList, poolsToRows)
+
+  // constQ suppresses loading state, and ?? null allows useCombinedQueries to run even when data is not yet loaded or present.
+  const enrichedPools = useCombinedQueries(
+    [isLite ? litePoolRows : poolRows, constQ(network), constQ(campaigns.data), constQ(positions.data ?? null)],
+    useCallback(
+      (pools, network, campaigns, positions) =>
+        pools.map(pool =>
+          enrichPoolRow(pool, network, campaigns, {
+            lpBalance:
+              positions?.positions.find(({ address }) => isAddressEqual(address, pool.address))?.totalBalance ?? '0',
+          }),
         ),
-        campaignsByAddress,
-      }),
-    [chainId, blockchainId, campaignsByAddress, userPoolPositions],
+      [],
+    ),
   )
 
-  /** Lite pools */
-  const litePoolListParams = { chainId }
-  const litePoolListQuery = useLitePoolList(litePoolListParams, isLite && isSupported)
-  const litePoolListTableQuery = useMappedQuery(
-    litePoolListQuery,
-    useCallback(({ pools }) => pools.map(pool => toPoolRow(litePoolToRowData(pool))), [toPoolRow]),
-  )
-
-  /** Normal network pools */
-  const poolListParams = {
-    chainId,
-    page,
-    pageSize: POOLS_PAGE_SIZE,
-    searchString: searchText || undefined,
-    ...filters,
-    sortBy,
-    sortDirection,
-  }
-  const poolListQuery = usePoolList(poolListParams, !isLite && isSupported)
-  const poolListTableQuery = useMappedQuery(
-    poolListQuery,
-    useCallback(({ pools }) => pools.map(pool => toPoolRow(poolToRowData(pool))), [toPoolRow]),
-  )
-
-  const tableQuery = poolListSupportQuery.data
-    ? isLite
-      ? litePoolListTableQuery
-      : poolListTableQuery
+  const tableQuery = poolListSupport.data
+    ? enrichedPools
     : q({
         data: undefined,
-        isLoading: poolListSupportQuery.isLoading,
-        error: poolListSupportQuery.data === false ? new UnsupportedPoolListError(chainId) : poolListSupportQuery.error,
+        isLoading: poolListSupport.isLoading,
+        error: poolListSupport.data === false ? new UnsupportedPoolListError(chainId) : poolListSupport.error,
       })
 
   return {
     isFetching:
-      isFetchingUserPoolPositions ||
+      positions.isFetching ||
+      campaigns.isLoading ||
       (isLite
-        ? litePoolChainsQuery.isFetching || litePoolListQuery.isFetching
-        : fullPoolChainsQuery.isFetching || poolListQuery.isFetching),
-    onReload: () =>
-      Promise.all([
-        resetPoolChains({}),
-        resetLitePoolChains({}),
-        resetLitePoolList(litePoolListParams),
-        resetPoolList(poolListParams),
-        resetUserPoolPositions(userPoolPositionsParams),
-      ]),
-    pageCount: isLite ? 1 : (poolListQuery.data?.pageCount ?? -1),
-    userHasPositions: tableQuery.data?.some(({ hasPosition }) => hasPosition),
+        ? litePoolChains.isFetching || litePoolList.isFetching
+        : fullPoolChains.isFetching || poolList.isFetching),
+    onReload: () => resetPoolLists({ chainId, userAddress }),
+    pageCount: isLite ? 1 : (poolList.data?.pageCount ?? -1),
+    userHasPositions: tableQuery.data?.some(({ userPosition }) => +userPosition.lpBalance > 0),
     tableQuery,
   }
 }

--- a/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
+++ b/apps/main/src/dex/features/pool-list/hooks/usePoolsVisibility.tsx
@@ -8,28 +8,27 @@ import type { MigrationOptions } from '@ui/features/storage/useStoredState'
 import type { VisibilityGroup } from '@ui/features/tables/visibility.types'
 import { useIsMobile } from '@ui/hooks/useBreakpoints'
 import { POOL_COLUMNS, POOLS_COLUMN_OPTIONS, PoolColumnId } from '../columns'
-import type { PoolsSorting } from './usePoolsSorting'
+import type { PoolTableVariant } from '../types'
 
-export type PoolColumnVariant = keyof typeof POOLS_COLUMN_OPTIONS
-
-const migration: MigrationOptions<Record<PoolColumnVariant, VisibilityGroup<PoolColumnId>[]>> = {
-  version: 5,
+const migration: MigrationOptions<Record<PoolTableVariant, VisibilityGroup<PoolColumnId>[]>> = {
+  version: 6,
   migrate: (oldValue, initialValue) =>
     mapRecord(initialValue, (variant, currentGroups) => preserveVisibilityChoices(oldValue[variant], currentGroups)),
 }
 
 /**
  * Create a map of column visibility for the pool list on mobile devices.
- * On mobile that is just the title and the column that is currently sorted.
+ * Show the title and the chosen metric, independently of how the table is sorted.
  */
-const createMobileColumns = (sortBy: PoolColumnId) =>
-  fromEntries(recordValues(PoolColumnId).map(key => [key, key === PoolColumnId.PoolName || key === sortBy]))
+const createMobileColumns = (mobileColumn: PoolColumnId) =>
+  fromEntries(recordValues(PoolColumnId).map(key => [key, key === PoolColumnId.PoolName || key === mobileColumn]))
 
-export function usePoolsVisibility(title: string, { isLite, sorting }: { isLite: boolean; sorting: PoolsSorting }) {
-  const variant: PoolColumnVariant = isLite ? 'lite' : 'full'
-  const [{ id: sortField }] = sorting
+export function usePoolsVisibility(
+  title: string,
+  { variant, mobileColumn }: { variant: PoolTableVariant; mobileColumn: PoolColumnId },
+) {
   const visibilitySettings = useVisibilitySettings(title, POOLS_COLUMN_OPTIONS, variant, POOL_COLUMNS, migration)
-  const columnVisibility = useMemo(() => createMobileColumns(sortField), [sortField])
+  const columnVisibility = useMemo(() => createMobileColumns(mobileColumn), [mobileColumn])
 
-  return { variant, sortField, ...visibilitySettings, ...(useIsMobile() && { columnVisibility }) }
+  return { variant, ...visibilitySettings, ...(useIsMobile() && { columnVisibility }) }
 }

--- a/apps/main/src/dex/features/pool-list/hooks/useUserPositionsTable.ts
+++ b/apps/main/src/dex/features/pool-list/hooks/useUserPositionsTable.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react'
+import { useConnection } from 'wagmi'
+import { resetPoolLists } from '@/dex/queries/invalidation'
+import { useUserPoolPositions } from '@/dex/queries/user-pool-positions.query'
+import type { NetworkConfig } from '@/dex/types/main.types'
+import { useCampaigns } from '@evm-ui/entities/campaigns'
+import { useCombinedQueries } from '@evm-ui/lib'
+import { useTokenUsdRates } from '@evm-ui/lib/model/entities/token-usd-rate'
+import { maybe } from '@primitives/objects.utils'
+import { constQ, mapQuery, useMappedQuery } from '@ui/features/queries/util'
+import { decimalCompare, decimalMultiply, decimalSum } from '@ui/lib/decimal'
+import { enrichPoolRow, poolToRowData } from '../utils'
+
+export const useUserPositionsTable = ({ network }: { network: NetworkConfig }) => {
+  const { chainId, blockchainId } = network
+  const { address: userAddress } = useConnection()
+
+  const campaigns = useCampaigns({ blockchainId })
+  const positions = useUserPoolPositions({ chainId, userAddress })
+
+  const { data: tokenAddresses } = useMappedQuery(
+    positions,
+    useCallback(({ positions }) => positions.map(({ lpTokenAddress }) => lpTokenAddress), []),
+  )
+  const tokenRates = useTokenUsdRates({ chainId, tokenAddresses }, !!userAddress)
+
+  // constQ suppresses loading state, and ?? null allows useCombinedQueries to run even when data is not yet loaded or present.
+  const tableQuery = useCombinedQueries(
+    [positions, constQ(network), constQ(campaigns.data), constQ(tokenRates.data ?? null)],
+    useCallback(
+      ({ positions }, network, campaigns, prices) =>
+        positions
+          .map(position =>
+            enrichPoolRow(poolToRowData(position), network, campaigns, {
+              lpBalance: position.totalBalance,
+              depositsUsd: maybe(prices?.[position.lpTokenAddress], price =>
+                decimalMultiply(position.totalBalance, price),
+              ),
+            }),
+          )
+          .toSorted((a, b) => decimalCompare(b.userPosition.depositsUsd ?? '0', a.userPosition.depositsUsd ?? '0')),
+      [],
+    ),
+  )
+
+  return {
+    isFetching: positions.isFetching || campaigns.isLoading,
+    onReload: () => resetPoolLists({ chainId, userAddress }),
+    tableQuery,
+    totalLiquidityUsd: mapQuery(tableQuery, rows =>
+      decimalSum(...rows.map(({ userPosition }) => userPosition.depositsUsd ?? '0')),
+    ),
+  }
+}

--- a/apps/main/src/dex/features/pool-list/index.tsx
+++ b/apps/main/src/dex/features/pool-list/index.tsx
@@ -3,6 +3,7 @@ import { useDexPoolListV2 } from '@evm-ui/hooks/useFeatureFlags'
 import { ListPageWrapper } from '@evm-ui/widgets/ListPageWrapper'
 import { LegacyPoolsTable } from './LegacyPoolsTable'
 import { PoolsTable } from './PoolsTable'
+import { UserPositionsTable } from './UserPositionsTable'
 
 export const PoolsList = () => {
   const network = useNetworkFromUrl()
@@ -10,7 +11,15 @@ export const PoolsList = () => {
 
   return (
     <ListPageWrapper>
-      {network && (isBetaPoolListEnabled ? <PoolsTable network={network} /> : <LegacyPoolsTable network={network} />)}
+      {network &&
+        (isBetaPoolListEnabled ? (
+          <>
+            <UserPositionsTable network={network} />
+            <PoolsTable network={network} />
+          </>
+        ) : (
+          <LegacyPoolsTable network={network} />
+        ))}
     </ListPageWrapper>
   )
 }

--- a/apps/main/src/dex/features/pool-list/types.ts
+++ b/apps/main/src/dex/features/pool-list/types.ts
@@ -3,6 +3,9 @@ import type { INetworkName } from '@curvefi/api/lib/interfaces'
 import type { CampaignRewards } from '@evm-ui/entities/campaigns'
 import type { Address } from '@primitives/address.utils'
 import type { Decimal } from '@primitives/decimal.utils'
+import type { TableMeta } from '@tanstack/react-table'
+import type { CurveTableFeatures } from '@ui/features/tables/data-table.utils'
+import type { POOLS_COLUMN_OPTIONS } from './columns/column.options'
 
 type PoolRowGauge = { address: Address; isKilled: boolean }
 
@@ -46,18 +49,27 @@ export type PoolRowData = {
   tvlUsd: number | undefined
 }
 
+type PoolUserPosition = {
+  /** Both staked and unstaked */
+  lpBalance: Decimal
+  depositsUsd?: Decimal
+}
+
 /** Additional pool context not in the main pool data (contextual information sourced with external sources) */
 type PoolRowContext = {
   chainId: number
   blockchainId: string
   campaigns: CampaignRewards[]
-  hasPosition: boolean | undefined
+  userPosition: PoolUserPosition
   hasVyperVulnerability: boolean | undefined
   url: string
 }
 
 /** Source-independent view model containing only data consumed by the pools table. */
 export type PoolRow = PoolRowData & PoolRowContext
+
+export type PoolTableVariant = keyof typeof POOLS_COLUMN_OPTIONS
+export type PoolTableMeta = TableMeta<CurveTableFeatures, PoolRow> & { variant: PoolTableVariant }
 
 export type LegacyPoolTag =
   'btc' | 'crypto' | 'kava' | 'eth' | 'usd' | 'others' | 'user' | 'crvusd' | 'tricrypto' | 'stableng' | 'cross-chain'

--- a/apps/main/src/dex/features/pool-list/utils.ts
+++ b/apps/main/src/dex/features/pool-list/utils.ts
@@ -1,0 +1,90 @@
+import type { NetworkConfig } from '@/dex/types/main.types'
+import { getPath } from '@/dex/utils/utilsRouter'
+import type { LitePool, V2Pool } from '@curvefi/prices-api/pools'
+import type { CampaignRewards } from '@evm-ui/entities/campaigns'
+import { DEX_ROUTES } from '@evm-ui/shared/routes'
+import { notFalsy } from '@primitives/objects.utils'
+import { isVyperVulnerablePool } from './alerts'
+import type { PoolRow, PoolRowData } from './types'
+
+/** Maps Prices API pool data into the source-independent pool-list model. */
+export const poolToRowData = (
+  pool: Pick<V2Pool, 'address' | 'name' | 'tradeableCoins' | 'extraRewardsApr'> & Partial<V2Pool>,
+): PoolRowData => ({
+  address: pool.address,
+  baseDailyApr: pool.baseDailyApr ?? undefined,
+  baseWeeklyApr: pool.baseWeeklyApr ?? undefined,
+  coins: pool.coins ?? pool.tradeableCoins,
+  creationDate: pool.creationDate ?? undefined,
+  crvApr: pool.crvApr ?? undefined,
+  crvAprBoosted: pool.crvAprBoosted ?? undefined,
+  extraRewardsApr: pool.extraRewardsApr.map(({ address, apr, name, symbol }) => ({
+    address: address ?? undefined,
+    apr,
+    name: name ?? undefined,
+    symbol: symbol ?? undefined,
+  })),
+  gauge: pool.gauge ?? undefined,
+  gauges: pool.gauges ?? [],
+  isMetapool: pool.isMetapool ?? false,
+  name: pool.name,
+  poolType: pool.poolType ?? undefined,
+  tradeableCoins: pool.tradeableCoins.map(({ address, symbol }) => ({ address, symbol })),
+  tradingVolume24h: pool.tradingVolume24h,
+  tvlUsd: pool.tvlUsd ?? undefined,
+})
+
+/** Maps API2's Lite pool shape into the source-independent pool-list model. */
+export const litePoolToRowData = (pool: LitePool): PoolRowData => {
+  const gauges = [...new Set(notFalsy(pool.gaugeAddress, pool.rootGaugeAddress))].map(address => ({
+    address,
+    isKilled: pool.gaugeIsKilled ?? false,
+  }))
+  const coins = (pool.coins ?? []).map(coin => ({ address: coin.address, symbol: coin.symbol ?? '' }))
+
+  return {
+    address: pool.address,
+    baseDailyApr: undefined,
+    baseWeeklyApr: undefined,
+    coins,
+    creationDate: undefined,
+    crvApr: pool.gaugeCrvApr?.[0],
+    crvAprBoosted: pool.gaugeCrvApr?.[1],
+    extraRewardsApr: (pool.gaugeExtraRewards ?? []).flatMap(reward =>
+      notFalsy(
+        reward.apr != null && {
+          address: reward.tokenAddress,
+          apr: reward.apr,
+          decimals: Number(reward.decimals),
+          name: reward.name,
+          price: reward.tokenPrice,
+          symbol: reward.symbol,
+        },
+      ),
+    ),
+    gauge: gauges[0],
+    gauges,
+    isMetapool: pool.isMetaPool,
+    name: pool.name ?? '',
+    poolType: undefined,
+    tradeableCoins: coins,
+    tradingVolume24h: undefined,
+    tvlUsd: pool.tvl,
+  }
+}
+
+/** Enriches a pool from the API into a fully fledged table row with all necessary data. */
+export const enrichPoolRow = (
+  pool: PoolRowData,
+  { chainId, blockchainId }: NetworkConfig,
+  campaignsByAddress: Record<string, CampaignRewards[]> | null | undefined,
+  userPosition: PoolRow['userPosition'] = { lpBalance: '0' },
+): PoolRow => ({
+  ...pool,
+  chainId,
+  blockchainId,
+  campaigns: campaignsByAddress?.[pool.address.toLowerCase()] ?? [],
+  hasVyperVulnerability: isVyperVulnerablePool(chainId, pool.address),
+  url: getPath({ network: blockchainId }, `${DEX_ROUTES.PAGE_POOLS}/${pool.address}`),
+  userPosition,
+})

--- a/apps/main/src/dex/queries/invalidation.ts
+++ b/apps/main/src/dex/queries/invalidation.ts
@@ -1,8 +1,17 @@
-import type { UserPoolParams } from '@evm-ui/lib/model'
+import { getCampaignsExternalQueryKey } from '@evm-ui/entities/campaigns/campaigns-external'
+import { getCampaignsPoolsMerklQueryKey } from '@evm-ui/entities/campaigns/campaigns-pools-merkl'
+import type { UserChainParams, UserPoolParams } from '@evm-ui/lib/model'
+import { queryClient } from '@ui/features/queries/query-client'
+import {
+  getLitePoolListQueryKey,
+  getPoolListRootQueryKey,
+  getPoolChainsQueryKey,
+  getLitePoolChainsQueryKey,
+} from './pool-list.query'
 import { invalidateUserPoolBalancesQuery } from './user-pool-balances.query'
 import { invalidateUserPoolBoostQuery } from './user-pool-boost.query'
 import { invalidateUserPoolLiquidityUsdQuery } from './user-pool-liquidity-usd.query'
-import { invalideUserPoolPositions } from './user-pool-positions.query'
+import { getUserPoolPositionsQueryKey, invalideUserPoolPositions } from './user-pool-positions.query'
 import { invalidateUserPoolRewardCrvApyQuery } from './user-pool-reward-crv-apy.query'
 import { invalidateUserPoolShareQuery } from './user-pool-share.query'
 
@@ -19,3 +28,16 @@ export const invalidateUserPoolInfo = async (params: UserPoolParams) => {
     invalideUserPoolPositions(params),
   ])
 }
+
+export const resetPoolLists = ({ chainId, userAddress }: UserChainParams) =>
+  Promise.all(
+    [
+      getPoolListRootQueryKey({ chainId }),
+      getLitePoolListQueryKey({ chainId }),
+      getPoolChainsQueryKey({}),
+      getLitePoolChainsQueryKey({}),
+      getUserPoolPositionsQueryKey({ chainId, userAddress }),
+      getCampaignsExternalQueryKey({}),
+      getCampaignsPoolsMerklQueryKey({}),
+    ].map(queryKey => queryClient.resetQueries({ queryKey })),
+  )

--- a/apps/main/src/dex/queries/pool-list.query.ts
+++ b/apps/main/src/dex/queries/pool-list.query.ts
@@ -6,7 +6,7 @@ import {
   type ListPoolsParams,
 } from '@curvefi/prices-api/pools'
 import { createValidationSuite, EmptyValidationSuite, type FieldsOf } from '@evm-ui/lib'
-import { queryFactory, rootKeys, type ChainQuery } from '@evm-ui/lib/model'
+import { queryFactory, rootKeys, type ChainParams, type ChainQuery } from '@evm-ui/lib/model'
 import { chainValidationGroup } from '@evm-ui/lib/model/query/chain-validation'
 import { getPageCount } from '@evm-ui/utils'
 
@@ -29,7 +29,10 @@ type PoolListRequestParams = Pick<
 type PoolListQuery = ChainQuery & PoolListRequestParams & { pageSize?: ListPoolsParams['pagination'] }
 type PoolListParams = FieldsOf<PoolListQuery>
 
-export const { reset: resetPoolList, useQuery: usePoolList } = queryFactory({
+export const getPoolListRootQueryKey = ({ chainId }: ChainParams) =>
+  [...rootKeys.chain({ chainId }), 'listPools'] as const
+
+export const { useQuery: usePoolList, queryKey: getPoolListQueryKey } = queryFactory({
   queryKey: ({
     chainId,
     page,
@@ -48,8 +51,7 @@ export const { reset: resetPoolList, useQuery: usePoolList } = queryFactory({
     sortDirection,
   }: PoolListParams) =>
     [
-      ...rootKeys.chain({ chainId }),
-      'listPools',
+      ...getPoolListRootQueryKey({ chainId }),
       { page },
       { pageSize },
       { searchString },
@@ -78,21 +80,21 @@ export const { reset: resetPoolList, useQuery: usePoolList } = queryFactory({
 type LitePoolListQuery = ChainQuery
 type LitePoolListParams = FieldsOf<LitePoolListQuery>
 
-export const { reset: resetLitePoolList, useQuery: useLitePoolList } = queryFactory({
+export const { useQuery: useLitePoolList, queryKey: getLitePoolListQueryKey } = queryFactory({
   queryKey: ({ chainId }: LitePoolListParams) => [...rootKeys.chain({ chainId }), 'listLitePools'] as const,
   queryFn: (params: LitePoolListQuery) => listLitePools(params),
   validationSuite: createValidationSuite(chainValidationGroup),
   category: 'dex.pools',
 })
 
-export const { reset: resetPoolChains, useQuery: usePoolChains } = queryFactory({
+export const { useQuery: usePoolChains, queryKey: getPoolChainsQueryKey } = queryFactory({
   queryKey: () => ['listPoolChains'] as const,
   queryFn: () => listPoolChains(),
   validationSuite: EmptyValidationSuite,
   category: 'dex.network',
 })
 
-export const { reset: resetLitePoolChains, useQuery: useLitePoolChains } = queryFactory({
+export const { useQuery: useLitePoolChains, queryKey: getLitePoolChainsQueryKey } = queryFactory({
   queryKey: () => ['listLitePoolChains'] as const,
   queryFn: () => listLitePoolChains(),
   validationSuite: EmptyValidationSuite,

--- a/apps/main/src/dex/queries/user-pool-positions.query.ts
+++ b/apps/main/src/dex/queries/user-pool-positions.query.ts
@@ -1,17 +1,33 @@
-import { getUserPoolPositions } from '@curvefi/prices-api/pools'
+import { paginate } from '@curvefi/prices-api/paginate'
+import { getUserPoolPositions, MAX_USER_POOL_PAGE_SIZE } from '@curvefi/prices-api/pools'
 import { createValidationSuite } from '@evm-ui/lib'
 import { queryFactory, rootKeys, type UserChainParams, type UserChainQuery } from '@evm-ui/lib/model'
 import { chainValidationGroup } from '@evm-ui/lib/model/query/chain-validation'
 import { userAddressValidationGroup } from '@evm-ui/lib/model/query/evm-address-validation'
+import { decimalDiv, decimalSum } from '@ui/lib/decimal'
 
 export const {
   useQuery: useUserPoolPositions,
+  queryKey: getUserPoolPositionsQueryKey,
   invalidate: invalideUserPoolPositions,
-  reset: resetUserPoolPositions,
 } = queryFactory({
   queryKey: ({ chainId, userAddress }: UserChainParams) =>
     [...rootKeys.userChain({ chainId, userAddress }), 'getUserPoolPositions'] as const,
-  queryFn: ({ chainId, userAddress }: UserChainQuery) => getUserPoolPositions({ chainId, userAddress }),
+  queryFn: async ({ chainId, userAddress }: UserChainQuery) => {
+    const positions = await paginate(
+      async (page, pagination) => (await getUserPoolPositions({ chainId, userAddress, page, pagination })).positions,
+      1,
+      MAX_USER_POOL_PAGE_SIZE,
+    )
+    return {
+      chainId,
+      user: userAddress,
+      positions: positions.map(position => ({
+        ...position,
+        totalBalance: decimalDiv(decimalSum(position.lpBalance, position.gaugeBalance), '1e18'),
+      })),
+    }
+  },
   validationSuite: createValidationSuite((params: UserChainParams) => {
     chainValidationGroup(params)
     userAddressValidationGroup(params)

--- a/apps/main/src/llamalend/features/market-list/UserPositionsTables.tsx
+++ b/apps/main/src/llamalend/features/market-list/UserPositionsTables.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react'
 import { useConnection } from 'wagmi'
 import type { LlamaMarketsTableResult } from '@/llamalend/queries/market-list/llama-market-stats'
 import type { LlamaMarket } from '@/llamalend/queries/market-list/llama-markets'
@@ -10,13 +9,11 @@ import { MarketRateType } from '@evm-ui/types/market'
 import Stack from '@mui/material/Stack'
 import { fromEntries, maybe, recordValues } from '@primitives/objects.utils'
 import { mapQuery, QueryProp } from '@ui/features/queries/util'
-import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
+import { CenteredEmptyState } from '@ui/features/tables/CenteredEmptyState'
 import { t } from '@ui/lib/i18n'
 import { borderStyle, directChildrenAfterFirst } from '@ui/lib/mui'
 import { UserPositionsMarketRateTable } from './UserPositionsMarketRateTable'
 import { UserPositionSummary } from './UserPositionsSummary'
-
-const { Spacing } = SizesAndSpaces
 
 type UserPositionsTableProps = { onReload: () => void; tableQuery: QueryProp<LlamaMarketsTableResult> }
 
@@ -26,12 +23,6 @@ const buildVaultUrl = (market: LlamaMarket) =>
     market.chain,
     `${LEND_ROUTES.PAGE_MARKETS}/${market.controllerAddress}${LEND_MARKET_ROUTES.PAGE_VAULT}`,
   )
-
-const CenteredEmptyState = ({ children }: { children: ReactNode }) => (
-  <Stack sx={{ alignItems: 'center', paddingBlock: Spacing.md, backgroundColor: t => t.design.Layer[1].Fill }}>
-    {children}
-  </Stack>
-)
 
 export const UserPositionsTables = ({
   onReload,

--- a/packages/evm-ui/src/entities/campaigns/campaigns-external.ts
+++ b/packages/evm-ui/src/entities/campaigns/campaigns-external.ts
@@ -46,7 +46,7 @@ const REWARDS = groupBy(
  *
  * @returns TanStack Query result with all active campaigns grouped by pool address
  */
-export const { getQueryOptions: getCampaignsExternalOptions } = queryFactory({
+export const { getQueryOptions: getCampaignsExternalOptions, queryKey: getCampaignsExternalQueryKey } = queryFactory({
   queryKey: () => ['campaigns-external'] as const,
   // eslint-disable-next-line @typescript-eslint/require-await -- Existing violation before enabling this rule.
   queryFn: async () => {

--- a/packages/evm-ui/src/entities/campaigns/campaigns-pools-merkl.ts
+++ b/packages/evm-ui/src/entities/campaigns/campaigns-pools-merkl.ts
@@ -2,10 +2,11 @@ import { EmptyValidationSuite } from '@evm-ui/lib'
 import { queryFactory } from '@evm-ui/lib/model'
 import { fetchMerklRewards } from './merkl'
 
-export const { getQueryOptions: getCampaignsPoolsMerklOptions } = queryFactory({
-  queryKey: () => ['campaigns-pools-merkl'] as const,
-  queryFn: async () =>
-    await fetchMerklRewards({ mainProtocolId: 'curve', test: false, status: 'LIVE', action: 'POOL' }),
-  validationSuite: EmptyValidationSuite,
-  category: 'global.campaigns',
-})
+export const { getQueryOptions: getCampaignsPoolsMerklOptions, queryKey: getCampaignsPoolsMerklQueryKey } =
+  queryFactory({
+    queryKey: () => ['campaigns-pools-merkl'] as const,
+    queryFn: async () =>
+      await fetchMerklRewards({ mainProtocolId: 'curve', test: false, status: 'LIVE', action: 'POOL' }),
+    validationSuite: EmptyValidationSuite,
+    category: 'global.campaigns',
+  })

--- a/packages/prices-api/src/pools/constants.ts
+++ b/packages/prices-api/src/pools/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_USER_POOL_PAGE_SIZE = 50

--- a/packages/prices-api/src/pools/index.ts
+++ b/packages/prices-api/src/pools/index.ts
@@ -5,6 +5,7 @@ import { getTimeRange } from '../timestamp'
 import * as Schema from './schema'
 
 export type * from './schema'
+export { MAX_USER_POOL_PAGE_SIZE } from './constants'
 
 const LITE_POOLS_HOST = 'https://api2.curve.finance'
 
@@ -113,11 +114,17 @@ export async function listPoolRegistries({ chainId }: { chainId: number }, optio
 }
 
 export async function getUserPoolPositions(
-  { chainId, userAddress, newTx }: { chainId: number; userAddress: Address; newTx?: Hex },
+  {
+    chainId,
+    userAddress,
+    newTx,
+    page,
+    pagination,
+  }: { chainId: number; userAddress: Address; newTx?: Hex; page?: number; pagination?: number },
   options?: Options,
 ) {
   const host = getHost(options)
-  const query = addQueryString({ new_tx: newTx })
+  const query = addQueryString({ new_tx: newTx, page, pagination })
   const response = await fetch(`${host}/v2/pools/${chainId}/users/${userAddress}/positions${query}`, {
     signal: options?.signal,
   })

--- a/packages/prices-api/src/pools/schema.ts
+++ b/packages/prices-api/src/pools/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v4'
 import { notFalsy } from '@primitives/objects.utils'
 import { address, camelizeKeys, chain, decimal, sortDirection, timestamp } from '../schemas'
+import { MAX_USER_POOL_PAGE_SIZE } from './constants'
 
 const rawCoin = z.object({ pool_index: z.number(), symbol: z.string(), address })
 
@@ -47,17 +48,6 @@ const poolTotals = z
   })
   .transform(camelizeKeys)
   .transform(({ totalTvl, ...data }) => ({ ...data, tvl: totalTvl }))
-
-const userPoolPosition = z
-  .object({
-    chain_id: z.number(),
-    pool_name: z.string(),
-    pool_address: address,
-    lp_token_address: address,
-    lp_balance: decimal,
-    gauge_balance: decimal,
-  })
-  .transform(camelizeKeys)
 
 const volume = z.object({ timestamp, volume: z.number(), fees: z.number() })
 
@@ -256,13 +246,34 @@ const v2Gauge = z
   .transform(camelizeKeys)
   .transform(({ isKilled, ...data }) => ({ ...data, isKilled: isKilled ?? false }))
 
-const v2Pool = z
-  .object({
-    chain_id: z.number(),
+// Sorry for the lack of a better name, but these are just a select few shared props between pool and user pool props
+const poolProperties = z.object({
+  chain_id: z.number(),
+  pool_type: poolType.nullable().optional(),
+  tradeable_coins: z.array(v2Coin).default([]),
+  base_daily_apr: z.number().nullable().optional(),
+  base_weekly_apr: z.number().nullable().optional(),
+  crv_apr: z.number().nullable().optional(),
+  crv_apr_boosted: z.number().nullable().optional(),
+  extra_rewards_apr: z.array(v2ExtraRewardApr).default([]),
+})
+
+const userPoolPosition = poolProperties
+  .extend({
+    pool_name: z.string(),
+    pool_address: address,
+    lp_token_address: address,
+    lp_balance: decimal,
+    gauge_balance: decimal,
+  })
+  .transform(camelizeKeys)
+  .transform(({ poolName, poolAddress, ...data }) => ({ ...data, name: poolName, address: poolAddress }))
+
+const v2Pool = poolProperties
+  .extend({
     name: z.string(),
     address,
     creation_date: timestamp.nullable(),
-    pool_type: poolType.nullable().optional(),
     is_metapool: z.boolean().nullable().optional(),
     base_pool: address.nullable().optional(),
     tvl_usd: z.number().nullable().optional(),
@@ -271,20 +282,14 @@ const v2Pool = z
     liquidity_volume_24h: z.number(),
     liquidity_fee_24h: z.number(),
     coins: z.array(v2Coin),
-    tradeable_coins: z.array(v2Coin),
-    base_daily_apr: z.number().nullable().optional(),
-    base_weekly_apr: z.number().nullable().optional(),
-    crv_apr: z.number().nullable().optional(),
-    crv_apr_boosted: z.number().nullable().optional(),
-    extra_rewards_apr: z.array(v2ExtraRewardApr).optional(),
     vyper_version: z.string().nullable().optional(),
     gauges: z.array(v2Gauge).optional(),
   })
   .transform(camelizeKeys)
-  .transform(({ extraRewardsApr, gauges, ...data }) => {
+  .transform(({ gauges, ...data }) => {
     const poolGauges = gauges ?? []
 
-    return { ...data, extraRewardsApr: extraRewardsApr ?? [], gauge: poolGauges[0] ?? null, gauges: poolGauges }
+    return { ...data, gauge: poolGauges[0] ?? null, gauges: poolGauges }
   })
 
 const v2PoolRegistry = z.object({ chain_id: z.number(), address, type: poolType }).transform(camelizeKeys)
@@ -426,7 +431,14 @@ export const listLitePoolsResponse = z
   .transform(({ data, generatedTimeMs }) => ({ pools: data.poolData ?? [], totalTvl: data.tvl, generatedTimeMs }))
 
 export const getUserPoolPositionsResponse = z
-  .object({ chain_id: z.number(), user: address, positions: z.array(userPoolPosition).default([]) })
+  .object({
+    page: z.number().int().positive(),
+    pagination: z.number().int().positive().max(MAX_USER_POOL_PAGE_SIZE),
+    count: z.number().int().nonnegative(),
+    chain_id: z.number(),
+    user: address,
+    positions: z.array(userPoolPosition).default([]),
+  })
   .transform(camelizeKeys)
 
 export const getVolumeResponse = z.object({ data: z.array(volume) }).transform(({ data }) => data)

--- a/packages/ui/src/features/tables/CenteredEmptyState.tsx
+++ b/packages/ui/src/features/tables/CenteredEmptyState.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+import Stack from '@mui/material/Stack'
+import { SizesAndSpaces } from '@ui/features/themes/design/1_sizes_spaces'
+
+const { Spacing } = SizesAndSpaces
+
+export const CenteredEmptyState = ({ children }: { children: ReactNode }) => (
+  <Stack sx={{ alignItems: 'center', paddingBlock: Spacing.md, backgroundColor: t => t.design.Layer[1].Fill }}>
+    {children}
+  </Stack>
+)

--- a/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
+++ b/tests/cypress/component/dex/pool-list-tooltip-content.cy.tsx
@@ -74,7 +74,7 @@ const createPool = (): PoolRow => ({
   gauge: { address: GAUGE_ADDRESS, isKilled: false },
   gauges: [{ address: GAUGE_ADDRESS, isKilled: false }],
   campaigns: [BOLD_CAMPAIGN, BOLD_APR_CAMPAIGN],
-  hasPosition: false,
+  userPosition: { lpBalance: '0' },
   hasVyperVulnerability: false,
   isMetapool: false,
   chainId: Chain.Ethereum,


### PR DESCRIPTION
Adds a new user pool positions table on top of the pools list. For now by default it shows just the pool name, net APR and the new deposits column.

The USD values are not returned by the API, so we'll have to use `useTokenUsdRates` for the time being. Using `useTokenUsdRates` may take a bit of time, which shouldn't block the table in a loading state. Because of this, both sorting and pagination happen client side, even though there's pagination in the endpoint call already.

A good address for testing is Convex with `0x989AEb4d175e16225E39E87d0D97A3360524AD80`.
I did not decide to hide this feature behind a beta flag; if it works it's good enough to immediately roll out and extend later.

<img width="1552" height="436" alt="image" src="https://github.com/user-attachments/assets/9d9f69a8-358a-4850-824c-c6d93812bcb9" />
