### PR TITLE
feat: add admin fee through prices api

### DIFF
--- a/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
+++ b/apps/main/src/llamalend/features/market-advanced-information/MarketLoanParameters.tsx
@@ -22,32 +22,33 @@ export const MarketLoanParameters = ({
     <>
       {(!apiMarket.data || marketId) && (
         // these fields are not exposed by the API yet
-        <>
-          <ActionInfo
-            testId="market-param-amm-swap-fee"
-            label={t`AMM swap fee`}
-            labelTooltip={{
-              title: t`The LLAMMA fee applied when collateral is gradually converted across liquidation bands.`,
-            }}
-            value={mapQuery(
-              mapQuery(parameters, d => d.fee),
-              value => formatNumber(value, 'percent.rate'),
-            )}
-          />
-
-          <ActionInfo
-            testId="market-param-admin-fee"
-            label={t`Admin fee`}
-            labelTooltip={{
-              title: t`The share of market interest routed to the market admin or fee receiver instead of lenders.`,
-            }}
-            value={mapQuery(
-              mapQuery(parameters, d => d.admin_fee),
-              value => formatNumber(value, 'percent.rate'),
-            )}
-          />
-        </>
+        <ActionInfo
+          testId="market-param-amm-swap-fee"
+          label={t`AMM swap fee`}
+          labelTooltip={{
+            title: t`The LLAMMA fee applied when collateral is gradually converted across liquidation bands.`,
+          }}
+          value={mapQuery(
+            mapQuery(parameters, d => d.fee),
+            value => formatNumber(value, 'percent.rate'),
+          )}
+        />
       )}
+
+      <ActionInfo
+        testId="market-param-admin-fee"
+        label={t`Admin fee`}
+        labelTooltip={{
+          title: t`The share of market interest routed to the market admin or fee receiver instead of lenders.`,
+        }}
+        value={mapQuery(
+          fallbackQ(
+            mapQuery(parameters, p => p.admin_fee),
+            mapQuery(apiMarket, m => m.parameters.adminFee),
+          ),
+          value => formatNumber(value, 'percent.rate'),
+        )}
+      />
 
       <ActionInfo
         testId="market-param-band-width-factor"

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -59,7 +59,7 @@ export type LlamaMarket = {
   oraclePrice?: number
   monetaryPolicyAddress?: Address
   oracleAddress?: Address
-  parameters: { A: number | null; loanDiscount: Decimal; liquidationDiscount: Decimal }
+  parameters: { A: number | null; loanDiscount: Decimal; liquidationDiscount: Decimal; adminFee: number }
   utilizationPercent: number
   liquidity: number
   liquidityUsd: number
@@ -139,6 +139,7 @@ const convertLendingVault = (
     priceOracle,
     policy,
     oracle,
+    adminFee,
   }: LendingVault,
   favoriteMarkets: Set<Address>,
   campaigns: Record<string, CampaignRewards[]> = {},
@@ -186,6 +187,7 @@ const convertLendingVault = (
       A: ammA,
       loanDiscount: scaledFractionToPercent(loanDiscount),
       liquidationDiscount: scaledFractionToPercent(liquidationDiscount),
+      adminFee: (adminFee / 10 ** 18) * 100,
     },
     utilizationPercent: totalAssetsUsd && (100 * totalDebtUsd) / totalAssetsUsd,
     solvencyPercent,
@@ -322,6 +324,7 @@ const convertMintMarket = (
       A: ammA ?? null,
       loanDiscount: scaledFractionToPercent(loanDiscount),
       liquidationDiscount: scaledFractionToPercent(liquidationDiscount),
+      adminFee: 0,
     },
     utilizationPercent: Math.min(100, (100 * borrowed) / debtCeiling), // debt ceiling may be lowered, so cap at 100%
     // solvency is only relevant for lending markets; if mint markets have bad debt that's a protocol problem, not a user problem

--- a/apps/main/src/llamalend/queries/market-list/llama-markets.ts
+++ b/apps/main/src/llamalend/queries/market-list/llama-markets.ts
@@ -59,7 +59,7 @@ export type LlamaMarket = {
   oraclePrice?: number
   monetaryPolicyAddress?: Address
   oracleAddress?: Address
-  parameters: { A: number | null; loanDiscount: Decimal; liquidationDiscount: Decimal; adminFee: number }
+  parameters: { A: number | null; loanDiscount: Decimal; liquidationDiscount: Decimal; adminFee: Decimal }
   utilizationPercent: number
   liquidity: number
   liquidityUsd: number
@@ -187,7 +187,7 @@ const convertLendingVault = (
       A: ammA,
       loanDiscount: scaledFractionToPercent(loanDiscount),
       liquidationDiscount: scaledFractionToPercent(liquidationDiscount),
-      adminFee: (adminFee / 10 ** 18) * 100,
+      adminFee: scaledFractionToPercent(adminFee),
     },
     utilizationPercent: totalAssetsUsd && (100 * totalDebtUsd) / totalAssetsUsd,
     solvencyPercent,
@@ -324,7 +324,7 @@ const convertMintMarket = (
       A: ammA ?? null,
       loanDiscount: scaledFractionToPercent(loanDiscount),
       liquidationDiscount: scaledFractionToPercent(liquidationDiscount),
-      adminFee: 0,
+      adminFee: '0',
     },
     utilizationPercent: Math.min(100, (100 * borrowed) / debtCeiling), // debt ceiling may be lowered, so cap at 100%
     // solvency is only relevant for lending markets; if mint markets have bad debt that's a protocol problem, not a user problem

--- a/packages/prices-api/src/llamalend/schema.ts
+++ b/packages/prices-api/src/llamalend/schema.ts
@@ -34,6 +34,7 @@ const market = z
     oracle: address,
     oracle_pools: z.array(address),
     rate: z.number(),
+    admin_fee: z.number(),
     borrow_total_apy: z.number(),
     borrow_apr: z.number(),
     borrow_total_apr: z.number(),

--- a/tests/cypress/support/helpers/lending-mocks.ts
+++ b/tests/cypress/support/helpers/lending-mocks.ts
@@ -90,6 +90,7 @@ const oneLendingPool = (
     extra_reward_apr: [],
     created_at: createdAt.getTime() / 1000,
     max_ltv: oneFloat(60, 110), // between 60% and 110%
+    admin_fee: 100000000000000000,
   }
 }
 


### PR DESCRIPTION
Should work now without having to connect a wallet. Mint markets have no fee iirc.

<img width="533" height="120" alt="image" src="https://github.com/user-attachments/assets/956e8ff5-12ef-4512-9c5d-dbe2a046329e" />
