### PR TITLE
fix: improve mobile DEX performance

### DIFF
--- a/packages/ui/src/features/tables/hooks/useTableStickyHeader.tsx
+++ b/packages/ui/src/features/tables/hooks/useTableStickyHeader.tsx
@@ -12,8 +12,8 @@ export const useTableStickyHeader = ({
   const enabled = !(disableStickyHeader || isLimited)
   const tableWrapperRef = useRef<HTMLDivElement>(null)
   const tableRef = useRef<HTMLTableElement>(null)
-  const [tableWrapperWidth] = useResizeObserver(tableWrapperRef, { enabled })
-  const [tableWidth] = useResizeObserver(tableRef, { enabled })
+  const [tableWrapperWidth] = useResizeObserver(tableWrapperRef, { enabled, dimension: 'width' })
+  const [tableWidth] = useResizeObserver(tableRef, { enabled, dimension: 'width' })
 
   return {
     tableRef,

--- a/packages/ui/src/hooks/useResizeObserver.ts
+++ b/packages/ui/src/hooks/useResizeObserver.ts
@@ -1,13 +1,22 @@
 import { type RefObject, useEffect, useState } from 'react'
 
-/** Options for the height resize observer */
-type ResizeObserverOptions = { threshold?: number; enabled?: boolean }
+type Dimension = 'width' | 'height'
 
+/** Options for the resize observer */
+type ResizeObserverOptions = {
+  threshold?: number
+  enabled?: boolean
+  /** Only changes to this dimension trigger updates. Watches both when omitted. */
+  dimension?: Dimension
+}
+
+const DIMENSION_INDEX: Record<Dimension, number> = { width: 0, height: 1 }
 const EMPTY_DIMENSIONS: readonly [] = []
 
 /**
  * A hook that observes an element's dimension changes (including borders) and returns the current dimensions.
- * Only updates when dimensions change beyond the threshold.
+ * Only updates when the selected dimension changes beyond the threshold (both by default).
+ * Returns both dimensions from the last accepted measurement, even when observing just one.
  *
  * @param elementRef - React ref object for the element to observe
  * @param options - Configuration options
@@ -32,7 +41,7 @@ const EMPTY_DIMENSIONS: readonly [] = []
  */
 export function useResizeObserver(
   elementRef: RefObject<Element | null>,
-  { threshold = 10, enabled = true }: ResizeObserverOptions = {},
+  { threshold = 10, enabled = true, dimension }: ResizeObserverOptions = {},
 ) {
   const [dimensions, setDimensions] = useState<[number, number] | null>(null)
 
@@ -48,11 +57,14 @@ export function useResizeObserver(
     const updateEntry = ([updatedEntry]: ResizeObserverEntry[]): void => {
       const { inlineSize: width, blockSize: height } = updatedEntry?.borderBoxSize[0] ?? {}
       const dimensions = [width, height].map(d => Math.round(d || 0)) as [number, number]
-      // Allow initial height to be set if prev is null
+      // Allow the initial measurement to be set if prev is null
       setDimensions((prev): [number, number] =>
         prev == null
           ? dimensions
-          : dimensions.some((dimension, i) => Math.abs(dimension - prev[i]) > threshold)
+          : dimensions.some(
+                (value, i) =>
+                  (dimension == null || i === DIMENSION_INDEX[dimension]) && Math.abs(value - prev[i]) > threshold,
+              )
             ? dimensions
             : prev,
       )
@@ -64,7 +76,7 @@ export function useResizeObserver(
     return () => {
       observer?.disconnect()
     }
-  }, [elementRef, threshold, enabled])
+  }, [elementRef, threshold, enabled, dimension])
 
   return dimensions ?? EMPTY_DIMENSIONS
 }


### PR DESCRIPTION
In the DEX table with 50 rows, opening one panel caused about 500 row renders. The panel’s animation repeatedly changed the table’s height, triggering sticky-header updates because `useResizeObserver` was watching both height and width. Each update caused the table to render its rows again, even though its width had not changed.

Watching only width reduced this to 50 row renders. All 50 rows still render once because opening a panel updates the table’s shared expansion state, causing the parent table and its rows to render again. We could potentially improve this further by allowing unchanged rows to skip rendering, so opening one panel would only render the affected row.